### PR TITLE
C++: Remove Destroy() methods

### DIFF
--- a/worker/include/Channel/UnixStreamSocket.hpp
+++ b/worker/include/Channel/UnixStreamSocket.hpp
@@ -20,8 +20,6 @@ namespace Channel
 
 	public:
 		explicit UnixStreamSocket(int fd);
-
-	private:
 		~UnixStreamSocket() override;
 
 	public:
@@ -42,7 +40,6 @@ namespace Channel
 		Json::CharReader* jsonReader{ nullptr };
 		Json::StreamWriter* jsonWriter{ nullptr };
 		size_t msgStart{ 0 }; // Where the latest message starts.
-		bool closed{ false };
 	};
 } // namespace Channel
 

--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -34,12 +34,9 @@ namespace RTC
 		  uint32_t consumerId,
 		  RTC::Media::Kind kind,
 		  uint32_t sourceProducerId);
-
-	private:
 		virtual ~Consumer();
 
 	public:
-		void Destroy();
 		Json::Value ToJson() const;
 		Json::Value GetStats() const;
 		void AddListener(RTC::ConsumerListener* listener);

--- a/worker/include/RTC/DtlsTransport.hpp
+++ b/worker/include/RTC/DtlsTransport.hpp
@@ -81,17 +81,13 @@ namespace RTC
 			  std::string& remoteCert) = 0;
 			// The DTLS connection has been closed as the result of an error (such as a
 			// DTLS alert or a failure to validate the remote fingerprint).
-			// NOTE: The caller MUST NOT call Destroy() during this callback.
 			virtual void OnDtlsFailed(const RTC::DtlsTransport* dtlsTransport) = 0;
 			// The DTLS connection has been closed due to receipt of a close_notify alert.
-			// NOTE: The caller MUST NOT call Destroy() during this callback.
 			virtual void OnDtlsClosed(const RTC::DtlsTransport* dtlsTransport) = 0;
 			// Need to send DTLS data to the peer.
-			// NOTE: The caller MUST NOT call Destroy() during this callback.
 			virtual void OnOutgoingDtlsData(
 			  const RTC::DtlsTransport* dtlsTransport, const uint8_t* data, size_t len) = 0;
 			// DTLS application data received.
-			// NOTE: The caller MUST NOT call Destroy() during this callback.
 			virtual void OnDtlsApplicationData(
 			  const RTC::DtlsTransport* dtlsTransport, const uint8_t* data, size_t len) = 0;
 		};

--- a/worker/include/RTC/DtlsTransport.hpp
+++ b/worker/include/RTC/DtlsTransport.hpp
@@ -122,12 +122,9 @@ namespace RTC
 
 	public:
 		explicit DtlsTransport(Listener* listener);
-
-	private:
 		~DtlsTransport() override;
 
 	public:
-		void Destroy();
 		void Dump() const;
 		void Run(Role localRole);
 		bool SetRemoteFingerprint(Fingerprint fingerprint);

--- a/worker/include/RTC/IceServer.hpp
+++ b/worker/include/RTC/IceServer.hpp
@@ -42,7 +42,6 @@ namespace RTC
 	public:
 		IceServer(Listener* listener, const std::string& usernameFragment, const std::string& password);
 
-		void Destroy();
 		void ProcessStunMessage(RTC::StunMessage* msg, RTC::TransportTuple* tuple);
 		const std::string& GetUsernameFragment() const;
 		const std::string& GetPassword() const;

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -57,13 +57,9 @@ namespace RTC
 		  RTC::RtpParameters& rtpParameters,
 		  struct RtpMapping& rtpMapping,
 		  bool paused);
+		~Producer();
 
 	public:
-		// Must be public because Router needs to call it.
-		virtual ~Producer();
-
-	public:
-		void Destroy();
 		Json::Value ToJson() const;
 		Json::Value GetStats() const;
 		void AddListener(RTC::ProducerListener* listener);

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -38,12 +38,9 @@ namespace RTC
 
 	public:
 		Router(Listener* listener, Channel::Notifier* notifier, uint32_t routerId);
-
-	private:
 		virtual ~Router();
 
 	public:
-		void Destroy();
 		Json::Value ToJson() const;
 		void HandleRequest(Channel::Request* request);
 

--- a/worker/include/RTC/SrtpSession.hpp
+++ b/worker/include/RTC/SrtpSession.hpp
@@ -31,12 +31,9 @@ namespace RTC
 
 	public:
 		SrtpSession(Type type, Profile profile, uint8_t* key, size_t keyLen);
-
-	private:
 		~SrtpSession();
 
 	public:
-		void Destroy();
 		bool EncryptRtp(const uint8_t** data, size_t* len);
 		bool DecryptSrtp(const uint8_t* data, size_t* len);
 		bool EncryptRtcp(const uint8_t** data, size_t* len);

--- a/worker/include/RTC/TcpConnection.hpp
+++ b/worker/include/RTC/TcpConnection.hpp
@@ -18,9 +18,6 @@ namespace RTC
 	public:
 		TcpConnection(Listener* listener, size_t bufferSize);
 
-	private:
-		~TcpConnection() override = default;
-
 	public:
 		void Send(const uint8_t* data, size_t len);
 		size_t GetRecvBytes() const;

--- a/worker/include/RTC/TcpServer.hpp
+++ b/worker/include/RTC/TcpServer.hpp
@@ -39,16 +39,13 @@ namespace RTC
 
 	public:
 		TcpServer(Listener* listener, RTC::TcpConnection::Listener* connListener, int addressFamily);
-
-	private:
-		~TcpServer() override = default;
+		~TcpServer() override;
 
 		/* Pure virtual methods inherited from ::TcpServer. */
 	public:
 		void UserOnTcpConnectionAlloc(::TcpConnection** connection) override;
 		void UserOnNewTcpConnection(::TcpConnection* connection) override;
 		void UserOnTcpConnectionClosed(::TcpConnection* connection, bool isClosedByPeer) override;
-		void UserOnTcpServerClosed() override;
 
 	private:
 		// Passed by argument.

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -67,12 +67,10 @@ namespace RTC
 
 	public:
 		Transport(Listener* listener, Channel::Notifier* notifier, uint32_t transportId);
-
-	protected:
 		virtual ~Transport();
 
 	public:
-		void Destroy();
+		void Close();
 		virtual Json::Value ToJson() const   = 0;
 		virtual Json::Value GetStats() const = 0;
 		void HandleProducer(RTC::Producer* producer);
@@ -132,9 +130,10 @@ namespace RTC
 		Channel::Notifier* notifier{ nullptr };
 		// Allocated by this.
 		Timer* rtcpTimer{ nullptr };
-		// Allocated (Mirroring).
 		RTC::UdpSocket* mirrorSocket{ nullptr };
 		RTC::TransportTuple* mirrorTuple{ nullptr };
+		// Others.
+		bool closed{ false };
 		// Others (Producers and Consumers).
 		std::unordered_set<RTC::Producer*> producers;
 		std::unordered_set<RTC::Consumer*> consumers;

--- a/worker/include/RTC/UdpSocket.hpp
+++ b/worker/include/RTC/UdpSocket.hpp
@@ -39,12 +39,11 @@ namespace RTC
 	public:
 		UdpSocket(Listener* listener, int addressFamily);
 		UdpSocket(Listener* listener, const std::string& ip);
-		~UdpSocket() override = default;
+		~UdpSocket() override;
 
 		/* Pure virtual methods inherited from ::UdpSocket. */
 	public:
 		void UserOnUdpDatagramRecv(const uint8_t* data, size_t len, const struct sockaddr* addr) override;
-		void UserOnUdpSocketClosed() override;
 
 	private:
 		// Passed by argument.

