### PR TITLE
Fix reading out of buffer when parsing malformed H.264 packets

### DIFF
--- a/worker/src/RTC/Codecs/H264.cpp
+++ b/worker/src/RTC/Codecs/H264.cpp
@@ -51,7 +51,7 @@ namespace RTC
 					}
 
 					// Check if there is room for the indicated NAL unit size.
-					if (len <= naluSize)
+					if (len < (naluSize + sizeof(naluSize)))
 						break;
 
 					offset += naluSize + sizeof(naluSize);


### PR DESCRIPTION
If naluSize value would be `len - 1` you would end up reading out of buffer because sizeof(naluSize) is 2.