### PR TITLE
Selective PLI

### DIFF
--- a/lib/Consumer.js
+++ b/lib/Consumer.js
@@ -598,6 +598,30 @@ class Consumer extends EnhancedEventEmitter
 			});
 	}
 
+	/**
+	 * Request a key frame to the source.
+	 */
+	requestKeyFrame()
+	{
+		logger.debug('requestKeyFrame()');
+
+		if (this._closed || !this.enabled || this.paused)
+			return;
+
+		if (this.kind !== 'video')
+			return;
+
+		this._channel.request('consumer.requestKeyFrame', this._internal)
+			.then(() =>
+			{
+				logger.debug('"consumer.requestKeyFrame" request succeeded');
+			})
+			.catch((error) =>
+			{
+				logger.error('"consumer.requestKeyFrame" request failed: %s', String(error));
+			});
+	}
+
 	_handleWorkerNotifications()
 	{
 		// Subscribe to notifications.

--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -54,7 +54,8 @@ namespace RTC
 		void ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket);
 		void ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReport* report);
 		uint32_t GetTransmissionRate(uint64_t now);
-		void RequestKeyFrame();
+		void RequestKeyFrame(
+		  RTC::RtpEncodingParameters::Profile profile = RTC::RtpEncodingParameters::Profile::CURRENT);
 
 	private:
 		void FillSupportedCodecPayloadTypes();

--- a/worker/include/RTC/ConsumerListener.hpp
+++ b/worker/include/RTC/ConsumerListener.hpp
@@ -1,6 +1,7 @@
 #ifndef MS_RTC_CONSUMER_LISTENER_HPP
 #define MS_RTC_CONSUMER_LISTENER_HPP
 
+#include "RTC/RtpDictionaries.hpp"
 #include "RTC/RtpPacket.hpp"
 
 namespace RTC
@@ -12,8 +13,9 @@ namespace RTC
 	class ConsumerListener
 	{
 	public:
-		virtual void OnConsumerClosed(RTC::Consumer* consumer)           = 0;
-		virtual void OnConsumerKeyFrameRequired(RTC::Consumer* consumer) = 0;
+		virtual void OnConsumerClosed(RTC::Consumer* consumer) = 0;
+		virtual void OnConsumerKeyFrameRequired(
+		  RTC::Consumer* consumer, RTC::RtpEncodingParameters::Profile profile) = 0;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -68,7 +68,7 @@ namespace RTC
 		void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t now);
 		void ReceiveRtcpFeedback(RTC::RTCP::FeedbackPsPacket* packet) const;
 		void ReceiveRtcpFeedback(RTC::RTCP::FeedbackRtpPacket* packet) const;
-		void RequestKeyFrame(bool force = false);
+		void RequestKeyFrame(RTC::RtpEncodingParameters::Profile profile, bool force = false);
 		const std::set<RTC::RtpEncodingParameters::Profile>& GetHealthyProfiles() const;
 
 	private:

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -8,6 +8,7 @@
 #include "RTC/ConsumerListener.hpp"
 #include "RTC/Producer.hpp"
 #include "RTC/ProducerListener.hpp"
+#include "RTC/RtpDictionaries.hpp"
 #include "RTC/RtpPacket.hpp"
 #include "RTC/Transport.hpp"
 #include "handles/Timer.hpp"
@@ -79,7 +80,8 @@ namespace RTC
 		/* Pure virtual methods inherited from RTC::ConsumerListener. */
 	public:
 		void OnConsumerClosed(RTC::Consumer* consumer) override;
-		void OnConsumerKeyFrameRequired(RTC::Consumer* consumer) override;
+		void OnConsumerKeyFrameRequired(
+		  RTC::Consumer* consumer, RTC::RtpEncodingParameters::Profile profile) override;
 
 		/* Pure virtual methods inherited from Timer::Listener. */
 	public:

--- a/worker/include/RTC/RtpDictionaries.hpp
+++ b/worker/include/RTC/RtpDictionaries.hpp
@@ -209,6 +209,8 @@ namespace RTC
 		enum class Profile : uint8_t
 		{
 			NONE = 0,
+			CURRENT,
+			ALL,
 			DEFAULT,
 			LOW,
 			MEDIUM,

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -9,6 +9,7 @@
 #include "RTC/RTCP/FeedbackPsAfb.hpp"
 #include "RTC/RTCP/Packet.hpp"
 #include "RTC/RTCP/ReceiverReport.hpp"
+#include "RTC/RtpDictionaries.hpp"
 #include "RTC/RtpListener.hpp"
 #include "RTC/RtpPacket.hpp"
 #include "handles/Timer.hpp"
@@ -85,7 +86,8 @@ namespace RTC
 		/* Pure virtual methods inherited from RTC::ConsumerListener. */
 	public:
 		void OnConsumerClosed(RTC::Consumer* consumer) override;
-		void OnConsumerKeyFrameRequired(RTC::Consumer* consumer) override;
+		void OnConsumerKeyFrameRequired(
+		  RTC::Consumer* consumer, RTC::RtpEncodingParameters::Profile profile) override;
 
 		/* Pure virtual methods inherited from Timer::Listener. */
 	public:

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -6,7 +6,6 @@
 #include "MediaSoupError.hpp"
 #include "Utils.hpp"
 #include "RTC/PlainRtpTransport.hpp"
-#include "RTC/RtpDictionaries.hpp"
 #include "RTC/WebRtcTransport.hpp"
 #include <cmath> // std::lround()
 #include <set>
@@ -1501,7 +1500,8 @@ namespace RTC
 		this->mapConsumerProducer.erase(consumer);
 	}
 
