### PR TITLE
Add support for sending packets from the Javascript side.

### DIFF
--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -180,22 +180,32 @@ class Channel extends EventEmitter
 		}, 250);
 	}
 
-	request(method, internal, data)
+	request(method, internal, data, binary)
 	{
 		let id = utils.randomNumber();
 
 		logger.debug('request() [method:%s, id:%s]', method, id);
 
-		let request = { id, method, internal, data };
+		let request = { id, method, internal, data, binary: binary !== undefined };
 		let ns = netstring.nsWrite(JSON.stringify(request));
 
 		if (Buffer.byteLength(ns) > NS_MAX_SIZE)
 			return Promise.reject(new Error('request too big'));
 
+    let binaryNs;
+    if (binary !== undefined) {
+      binaryNs = netstring.nsWrite(binary);
+      if (Buffer.byteLength(binaryNs) > NS_MAX_SIZE)
+        return Promise.reject(new Error('binary data too big'));
+    }
+
 		// This may raise if closed or remote side ended.
 		try
 		{
 			this._socket.write(ns);
+      if (binaryNs) {
+        this._socket.write(binaryNs);
+      }
 		}
 		catch (error)
 		{

--- a/lib/Channel.js
+++ b/lib/Channel.js
@@ -192,20 +192,20 @@ class Channel extends EventEmitter
 		if (Buffer.byteLength(ns) > NS_MAX_SIZE)
 			return Promise.reject(new Error('request too big'));
 
-    let binaryNs;
-    if (binary !== undefined) {
-      binaryNs = netstring.nsWrite(binary);
-      if (Buffer.byteLength(binaryNs) > NS_MAX_SIZE)
-        return Promise.reject(new Error('binary data too big'));
-    }
+		let binaryNs;
+		if (binary !== undefined) {
+			binaryNs = netstring.nsWrite(binary);
+			if (Buffer.byteLength(binaryNs) > NS_MAX_SIZE)
+				return Promise.reject(new Error('binary data too big'));
+		}
 
 		// This may raise if closed or remote side ended.
 		try
 		{
 			this._socket.write(ns);
-      if (binaryNs) {
-        this._socket.write(binaryNs);
-      }
+			if (binaryNs) {
+				this._socket.write(binaryNs);
+			}
 		}
 		catch (error)
 		{

--- a/lib/Peer.js
+++ b/lib/Peer.js
@@ -323,28 +323,27 @@ class Peer extends EventEmitter
 		if (KINDS.indexOf(kind) === -1)
 			throw new TypeError(`unsupported kind: ${kind}`);
 
-		// Ensure `transport` is given.
-		if (!transport)
-			throw new TypeError('transport not given');
+    // Transport is optional
+		if (transport) {
+  		// Ensure `transport` is a Transport.
+  		if (!(transport instanceof Transport))
+  			throw new TypeError('transport must be a instance of Transport');
 
-		// Ensure `transport` is a Transport.
-		if (!(transport instanceof Transport))
-			throw new TypeError('transport must be a instance of Transport');
+  		// Ensure `transport` is not closed.
+  		if (transport.closed)
+  			throw new errors.InvalidStateError('transport is closed');
 
-		// Ensure `transport` is not closed.
-		if (transport.closed)
-			throw new errors.InvalidStateError('transport is closed');
-
-		// Ensure `transport` belongs to this Peer.
-		if (!this._transports.has(transport))
-			throw new Error('transport not found');
+  		// Ensure `transport` belongs to this Peer.
+  		if (!this._transports.has(transport))
+  			throw new Error('transport not found');
+    }
 
 		let internal =
 		{
 			roomId        : this._internal.roomId,
 			peerId        : this._internal.peerId,
 			rtpReceiverId : utils.randomNumber(),
-			transportId   : transport._internal.transportId
+			transportId   : transport ? transport._internal.transportId : 0
 		};
 
 		let data =

--- a/lib/Peer.js
+++ b/lib/Peer.js
@@ -323,20 +323,20 @@ class Peer extends EventEmitter
 		if (KINDS.indexOf(kind) === -1)
 			throw new TypeError(`unsupported kind: ${kind}`);
 
-    // Transport is optional
+		// Transport is optional
 		if (transport) {
-  		// Ensure `transport` is a Transport.
-  		if (!(transport instanceof Transport))
-  			throw new TypeError('transport must be a instance of Transport');
+			// Ensure `transport` is a Transport.
+			if (!(transport instanceof Transport))
+				throw new TypeError('transport must be a instance of Transport');
 
-  		// Ensure `transport` is not closed.
-  		if (transport.closed)
-  			throw new errors.InvalidStateError('transport is closed');
+			// Ensure `transport` is not closed.
+			if (transport.closed)
+				throw new errors.InvalidStateError('transport is closed');
 
-  		// Ensure `transport` belongs to this Peer.
-  		if (!this._transports.has(transport))
-  			throw new Error('transport not found');
-    }
+			// Ensure `transport` belongs to this Peer.
+			if (!this._transports.has(transport))
+				throw new Error('transport not found');
+		}
 
 		let internal =
 		{

--- a/lib/RtpReceiver.js
+++ b/lib/RtpReceiver.js
@@ -283,6 +283,31 @@ class RtpReceiver extends EventEmitter
 				throw error;
 			});
 	}
