### PR TITLE
Added missing include cmath so that std::round can be used

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "files.associations": {
+    "__config": "cpp",
+    "__nullptr": "cpp",
+    "exception": "cpp",
+    "initializer_list": "cpp",
+    "new": "cpp",
+    "stdexcept": "cpp",
+    "typeinfo": "cpp",
+    "algorithm": "cpp"
+  }
+}

--- a/worker/src/RTC/RtpMonitor.cpp
+++ b/worker/src/RTC/RtpMonitor.cpp
@@ -3,6 +3,8 @@
 
 #include "RTC/RtpMonitor.hpp"
 #include "Logger.hpp"
+#include <cmath>
+
 
 namespace RTC
 {


### PR DESCRIPTION
std::round needs `#include <cmath>` to work in g++ 6.3.0 and clang 9.0.0