--- a/worker/include/RTC/UdpSocket.hpp
+++ b/worker/include/RTC/UdpSocket.hpp
@@ -39,8 +39,6 @@ namespace RTC
 	public:
 		UdpSocket(Listener* listener, int addressFamily);
 		UdpSocket(Listener* listener, const std::string& ip);
-
-	private:
 		~UdpSocket() override = default;
 
 		/* Pure virtual methods inherited from ::UdpSocket. */

--- a/worker/include/RTC/WebRtcTransport.hpp
+++ b/worker/include/RTC/WebRtcTransport.hpp
@@ -42,9 +42,7 @@ namespace RTC
 		  Channel::Notifier* notifier,
 		  uint32_t transportId,
 		  Options& options);
-
-	private:
-		~WebRtcTransport();
+		~WebRtcTransport() override;
 
 	public:
 		Json::Value ToJson() const override;

--- a/worker/include/handles/SignalsHandler.hpp
+++ b/worker/include/handles/SignalsHandler.hpp
@@ -19,12 +19,10 @@ public:
 
 public:
 	explicit SignalsHandler(Listener* listener);
-
-private:
-	~SignalsHandler() = default;
+	~SignalsHandler();
 
 public:
-	void Destroy();
+	void Close();
 	void AddSignal(int signum, const std::string& name);
 
 	/* Callbacks fired by UV events. */
@@ -36,6 +34,8 @@ private:
 	Listener* listener{ nullptr };
 	// Allocated by this.
 	std::vector<uv_signal_t*> uvHandles;
+	// Others.
+	bool closed{ false };
 };
 
 #endif

--- a/worker/include/handles/TcpConnection.hpp
+++ b/worker/include/handles/TcpConnection.hpp
@@ -37,19 +37,17 @@ public:
 	explicit TcpConnection(size_t bufferSize);
 	TcpConnection& operator=(const TcpConnection&) = delete;
 	TcpConnection(const TcpConnection&)            = delete;
-
-protected:
 	virtual ~TcpConnection();
 
 public:
-	void Destroy();
+	void Close();
 	virtual void Dump() const;
 	void Setup(
 	  Listener* listener,
 	  struct sockaddr_storage* localAddr,
 	  const std::string& localIP,
 	  uint16_t localPort);
-	bool IsClosing() const;
+	bool IsClosed() const;
 	uv_tcp_t* GetUvHandle() const;
 	void Start();
 	void Write(const uint8_t* data, size_t len);
@@ -71,8 +69,6 @@ public:
 	void OnUvReadAlloc(size_t suggestedSize, uv_buf_t* buf);
 	void OnUvRead(ssize_t nread, const uv_buf_t* buf);
 	void OnUvWriteError(int error);
-	void OnUvShutdown(uv_shutdown_t* req, int status);
-	void OnUvClosed();
 
 	/* Pure virtual methods that must be implemented by the subclass. */
 protected:
@@ -85,7 +81,7 @@ private:
 	uv_tcp_t* uvHandle{ nullptr };
 	// Others.
 	struct sockaddr_storage* localAddr{ nullptr };
-	bool isClosing{ false };
+	bool closed{ false };
 	bool isClosedByPeer{ false };
 	bool hasError{ false };
 
@@ -105,9 +101,9 @@ protected:
 
 /* Inline methods. */
 
-inline bool TcpConnection::IsClosing() const
+inline bool TcpConnection::IsClosed() const
 {
-	return this->isClosing;
+	return this->closed;
 }
 
 inline uv_tcp_t* TcpConnection::GetUvHandle() const

--- a/worker/include/handles/TcpServer.hpp
+++ b/worker/include/handles/TcpServer.hpp
@@ -15,14 +15,11 @@ public:
 	 * uvHandle must be an already initialized and binded uv_tcp_t pointer.
 	 */
 	TcpServer(uv_tcp_t* uvHandle, int backlog);
-
-protected:
-	~TcpServer() override;
+	virtual ~TcpServer() override;
 
 public:
-	void Destroy();
+	void Close();
 	virtual void Dump() const;
-	bool IsClosing() const;
 	const struct sockaddr* GetLocalAddress() const;
 	int GetLocalFamily() const;
 	const std::string& GetLocalIP() const;
@@ -37,12 +34,10 @@ protected:
 	virtual void UserOnTcpConnectionAlloc(TcpConnection** connection)                      = 0;
 	virtual void UserOnNewTcpConnection(TcpConnection* connection)                         = 0;
 	virtual void UserOnTcpConnectionClosed(TcpConnection* connection, bool isClosedByPeer) = 0;
-	virtual void UserOnTcpServerClosed()                                                   = 0;
 
 	/* Callbacks fired by UV events. */
 public:
 	void OnUvConnection(int status);
-	void OnUvClosed();
 
 	/* Methods inherited from TcpConnection::Listener. */
 public:
@@ -53,7 +48,7 @@ private:
 	uv_tcp_t* uvHandle{ nullptr };
 	// Others.
 	std::unordered_set<TcpConnection*> connections;
-	bool isClosing{ false };
+	bool closed{ false };
 
 protected:
 	struct sockaddr_storage localAddr;
@@ -62,11 +57,6 @@ protected:
 };
 
 /* Inline methods. */
-
-inline bool TcpServer::IsClosing() const
-{
-	return this->isClosing;
-}
 
 inline size_t TcpServer::GetNumConnections() const
 {

--- a/worker/include/handles/Timer.hpp
+++ b/worker/include/handles/Timer.hpp
@@ -20,12 +20,10 @@ public:
 	explicit Timer(Listener* listener);
 	Timer& operator=(const Timer&) = delete;
 	Timer(const Timer&)            = delete;
-
-private:
-	~Timer() = default;
+	~Timer();
 
 public:
-	void Destroy();
+	void Close();
 	void Start(uint64_t timeout, uint64_t repeat = 0);
 	void Stop();
 	void Reset();
@@ -42,6 +40,7 @@ private:
 	// Allocated by this.
 	uv_timer_t* uvHandle{ nullptr };
 	// Others.
+	bool closed{ false };
 	uint64_t timeout{ 0 };
 	uint64_t repeat{ 0 };
 };

--- a/worker/include/handles/UdpSocket.hpp
+++ b/worker/include/handles/UdpSocket.hpp
@@ -52,7 +52,6 @@ public:
 	/* Pure virtual methods that must be implemented by the subclass. */
 protected:
 	virtual void UserOnUdpDatagramRecv(const uint8_t* data, size_t len, const struct sockaddr* addr) = 0;
-	virtual void UserOnUdpSocketClosed() = 0;
 
 private:
 	// Allocated by this (may be passed by argument).

--- a/worker/include/handles/UdpSocket.hpp
+++ b/worker/include/handles/UdpSocket.hpp
@@ -24,12 +24,10 @@ public:
 	explicit UdpSocket(uv_udp_t* uvHandle);
 	UdpSocket& operator=(const UdpSocket&) = delete;
 	UdpSocket(const UdpSocket&)            = delete;
-
-protected:
 	virtual ~UdpSocket();
 
 public:
-	void Destroy();
+	void Close();
 	virtual void Dump() const;
 	void Send(const uint8_t* data, size_t len, const struct sockaddr* addr);
 	void Send(const std::string& data, const struct sockaddr* addr);
@@ -50,7 +48,6 @@ public:
 	void OnUvRecvAlloc(size_t suggestedSize, uv_buf_t* buf);
 	void OnUvRecv(ssize_t nread, const uv_buf_t* buf, const struct sockaddr* addr, unsigned int flags);
 	void OnUvSendError(int error);
