### PR TITLE
Add localIP option for RtpStreamer and RTP mirroring (fixes #198)

### DIFF
--- a/lib/Room.js
+++ b/lib/Room.js
@@ -299,13 +299,15 @@ class Room extends EnhancedEventEmitter
 
 				return rtpStreamer;
 			})
-			.catch(() =>
+			.catch((error) =>
 			{
 				if (plainRtpTransport)
 					plainRtpTransport.close();
 
 				if (consumer)
 					consumer.close();
+
+				throw error;
 			});
 	}
 

--- a/worker/include/RTC/PlainRtpTransport.hpp
+++ b/worker/include/RTC/PlainRtpTransport.hpp
@@ -16,6 +16,7 @@ namespace RTC
 		{
 			std::string remoteIP;
 			uint16_t remotePort;
+			std::string localIP;
 		};
 
 	public:

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -59,6 +59,7 @@ namespace RTC
 		{
 			std::string remoteIP;
 			uint16_t remotePort;
+			std::string localIP;
 			bool sendRtp{ true };
 			bool sendRtcp{ true };
 			bool recvRtp{ true };

--- a/worker/include/RTC/UdpSocket.hpp
+++ b/worker/include/RTC/UdpSocket.hpp
@@ -4,6 +4,7 @@
 #include "common.hpp"
 #include "handles/UdpSocket.hpp"
 #include <uv.h>
+#include <string>
 #include <unordered_map>
 
 namespace RTC
@@ -37,6 +38,7 @@ namespace RTC
 
 	public:
 		UdpSocket(Listener* listener, int addressFamily);
+		UdpSocket(Listener* listener, const std::string& ip);
 
 	private:
 		~UdpSocket() override = default;

--- a/worker/src/RTC/PlainRtpTransport.cpp
+++ b/worker/src/RTC/PlainRtpTransport.cpp
@@ -29,7 +29,7 @@ namespace RTC
 		{
 			case AF_INET:
 			{
-				if (!Settings::configuration.hasIPv4)
+				if (!Settings::configuration.hasIPv4 && options.localIP.empty())
 					MS_THROW_ERROR("IPv4 disabled");
 
 				err = uv_ip4_addr(
@@ -49,7 +49,7 @@ namespace RTC
 
 			case AF_INET6:
 			{
-				if (!Settings::configuration.hasIPv6)
+				if (!Settings::configuration.hasIPv6 && options.localIP.empty())
 					MS_THROW_ERROR("IPv6 disabled");
 
 				err = uv_ip6_addr(
@@ -58,8 +58,6 @@ namespace RTC
 				  reinterpret_cast<struct sockaddr_in6*>(&this->remoteAddrStorage));
 				if (err != 0)
 					MS_ABORT("uv_ipv6_addr() failed: %s", uv_strerror(err));
-
-				this->udpSocket = new RTC::UdpSocket(this, AF_INET6);
 
 				if (options.localIP.empty())
 					this->udpSocket = new RTC::UdpSocket(this, AF_INET6);

--- a/worker/src/RTC/PlainRtpTransport.cpp
+++ b/worker/src/RTC/PlainRtpTransport.cpp
@@ -39,7 +39,10 @@ namespace RTC
 				if (err != 0)
 					MS_ABORT("uv_ipv4_addr() failed: %s", uv_strerror(err));
 
-				this->udpSocket = new RTC::UdpSocket(this, AF_INET);
+				if (options.localIP.empty())
+					this->udpSocket = new RTC::UdpSocket(this, AF_INET);
+				else
+					this->udpSocket = new RTC::UdpSocket(this, options.localIP);
 
 				break;
 			}
@@ -57,6 +60,11 @@ namespace RTC
 					MS_ABORT("uv_ipv6_addr() failed: %s", uv_strerror(err));
 
 				this->udpSocket = new RTC::UdpSocket(this, AF_INET6);
+
+				if (options.localIP.empty())
+					this->udpSocket = new RTC::UdpSocket(this, AF_INET6);
+				else
+					this->udpSocket = new RTC::UdpSocket(this, options.localIP);
 
 				break;
 			}

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -240,6 +240,7 @@ namespace RTC
 			{
 				static const Json::StaticString JsonStringRemoteIP{ "remoteIP" };
 				static const Json::StaticString JsonStringRemotePort{ "remotePort" };
+				static const Json::StaticString JsonStringLocalIP{ "localIP" };
 
 				uint32_t transportId;
 
@@ -273,6 +274,9 @@ namespace RTC
 				}
 
 				options.remotePort = request->data[JsonStringRemotePort].asUInt();
+
+				if (request->data[JsonStringLocalIP].isString())
+					options.localIP = request->data[JsonStringLocalIP].asString();
 
 				RTC::PlainRtpTransport* plainRtpTransport;
 
@@ -837,6 +841,7 @@ namespace RTC
 			{
 				static const Json::StaticString JsonStringRemoteIP{ "remoteIP" };
 				static const Json::StaticString JsonStringRemotePort{ "remotePort" };
+				static const Json::StaticString JsonStringLocalIP{ "localIP" };
 				static const Json::StaticString JsonStringSendRtp{ "sendRtp" };
 				static const Json::StaticString JsonStringSendRtcp{ "sendRtcp" };
 				static const Json::StaticString JsonStringRecvRtp{ "recvRtp" };
@@ -874,6 +879,9 @@ namespace RTC
 				}
 
 				options.remotePort = request->data[JsonStringRemotePort].asUInt();
+
+				if (request->data[JsonStringLocalIP].isString())
+					options.localIP = request->data[JsonStringLocalIP].asString();
 
 				if (request->data[JsonStringSendRtp].isBool())
 					options.sendRtp = request->data[JsonStringSendRtp].asBool();

--- a/worker/src/RTC/TcpServer.cpp
+++ b/worker/src/RTC/TcpServer.cpp
@@ -215,7 +215,7 @@ namespace RTC
 	  : // Provide the parent class constructor with a UDP uv handle.
 	    // NOTE: This may throw a MediaSoupError exception if the address family is not available
 	    // or there are no available ports.
-	    ::TcpServer::TcpServer(GetRandomPort(addressFamily), 256), listener(listener),
+	    ::TcpServer::TcpServer(TcpServer::GetRandomPort(addressFamily), 256), listener(listener),
 	    connListener(connListener)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -79,7 +79,7 @@ namespace RTC
 		{
 			case AF_INET:
 			{
-				if (!Settings::configuration.hasIPv4)
+				if (!Settings::configuration.hasIPv4 && options.localIP.empty())
 					MS_THROW_ERROR("IPv4 disabled");
 
 				err = uv_ip4_addr(
@@ -99,7 +99,7 @@ namespace RTC
 
 			case AF_INET6:
 			{
-				if (!Settings::configuration.hasIPv6)
+				if (!Settings::configuration.hasIPv6 && options.localIP.empty())
 					MS_THROW_ERROR("IPv6 disabled");
 
 				err = uv_ip6_addr(

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -89,7 +89,10 @@ namespace RTC
 				if (err != 0)
 					MS_ABORT("uv_ipv4_addr() failed: %s", uv_strerror(err));
 
-				this->mirrorSocket = new RTC::UdpSocket(this, AF_INET);
+				if (options.localIP.empty())
+					this->mirrorSocket = new RTC::UdpSocket(this, AF_INET);
+				else
+					this->mirrorSocket = new RTC::UdpSocket(this, options.localIP);
 
 				break;
 			}
@@ -106,7 +109,10 @@ namespace RTC
 				if (err != 0)
 					MS_ABORT("uv_ipv6_addr() failed: %s", uv_strerror(err));
 
-				this->mirrorSocket = new RTC::UdpSocket(this, AF_INET6);
+				if (options.localIP.empty())
+					this->mirrorSocket = new RTC::UdpSocket(this, AF_INET6);
+				else
+					this->mirrorSocket = new RTC::UdpSocket(this, options.localIP);
 
 				break;
 			}

--- a/worker/src/RTC/UdpSocket.cpp
+++ b/worker/src/RTC/UdpSocket.cpp
@@ -214,7 +214,15 @@ namespace RTC
 	  : // Provide the parent class constructor with a UDP uv handle.
 	    // NOTE: This may throw a MediaSoupError exception if the address family is not available
 	    // or there are no available ports.
-	    ::UdpSocket::UdpSocket(GetRandomPort(addressFamily)), listener(listener)
+	    ::UdpSocket::UdpSocket(UdpSocket::GetRandomPort(addressFamily)), listener(listener)
+	{
+		MS_TRACE();
+	}
+
+	UdpSocket::UdpSocket(Listener* listener, const std::string& ip)
+	  : // Provide the parent class constructor with an IP and port 0.
+	    // NOTE: This may throw a MediaSoupError exception if the given IP is invalid.
+	    ::UdpSocket::UdpSocket(ip, 0), listener(listener)
 	{
 		MS_TRACE();
 	}


### PR DESCRIPTION
Related to #198.

Adds a new `localIP` optional setting for [RtpStreamerOptions](https://mediasoup.org/documentation/mediasoup/api/#RtpStreamer-RtpStreamerOptions) and [MirroringOptions](https://mediasoup.org/documentation/mediasoup/api/#WebRtcTransport-MirroringOptions).

If set, such a IP will be used as local IP rather than the `rtcIPv4` or `rtcIPv6`.

Note that when it's set, a random port will be chosen and this won't be necessarily in the range of `rtcMinPort`-`rtcMaxPort`.