### PR TITLE
Fix serialization of RTX decoded packets.

### DIFF
--- a/TODO_V2.md
+++ b/TODO_V2.md
@@ -1,9 +1,5 @@
 # TODO in mediasoup v2 (server-side)
 
-* `RtpPacket::RtxEncode()` should remove the original padding (also the header flag by using `SetPayloadPaddingFlag(false)`), then set the RTX payload, then check whether padding is required and, if so, set the padding flag and bytes.
-  - Similar stuff (inverse) with `RtxDecode()`.
-  - NOTE: Nobody does this. Also, it's dangerous since after `RtxDecode()` it may happen that N bytes of padding are needed, but those exceed the original RTX packet size.
-
 * In `RtpStreamSend::StorePacket()` we should remove old packets (as `NackGenerator` does).
 
 * Remove `producer.on('rtprawpacket')` and, instead, create a special `RtpConsumer` or something like that.

--- a/TODO_V2.md
+++ b/TODO_V2.md
@@ -1,5 +1,9 @@
 # TODO in mediasoup v2 (server-side)
 
+* `RtpPacket::RtxEncode()` should remove the original padding (also the header flag by using `SetPayloadPaddingFlag(false)`), then set the RTX payload, then check whether padding is required and, if so, set the padding flag and bytes.
+  - Similar stuff (inverse) with `RtxDecode()`.
+  - NOTE: Nobody does this. Also, it's dangerous since after `RtxDecode()` it may happen that N bytes of padding are needed, but those exceed the original RTX packet size.
+
 * In `RtpStreamSend::StorePacket()` we should remove old packets (as `NackGenerator` does).
 
 * Remove `producer.on('rtprawpacket')` and, instead, create a special `RtpConsumer` or something like that.

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -95,6 +95,7 @@ namespace RTC
 		void SetPayloadType(uint8_t payloadType);
 		bool HasMarker() const;
 		void SetMarker(bool marker);
+		void SetPayloadPaddingFlag(bool flag);
 		uint16_t GetSequenceNumber() const;
 		void SetSequenceNumber(uint16_t seq);
 		uint32_t GetExtendedSequenceNumber() const;
@@ -188,6 +189,11 @@ namespace RTC
 	inline void RtpPacket::SetMarker(bool marker)
 	{
 		this->header->marker = marker;
+	}
+
+	inline void RtpPacket::SetPayloadPaddingFlag(bool flag)
+	{
+		this->header->padding = flag;
 	}
 
 	inline uint16_t RtpPacket::GetSequenceNumber() const

--- a/worker/src/RTC/NackGenerator.cpp
+++ b/worker/src/RTC/NackGenerator.cpp
@@ -9,10 +9,10 @@ namespace RTC
 {
 	/* Static. */
 
-	constexpr uint32_t MaxPacketAge{ 10000 };
+	constexpr uint32_t MaxPacketAge{ 5000 };
 	constexpr size_t MaxNackPackets{ 1000 };
 	constexpr uint32_t DefaultRtt{ 100 };
-	constexpr uint8_t MaxNackRetries{ 10 };
+	constexpr uint8_t MaxNackRetries{ 8 };
 	constexpr uint64_t TimerInterval{ 50 };
 
 	/* Instance methods. */

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -14,8 +14,6 @@ namespace RTC
 	/* Static. */
 
 	static constexpr uint64_t KeyFrameRequestBlockTimeout{ 1000 }; // In ms.
-	static constexpr size_t ClonedPacketBufferSize{ 65536 };
-	static uint8_t ClonedPacketBuffer[ClonedPacketBufferSize];
 
 	/* Instance methods. */
 
@@ -294,14 +292,6 @@ namespace RTC
 			// Process the packet.
 			if (!rtpStream->ReceiveRtxPacket(packet))
 				return;
-
-			// We need to clone the RTX decoded packet so it becomes later serializable
-			// by just taking its GetData() and GetSize(), so clone it and reassign the
-			// new RtpPacket to the packet pointer (so the rest of the code below doesn't
-			// need any change) and assign it to the unique_ptr to be automatically
-			// freed once this method returns.
-			packet = packet->Clone(ClonedPacketBuffer);
-			rtxDecodedPacket.reset(packet);
 		}
 		else
 		{

--- a/worker/test/test-rtp.cpp
+++ b/worker/test/test-rtp.cpp
@@ -283,7 +283,8 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			0b00010000, 0, 0, 3, // Extension header
 			1, 0, 2, 1,
 			0xFF, 0, 3, 4,
-			0xFF, 0xFF, 0xFF, 0xFF
+			0xFF, 0xFF, 0xFF, 0xFF,
+			0x11, 0x11, 0x11, 0x11 // Payload
 		};
 
 		uint8_t rtxPayloadType = 102;
@@ -302,7 +303,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetSequenceNumber() == 8);
 		REQUIRE(packet->GetTimestamp() == 4);
 		REQUIRE(packet->GetSsrc() == 5);
-		REQUIRE(packet->GetPayloadLength() == 0);
+		REQUIRE(packet->GetPayloadLength() == 4);
 		REQUIRE(!packet->HasOneByteExtensions());
 		REQUIRE(packet->HasTwoBytesExtensions());
 
@@ -319,7 +320,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(rtxPacket->GetSequenceNumber() == rtxSeq);
 		REQUIRE(rtxPacket->GetTimestamp() == 4);
 		REQUIRE(rtxPacket->GetSsrc() == rtxSsrc);
-		REQUIRE(rtxPacket->GetPayloadLength() == 2);
+		REQUIRE(rtxPacket->GetPayloadLength() == 6);
 		REQUIRE(!rtxPacket->HasOneByteExtensions());
 		REQUIRE(rtxPacket->HasTwoBytesExtensions());
 
@@ -332,7 +333,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(rtxPacket->GetSequenceNumber() == 8);
 		REQUIRE(rtxPacket->GetTimestamp() == 4);
 		REQUIRE(rtxPacket->GetSsrc() == 5);
-		REQUIRE(rtxPacket->GetPayloadLength() == 0);
+		REQUIRE(rtxPacket->GetPayloadLength() == 4);
 		REQUIRE(!rtxPacket->HasOneByteExtensions());
 		REQUIRE(rtxPacket->HasTwoBytesExtensions());
 


### PR DESCRIPTION
Clone decodec RTX packets so they become later serializable by just getting their `GetData()` and `GetSize()`.

NOTE: This fix also required this [change](9f47d41aee1641cf1e7cf1493b95ee9daa8c34d8) in `RtpPacket::Clone()`.