-	void OnUvClosed();
 
 	/* Pure virtual methods that must be implemented by the subclass. */
 protected:
@@ -61,7 +58,7 @@ private:
 	// Allocated by this (may be passed by argument).
 	uv_udp_t* uvHandle{ nullptr };
 	// Others.
-	bool isClosing{ false };
+	bool closed{ false };
 	size_t recvBytes{ 0 };
 	size_t sentBytes{ 0 };
 

--- a/worker/include/handles/UnixStreamSocket.hpp
+++ b/worker/include/handles/UnixStreamSocket.hpp
@@ -20,13 +20,11 @@ public:
 	UnixStreamSocket(int fd, size_t bufferSize);
 	UnixStreamSocket& operator=(const UnixStreamSocket&) = delete;
 	UnixStreamSocket(const UnixStreamSocket&)            = delete;
-
-protected:
 	virtual ~UnixStreamSocket();
 
 public:
-	void Destroy();
-	bool IsClosing() const;
+	void Close();
+	bool IsClosed() const;
 	void Write(const uint8_t* data, size_t len);
 	void Write(const std::string& data);
 
@@ -35,8 +33,6 @@ public:
 	void OnUvReadAlloc(size_t suggestedSize, uv_buf_t* buf);
 	void OnUvRead(ssize_t nread, const uv_buf_t* buf);
 	void OnUvWriteError(int error);
-	void OnUvShutdown(uv_shutdown_t* req, int status);
-	void OnUvClosed();
 
 	/* Pure virtual methods that must be implemented by the subclass. */
 protected:
@@ -47,7 +43,7 @@ private:
 	// Allocated by this.
 	uv_pipe_t* uvHandle{ nullptr };
 	// Others.
-	bool isClosing{ false };
+	bool closed{ false };
 	bool isClosedByPeer{ false };
 	bool hasError{ false };
 
@@ -62,9 +58,9 @@ protected:
 
 /* Inline methods. */
 
-inline bool UnixStreamSocket::IsClosing() const
+inline bool UnixStreamSocket::IsClosed() const
 {
-	return this->isClosing;
+	return this->closed;
 }
 
 inline void UnixStreamSocket::Write(const std::string& data)

--- a/worker/src/Channel/UnixStreamSocket.cpp
+++ b/worker/src/Channel/UnixStreamSocket.cpp
@@ -73,7 +73,7 @@ namespace Channel
 
 	void UnixStreamSocket::Send(Json::Value& msg)
 	{
-		if (this->closed)
+		if (IsClosed())
 			return;
 
 		// MS_TRACE_STD();
@@ -117,7 +117,7 @@ namespace Channel
 
 	void UnixStreamSocket::SendLog(char* nsPayload, size_t nsPayloadLen)
 	{
-		if (this->closed)
+		if (IsClosed())
 			return;
 
 		// MS_TRACE_STD();
@@ -154,7 +154,7 @@ namespace Channel
 
 	void UnixStreamSocket::SendBinary(const uint8_t* nsPayload, size_t nsPayloadLen)
 	{
-		if (this->closed)
+		if (IsClosed())
 			return;
 
 		size_t nsNumLen;
@@ -194,7 +194,7 @@ namespace Channel
 		// Be ready to parse more than a single message in a single TCP chunk.
 		while (true)
 		{
-			if (IsClosing())
+			if (IsClosed())
 				return;
 
 			size_t readLen  = this->bufferDataLen - this->msgStart;
@@ -329,12 +329,8 @@ namespace Channel
 	{
 		MS_TRACE_STD();
 
-		this->closed = true;
-
+		// Notify the listener.
 		if (isClosedByPeer)
-		{
-			// Notify the listener.
 			this->listener->OnChannelUnixStreamSocketRemotelyClosed(this);
-		}
 	}
 } // namespace Channel

--- a/worker/src/RTC/Consumer.cpp
+++ b/worker/src/RTC/Consumer.cpp
@@ -39,11 +39,6 @@ namespace RTC
 
 		delete this->rtpStream;
 		delete this->rtpMonitor;
-	}
-
-	void Consumer::Destroy()
-	{
-		MS_TRACE();
 
 		for (auto& listener : this->listeners)
 		{
@@ -51,8 +46,6 @@ namespace RTC
 		}
 
 		this->notifier->Emit(this->consumerId, "close");
-
-		delete this;
 	}
 
 	Json::Value Consumer::ToJson() const

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -579,19 +579,6 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		if (this->ssl != nullptr)
-		{
-			SSL_free(this->ssl);
-			this->ssl               = nullptr;
-			this->sslBioFromNetwork = nullptr;
-			this->sslBioToNetwork   = nullptr;
-		}
-	}
-
-	void DtlsTransport::Destroy()
-	{
-		MS_TRACE();
-
 		if (IsRunning())
 		{
 			// Send close alert to the peer.
@@ -599,10 +586,16 @@ namespace RTC
 			SendPendingOutgoingDtlsData();
 		}
 
-		// Destroy the DTLS timer.
-		delete this->timer;
+		if (this->ssl != nullptr)
+		{
+			SSL_free(this->ssl);
+			this->ssl               = nullptr;
+			this->sslBioFromNetwork = nullptr;
+			this->sslBioToNetwork   = nullptr;
+		}
 
-		delete this;
+		// Close the DTLS timer.
+		delete this->timer;
 	}
 
 	void DtlsTransport::Dump() const

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -600,7 +600,7 @@ namespace RTC
 		}
 
 		// Destroy the DTLS timer.
-		this->timer->Destroy();
+		delete this->timer;
 
 		delete this;
 	}

--- a/worker/src/RTC/IceServer.cpp
+++ b/worker/src/RTC/IceServer.cpp
@@ -27,13 +27,6 @@ namespace RTC
 		  this->password.c_str());
 	}
 
-	void IceServer::Destroy()
-	{
-		MS_TRACE();
-
-		delete this;
-	}
-
 	void IceServer::ProcessStunMessage(RTC::StunMessage* msg, RTC::TransportTuple* tuple)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/NackGenerator.cpp
+++ b/worker/src/RTC/NackGenerator.cpp
@@ -31,7 +31,7 @@ namespace RTC
 		MS_TRACE();
 
 		// Close the timer.
-		this->timer->Destroy();
+		delete this->timer;
 	}
 
 	// Returns true if this is a found nacked packet. False otherwise.

--- a/worker/src/RTC/PlainRtpTransport.cpp
+++ b/worker/src/RTC/PlainRtpTransport.cpp
@@ -43,7 +43,8 @@ namespace RTC
 			catch (const MediaSoupError& error)
 			{
 				// Destroy UdpSocket since ~PlainRtpTransport() will not be called.
-				this->udpSocket->Destroy();
+				this->udpSocket->Close();
+				delete this->udpSocket;
 
 				throw;
 			}
@@ -86,7 +87,10 @@ namespace RTC
 		delete this->tuple;
 
 		if (this->udpSocket != nullptr)
-			this->udpSocket->Destroy();
+		{
+			this->udpSocket->Close();
+			delete this->udpSocket;
+		}
 	}
 
 	Json::Value PlainRtpTransport::ToJson() const

