### PR TITLE
Fix #188. Increase profiles one by one unless explicitly forced

### DIFF
--- a/worker/src/RTC/Consumer.cpp
+++ b/worker/src/RTC/Consumer.cpp
@@ -934,12 +934,15 @@ namespace RTC
 			// Downgrade the target profile.
 			newTargetProfile = (std::prev(it))->first;
 		}
-		// If there is no preferred profile, get the highest one.
+		// If there is no preferred profile, get the next higher one available.
 		else if (GetPreferredProfile() == RTC::RtpEncodingParameters::Profile::DEFAULT)
 		{
-			auto it = this->mapProfileRtpStream.crbegin();
+			auto it = this->mapProfileRtpStream.upper_bound(this->effectiveProfile);
 
-			newTargetProfile = it->first;
+			if (it != this->mapProfileRtpStream.end())
+				newTargetProfile = it->first;
+			else
+				newTargetProfile = this->effectiveProfile;
 		}
 		// Try with the closest profile to the preferred one.
 		else


### PR DESCRIPTION
 @ibc,

This was already there and remove by https://github.com/versatica/mediasoup/commit/b291ef4ed7dbda3f824731cdad7746b404f2af38#diff-89773978bd7f2fe02e0919ba2011c27aL1006

It prevents the levels to be upgraded one by one as it should which causes the issue #188