-	void Router::OnConsumerKeyFrameRequired(RTC::Consumer* consumer)
+	void Router::OnConsumerKeyFrameRequired(
+	  RTC::Consumer* consumer, RTC::RtpEncodingParameters::Profile profile)
 	{
 		MS_TRACE();
 
@@ -1511,7 +1511,7 @@ namespace RTC
 
 		auto* producer = this->mapConsumerProducer[consumer];
 
-		producer->RequestKeyFrame();
+		producer->RequestKeyFrame(profile);
 	}
 
 	inline void Router::OnTimer(Timer* timer)

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -8,7 +8,6 @@
 #include "RTC/Consumer.hpp"
 #include "RTC/Producer.hpp"
 #include "RTC/RTCP/FeedbackPsRemb.hpp"
-#include "RTC/RtpDictionaries.hpp"
 
 /* Consts. */
 
@@ -112,7 +111,7 @@ namespace RTC
 				  rtcp, rtx, "requesting key frame for new Consumer since Transport already connected");
 			}
 
-			consumer->RequestKeyFrame();
+			consumer->RequestKeyFrame(RTC::RtpEncodingParameters::Profile::ALL);
 		}
 	}
 
@@ -490,7 +489,8 @@ namespace RTC
 		this->consumers.erase(consumer);
 	}
 
-	void Transport::OnConsumerKeyFrameRequired(RTC::Consumer* /*consumer*/)
+	void Transport::OnConsumerKeyFrameRequired(
+	  RTC::Consumer* /*consumer*/, RTC::RtpEncodingParameters::Profile /*profile*/)
 	{
 		// Do nothing.
 	}

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -10,7 +10,6 @@
 #include "RTC/Consumer.hpp"
 #include "RTC/Producer.hpp"
 #include "RTC/RTCP/FeedbackPsRemb.hpp"
-#include "RTC/RtpDictionaries.hpp"
 #include <cmath>    // std::pow()
 #include <iterator> // std::ostream_iterator
 #include <sstream>  // std::ostringstream
@@ -1007,7 +1006,7 @@ namespace RTC
 			if (consumer->kind == RTC::Media::Kind::VIDEO)
 				MS_DEBUG_2TAGS(rtcp, rtx, "Transport connected, requesting key frame for Consumers");
 
-			consumer->RequestKeyFrame();
+			consumer->RequestKeyFrame(RTC::RtpEncodingParameters::Profile::ALL);
 		}
 	}
 
@@ -1127,7 +1126,7 @@ namespace RTC
 				// Request key frame for all the Producers.
 				for (auto* producer : this->producers)
 				{
-					producer->RequestKeyFrame();
+					producer->RequestKeyFrame(RTC::RtpEncodingParameters::Profile::ALL);
 				}
 			}
 

--- a/worker/test/test-rtpstreamrecv.cpp
+++ b/worker/test/test-rtpstreamrecv.cpp
@@ -36,7 +36,7 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 			this->seqNumbers = seqNumbers;
 		}
 
-		virtual void OnRtpStreamRecvPliRequired(RtpStreamRecv* rtpStream, RTC::RtpEncodingParameters::Profile profile) override
+		virtual void OnRtpStreamRecvPliRequired(RtpStreamRecv* rtpStream) override
 		{
 			INFO("PLI required");
 

--- a/worker/test/test-rtpstreamrecv.cpp
+++ b/worker/test/test-rtpstreamrecv.cpp
@@ -36,7 +36,7 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 			this->seqNumbers = seqNumbers;
 		}
 
-		virtual void OnRtpStreamRecvPliRequired(RtpStreamRecv* rtpStream) override
+		virtual void OnRtpStreamRecvPliRequired(RtpStreamRecv* rtpStream, RTC::RtpEncodingParameters::Profile profile) override
 		{
 			INFO("PLI required");
 


### PR DESCRIPTION
It's funny. When testing this PR I've realized that Chrome sends a key frame for all the simulcast streams even if it just receives a PLI for one of them:

```
mediasoup:mediasoup-worker [id:uqevlwkr#1] RTC::Producer::OnRtpStreamRecvPliRequired() | sending PLI [ssrc:2896908517] +11s
mediasoup:Consumer "consumer.requestKeyFrame" request succeeded +4ms
mediasoup:mediasoup-worker [id:uqevlwkr#1] RTC::Producer::ReceiveRtpPacket() | key frame received [ssrc:2896908517, seq:31142, profile:medium] +220ms
mediasoup:mediasoup-worker [id:uqevlwkr#1] RTC::Producer::ReceiveRtpPacket() | key frame received [ssrc:2896908516, seq:14254, profile:low] +30ms
```