--- a/worker/src/RTC/PlainRtpTransport.cpp
+++ b/worker/src/RTC/PlainRtpTransport.cpp
@@ -42,7 +42,7 @@ namespace RTC
 			}
 			catch (const MediaSoupError& error)
 			{
-				// Destroy UdpSocket since ~PlainRtpTransport() will not be called.
+				// Close UdpSocket since ~PlainRtpTransport() will not be called.
 				delete this->udpSocket;
 
 				throw;

--- a/worker/src/RTC/PlainRtpTransport.cpp
+++ b/worker/src/RTC/PlainRtpTransport.cpp
@@ -43,7 +43,6 @@ namespace RTC
 			catch (const MediaSoupError& error)
 			{
 				// Destroy UdpSocket since ~PlainRtpTransport() will not be called.
-				this->udpSocket->Close();
 				delete this->udpSocket;
 
 				throw;
@@ -85,12 +84,7 @@ namespace RTC
 		MS_TRACE();
 
 		delete this->tuple;
-
-		if (this->udpSocket != nullptr)
-		{
-			this->udpSocket->Close();
-			delete this->udpSocket;
-		}
+		delete this->udpSocket;
 	}
 
 	Json::Value PlainRtpTransport::ToJson() const

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -57,21 +57,14 @@ namespace RTC
 
 			delete rtpStream;
 		}
-	}
 
-	void Producer::Destroy()
-	{
-		MS_TRACE();
+		// Close the RTP key frame request block timer.
+		delete this->keyFrameRequestBlockTimer;
 
 		for (auto& listener : this->listeners)
 		{
 			listener->OnProducerClosed(this);
 		}
-
-		// Close the RTP key frame request block timer.
-		delete this->keyFrameRequestBlockTimer;
-
-		delete this;
 	}
 
 	Json::Value Producer::ToJson() const

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -69,7 +69,7 @@ namespace RTC
 		}
 
 		// Close the RTP key frame request block timer.
-		this->keyFrameRequestBlockTimer->Destroy();
+		delete this->keyFrameRequestBlockTimer;
 
 		delete this;
 	}

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -33,11 +33,6 @@ namespace RTC
 	Router::~Router()
 	{
 		MS_TRACE();
-	}
-
-	void Router::Destroy()
-	{
-		MS_TRACE();
 
 		// Close all the Producers.
 		for (auto it = this->producers.begin(); it != this->producers.end();)
@@ -73,8 +68,6 @@ namespace RTC
 
 		// Notify the listener.
 		this->listener->OnRouterClosed(this);
-
-		delete this;
 	}
 
 	Json::Value Router::ToJson() const

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -40,7 +40,7 @@ namespace RTC
 			auto* producer = it->second;
 
 			it = this->producers.erase(it);
-			producer->Destroy();
+			delete producer;
 		}
 
 		// Close all the Consumers.
@@ -49,18 +49,18 @@ namespace RTC
 			auto* consumer = it->second;
 
 			it = this->consumers.erase(it);
-			consumer->Destroy();
+			delete consumer;
 		}
 
 		// Close all the Transports.
 		// NOTE: It is critical to close Transports after Producers/Consumers
-		// because their Destroy() method fires an event in the Transport.
+		// because their destructor fires an event in the Transport.
 		for (auto it = this->transports.begin(); it != this->transports.end();)
 		{
 			auto* transport = it->second;
 
 			it = this->transports.erase(it);
-			transport->Destroy();
+			delete transport;
 		}
 
 		// Close the audio level timer.
@@ -594,7 +594,7 @@ namespace RTC
 					return;
 				}
 
-				transport->Destroy();
+				delete transport;
 
 				MS_DEBUG_DEV("Transport closed [transportId:%" PRIu32 "]", transport->transportId);
 
@@ -992,7 +992,7 @@ namespace RTC
 					return;
 				}
 
-				producer->Destroy();
+				delete producer;
 
 				MS_DEBUG_DEV("Producer closed [producerId:%" PRIu32 "]", producer->producerId);
 
@@ -1164,7 +1164,7 @@ namespace RTC
 					return;
 				}
 
-				consumer->Destroy();
+				delete consumer;
 
 				request->Accept();
 
@@ -1604,6 +1604,7 @@ namespace RTC
 		this->producers.erase(producer->producerId);
 
 		// Remove the Producer from the map.
+		// NOTE: It may not exist if it failed before being inserted into the maps.
 		if (this->mapProducerConsumers.find(producer) != this->mapProducerConsumers.end())
 		{
 			// Iterate the map and close all the Consumers associated to it.
@@ -1614,7 +1615,7 @@ namespace RTC
 				auto* consumer = *it;
 
 				it = consumers.erase(it);
-				consumer->Destroy();
+				delete consumer;
 			}
 
 			// Finally delete the Producer entry in the map.

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -69,7 +69,7 @@ namespace RTC
 		}
 
 		// Close the audio level timer.
-		this->audioLevelsTimer->Destroy();
+		delete this->audioLevelsTimer;
 
 		// Notify the listener.
 		this->listener->OnRouterClosed(this);

--- a/worker/src/RTC/RtpStream.cpp
+++ b/worker/src/RTC/RtpStream.cpp
@@ -32,7 +32,7 @@ namespace RTC
 		MS_TRACE();
 
 		// Close the status check timer.
-		this->statusCheckTimer->Destroy();
+		delete this->statusCheckTimer;
 	}
 
 	Json::Value RtpStream::ToJson()
@@ -260,8 +260,6 @@ namespace RTC
 		MS_TRACE();
 
 		if (timer == this->statusCheckTimer)
-		{
 			CheckStatus();
-		}
 	}
 } // namespace RTC

--- a/worker/src/RTC/SrtpSession.cpp
+++ b/worker/src/RTC/SrtpSession.cpp
@@ -115,13 +115,6 @@ namespace RTC
 		}
 	}
 
-	void SrtpSession::Destroy()
-	{
-		MS_TRACE();
-
-		delete this;
-	}
-
 	bool SrtpSession::EncryptRtp(const uint8_t** data, size_t* len)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/TcpConnection.cpp
+++ b/worker/src/RTC/TcpConnection.cpp
@@ -47,9 +47,9 @@ namespace RTC
 		while (true)
 		{
 			// We may receive multiple packets in the same TCP chunk. If one of them is
-			// a DTLS Close Alert this would be closed (Destroy() called) so we cannot call
+			// a DTLS Close Alert this would be closed (Close() called) so we cannot call
 			// our listeners anymore.
-			if (IsClosing())
+			if (IsClosed())
 				return;
 
 			size_t dataLen = this->bufferDataLen - this->frameStart;
@@ -125,7 +125,7 @@ namespace RTC
 					  "connection");
 
 					// Close the socket.
-					Destroy();
+					Close();
 				}
 			}
 			// The buffer is not full.

--- a/worker/src/RTC/TcpConnection.cpp
+++ b/worker/src/RTC/TcpConnection.cpp
@@ -151,7 +151,6 @@ namespace RTC
 		uint8_t frameLen[2];
 
 		Utils::Byte::Set2Bytes(frameLen, 0, len);
-
 		Write(frameLen, 2, data, len);
 	}
 } // namespace RTC

--- a/worker/src/RTC/TcpServer.cpp
+++ b/worker/src/RTC/TcpServer.cpp
@@ -243,7 +243,7 @@ namespace RTC
 
 		// Allow just MaxTcpConnectionsPerServer.
 		if (GetNumConnections() > MaxTcpConnectionsPerServer)
-			connection->Destroy();
+			connection->Close();
 	}
 
 	void TcpServer::UserOnTcpConnectionClosed(::TcpConnection* connection, bool isClosedByPeer)

--- a/worker/src/RTC/TcpServer.cpp
+++ b/worker/src/RTC/TcpServer.cpp
@@ -229,6 +229,17 @@ namespace RTC
 		MS_TRACE();
 	}
 
