### PR TITLE
RtpSender: allow disable()/enable() without forcing SDP renegotiation

### DIFF
--- a/lib/RtpSender.js
+++ b/lib/RtpSender.js
@@ -211,15 +211,21 @@ class RtpSender extends EventEmitter
 	 *
 	 * @return {Promise} Resolves to this.
 	 */
-	enable()
+	enable(options)
 	{
-		logger.debug('enable()');
+		logger.debug('enable() [options:%o]', options);
 
 		if (this._closed)
 			return Promise.reject(new errors.InvalidStateError('RtpSender closed'));
 
+		options = options || {};
+
 		// Send Channel request.
-		return this._channel.request('rtpSender.disable', this._internal, { disabled: false })
+		return this._channel.request('rtpSender.disable', this._internal,
+			{
+				disabled : false,
+				emit     : !!options.emit
+			})
 			.then(() =>
 			{
 				logger.debug('"rtpSender.disable" request succeeded');
@@ -239,15 +245,21 @@ class RtpSender extends EventEmitter
 	 *
 	 * @return {Promise} Resolves to this.
 	 */
-	disable()
+	disable(options)
 	{
-		logger.debug('disable()');
+		logger.debug('disable() [options:%o]', options);
 
 		if (this._closed)
 			return Promise.reject(new errors.InvalidStateError('RtpSender closed'));
 
+		options = options || {};
+
 		// Send Channel request.
-		return this._channel.request('rtpSender.disable', this._internal, { disabled: true })
+		return this._channel.request('rtpSender.disable', this._internal,
+			{
+				disabled : true,
+				emit     : !!options.emit
+			})
 			.then(() =>
 			{
 				logger.debug('"rtpSender.disable" request succeeded');

--- a/worker/include/RTC/Peer.hpp
+++ b/worker/include/RTC/Peer.hpp
@@ -97,6 +97,7 @@ namespace RTC
 		/* Pure virtual methods inherited from RTC::RtpSender::Listener. */
 	public:
 		void OnRtpSenderClosed(RTC::RtpSender* rtpSender) override;
+		void OnRtpSenderFullFrameRequired(RTC::RtpSender* rtpSender) override;
 
 		/* Pure virtual methods inherited from Timer::Listener. */
 	public:

--- a/worker/include/RTC/RtpSender.hpp
+++ b/worker/include/RTC/RtpSender.hpp
@@ -27,7 +27,8 @@ namespace RTC
 		class Listener
 		{
 		public:
-			virtual void OnRtpSenderClosed(RtpSender* rtpSender) = 0;
+			virtual void OnRtpSenderClosed(RtpSender* rtpSender)            = 0;
+			virtual void OnRtpSenderFullFrameRequired(RtpSender* rtpSender) = 0;
 		};
 
 	public:

--- a/worker/src/RTC/Peer.cpp
+++ b/worker/src/RTC/Peer.cpp
@@ -950,6 +950,10 @@ namespace RTC
 
 							if (rtpSender != nullptr)
 							{
+								// If the RtpSender is not active, drop the packet.
+								if (!rtpSender->GetActive())
+									break;
+
 								if (feedback->GetMessageType() == RTCP::FeedbackPs::MessageType::PLI)
 								{
 									MS_DEBUG_TAG(rtx, "PLI received [media ssrc:%" PRIu32 "]", feedback->GetMediaSsrc());
@@ -1148,6 +1152,13 @@ namespace RTC
 
 		// Notify the listener (Room) so it can remove this RtpSender from its map.
 		this->listener->OnPeerRtpSenderClosed(this, rtpSender);
+	}
+
+	void Peer::OnRtpSenderFullFrameRequired(RTC::RtpSender* rtpSender)
+	{
+		MS_TRACE();
+
+		this->listener->OnFullFrameRequired(this, rtpSender);
 	}
 
 	void Peer::OnTimer(Timer* /*timer*/)

--- a/worker/src/RTC/RtpSender.cpp
+++ b/worker/src/RTC/RtpSender.cpp
@@ -112,6 +112,7 @@ namespace RTC
 			case Channel::Request::MethodId::RTP_SENDER_DISABLE:
 			{
 				static const Json::StaticString JsonStringDisabled{ "disabled" };
+				static const Json::StaticString JsonStringEmit{ "emit" };
 
 				if (!request->data[JsonStringDisabled].isBool())
 				{
@@ -121,6 +122,10 @@ namespace RTC
 				}
 
 				bool disabled = request->data[JsonStringDisabled].asBool();
+				bool emit     = true;
+
+				if (request->data[JsonStringEmit].isBool())
+					emit = request->data[JsonStringEmit].asBool();
 
 				// Nothing changed.
 				if (this->disabled == disabled)
@@ -135,7 +140,13 @@ namespace RTC
 				this->disabled = disabled;
 
 				if (wasActive != this->GetActive())
-					EmitActiveChange();
+				{
+					if (emit)
+						EmitActiveChange();
+
+					if (this->GetActive())
+						this->listener->OnRtpSenderFullFrameRequired(this);
+				}
 
 				request->Accept();
 


### PR DESCRIPTION
It fixes #113.

Related documentation [here](https://mediasoup.org/api/#rtpSender-disable).