+
+  receiveRtpPacket(packet) {
+    logger.debug('receiveRtpPacket()');
+
+    if (this._closed)
+			return Promise.reject(new errors.InvalidStateError('RtpReceiver closed'));
+
+    if (!this._data.rtpParameters)
+			return Promise.reject(new errors.InvalidStateError('RtpReceiver params not set'));
+
+    // Send Channel request.
+		return this._channel.request('rtpReceiver.receiveRtpPacket', this._internal, {}, packet)
+			.then((data) =>
+			{
+				logger.debug('"rtpReceiver.receiveRtpPacket" request succeeded');
+
+				return this;
+			})
+			.catch((error) =>
+			{
+				logger.error('"rtpReceiver.receiveRtpPacket" request failed: %s', error);
+
+				throw error;
+			});
+  }
 }
 
 module.exports = RtpReceiver;

--- a/lib/RtpReceiver.js
+++ b/lib/RtpReceiver.js
@@ -284,16 +284,16 @@ class RtpReceiver extends EventEmitter
 			});
 	}
 
-  receiveRtpPacket(packet) {
-    logger.debug('receiveRtpPacket()');
+	receiveRtpPacket(packet) {
+		logger.debug('receiveRtpPacket()');
 
-    if (this._closed)
+		if (this._closed)
 			return Promise.reject(new errors.InvalidStateError('RtpReceiver closed'));
 
-    if (!this._data.rtpParameters)
+		if (!this._data.rtpParameters)
 			return Promise.reject(new errors.InvalidStateError('RtpReceiver params not set'));
 
-    // Send Channel request.
+		// Send Channel request.
 		return this._channel.request('rtpReceiver.receiveRtpPacket', this._internal, {}, packet)
 			.then((data) =>
 			{
@@ -307,7 +307,7 @@ class RtpReceiver extends EventEmitter
 
 				throw error;
 			});
-  }
+	}
 }
 
 module.exports = RtpReceiver;

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "mvrs-mediasoup",
-  "version": "0.5.1",
-  "description": "Metaversity fork of MediaSoup.",
+  "name": "mediasoup",
+  "version": "0.5.0",
+  "description": "Powerful WebRTC SFU for Node.js",
   "main": "lib/mediasoup.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/mpk934/mediasoup.git"
+    "url": "https://github.com/ibc/mediasoup.git"
   },
   "author": "Iñaki Baz Castillo <ibc@aliax.net>",
   "license": "ISC",
@@ -42,9 +42,6 @@
     "gulp-shell": "^0.6.1",
     "gulp-touch-cmd": "0.0.1",
     "tap": "^10.3.0"