+	TcpServer::~TcpServer()
+	{
+		MS_TRACE();
+
+		// Mark the port as available again.
+		if (this->localAddr.ss_family == AF_INET)
+			RTC::TcpServer::availableIPv4Ports[this->localPort] = true;
+		else if (this->localAddr.ss_family == AF_INET6)
+			RTC::TcpServer::availableIPv6Ports[this->localPort] = true;
+	}
+
 	void TcpServer::UserOnTcpConnectionAlloc(::TcpConnection** connection)
 	{
 		MS_TRACE();
@@ -250,24 +261,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// Notify the listener.
-		// NOTE: Don't do it if closing (since at this point the listener is already freed).
-		// At the end, this is just called if the connection was remotely closed.
-		if (!IsClosing())
-		{
-			this->listener->OnRtcTcpConnectionClosed(
-			  this, dynamic_cast<RTC::TcpConnection*>(connection), isClosedByPeer);
-		}
-	}
-
-	void TcpServer::UserOnTcpServerClosed()
-	{
-		MS_TRACE();
-
-		// Mark the port as available again.
-		if (this->localAddr.ss_family == AF_INET)
-			RTC::TcpServer::availableIPv4Ports[this->localPort] = true;
-		else if (this->localAddr.ss_family == AF_INET6)
-			RTC::TcpServer::availableIPv6Ports[this->localPort] = true;
+		this->listener->OnRtcTcpConnectionClosed(
+		  this, dynamic_cast<RTC::TcpConnection*>(connection), isClosedByPeer);
 	}
 } // namespace RTC

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -48,9 +48,8 @@ namespace RTC
 			consumer->RemoveListener(this);
 		}
 
-		// Destroy the RTCP timer.
-		if (this->rtcpTimer != nullptr)
-			this->rtcpTimer->Destroy();
+		// Close the RTCP timer.
+		delete this->rtcpTimer;
 
 		// Delete mirror tuple.
 		if (this->mirrorTuple != nullptr)

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -51,6 +51,14 @@ namespace RTC
 		// Destroy the RTCP timer.
 		if (this->rtcpTimer != nullptr)
 			this->rtcpTimer->Destroy();
+
+		// Delete mirror tuple.
+		if (this->mirrorTuple != nullptr)
+			delete this->mirrorTuple;
+
+		// Delete mirror socket.
+		if (this->mirrorSocket != nullptr)
+			delete this->mirrorSocket;
 	}
 
 	void Transport::Destroy()
@@ -132,12 +140,7 @@ namespace RTC
 	void Transport::StopMirroring()
 	{
 		delete this->mirrorTuple;
-
-		if (this->mirrorSocket != nullptr)
-		{
-			this->mirrorSocket->Close();
-			delete this->mirrorSocket;
-		}
+		delete this->mirrorSocket;
 
 		this->mirrorTuple  = nullptr;
 		this->mirrorSocket = nullptr;

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -30,13 +30,26 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		if (!this->closed)
+			Close();
+	}
+
+	void Transport::Close()
+	{
+		MS_TRACE();
+
+		if (this->closed)
+			return;
+
+		this->closed = true;
+
 		// Close all the handled Producers.
 		for (auto it = this->producers.begin(); it != this->producers.end();)
 		{
 			auto* producer = *it;
 
 			it = this->producers.erase(it);
-			producer->Destroy();
+			delete producer;
 		}
 
 		// Disable all the handled Consumers.
@@ -58,19 +71,12 @@ namespace RTC
 		// Delete mirror socket.
 		if (this->mirrorSocket != nullptr)
 			delete this->mirrorSocket;
-	}
-
-	void Transport::Destroy()
-	{
-		MS_TRACE();
-
-		// Notify.
-		this->notifier->Emit(this->transportId, "close");
 
 		// Notify the listener.
 		this->listener->OnTransportClosed(this);
 
-		delete this;
+		// Notify.
+		this->notifier->Emit(this->transportId, "close");
 	}
 
 	void Transport::StartMirroring(MirroringOptions& options)

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -134,7 +134,10 @@ namespace RTC
 		delete this->mirrorTuple;
 
 		if (this->mirrorSocket != nullptr)
-			this->mirrorSocket->Destroy();
+		{
+			this->mirrorSocket->Close();
+			delete this->mirrorSocket;
+		}
 
 		this->mirrorTuple  = nullptr;
 		this->mirrorSocket = nullptr;

--- a/worker/src/RTC/UdpSocket.cpp
+++ b/worker/src/RTC/UdpSocket.cpp
@@ -11,7 +11,7 @@
 
 /* Static methods for UV callbacks. */
 
-static inline void onErrorClose(uv_handle_t* handle)
+static inline void onClose(uv_handle_t* handle)
 {
 	delete handle;
 }
@@ -188,7 +188,7 @@ namespace RTC
 				  iteratingPort,
 				  uv_strerror(err));
 
-				uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onErrorClose));
+				uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onClose));
 
 				// If bind() fails due to "too many open files" stop here.
 				if (err == UV_EMFILE)

--- a/worker/src/RTC/UdpSocket.cpp
+++ b/worker/src/RTC/UdpSocket.cpp
@@ -235,6 +235,17 @@ namespace RTC
 		MS_TRACE();
 	}
 
+	UdpSocket::~UdpSocket()
+	{
+		MS_TRACE();
+
+		// Mark the port as available again.
+		if (this->localAddr.ss_family == AF_INET)
+			RTC::UdpSocket::availableIPv4Ports[this->localPort] = true;
+		else if (this->localAddr.ss_family == AF_INET6)
+			RTC::UdpSocket::availableIPv6Ports[this->localPort] = true;
+	}
+
 	void UdpSocket::UserOnUdpDatagramRecv(const uint8_t* data, size_t len, const struct sockaddr* addr)
 	{
 		MS_TRACE();
@@ -248,16 +259,5 @@ namespace RTC
 
 		// Notify the reader.
 		this->listener->OnPacketRecv(this, data, len, addr);
-	}
-
-	void UdpSocket::UserOnUdpSocketClosed()
-	{
-		MS_TRACE();
-
-		// Mark the port as available again.
-		if (this->localAddr.ss_family == AF_INET)
-			RTC::UdpSocket::availableIPv4Ports[this->localPort] = true;
-		else if (this->localAddr.ss_family == AF_INET6)
-			RTC::UdpSocket::availableIPv6Ports[this->localPort] = true;
 	}
 } // namespace RTC

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -173,13 +173,12 @@ namespace RTC
 
 			for (auto* socket : this->udpSockets)
 			{
-				socket->Close();
 				delete socket;
 			}
 
 			for (auto* server : this->tcpServers)
 			{
-				server->Destroy();
+				delete server;
 			}
 
 			MS_THROW_ERROR("could not open any IP:port");
