### PR TITLE
Fixes build errors on OS X

### DIFF
--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -21,10 +21,10 @@ namespace RTC
 	}
 
 	template<typename T>
-	const typename SeqManager<T>::SeqLowerThan SeqManager<T>::isSeqLowerThan;
+	const typename SeqManager<T>::SeqLowerThan SeqManager<T>::isSeqLowerThan{};
 
 	template<typename T>
-	const typename SeqManager<T>::SeqHigherThan SeqManager<T>::isSeqHigherThan;
+	const typename SeqManager<T>::SeqHigherThan SeqManager<T>::isSeqHigherThan{};
 
 	template<typename T>
 	bool SeqManager<T>::IsSeqLowerThan(const T lhs, const T rhs)


### PR DESCRIPTION
build on OS X fails with the folowing errors

> /Applications/Xcode.app/Contents/Developer/usr/bin/make BUILDTYPE=Release -C worker/out
>   CXX(target) mediasoup/worker/out/Release/obj.target/mediasoup-worker/src/RTC/SeqManager.o
> ../src/RTC/SeqManager.cpp:24:60: error: default initialization of an object of const type 'const typename SeqManager<unsigned
>       char>::SeqLowerThan' without a user-provided default constructor
>         const typename SeqManager<T>::SeqLowerThan SeqManager<T>::isSeqLowerThan;
>                                                                   ^
>                                                                                 {}
> ../src/RTC/SeqManager.cpp:133:17: note: in instantiation of static data member 'RTC::SeqManager<unsigned char>::isSeqLowerThan' requested
>       here
>         template class SeqManager<uint8_t>;
>                        ^
> ../src/RTC/SeqManager.cpp:27:61: error: default initialization of an object of const type 'const typename SeqManager<unsigned
>       char>::SeqHigherThan' without a user-provided default constructor
>         const typename SeqManager<T>::SeqHigherThan SeqManager<T>::isSeqHigherThan;
>                                                                    ^
>                                                                                   {}
> ...