-  },
-  "publishConfig": {
-    "registry": "https://www.mpk934.com/registry"
   },
   "scripts": {
     "test": "gulp test",

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "mediasoup",
+  "name": "mvrs-mediasoup",
   "version": "0.5.0",
-  "description": "Powerful WebRTC SFU for Node.js",
+  "description": "Metaversity fork of MediaSoup.",
   "main": "lib/mediasoup.js",
   "repository": {
     "type": "git",
-    "url": "https://github.com/ibc/mediasoup.git"
+    "url": "https://github.com/mpk934/mediasoup.git"
   },
   "author": "Iñaki Baz Castillo <ibc@aliax.net>",
   "license": "ISC",
@@ -42,6 +42,9 @@
     "gulp-shell": "^0.6.1",
     "gulp-touch-cmd": "0.0.1",
     "tap": "^10.3.0"
+  },
+  "publishConfig": {
+    "registry": "https://www.mpk934.com/registry"
   },
   "scripts": {
     "test": "gulp test",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mvrs-mediasoup",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Metaversity fork of MediaSoup.",
   "main": "lib/mediasoup.js",
   "repository": {

--- a/worker/include/Channel/Request.hpp
+++ b/worker/include/Channel/Request.hpp
@@ -36,7 +36,7 @@ namespace Channel
 			rtpReceiver_receive,
 			rtpReceiver_setRtpRawEvent,
 			rtpReceiver_setRtpObjectEvent,
-      rtpReceiver_receiveRtpPacket,
+			rtpReceiver_receiveRtpPacket,
 			rtpSender_dump,
 			rtpSender_setTransport,
 			rtpSender_disable
@@ -62,8 +62,8 @@ namespace Channel
 		MethodId methodId;
 		Json::Value internal;
 		Json::Value data;
-    const uint8_t* binary;
-    size_t len;
+		const uint8_t* binary;
+		size_t len;
 		// Others.
 		bool replied = false;
 	};

--- a/worker/include/Channel/Request.hpp
+++ b/worker/include/Channel/Request.hpp
@@ -36,6 +36,7 @@ namespace Channel
 			rtpReceiver_receive,
 			rtpReceiver_setRtpRawEvent,
 			rtpReceiver_setRtpObjectEvent,
+      rtpReceiver_receiveRtpPacket,
 			rtpSender_dump,
 			rtpSender_setTransport,
 			rtpSender_disable
@@ -45,7 +46,7 @@ namespace Channel
 		static std::unordered_map<std::string, MethodId> string2MethodId;
 
 	public:
-		Request(Channel::UnixStreamSocket* channel, Json::Value& json);
+		Request(Channel::UnixStreamSocket* channel, Json::Value& json, const uint8_t* binary, size_t len);
 		virtual ~Request();
 
 		void Accept();
@@ -61,6 +62,8 @@ namespace Channel
 		MethodId methodId;
 		Json::Value internal;
 		Json::Value data;
+    const uint8_t* binary;
+    size_t len;
 		// Others.
 		bool replied = false;
 	};

--- a/worker/include/Channel/UnixStreamSocket.hpp
+++ b/worker/include/Channel/UnixStreamSocket.hpp
@@ -37,12 +37,15 @@ namespace Channel
 		virtual void userOnUnixStreamSocketClosed(bool is_closed_by_peer) override;
 
 	private:
+    void HandleRequest(Json::Value& json, const uint8_t* binary = nullptr, size_t len = 0);
+
 		// Passed by argument.
 		Listener* listener = nullptr;
 		// Others.
 		Json::CharReader* jsonReader = nullptr;
 		Json::StreamWriter* jsonWriter = nullptr;
 		size_t msgStart = 0; // Where the latest message starts.
+    Json::Value lastBinaryRequest;
 		bool closed = false;
 	};
 }

--- a/worker/include/Channel/UnixStreamSocket.hpp
+++ b/worker/include/Channel/UnixStreamSocket.hpp
@@ -37,7 +37,7 @@ namespace Channel
 		virtual void userOnUnixStreamSocketClosed(bool is_closed_by_peer) override;
 
 	private:
-    void HandleRequest(Json::Value& json, const uint8_t* binary = nullptr, size_t len = 0);
+		void HandleRequest(Json::Value& json, const uint8_t* binary = nullptr, size_t len = 0);
 
 		// Passed by argument.
 		Listener* listener = nullptr;
@@ -45,7 +45,7 @@ namespace Channel
 		Json::CharReader* jsonReader = nullptr;
 		Json::StreamWriter* jsonWriter = nullptr;
 		size_t msgStart = 0; // Where the latest message starts.
-    Json::Value lastBinaryRequest;
+		Json::Value lastBinaryRequest;
 		bool closed = false;
 	};
 }