@@ -213,14 +212,13 @@ namespace RTC
 
 		for (auto* socket : this->udpSockets)
 		{
-			socket->Close();
 			delete socket;
 		}
 		this->udpSockets.clear();
 
 		for (auto* server : this->tcpServers)
 		{
-			server->Destroy();
+			delete server;
 		}
 		this->tcpServers.clear();
 

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -163,13 +163,7 @@ namespace RTC
 		// Ensure there is at least one IP:port binding.
 		if (this->udpSockets.empty() && this->tcpServers.empty())
 		{
-			// NOTE: We must manually delete above allocated objects. We cannot call `delete this`
-			// here since it would call the parent ~Transport destructor, and it would be called
-			// again after throwing the exception here.
-			//
-			// See: https://github.com/versatica/mediasoup/issues/222
-
-			this->iceServer->Destroy();
+			delete this->iceServer;
 
 			for (auto* socket : this->udpSockets)
 			{
@@ -198,17 +192,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		if (this->srtpRecvSession != nullptr)
-			this->srtpRecvSession->Destroy();
-
-		if (this->srtpSendSession != nullptr)
-			this->srtpSendSession->Destroy();
-
-		if (this->dtlsTransport != nullptr)
-			this->dtlsTransport->Destroy();
-
-		if (this->iceServer != nullptr)
-			this->iceServer->Destroy();
+		delete this->iceServer;
 
 		for (auto* socket : this->udpSockets)
 		{
@@ -222,7 +206,13 @@ namespace RTC
 		}
 		this->tcpServers.clear();
 
-		this->selectedTuple = nullptr;
+		delete this->dtlsTransport;
+
+		if (this->srtpRecvSession != nullptr)
+			delete this->srtpRecvSession;
+
+		if (this->srtpSendSession != nullptr)
+			delete this->srtpSendSession;
 	}
 
 	Json::Value WebRtcTransport::ToJson() const
@@ -1128,12 +1118,12 @@ namespace RTC
 		// Close it if it was already set and update it.
 		if (this->srtpSendSession != nullptr)
 		{
-			this->srtpSendSession->Destroy();
+			delete this->srtpSendSession;
 			this->srtpSendSession = nullptr;
 		}
 		if (this->srtpRecvSession != nullptr)
 		{
-			this->srtpRecvSession->Destroy();
+			delete this->srtpRecvSession;
 			this->srtpRecvSession = nullptr;
 		}
 
@@ -1156,7 +1146,7 @@ namespace RTC
 		{
 			MS_ERROR("error creating SRTP receiving session: %s", error.what());
 
-			this->srtpSendSession->Destroy();
+			delete this->srtpSendSession;
 			this->srtpSendSession = nullptr;
 		}
 

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -173,7 +173,8 @@ namespace RTC
 
 			for (auto* socket : this->udpSockets)
 			{
-				socket->Destroy();
+				socket->Close();
+				delete socket;
 			}
 
 			for (auto* server : this->tcpServers)
@@ -212,7 +213,8 @@ namespace RTC
 
 		for (auto* socket : this->udpSockets)
 		{
-			socket->Destroy();
+			socket->Close();
+			delete socket;
 		}
 		this->udpSockets.clear();
 

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -192,6 +192,10 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		// It's important deleting DTLS transport first since it will generate a
+		// DTLS alert to be sent.
+		delete this->dtlsTransport;
+
 		delete this->iceServer;
 
 		for (auto* socket : this->udpSockets)
@@ -205,8 +209,6 @@ namespace RTC
 			delete server;
 		}
 		this->tcpServers.clear();
-
-		delete this->dtlsTransport;
 
 		if (this->srtpRecvSession != nullptr)
 			delete this->srtpRecvSession;
@@ -1181,7 +1183,7 @@ namespace RTC
 		this->notifier->Emit(this->transportId, "dtlsstatechange", eventData);
 
 		// This is a fatal error so close the transport.
-		Destroy();
+		Close();
 	}
 
 	void WebRtcTransport::OnDtlsClosed(const RTC::DtlsTransport* /*dtlsTransport*/)
@@ -1200,7 +1202,7 @@ namespace RTC
 		this->notifier->Emit(this->transportId, "dtlsstatechange", eventData);
 
 		// This is a fatal error so close the transport.
-		Destroy();
+		Close();
 	}
 
 	void WebRtcTransport::OnOutgoingDtlsData(

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -46,11 +46,7 @@ void Worker::Close()
 	MS_TRACE();
 
 	if (this->closed)
-	{
-		MS_ERROR("already closed");
-
 		return;
-	}
 
 	this->closed = true;
 
@@ -74,8 +70,7 @@ void Worker::Close()
 	delete this->notifier;
 
 	// Close the Channel socket.
-	if (this->channel != nullptr)
-		this->channel->Destroy();
+	delete this->channel;
 }
 
 RTC::Router* Worker::GetRouterFromRequest(Channel::Request* request, uint32_t* routerId)
@@ -321,8 +316,6 @@ void Worker::OnChannelUnixStreamSocketRemotelyClosed(Channel::UnixStreamSocket* 
 	// If the pipe is remotely closed it means that mediasoup Node process
 	// abruptly died (SIGKILL?) so we must die.
 	MS_ERROR_STD("Channel remotely closed, killing myself");
-
-	this->channel = nullptr;
 
 	Close();
 }

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -65,7 +65,7 @@ void Worker::Close()
 		RTC::Router* router = it->second;
 
 		it = this->routers.erase(it);
-		router->Destroy();
+		delete router;
 	}
 
 	// Delete the Notifier.
@@ -238,7 +238,8 @@ void Worker::OnChannelRequest(Channel::UnixStreamSocket* /*channel*/, Channel::R
 				return;
 			}
 
-			router->Destroy();
+			delete router;
+
 			request->Accept();
 
 			break;

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -39,6 +39,9 @@ Worker::Worker(Channel::UnixStreamSocket* channel) : channel(channel)
 Worker::~Worker()
 {
 	MS_TRACE();
+
+	if (!this->closed)
+		Close();
 }
 
 void Worker::Close()
@@ -51,8 +54,7 @@ void Worker::Close()
 	this->closed = true;
 
 	// Close the SignalsHandler.
-	if (this->signalsHandler != nullptr)
-		this->signalsHandler->Destroy();
+	delete this->signalsHandler;
 
 	// Close all the Routers.
 	// NOTE: Upon Router closure the onRouterClosed() method is called, which

--- a/worker/src/handles/TcpConnection.cpp
+++ b/worker/src/handles/TcpConnection.cpp
@@ -36,7 +36,6 @@ inline static void onWrite(uv_write_t* req, int status)
 
 inline static void onClose(uv_handle_t* handle)
 {
-	MS_ERROR("---- delete handle");
 	delete handle;
 }
 
@@ -44,10 +43,8 @@ inline static void onShutdown(uv_shutdown_t* req, int status)
 {
 	auto* handle = req->handle;
 
-	MS_ERROR("---- delete req");
 	delete req;
 
-	MS_ERROR("---- calling uv_close()");
 	// Now do close the handle.
 	uv_close(reinterpret_cast<uv_handle_t*>(handle), static_cast<uv_close_cb>(onClose));
 }
@@ -130,6 +127,14 @@ void TcpConnection::Setup(
 {
 	MS_TRACE();
 
+	// Set the listener.
+	this->listener = listener;
+
+	// Set the local address.
+	this->localAddr = localAddr;
+	this->localIP   = localIP;
+	this->localPort = localPort;
+
 	int err;
 
 	// Set the UV handle.
@@ -141,14 +146,6 @@ void TcpConnection::Setup(
 
 		MS_THROW_ERROR("uv_tcp_init() failed: %s", uv_strerror(err));
 	}
-
-	// Set the listener.
-	this->listener = listener;
-
-	// Set the local address.
-	this->localAddr = localAddr;
-	this->localIP   = localIP;
-	this->localPort = localPort;
 }
 
 void TcpConnection::Start()

--- a/worker/src/handles/TcpServer.cpp
+++ b/worker/src/handles/TcpServer.cpp
@@ -16,11 +16,6 @@ inline static void onConnection(uv_stream_t* handle, int status)
 
 inline static void onClose(uv_handle_t* handle)
 {
-	static_cast<TcpServer*>(handle->data)->OnUvClosed();
-}
-
-inline static void onErrorClose(uv_handle_t* handle)
-{
 	delete handle;
 }
 
@@ -76,7 +71,7 @@ TcpServer::TcpServer(const std::string& ip, uint16_t port, int backlog)
 
 		default:
 		{
-			uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onErrorClose));
+			uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
 
 			MS_THROW_ERROR("invalid binding IP '%s'", ip.c_str());
 
@@ -87,7 +82,7 @@ TcpServer::TcpServer(const std::string& ip, uint16_t port, int backlog)
 	err = uv_tcp_bind(this->uvHandle, reinterpret_cast<const struct sockaddr*>(&bindAddr), flags);
 	if (err != 0)
 	{
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onErrorClose));
+		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
 		MS_THROW_ERROR("uv_tcp_bind() failed: %s", uv_strerror(err));
 	}
 
