### PR TITLE
Fix crash in TcpConnection (#258)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "randomatic": "^3.1.1"
   },
   "devDependencies": {
-    "eslint": "^5.12.0",
+    "eslint": "^5.12.1",
     "gulp": "^4.0.0",
     "gulp-clang-format": "^1.0.27",
     "gulp-eslint": "^5.0.0",
@@ -44,7 +44,7 @@
     "gulp-replace": "^1.0.0",
     "gulp-shell": "^0.6.5",
     "gulp-touch-cmd": "0.0.1",
-    "tap": "^12.1.1"
+    "tap": "^12.4.0"
   },
   "optionalDependencies": {
     "clang-tools-prebuilt": "^0.1.4"

--- a/worker/include/handles/TcpConnection.hpp
+++ b/worker/include/handles/TcpConnection.hpp
@@ -25,7 +25,6 @@ public:
 	/* Struct for the data field of uv_req_t when writing into the connection. */
 	struct UvWriteData
 	{
-		TcpConnection* connection{ nullptr };
 		uv_write_t req;
 		uint8_t store[1];
 	};

--- a/worker/include/handles/UdpSocket.hpp
+++ b/worker/include/handles/UdpSocket.hpp
@@ -11,7 +11,6 @@ public:
 	/* Struct for the data field of uv_req_t when sending a datagram. */
 	struct UvSendData
 	{
-		UdpSocket* socket{ nullptr };
 		uv_udp_send_t req;
 		uint8_t store[1];
 	};

--- a/worker/include/handles/UnixStreamSocket.hpp
+++ b/worker/include/handles/UnixStreamSocket.hpp
@@ -11,7 +11,6 @@ public:
 	/* Struct for the data field of uv_req_t when writing data. */
 	struct UvWriteData
 	{
-		UnixStreamSocket* socket{ nullptr };
 		uv_write_t req;
 		uint8_t store[1];
 	};

--- a/worker/src/handles/TcpServer.cpp
+++ b/worker/src/handles/TcpServer.cpp
@@ -11,7 +11,9 @@
 
 inline static void onConnection(uv_stream_t* handle, int status)
 {
-	static_cast<TcpServer*>(handle->data)->OnUvConnection(status);
+	auto* server = static_cast<TcpServer*>(handle->data);
+
+	server->OnUvConnection(status);
 }
 
 inline static void onClose(uv_handle_t* handle)
@@ -146,6 +148,9 @@ void TcpServer::Close()
 		return;
 
 	this->closed = true;
+
+	// Tell the UV handle that the TcpServer has been closed.
+	this->uvHandle->data = nullptr;
 
 	MS_DEBUG_DEV("closing %zu active connections", this->connections.size());
 

--- a/worker/src/handles/UnixStreamSocket.cpp
+++ b/worker/src/handles/UnixStreamSocket.cpp
@@ -17,21 +17,35 @@
 
 inline static void onAlloc(uv_handle_t* handle, size_t suggestedSize, uv_buf_t* buf)
 {
-	static_cast<UnixStreamSocket*>(handle->data)->OnUvReadAlloc(suggestedSize, buf);
+	auto* socket = static_cast<UnixStreamSocket*>(handle->data);
+
+	if (socket == nullptr)
+		return;
+
+	socket->OnUvReadAlloc(suggestedSize, buf);
 }
 
 inline static void onRead(uv_stream_t* handle, ssize_t nread, const uv_buf_t* buf)
 {
-	static_cast<UnixStreamSocket*>(handle->data)->OnUvRead(nread, buf);
+	auto* socket = static_cast<UnixStreamSocket*>(handle->data);
+
+	if (socket == nullptr)
+		return;
+
+	socket->OnUvRead(nread, buf);
 }
 
 inline static void onWrite(uv_write_t* req, int status)
 {
-	auto* writeData          = static_cast<UnixStreamSocket::UvWriteData*>(req->data);
-	UnixStreamSocket* socket = writeData->socket;
+	auto* writeData = static_cast<UnixStreamSocket::UvWriteData*>(req->data);
+	auto* handle    = req->handle;
+	auto* socket    = static_cast<UnixStreamSocket*>(handle->data);
 
 	// Delete the UvWriteData struct (which includes the uv_req_t and the store char[]).
 	std::free(writeData);
+
+	if (socket == nullptr)
+		return;
 
 	// Just notify the UnixStreamSocket when error.
 	if (status != 0)
@@ -117,6 +131,9 @@ void UnixStreamSocket::Close()
 
 	this->closed = true;
 
+	// Tell the UV handle that the UnixStreamSocket has been closed.
+	this->uvHandle->data = nullptr;
+
 	// Don't read more.
 	err = uv_read_stop(reinterpret_cast<uv_stream_t*>(this->uvHandle));
 	if (err != 0)
@@ -164,7 +181,7 @@ void UnixStreamSocket::Write(const uint8_t* data, size_t len)
 		return;
 	}
 	// Cannot write any data at first time. Use uv_write().
-	if (written == UV_EAGAIN || written == UV_ENOSYS)
+	else if (written == UV_EAGAIN || written == UV_ENOSYS)
 	{
 		// Set written to 0 so pendingLen can be properly calculated.
 		written = 0;
@@ -187,7 +204,6 @@ void UnixStreamSocket::Write(const uint8_t* data, size_t len)
 	// Allocate a special UvWriteData struct pointer.
 	auto* writeData = static_cast<UvWriteData*>(std::malloc(sizeof(UvWriteData) + pendingLen));
 
-	writeData->socket = this;
 	std::memcpy(writeData->store, data + written, pendingLen);
 	writeData->req.data = (void*)writeData;
 


### PR DESCRIPTION
Verify within libuv static callbacks that the associated C++ instance has not been deallocated.