--- a/worker/src/Channel/Request.cpp
+++ b/worker/src/Channel/Request.cpp
@@ -30,7 +30,7 @@ namespace Channel
 		{ "rtpReceiver.receive",               Request::MethodId::rtpReceiver_receive               },
 		{ "rtpReceiver.setRtpRawEvent",        Request::MethodId::rtpReceiver_setRtpRawEvent        },
 		{ "rtpReceiver.setRtpObjectEvent",     Request::MethodId::rtpReceiver_setRtpObjectEvent     },
-    { "rtpReceiver.receiveRtpPacket",      Request::MethodId::rtpReceiver_receiveRtpPacket      },
+		{ "rtpReceiver.receiveRtpPacket",      Request::MethodId::rtpReceiver_receiveRtpPacket      },
 		{ "rtpSender.dump",                    Request::MethodId::rtpSender_dump                    },
 		{ "rtpSender.setTransport",            Request::MethodId::rtpSender_setTransport            },
 		{ "rtpSender.disable",                 Request::MethodId::rtpSender_disable                 }
@@ -40,8 +40,8 @@ namespace Channel
 
 	Request::Request(Channel::UnixStreamSocket* channel, Json::Value& json, const uint8_t* binary, size_t len) :
 		channel(channel),
-    binary(binary),
-    len(len)
+		binary(binary),
+		len(len)
 	{
 		MS_TRACE();
 

--- a/worker/src/Channel/Request.cpp
+++ b/worker/src/Channel/Request.cpp
@@ -30,6 +30,7 @@ namespace Channel
 		{ "rtpReceiver.receive",               Request::MethodId::rtpReceiver_receive               },
 		{ "rtpReceiver.setRtpRawEvent",        Request::MethodId::rtpReceiver_setRtpRawEvent        },
 		{ "rtpReceiver.setRtpObjectEvent",     Request::MethodId::rtpReceiver_setRtpObjectEvent     },
+    { "rtpReceiver.receiveRtpPacket",      Request::MethodId::rtpReceiver_receiveRtpPacket      },
 		{ "rtpSender.dump",                    Request::MethodId::rtpSender_dump                    },
 		{ "rtpSender.setTransport",            Request::MethodId::rtpSender_setTransport            },
 		{ "rtpSender.disable",                 Request::MethodId::rtpSender_disable                 }
@@ -37,8 +38,10 @@ namespace Channel
 
 	/* Instance methods. */
 
-	Request::Request(Channel::UnixStreamSocket* channel, Json::Value& json) :
-		channel(channel)
+	Request::Request(Channel::UnixStreamSocket* channel, Json::Value& json, const uint8_t* binary, size_t len) :
+		channel(channel),
+    binary(binary),
+    len(len)
 	{
 		MS_TRACE();
 

--- a/worker/src/Channel/UnixStreamSocket.cpp
+++ b/worker/src/Channel/UnixStreamSocket.cpp
@@ -107,10 +107,10 @@ namespace Channel
 		}
 		else
 		{
-		  ns_num_len = (size_t)std::ceil(std::log10((double)ns_payload_len + 1));
-		  std::sprintf((char*)UnixStreamSocket::writeBuffer, "%zu:", ns_payload_len);
-		  std::memcpy(UnixStreamSocket::writeBuffer + ns_num_len + 1, ns_payload.c_str(), ns_payload_len);
-		  UnixStreamSocket::writeBuffer[ns_num_len + ns_payload_len + 1] = ',';
+			ns_num_len = (size_t)std::ceil(std::log10((double)ns_payload_len + 1));
+			std::sprintf((char*)UnixStreamSocket::writeBuffer, "%zu:", ns_payload_len);
+			std::memcpy(UnixStreamSocket::writeBuffer + ns_num_len + 1, ns_payload.c_str(), ns_payload_len);
+			UnixStreamSocket::writeBuffer[ns_num_len + ns_payload_len + 1] = ',';
 		}
 
 		ns_len = ns_num_len + ns_payload_len + 2;
@@ -144,10 +144,10 @@ namespace Channel
 		}
 		else
 		{
-		  ns_num_len = (size_t)std::ceil(std::log10((double)ns_payload_len + 1));
-		  std::sprintf((char*)UnixStreamSocket::writeBuffer, "%zu:", ns_payload_len);
-		  std::memcpy(UnixStreamSocket::writeBuffer + ns_num_len + 1, ns_payload, ns_payload_len);
-		  UnixStreamSocket::writeBuffer[ns_num_len + ns_payload_len + 1] = ',';
+			ns_num_len = (size_t)std::ceil(std::log10((double)ns_payload_len + 1));
+			std::sprintf((char*)UnixStreamSocket::writeBuffer, "%zu:", ns_payload_len);
+			std::memcpy(UnixStreamSocket::writeBuffer + ns_num_len + 1, ns_payload, ns_payload_len);
+			UnixStreamSocket::writeBuffer[ns_num_len + ns_payload_len + 1] = ',';
 		}
 
 		ns_len = ns_num_len + ns_payload_len + 2;