@@ -97,14 +92,14 @@ TcpServer::TcpServer(const std::string& ip, uint16_t port, int backlog)
 	  static_cast<uv_connection_cb>(onConnection));
 	if (err != 0)
 	{
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onErrorClose));
+		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
 		MS_THROW_ERROR("uv_listen() failed: %s", uv_strerror(err));
 	}
 
 	// Set local address.
 	if (!SetLocalAddress())
 	{
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onErrorClose));
+		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
 		MS_THROW_ERROR("error setting local IP and port");
 	}
 }
@@ -123,14 +118,14 @@ TcpServer::TcpServer(uv_tcp_t* uvHandle, int backlog) : uvHandle(uvHandle)
 	  static_cast<uv_connection_cb>(onConnection));
 	if (err != 0)
 	{
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onErrorClose));
+		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
 		MS_THROW_ERROR("uv_listen() failed: %s", uv_strerror(err));
 	}
 
 	// Set local address.
 	if (!SetLocalAddress())
 	{
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onErrorClose));
+		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
 		MS_THROW_ERROR("error setting local IP and port");
 	}
 }
@@ -139,34 +134,30 @@ TcpServer::~TcpServer()
 {
 	MS_TRACE();
 
-	delete this->uvHandle;
+	if (!this->closed)
+		Close();
 }
 
-void TcpServer::Destroy()
+void TcpServer::Close()
 {
 	MS_TRACE();
 
-	if (this->isClosing)
+	if (this->closed)
 		return;
 
-	this->isClosing = true;
+	this->closed = true;
 
-	// If there are no connections then close now.
-	if (this->connections.empty())
-	{
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
-	}
-	// Otherwise close all the connections (but not the TCP server).
-	else
-	{
-		MS_DEBUG_DEV("closing %zu active connections", this->connections.size());
+	MS_DEBUG_DEV("closing %zu active connections", this->connections.size());
 
-		for (auto connection : this->connections)
-		{
-			connection->Close();
-			delete connection;
-		}
+	for (auto it = this->connections.begin(); it != this->connections.end();)
+	{
+		auto* connection = *it;
+
+		it = this->connections.erase(it);
+		delete connection;
 	}
+
+ 	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
 }
 
 void TcpServer::Dump() const
@@ -176,7 +167,7 @@ void TcpServer::Dump() const
 	  "  [TCP, local:%s :%" PRIu16 ", status:%s, connections:%zu]",
 	  this->localIP.c_str(),
 	  static_cast<uint16_t>(this->localPort),
-	  (!this->isClosing) ? "open" : "closed",
+	  (!this->closed) ? "open" : "closed",
 	  this->connections.size());
 	MS_DEBUG_DEV("</TcpServer>");
 }
@@ -211,7 +202,7 @@ inline void TcpServer::OnUvConnection(int status)
 {
 	MS_TRACE();
 
-	if (this->isClosing)
+	if (this->closed)
 		return;
 
 	int err;
@@ -262,49 +253,23 @@ inline void TcpServer::OnUvConnection(int status)
 	{
 		MS_ERROR("cannot run the TCP connection, closing the connection: %s", error.what());
 
-		connection->Close();
 		delete connection;
 	}
 }
 
-inline void TcpServer::OnUvClosed()
+void TcpServer::OnTcpConnectionClosed(TcpConnection* connection, bool isClosedByPeer)
 {
 	MS_TRACE();
-
-	// Notify the subclass.
-	UserOnTcpServerClosed();
-
-	// And delete this.
-	delete this;
-}
-
-inline void TcpServer::OnTcpConnectionClosed(TcpConnection* connection, bool isClosedByPeer)
-{
-	MS_TRACE();
-
-	// NOTE:
-	// Worst scenario is that in which this is the latest connection,
-	// which is remotely closed (no TcpServer.Destroy() was called) and the user
-	// call TcpServer.Destroy() on UserOnTcpConnectionClosed() callback, so Destroy()
-	// is called with zero connections and calls uv_close(), but then
-	// onTcpConnectionClosed() continues and finds that isClosing is true and
-	// there are zero connections, so calls uv_close() again and get a crash.
-	//
-	// SOLUTION:
-	// Check isClosing value *before* onTcpConnectionClosed() callback.
-
-	bool wasClosing = this->isClosing;
 
 	MS_DEBUG_DEV("TCP connection closed");
 
 	// Remove the TcpConnection from the set.
-	this->connections.erase(connection);
+	size_t numErased = this->connections.erase(connection);
+
+	// If the closed connection was not present in the set, do nothing else.
+	if (numErased == 0)
+		return;
 
 	// Notify the subclass.
 	UserOnTcpConnectionClosed(connection, isClosedByPeer);
-
-	// Check if the server was closing connections, and if this is the last
-	// connection then close the server now.
-	if (wasClosing && this->connections.empty())
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
 }

--- a/worker/src/handles/TcpServer.cpp
+++ b/worker/src/handles/TcpServer.cpp
@@ -163,7 +163,8 @@ void TcpServer::Destroy()
 
 		for (auto connection : this->connections)
 		{
-			connection->Destroy();
+			connection->Close();
+			delete connection;
 		}
 	}
 }
@@ -253,19 +254,17 @@ inline void TcpServer::OnUvConnection(int status)
 	try
 	{
 		connection->Start();
+
+		// Notify the subclass.
+		UserOnNewTcpConnection(connection);
 	}
 	catch (const MediaSoupError& error)
 	{
 		MS_ERROR("cannot run the TCP connection, closing the connection: %s", error.what());
 
-		connection->Destroy();
-
-		// NOTE: Don't return here so the user won't be notified about a TCP connection
-		// closure for which there was not a previous creation event.
+		connection->Close();
+		delete connection;
 	}
-
-	// Notify the subclass.
-	UserOnNewTcpConnection(connection);
 }
 
 inline void TcpServer::OnUvClosed()

--- a/worker/src/handles/TcpServer.cpp
+++ b/worker/src/handles/TcpServer.cpp
@@ -157,7 +157,7 @@ void TcpServer::Close()
 		delete connection;
 	}
 
- 	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
+	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
 }
 
 void TcpServer::Dump() const

--- a/worker/src/handles/Timer.cpp
+++ b/worker/src/handles/Timer.cpp
@@ -39,19 +39,32 @@ Timer::Timer(Listener* listener) : listener(listener)
 	}
 }
 
-void Timer::Destroy()
+Timer::~Timer()
 {
 	MS_TRACE();
 
-	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
+	if (!this->closed)
+		Close();
+}
 
-	// Delete this.
-	delete this;
+void Timer::Close()
+{
+	MS_TRACE();
+
+	if (this->closed)
+		return;
+
+	this->closed = true;
+
+	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
 }
 
 void Timer::Start(uint64_t timeout, uint64_t repeat)
 {
 	MS_TRACE();
+
+	if (this->closed)
+		MS_THROW_ERROR("closed");
 
 	this->timeout = timeout;
 	this->repeat  = repeat;
@@ -70,6 +83,9 @@ void Timer::Stop()
 {
 	MS_TRACE();
 
+	if (this->closed)
+		MS_THROW_ERROR("closed");
+
 	int err;
 
 	err = uv_timer_stop(this->uvHandle);
@@ -80,6 +96,9 @@ void Timer::Stop()
 void Timer::Reset()
 {
 	MS_TRACE();
+
+	if (this->closed)
+		MS_THROW_ERROR("closed");
 
 	int err;
 
@@ -97,6 +116,9 @@ void Timer::Reset()
 void Timer::Restart()
 {
 	MS_TRACE();
+
+	if (this->closed)
+		MS_THROW_ERROR("closed");
 
 	int err;
 

--- a/worker/src/handles/UdpSocket.cpp
+++ b/worker/src/handles/UdpSocket.cpp
@@ -40,7 +40,6 @@ inline static void onSend(uv_udp_send_t* req, int status)
 
 inline static void onClose(uv_handle_t* handle)
 {
-	MS_ERROR("---- delete handle");
 	delete handle;
 }
 
@@ -176,9 +175,6 @@ void UdpSocket::Close()
 		MS_ABORT("uv_udp_recv_stop() failed: %s", uv_strerror(err));
 
 	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
-
-	// Notify the subclass.
-	UserOnUdpSocketClosed();
 }
 
 void UdpSocket::Dump() const

--- a/worker/src/handles/UnixStreamSocket.cpp
+++ b/worker/src/handles/UnixStreamSocket.cpp
@@ -38,20 +38,21 @@ inline static void onWrite(uv_write_t* req, int status)
 		socket->OnUvWriteError(status);
 }
 
-inline static void onShutdown(uv_shutdown_t* req, int status)
-{
-	static_cast<UnixStreamSocket*>(req->data)->OnUvShutdown(req, status);
-}
-
 inline static void onClose(uv_handle_t* handle)
-{
-	static_cast<UnixStreamSocket*>(handle->data)->OnUvClosed();
-}
-
-inline static void onErrorClose(uv_handle_t* handle)
 {
 	delete handle;
 }
+
+inline static void onShutdown(uv_shutdown_t* req, int status)
+{
+	auto* handle = req->handle;
+
+	delete req;
+
+	// Now do close the handle.
+	uv_close(reinterpret_cast<uv_handle_t*>(handle), static_cast<uv_close_cb>(onClose));
+}
+
 
 /* Instance methods. */
 
@@ -76,7 +77,7 @@ UnixStreamSocket::UnixStreamSocket(int fd, size_t bufferSize) : bufferSize(buffe
 	err = uv_pipe_open(this->uvHandle, fd);
 	if (err != 0)
 	{
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onErrorClose));
+		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
 
 		MS_THROW_ERROR_STD("uv_pipe_open() failed: %s", uv_strerror(err));
 	}
@@ -88,7 +89,7 @@ UnixStreamSocket::UnixStreamSocket(int fd, size_t bufferSize) : bufferSize(buffe
 	  static_cast<uv_read_cb>(onRead));
 	if (err != 0)
 	{
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onErrorClose));
+		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
 
 		MS_THROW_ERROR_STD("uv_read_start() failed: %s", uv_strerror(err));
 	}
@@ -100,20 +101,22 @@ UnixStreamSocket::~UnixStreamSocket()
 {
 	MS_TRACE_STD();
 
-	delete this->uvHandle;
+	if (!this->closed)
+		Close();
+
 	delete[] this->buffer;
 }
 
-void UnixStreamSocket::Destroy()
+void UnixStreamSocket::Close()
 {
 	MS_TRACE_STD();
 
-	if (this->isClosing)
+	if (this->closed)
 		return;
 
 	int err;
 
-	this->isClosing = true;
+	this->closed = true;
 
 	// Don't read more.
 	err = uv_read_stop(reinterpret_cast<uv_stream_t*>(this->uvHandle));
@@ -140,7 +143,7 @@ void UnixStreamSocket::Destroy()
 
 void UnixStreamSocket::Write(const uint8_t* data, size_t len)
 {
-	if (this->isClosing)
+	if (this->closed)
 		return;
 
 	if (len == 0)
@@ -172,7 +175,10 @@ void UnixStreamSocket::Write(const uint8_t* data, size_t len)
 	{
 		MS_ERROR_STD("uv_try_write() failed, closing the socket: %s", uv_strerror(written));
 
-		Destroy();
+		Close();
+
+		// Notify the subclass.
+		UserOnUnixStreamSocketClosed(this->isClosedByPeer);
 
 		return;
 	}
@@ -202,6 +208,9 @@ inline void UnixStreamSocket::OnUvReadAlloc(size_t /*suggestedSize*/, uv_buf_t* 
 {
 	MS_TRACE_STD();
 
+	if (this->closed)
+		return;
+
 	// If this is the first call to onUvReadAlloc() then allocate the receiving buffer now.
 	if (this->buffer == nullptr)
 		this->buffer = new uint8_t[this->bufferSize];
@@ -225,6 +234,9 @@ inline void UnixStreamSocket::OnUvRead(ssize_t nread, const uv_buf_t* /*buf*/)
 {
 	MS_TRACE_STD();
 
+	if (this->closed)
+		return;
+
 	if (nread == 0)
 		return;
 
@@ -243,7 +255,10 @@ inline void UnixStreamSocket::OnUvRead(ssize_t nread, const uv_buf_t* /*buf*/)
 		this->isClosedByPeer = true;
 
 		// Close local side of the pipe.
-		Destroy();
+		Close();
+
+		// Notify the subclass.
+		UserOnUnixStreamSocketClosed(this->isClosedByPeer);
 	}
 	// Some error.
 	else
@@ -253,7 +268,10 @@ inline void UnixStreamSocket::OnUvRead(ssize_t nread, const uv_buf_t* /*buf*/)
 		this->hasError = true;
 
 		// Close the socket.
-		Destroy();
+		Close();
+
+		// Notify the subclass.
+		UserOnUnixStreamSocketClosed(this->isClosedByPeer);
 	}
 }
 
@@ -261,7 +279,7 @@ inline void UnixStreamSocket::OnUvWriteError(int error)
 {
 	MS_TRACE_STD();
 
-	if (this->isClosing)
+	if (this->closed)
 		return;
 
 	if (error != UV_EPIPE && error != UV_ENOTCONN)
@@ -269,31 +287,8 @@ inline void UnixStreamSocket::OnUvWriteError(int error)
 
 	MS_ERROR_STD("write error, closing the pipe: %s", uv_strerror(error));
 
-	Destroy();
-}
-
-inline void UnixStreamSocket::OnUvShutdown(uv_shutdown_t* req, int status)
-{
-	MS_TRACE_STD();
-
-	delete req;
-
-	if (status != 0)
-	{
-		MS_ERROR_STD("shutdown error: %s", uv_strerror(status));
-	}
-
-	// Now do close the handle.
-	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
-}
-
-inline void UnixStreamSocket::OnUvClosed()
-{
-	MS_TRACE_STD();
+	Close();
 
 	// Notify the subclass.
 	UserOnUnixStreamSocketClosed(this->isClosedByPeer);
-
-	// And delete this.
-	delete this;
 }

--- a/worker/src/handles/UnixStreamSocket.cpp
+++ b/worker/src/handles/UnixStreamSocket.cpp
@@ -53,7 +53,6 @@ inline static void onShutdown(uv_shutdown_t* req, int status)
 	uv_close(reinterpret_cast<uv_handle_t*>(handle), static_cast<uv_close_cb>(onClose));
 }
 
-
 /* Instance methods. */
 
 UnixStreamSocket::UnixStreamSocket(int fd, size_t bufferSize) : bufferSize(bufferSize)

--- a/worker/src/main.cpp
+++ b/worker/src/main.cpp
@@ -92,6 +92,7 @@ int main(int argc, char* argv[])
 
 		// Worker ended.
 		destroy();
+
 		exitSuccess();
 	}
 	catch (const MediaSoupError& error)


### PR DESCRIPTION
Having `Destroy()` methods that call `delete this` is an ugly anti-pattern. This PR gets rid of them.