@@ -179,10 +179,10 @@ namespace Channel
 		}
 		else
 		{
-		  ns_num_len = (size_t)std::ceil(std::log10((double)ns_payload_len + 1));
-		  std::sprintf((char*)UnixStreamSocket::writeBuffer, "%zu:", ns_payload_len);
-		  std::memcpy(UnixStreamSocket::writeBuffer + ns_num_len + 1, ns_payload, ns_payload_len);
-		  UnixStreamSocket::writeBuffer[ns_num_len + ns_payload_len + 1] = ',';
+			ns_num_len = (size_t)std::ceil(std::log10((double)ns_payload_len + 1));
+			std::sprintf((char*)UnixStreamSocket::writeBuffer, "%zu:", ns_payload_len);
+			std::memcpy(UnixStreamSocket::writeBuffer + ns_num_len + 1, ns_payload, ns_payload_len);
+			UnixStreamSocket::writeBuffer[ns_num_len + ns_payload_len + 1] = ',';
 		}
 
 		ns_len = ns_num_len + ns_payload_len + 2;
@@ -190,28 +190,28 @@ namespace Channel
 		Write(UnixStreamSocket::writeBuffer, ns_len);
 	}
 
-  void UnixStreamSocket::HandleRequest(Json::Value& json, const uint8_t* binary, size_t len)
-  {
-    Channel::Request* request = nullptr;
+	void UnixStreamSocket::HandleRequest(Json::Value& json, const uint8_t* binary, size_t len)
+	{
+		Channel::Request* request = nullptr;
 
-    try
-    {
-      request = new Channel::Request(this, json, binary, len);
-    }
-    catch (const MediaSoupError &error)
-    {
-      MS_ERROR_STD("discarding wrong Channel request");
-    }
+		try
+		{
+			request = new Channel::Request(this, json, binary, len);
+		}
+		catch (const MediaSoupError &error)
+		{
+			MS_ERROR_STD("discarding wrong Channel request");
+		}
 
-    if (request)
-    {
-      // Notify the listener.
-      this->listener->onChannelRequest(this, request);
+		if (request)
+		{
+			// Notify the listener.
+			this->listener->onChannelRequest(this, request);
 
-      // Delete the Request.
-      delete request;
-    }
-  }
+			// Delete the Request.
+			delete request;
+		}
+	}
 
 	void UnixStreamSocket::userOnUnixStreamRead()
 	{
@@ -295,19 +295,19 @@ namespace Channel
 			Json::Value json;
 			std::string json_parse_error;
 
-      if (!!this->lastBinaryRequest) {
-        this->HandleRequest(this->lastBinaryRequest, (const uint8_t*)json_start, json_len);
-        this->lastBinaryRequest = Json::Value();
-      }
-      else if (this->jsonReader->parse((const char*)json_start, (const char*)json_start + json_len, &json, &json_parse_error))
+			if (!!this->lastBinaryRequest) {
+				this->HandleRequest(this->lastBinaryRequest, (const uint8_t*)json_start, json_len);
+				this->lastBinaryRequest = Json::Value();
+			}
+			else if (this->jsonReader->parse((const char*)json_start, (const char*)json_start + json_len, &json, &json_parse_error))
 			{
-        static const Json::StaticString k_binary("binary");
-        if (json[k_binary].isBool() && json[k_binary].asBool()) {
-          this->lastBinaryRequest = json;
+				static const Json::StaticString k_binary("binary");
+				if (json[k_binary].isBool() && json[k_binary].asBool()) {
+					this->lastBinaryRequest = json;
 
-        } else {
-  				this->HandleRequest(json);
-        }
+				} else {
+					this->HandleRequest(json);
+				}
 			}
 			else
 			{

--- a/worker/src/Channel/UnixStreamSocket.cpp
+++ b/worker/src/Channel/UnixStreamSocket.cpp
@@ -107,10 +107,10 @@ namespace Channel
 		}
 		else
 		{
-			ns_num_len = (size_t)std::ceil(std::log10((double)ns_payload_len + 1));
-			std::sprintf((char*)UnixStreamSocket::writeBuffer, "%zu:", ns_payload_len);
-			std::memcpy(UnixStreamSocket::writeBuffer + ns_num_len + 1, ns_payload.c_str(), ns_payload_len);
-			UnixStreamSocket::writeBuffer[ns_num_len + ns_payload_len + 1] = ',';
+		  ns_num_len = (size_t)std::ceil(std::log10((double)ns_payload_len + 1));
+		  std::sprintf((char*)UnixStreamSocket::writeBuffer, "%zu:", ns_payload_len);
+		  std::memcpy(UnixStreamSocket::writeBuffer + ns_num_len + 1, ns_payload.c_str(), ns_payload_len);
+		  UnixStreamSocket::writeBuffer[ns_num_len + ns_payload_len + 1] = ',';
 		}
 
 		ns_len = ns_num_len + ns_payload_len + 2;
@@ -144,10 +144,10 @@ namespace Channel
 		}
 		else
 		{
-			ns_num_len = (size_t)std::ceil(std::log10((double)ns_payload_len + 1));
-			std::sprintf((char*)UnixStreamSocket::writeBuffer, "%zu:", ns_payload_len);
-			std::memcpy(UnixStreamSocket::writeBuffer + ns_num_len + 1, ns_payload, ns_payload_len);
-			UnixStreamSocket::writeBuffer[ns_num_len + ns_payload_len + 1] = ',';
+		  ns_num_len = (size_t)std::ceil(std::log10((double)ns_payload_len + 1));
+		  std::sprintf((char*)UnixStreamSocket::writeBuffer, "%zu:", ns_payload_len);
+		  std::memcpy(UnixStreamSocket::writeBuffer + ns_num_len + 1, ns_payload, ns_payload_len);
+		  UnixStreamSocket::writeBuffer[ns_num_len + ns_payload_len + 1] = ',';
 		}
 
 		ns_len = ns_num_len + ns_payload_len + 2;
@@ -179,10 +179,10 @@ namespace Channel
 		}
 		else
 		{
-			ns_num_len = (size_t)std::ceil(std::log10((double)ns_payload_len + 1));
-			std::sprintf((char*)UnixStreamSocket::writeBuffer, "%zu:", ns_payload_len);
-			std::memcpy(UnixStreamSocket::writeBuffer + ns_num_len + 1, ns_payload, ns_payload_len);
-			UnixStreamSocket::writeBuffer[ns_num_len + ns_payload_len + 1] = ',';
+		  ns_num_len = (size_t)std::ceil(std::log10((double)ns_payload_len + 1));
+		  std::sprintf((char*)UnixStreamSocket::writeBuffer, "%zu:", ns_payload_len);
+		  std::memcpy(UnixStreamSocket::writeBuffer + ns_num_len + 1, ns_payload, ns_payload_len);
+		  UnixStreamSocket::writeBuffer[ns_num_len + ns_payload_len + 1] = ',';
 		}
 
 		ns_len = ns_num_len + ns_payload_len + 2;

--- a/worker/src/Loop.cpp
+++ b/worker/src/Loop.cpp
@@ -228,6 +228,7 @@ void Loop::onChannelRequest(Channel::UnixStreamSocket* channel, Channel::Request
 		case Channel::Request::MethodId::rtpReceiver_receive:
 		case Channel::Request::MethodId::rtpReceiver_setRtpRawEvent:
 		case Channel::Request::MethodId::rtpReceiver_setRtpObjectEvent:
+    case Channel::Request::MethodId::rtpReceiver_receiveRtpPacket:
 		case Channel::Request::MethodId::rtpSender_dump:
 		case Channel::Request::MethodId::rtpSender_setTransport:
 		case Channel::Request::MethodId::rtpSender_disable:

--- a/worker/src/Loop.cpp
+++ b/worker/src/Loop.cpp
@@ -228,7 +228,7 @@ void Loop::onChannelRequest(Channel::UnixStreamSocket* channel, Channel::Request
 		case Channel::Request::MethodId::rtpReceiver_receive:
 		case Channel::Request::MethodId::rtpReceiver_setRtpRawEvent:
 		case Channel::Request::MethodId::rtpReceiver_setRtpObjectEvent:
-    case Channel::Request::MethodId::rtpReceiver_receiveRtpPacket:
+		case Channel::Request::MethodId::rtpReceiver_receiveRtpPacket:
 		case Channel::Request::MethodId::rtpSender_dump:
 		case Channel::Request::MethodId::rtpSender_setTransport:
 		case Channel::Request::MethodId::rtpSender_disable:

--- a/worker/src/RTC/Peer.cpp
+++ b/worker/src/RTC/Peer.cpp
@@ -259,13 +259,6 @@ namespace RTC
 				RTC::Transport* transport = nullptr;
 				uint32_t rtpReceiverId;
 
-				// Capabilities must be set.
-				if (!this->hasCapabilities)
-				{
-					request->Reject("peer capabilities are not yet set");
-					return;
-				}
-
 				try
 				{
 					rtpReceiver = GetRtpReceiverFromRequest(request, &rtpReceiverId);
@@ -289,12 +282,6 @@ namespace RTC
 				catch (const MediaSoupError &error)
 				{
 					request->Reject(error.what());
-					return;
-				}
-
-				if (!transport)
-				{
-					request->Reject("Transport does not exist");
 					return;
 				}
 
@@ -721,11 +708,13 @@ namespace RTC
 
 		auto rtpParameters = rtpReceiver->GetParameters();
 
-		// Remove unsupported codecs and their associated encodings.
-		rtpParameters->ReduceCodecsAndEncodings(this->capabilities);
+    if (this->hasCapabilities) {
+  		// Remove unsupported codecs and their associated encodings.
+  		rtpParameters->ReduceCodecsAndEncodings(this->capabilities);
 
-		// Remove unsupported header extensions.
-		rtpParameters->ReduceHeaderExtensions(this->capabilities.headerExtensions);
+  		// Remove unsupported header extensions.
+  		rtpParameters->ReduceHeaderExtensions(this->capabilities.headerExtensions);
+    }
 
 		auto transport = rtpReceiver->GetTransport();
 

--- a/worker/src/RTC/Peer.cpp
+++ b/worker/src/RTC/Peer.cpp
@@ -347,7 +347,7 @@ namespace RTC
 			case Channel::Request::MethodId::rtpReceiver_receive:
 			case Channel::Request::MethodId::rtpReceiver_setRtpRawEvent:
 			case Channel::Request::MethodId::rtpReceiver_setRtpObjectEvent:
-      case Channel::Request::MethodId::rtpReceiver_receiveRtpPacket:
+			case Channel::Request::MethodId::rtpReceiver_receiveRtpPacket:
 			{
 				RTC::RtpReceiver* rtpReceiver;
 
@@ -709,13 +709,13 @@ namespace RTC
 
 		auto rtpParameters = rtpReceiver->GetParameters();
 
-    if (this->hasCapabilities) {
-  		// Remove unsupported codecs and their associated encodings.
-  		rtpParameters->ReduceCodecsAndEncodings(this->capabilities);
+		if (this->hasCapabilities) {
+			// Remove unsupported codecs and their associated encodings.
+			rtpParameters->ReduceCodecsAndEncodings(this->capabilities);
 
-  		// Remove unsupported header extensions.
-  		rtpParameters->ReduceHeaderExtensions(this->capabilities.headerExtensions);
-    }
+			// Remove unsupported header extensions.
+			rtpParameters->ReduceHeaderExtensions(this->capabilities.headerExtensions);
+		}
 
 		auto transport = rtpReceiver->GetTransport();
 

--- a/worker/src/RTC/Peer.cpp
+++ b/worker/src/RTC/Peer.cpp
@@ -347,6 +347,7 @@ namespace RTC
 			case Channel::Request::MethodId::rtpReceiver_receive:
 			case Channel::Request::MethodId::rtpReceiver_setRtpRawEvent:
 			case Channel::Request::MethodId::rtpReceiver_setRtpObjectEvent:
+      case Channel::Request::MethodId::rtpReceiver_receiveRtpPacket:
 			{
 				RTC::RtpReceiver* rtpReceiver;
 

--- a/worker/src/RTC/Room.cpp
+++ b/worker/src/RTC/Room.cpp
@@ -301,6 +301,7 @@ namespace RTC
 			case Channel::Request::MethodId::rtpReceiver_receive:
 			case Channel::Request::MethodId::rtpReceiver_setRtpRawEvent:
 			case Channel::Request::MethodId::rtpReceiver_setRtpObjectEvent:
+      case Channel::Request::MethodId::rtpReceiver_receiveRtpPacket:
 			case Channel::Request::MethodId::rtpSender_dump:
 			case Channel::Request::MethodId::rtpSender_setTransport:
 			case Channel::Request::MethodId::rtpSender_disable:

--- a/worker/src/RTC/Room.cpp
+++ b/worker/src/RTC/Room.cpp
@@ -301,7 +301,7 @@ namespace RTC
 			case Channel::Request::MethodId::rtpReceiver_receive:
 			case Channel::Request::MethodId::rtpReceiver_setRtpRawEvent:
 			case Channel::Request::MethodId::rtpReceiver_setRtpObjectEvent:
-      case Channel::Request::MethodId::rtpReceiver_receiveRtpPacket:
+			case Channel::Request::MethodId::rtpReceiver_receiveRtpPacket:
 			case Channel::Request::MethodId::rtpSender_dump:
 			case Channel::Request::MethodId::rtpSender_setTransport:
 			case Channel::Request::MethodId::rtpSender_disable:

--- a/worker/src/RTC/RtpReceiver.cpp
+++ b/worker/src/RTC/RtpReceiver.cpp
@@ -243,22 +243,22 @@ namespace RTC
 				break;
 			}
 
-      case Channel::Request::MethodId::rtpReceiver_receiveRtpPacket:
+			case Channel::Request::MethodId::rtpReceiver_receiveRtpPacket:
 			{
-        if (!request->binary) {
-  				request->Reject("missing binary packet");
-          return;
-        }
-        auto packet = RTC::RtpPacket::Parse(request->binary, request->len);
-        if (!packet) {
-          request->Reject("invalid rtp packet");
-          return;
-        }
-        this->ReceiveRtpPacket(packet);
-        delete packet;
-        request->Accept();
-        break;
-      }
+				if (!request->binary) {
+					request->Reject("missing binary packet");
+					return;
+				}
+				auto packet = RTC::RtpPacket::Parse(request->binary, request->len);
+				if (!packet) {
+					request->Reject("invalid rtp packet");
+					return;
+				}
+				this->ReceiveRtpPacket(packet);
+				delete packet;
+				request->Accept();
+				break;
+			}
 
 			default:
 			{

--- a/worker/src/RTC/RtpReceiver.cpp
+++ b/worker/src/RTC/RtpReceiver.cpp
@@ -243,6 +243,23 @@ namespace RTC
 				break;
 			}
 
+      case Channel::Request::MethodId::rtpReceiver_receiveRtpPacket:
+			{
+        if (!request->binary) {
+  				request->Reject("missing binary packet");
+          return;
+        }
+        auto packet = RTC::RtpPacket::Parse(request->binary, request->len);
+        if (!packet) {
+          request->Reject("invalid rtp packet");
+          return;
+        }
+        this->ReceiveRtpPacket(packet);
+        delete packet;
+        request->Accept();
+        break;
+      }
+
 			default:
 			{
 				MS_ERROR("unknown method");


### PR DESCRIPTION
In order to allow replaying packet streams recorded from the 'rtpraw' event, this provides a means to create a Peer and RtpReceiver without setting the transport or capabilities.   The Javascript playback code can then create a Peer and an RtpReceiver, initializing the latter with previously recorded rtpParameters, and call RtpReceiver.receiveRtpPacket to "play" recorded packets.

This is pretty rough, and thus I wouldn't expect you to merge it directly, but I thought you'd be interested.  The background is that we wanted to play with this functionality sooner rather than later for our project, and we weren't sure where it was on your road map.

In testing, I've managed to get it working (that is, playing recorded audio) on Firefox and Chrome, though there may be some timing issues (sometimes the streams don't register--haven't yet delved into WebRTC debugging to figure out why), and there are certainly issues with playing the stream more than once (I am currently generating switching the stream to use random ssrc and msid values to work around this, which seems to work on Chrome but not Firefox).  