### PR TITLE
RtpPacket: full replacement of RTP extensions

### DIFF
--- a/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
@@ -23,7 +23,7 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	uint32_t absSendTime;
 	std::string mid;
 	std::string rid;
-	std::vector<RTC::RtpPacket::GenericExtension> extensions;
+	std::vector<::RTC::RtpPacket::GenericExtension> extensions;
 
 	std::memcpy(data2, data, len);
 
@@ -93,6 +93,35 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	packet->SetExtensions(2, extensions);
 
 	extensions.clear();
+
+	packet->SetExtensions(2, extensions);
+	packet->SetExtensions(1, extensions);
+
+	uint8_t value3[] = { 0x01, 0x02, 0x03 };
+
+	extensions.emplace_back(
+	  14,    // id
+	  3,     // len
+	  value3 // value
+	);
+
+	extensions.emplace_back(
+	  15,    // id
+	  3,     // len
+	  value3 // value
+	);
+
+	extensions.emplace_back(
+	  22,    // id
+	  3,     // len
+	  value3 // value
+	);
+
+	extensions.emplace_back(
+	  0,     // id
+	  3,     // len
+	  value3 // value
+	);
 
 	packet->SetExtensions(2, extensions);
 	packet->SetExtensions(1, extensions);

--- a/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
@@ -44,10 +44,10 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	packet->SetTimestamp(8888);
 	packet->GetSsrc();
 	packet->SetSsrc(666);
-	packet->HasExtensionHeader();
-	packet->GetExtensionHeaderId();
-	packet->GetExtensionHeaderLength();
-	packet->GetExtensionHeaderValue();
+	packet->HasHeaderExtension();
+	packet->GetHeaderExtensionId();
+	packet->GetHeaderExtensionLength();
+	packet->GetHeaderExtensionValue();
 	packet->HasOneByteExtensions();
 	packet->HasTwoBytesExtensions();
 
@@ -75,7 +75,7 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	idMapping[2] = 12;
 	idMapping[3] = 13;
 
-	packet->MangleExtensionHeaderIds(idMapping);
+	packet->MangleHeaderExtensionIds(idMapping);
 
 	packet->SetAudioLevelExtensionId(11);
 	packet->GetExtension(11, extenLen);

--- a/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
@@ -11,7 +11,9 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 
 	// We need to clone the given data into a separate buffer because setters
 	// below will try to write into packet memory.
-	uint8_t data2[len];
+	//
+	// NOTE: Let's make the buffer bigger to test API that increases packet size.
+	uint8_t data2[len + 16];
 	uint8_t extenLen;
 	bool voice;
 	uint8_t volume;
@@ -94,7 +96,10 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	packet->GetPayloadPadding();
 	packet->IsKeyFrame();
 
-	uint8_t buffer[len];
+	packet->SetOneByteHeaderExtension();
+	packet->SetTwoBytesHeaderExtension();
+
+	uint8_t buffer[len + 16];
 	auto* clonedPacket = packet->Clone(buffer);
 
 	delete clonedPacket;

--- a/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
@@ -1,8 +1,8 @@
 #include "RTC/FuzzerRtpPacket.hpp"
 #include "RTC/RtpPacket.hpp"
 #include <cstring> // std::memory()
-#include <map>
 #include <string>
+#include <vector>
 
 void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 {
@@ -13,7 +13,7 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	// below will try to write into packet memory.
 	//
 	// NOTE: Let's make the buffer bigger to test API that increases packet size.
-	uint8_t data2[len + 16];
+	uint8_t data2[len + 64];
 	uint8_t extenLen;
 	bool voice;
 	uint8_t volume;
@@ -23,7 +23,7 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	uint32_t absSendTime;
 	std::string mid;
 	std::string rid;
-	std::map<uint8_t, uint8_t> idMapping;
+	std::vector<RTC::RtpPacket::GenericExtension> extensions;
 
 	std::memcpy(data2, data, len);
 
@@ -73,11 +73,29 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	packet->GetExtension(6, extenLen);
 	packet->ReadRid(rid);
 
-	idMapping[1] = 11;
-	idMapping[2] = 12;
-	idMapping[3] = 13;
+	uint8_t value1[] = { 0x01, 0x02, 0x03, 0x04 };
 
-	packet->MangleHeaderExtensionIds(idMapping);
+	extensions.emplace_back(
+	  1,     // id
+	  4,     // len
+	  value1 // value
+	);
+
+	uint8_t value2[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11 };
+
+	extensions.emplace_back(
+	  2,     // id
+	  11,    // len
+	  value2 // value
+	);
+
+	packet->SetExtensions(1, extensions);
+	packet->SetExtensions(2, extensions);
+
+	extensions.clear();
+
+	packet->SetExtensions(2, extensions);
+	packet->SetExtensions(1, extensions);
 
 	packet->SetAudioLevelExtensionId(11);
 	packet->GetExtension(11, extenLen);
@@ -95,9 +113,6 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	packet->GetPayloadLength();
 	packet->GetPayloadPadding();
 	packet->IsKeyFrame();
-
-	packet->SetOneByteHeaderExtension();
-	packet->SetTwoBytesHeaderExtension();
 
 	uint8_t buffer[len + 16];
 	auto* clonedPacket = packet->Clone(buffer);

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -477,7 +477,7 @@ namespace RTC
 
 	inline uint8_t* RtpPacket::GetPayload() const
 	{
-		return this->payload;
+		return this->payloadLength != 0 ? this->payload : nullptr;
 	}
 
 	inline size_t RtpPacket::GetPayloadLength() const

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -77,6 +77,8 @@ namespace RTC
 		/* Struct for replacing and setting header extensions. */
 		struct GenericExtension
 		{
+			GenericExtension(uint8_t id, uint8_t len, uint8_t* value) : id(id), len(len), value(value){};
+
 			uint8_t id : 8;
 			uint8_t len : 8;
 			uint8_t* value;
@@ -114,7 +116,7 @@ namespace RTC
 		void SetSsrc(uint32_t ssrc);
 		bool HasHeaderExtension() const;
 		// After calling this method, all the extension ids are reset to 0.
-		void SetHeaderExtensions(uint8_t type, const std::vector<GenericExtension>& extensions);
+		void SetExtensions(uint8_t type, const std::vector<GenericExtension>& extensions);
 		uint16_t GetHeaderExtensionId() const;
 		size_t GetHeaderExtensionLength() const;
 		uint8_t* GetHeaderExtensionValue() const;

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -76,7 +76,7 @@ namespace RTC
 		static bool IsRtp(const uint8_t* data, size_t len);
 		static RtpPacket* Parse(const uint8_t* data, size_t len);
 
-	public:
+	private:
 		RtpPacket(
 		  Header* header,
 		  ExtensionHeader* extensionHeader,
@@ -84,6 +84,8 @@ namespace RTC
 		  size_t payloadLength,
 		  uint8_t payloadPadding,
 		  size_t size);
+
+	public:
 		~RtpPacket();
 
 		void Dump() const;

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -103,6 +103,8 @@ namespace RTC
 		uint32_t GetSsrc() const;
 		void SetSsrc(uint32_t ssrc);
 		bool HasHeaderExtension() const;
+		bool SetOneByteHeaderExtension();
+		bool SetTwoBytesHeaderExtension();
 		uint16_t GetHeaderExtensionId() const;
 		size_t GetHeaderExtensionLength() const;
 		uint8_t* GetHeaderExtensionValue() const;

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -6,6 +6,7 @@
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
 #include <map>
 #include <string>
+#include <vector>
 
 namespace RTC
 {
@@ -73,6 +74,15 @@ namespace RTC
 		};
 
 	public:
+		/* Struct for replacing and setting header extensions. */
+		struct GenericExtension
+		{
+			uint8_t id : 8;
+			uint8_t len : 8;
+			uint8_t* value;
+		};
+
+	public:
 		static bool IsRtp(const uint8_t* data, size_t len);
 		static RtpPacket* Parse(const uint8_t* data, size_t len);
 
@@ -103,13 +113,11 @@ namespace RTC
 		uint32_t GetSsrc() const;
 		void SetSsrc(uint32_t ssrc);
 		bool HasHeaderExtension() const;
-		bool SetOneByteHeaderExtension();
-		bool SetTwoBytesHeaderExtension();
+		// After calling this method, all the extension ids are reset to 0.
+		void SetHeaderExtensions(uint8_t type, const std::vector<GenericExtension>& extensions);
 		uint16_t GetHeaderExtensionId() const;
 		size_t GetHeaderExtensionLength() const;
 		uint8_t* GetHeaderExtensionValue() const;
-		// After calling this method, all the extension ids are reset to 0.
-		void MangleHeaderExtensionIds(const std::map<uint8_t, uint8_t>& idMapping);
 		bool HasOneByteExtensions() const;
 		bool HasTwoBytesExtensions() const;
 		void SetAudioLevelExtensionId(uint8_t id);

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -41,8 +41,8 @@ namespace RTC
 		};
 
 	private:
-		/* Struct for RTP extension header. */
-		struct ExtensionHeader
+		/* Struct for RTP header extension. */
+		struct HeaderExtension
 		{
 			uint16_t id;
 			uint16_t length; // Size of value in multiples of 4 bytes.
@@ -79,7 +79,7 @@ namespace RTC
 	private:
 		RtpPacket(
 		  Header* header,
-		  ExtensionHeader* extensionHeader,
+		  HeaderExtension* headerExtension,
 		  const uint8_t* payload,
 		  size_t payloadLength,
 		  uint8_t payloadPadding,
@@ -102,12 +102,12 @@ namespace RTC
 		void SetTimestamp(uint32_t timestamp);
 		uint32_t GetSsrc() const;
 		void SetSsrc(uint32_t ssrc);
-		bool HasExtensionHeader() const;
-		uint16_t GetExtensionHeaderId() const;
-		size_t GetExtensionHeaderLength() const;
-		uint8_t* GetExtensionHeaderValue() const;
+		bool HasHeaderExtension() const;
+		uint16_t GetHeaderExtensionId() const;
+		size_t GetHeaderExtensionLength() const;
+		uint8_t* GetHeaderExtensionValue() const;
 		// After calling this method, all the extension ids are reset to 0.
-		void MangleExtensionHeaderIds(const std::map<uint8_t, uint8_t>& idMapping);
+		void MangleHeaderExtensionIds(const std::map<uint8_t, uint8_t>& idMapping);
 		bool HasOneByteExtensions() const;
 		bool HasTwoBytesExtensions() const;
 		void SetAudioLevelExtensionId(uint8_t id);
@@ -141,7 +141,7 @@ namespace RTC
 		// Passed by argument.
 		Header* header{ nullptr };
 		uint8_t* csrcList{ nullptr };
-		ExtensionHeader* extensionHeader{ nullptr };
+		HeaderExtension* headerExtension{ nullptr };
 		std::map<uint8_t, OneByteExtension*> oneByteExtensions;
 		std::map<uint8_t, TwoBytesExtension*> twoBytesExtensions;
 		uint8_t audioLevelExtensionId{ 0 };
@@ -241,43 +241,43 @@ namespace RTC
 		this->header->ssrc = uint32_t{ htonl(ssrc) };
 	}
 
-	inline bool RtpPacket::HasExtensionHeader() const
+	inline bool RtpPacket::HasHeaderExtension() const
 	{
-		return (this->extensionHeader ? true : false);
+		return (this->headerExtension ? true : false);
 	}
 
-	inline uint16_t RtpPacket::GetExtensionHeaderId() const
+	inline uint16_t RtpPacket::GetHeaderExtensionId() const
 	{
-		if (!this->extensionHeader)
+		if (!this->headerExtension)
 			return 0;
 
-		return uint16_t{ ntohs(this->extensionHeader->id) };
+		return uint16_t{ ntohs(this->headerExtension->id) };
 	}
 
-	inline size_t RtpPacket::GetExtensionHeaderLength() const
+	inline size_t RtpPacket::GetHeaderExtensionLength() const
 	{
-		if (!this->extensionHeader)
+		if (!this->headerExtension)
 			return 0;
 
-		return static_cast<size_t>(ntohs(this->extensionHeader->length) * 4);
+		return static_cast<size_t>(ntohs(this->headerExtension->length) * 4);
 	}
 
-	inline uint8_t* RtpPacket::GetExtensionHeaderValue() const
+	inline uint8_t* RtpPacket::GetHeaderExtensionValue() const
 	{
-		if (!this->extensionHeader)
+		if (!this->headerExtension)
 			return nullptr;
 
-		return this->extensionHeader->value;
+		return this->headerExtension->value;
 	}
 
 	inline bool RtpPacket::HasOneByteExtensions() const
 	{
-		return GetExtensionHeaderId() == 0xBEDE;
+		return GetHeaderExtensionId() == 0xBEDE;
 	}
 
 	inline bool RtpPacket::HasTwoBytesExtensions() const
 	{
-		return (GetExtensionHeaderId() & 0b1111111111110000) == 0b0001000000000000;
+		return (GetHeaderExtensionId() & 0b1111111111110000) == 0b0001000000000000;
 	}
 
 	inline void RtpPacket::SetAudioLevelExtensionId(uint8_t id)

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -104,7 +104,7 @@ namespace RTC
 		uint16_t GetExtensionHeaderId() const;
 		size_t GetExtensionHeaderLength() const;
 		uint8_t* GetExtensionHeaderValue() const;
-		// After calling this method, all the extIDs are reset to 0.
+		// After calling this method, all the extension ids are reset to 0.
 		void MangleExtensionHeaderIds(const std::map<uint8_t, uint8_t>& idMapping);
 		bool HasOneByteExtensions() const;
 		bool HasTwoBytesExtensions() const;

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -867,8 +867,9 @@ namespace RTC
 
 		packet->SetSsrc(mappedSsrc);
 
+		// TODO: Redo.
 		// Mangle RTP header extension ids.
-		packet->MangleHeaderExtensionIds(this->rtpMapping.headerExtensions);
+		// packet->MangleHeaderExtensionIds(this->rtpMapping.headerExtensions);
 
 		// Assign mapped RTP header extension ids.
 		if (this->mappedRtpHeaderExtensionIds.ssrcAudioLevel != 0u)

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -868,7 +868,7 @@ namespace RTC
 		packet->SetSsrc(mappedSsrc);
 
 		// Mangle RTP header extension ids.
-		packet->MangleExtensionHeaderIds(this->rtpMapping.headerExtensions);
+		packet->MangleHeaderExtensionIds(this->rtpMapping.headerExtensions);
 
 		// Assign mapped RTP header extension ids.
 		if (this->mappedRtpHeaderExtensionIds.ssrcAudioLevel != 0u)

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -515,9 +515,7 @@ namespace RTC
 		MS_ASSERT(payloadOffset < this->payloadLength, "payload offset bigger than payload size");
 
 		if (!expand)
-		{
-			MS_ASSERT(shift <= (this->payloadLength - payloadOffset), "shift to big");
-		}
+			MS_ASSERT(shift <= (this->payloadLength - payloadOffset), "shift too big");
 
 		uint8_t* payloadOffsetPtr = this->payload + payloadOffset;
 		size_t shiftedLen;

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -562,23 +562,31 @@ namespace RTC
 				uint8_t id = (*ptr & 0xF0) >> 4;
 				size_t len = static_cast<size_t>(*ptr & 0x0F) + 1;
 
-				if (ptr + 1 + len > extensionEnd)
-				{
-					MS_WARN_TAG(
-					  rtp, "not enough space for the announced One-Byte header extension element value");
-
-					break;
-				}
-
 				// id=15 in One-Byte extensions means "stop parsing here".
 				if (id == 15u)
 					break;
 
-				// Store the One-Byte extension element in a map. Ignore if 0 (padding).
+				// Valid extension id.
 				if (id != 0u)
+				{
+					if (ptr + 1 + len > extensionEnd)
+					{
+						MS_WARN_TAG(
+						  rtp, "not enough space for the announced One-Byte header extension element value");
+
+						break;
+					}
+
+					// Store the One-Byte extension element in a map.
 					this->oneByteExtensions[id] = reinterpret_cast<OneByteExtension*>(ptr);
 
-				ptr += (1 + len);
+					ptr += (1 + len);
+				}
+				// id=0 means alignment.
+				else
+				{
+					++ptr;
+				}
 
 				// Counting padding bytes.
 				while ((ptr < extensionEnd) && (*ptr == 0))
@@ -606,19 +614,27 @@ namespace RTC
 				uint8_t id  = *ptr;
 				uint8_t len = *(ptr + 1);
 
-				if (ptr + 2 + len > extensionEnd)
-				{
-					MS_WARN_TAG(
-					  rtp, "not enough space for the announced Two-Bytes header extension element value");
-
-					break;
-				}
-
-				// Store the Two-Bytes extension element in a map. Ignore if 0.
+				// Valid extension id.
 				if (id != 0u)
+				{
+					if (ptr + 2 + len > extensionEnd)
+					{
+						MS_WARN_TAG(
+						  rtp, "not enough space for the announced Two-Bytes header extension element value");
+
+						break;
+					}
+
+					// Store the Two-Bytes extension element in a map.
 					this->twoBytesExtensions[id] = reinterpret_cast<TwoBytesExtension*>(ptr);
 
-				ptr += (2 + len);
+					ptr += (2 + len);
+				}
+				// id=0 means alignment.
+				else
+				{
+					++ptr;
+				}
 
 				// Counting padding bytes.
 				while ((ptr < extensionEnd) && (*ptr == 0))

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -277,16 +277,13 @@ namespace RTC
 	{
 		// If already set, return true.
 		if (HasOneByteExtensions())
-		{
 			return true;
-		}
 		// If it has Two-Bytes extensions, return false.
 		else if (HasTwoBytesExtensions())
-		{
 			return false;
-		}
-
-		MS_ERROR("---------- YES 1 !!!");
+		// If it has a different header extension, return false.
+		else if (this->headerExtension)
+			return false;
 
 		// Set the header extension bit.
 		this->header->extension = 1u;
@@ -312,16 +309,13 @@ namespace RTC
 	{
 		// If already set, return true.
 		if (HasTwoBytesExtensions())
-		{
 			return true;
-		}
 		// If it has One-Byte extensions, return false.
 		else if (HasOneByteExtensions())
-		{
 			return false;
-		}
-
-		MS_ERROR("---------- YES 2 !!!");
+		// If it has a different header extension, return false.
+		else if (this->headerExtension)
+			return false;
 
 		// Set the header extension bit.
 		this->header->extension = 1u;
@@ -444,38 +438,19 @@ namespace RTC
 
 		if (this->payloadLength != 0)
 		{
-			MS_ERROR("----- OH!! this->payloadLength != 0");
-
 			numBytes = this->payloadLength;
 			std::memcpy(ptr, this->payload, numBytes);
 
 			// Update pointer.
 			ptr += numBytes;
 		}
-		else
-		{
-			MS_ERROR("----- OH!! this->payloadLength == 0");
-		}
 
 		// Copy payload padding.
 
 		if (this->payloadPadding != 0u)
 		{
-			MS_ERROR("----- OH!! this->payloadPadding:%" PRIu8, this->payloadPadding);
-
 			*(ptr + static_cast<size_t>(this->payloadPadding) - 1) = this->payloadPadding;
 			ptr += size_t{ this->payloadPadding };
-		}
-		else
-		{
-			MS_ERROR("----- OH!! this->payloadPadding == 0");
-		}
-
-		if (static_cast<size_t>(ptr - buffer) != this->size)
-		{
-			MS_ERROR(
-				"----- OH!! (ptr - buffer):%zu, this->size:%zu, this->headerExtension->length:%" PRIu16 ", GetHeaderExtensionLength():%zu",
-				static_cast<size_t>(ptr - buffer), this->size, this->headerExtension->length, GetHeaderExtensionLength());
 		}
 
 		MS_ASSERT(static_cast<size_t>(ptr - buffer) == this->size, "ptr - buffer == this->size");

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -296,7 +296,7 @@ namespace RTC
 		{
 			// Nothing to do.
 		}
-		// Otherwise, if there is header extension of unknown type, modify its id.
+		// Otherwise, if there is header extension of non matching type, modify its id.
 		else if (this->headerExtension)
 		{
 			if (type == 1u)
@@ -392,7 +392,7 @@ namespace RTC
 				if (extension.id == 0 || extension.id > 14 || extension.len == 0 || extension.len > 16)
 					continue;
 
-				*ptr = (extension.id & 0x0F) | ((extension.len - 1) << 4);
+				*ptr = (extension.id << 4) | ((extension.len - 1) & 0x0F);
 				++ptr;
 				std::memmove(ptr, extension.value, extension.len);
 				ptr += extension.len;

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -272,7 +272,7 @@ namespace RTC
 		MS_DEBUG_DEV("</RtpPacket>");
 	}
 
-	void RtpPacket::SetHeaderExtensions(uint8_t type, const std::vector<GenericExtension>& extensions)
+	void RtpPacket::SetExtensions(uint8_t type, const std::vector<GenericExtension>& extensions)
 	{
 		MS_ASSERT(type == 1u || type == 2u, "type must be 1 or 2");
 
@@ -312,15 +312,15 @@ namespace RTC
 		{
 			if (type == 1u)
 			{
-				MS_ASSERT(
-				  extension.id >= 1 && extension.id <= 14 && extension.len >= 1 && extension.len <= 16,
-				  "invalid One-Byte extension");
+				if (extension.id == 0 || extension.id > 14 || extension.len == 0 || extension.len > 16)
+					continue;
 
 				extensionsTotalSize += (1 + extension.len);
 			}
 			else if (type == 2u)
 			{
-				MS_ASSERT(extension.id >= 1, "invalid Two-Bytes extension");
+				if (extension.id == 0)
+					continue;
 
 				extensionsTotalSize += (2 + extension.len);
 			}
@@ -389,6 +389,9 @@ namespace RTC
 		{
 			if (type == 1u)
 			{
+				if (extension.id == 0 || extension.id > 14 || extension.len == 0 || extension.len > 16)
+					continue;
+
 				*ptr = (extension.id & 0x0F) | ((extension.len - 1) << 4);
 				++ptr;
 				std::memmove(ptr, extension.value, extension.len);
@@ -396,6 +399,9 @@ namespace RTC
 			}
 			else if (type == 2u)
 			{
+				if (extension.id == 0)
+					continue;
+
 				*ptr = extension.id;
 				++ptr;
 				*ptr = extension.len;

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -382,10 +382,9 @@ namespace RTC
 			this->headerExtension->length = htons(extensionsTotalSize / 4);
 		}
 
-		// ptr starts in the header extension value position.
+		// Write the new extensions into the header extension value.
 		uint8_t* ptr = this->headerExtension->value;
 
-		// Write the new extensions into the header extension value.
 		for (auto& extension : extensions)
 		{
 			if (type == 1u)

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -118,7 +118,8 @@ namespace RTC
 		           payloadLength + size_t{ payloadPadding },
 		  "packet's computed size does not match received size");
 
-		auto packet = new RtpPacket(header, extensionHeader, payload, payloadLength, payloadPadding, len);
+		auto* packet =
+		  new RtpPacket(header, extensionHeader, payload, payloadLength, payloadPadding, len);
 
 		// Parse RFC 5285 extension header.
 		packet->ParseExtensions();
@@ -393,7 +394,7 @@ namespace RTC
 		MS_ASSERT(static_cast<size_t>(ptr - buffer) == this->size, "ptr - buffer == this->size");
 
 		// Create the new RtpPacket instance and return it.
-		auto packet = new RtpPacket(
+		auto* packet = new RtpPacket(
 		  newHeader, newExtensionHeader, newPayload, this->payloadLength, this->payloadPadding, this->size);
 
 		// Parse RFC 5285 extension header.

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -273,6 +273,72 @@ namespace RTC
 		MS_DEBUG_DEV("</RtpPacket>");
 	}
 
+	bool RtpPacket::SetOneByteHeaderExtension()
+	{
+		// If already set, return true.
+		if (HasOneByteExtensions())
+		{
+			return true;
+		}
+		// If it has Two-Bytes extensions, return false.
+		else if (HasTwoBytesExtensions())
+		{
+			return false;
+		}
+
+		// Set the header extension bit.
+		this->header->extension = 1u;
+
+		// Set the header extension pointing to the current payload.
+		this->headerExtension = reinterpret_cast<HeaderExtension*>(this->payload);
+
+		// Shift the payload 4 bytes (the length of the header extension).
+		std::memmove(this->payload + 4, this->payload, this->payloadLength + this->payloadPadding);
+		this->payload += 4;
+
+		// Increase size.
+		this->size += 4;
+
+		// Set the header extension id and length.
+		this->headerExtension->id     = uint16_t{ htons(0xBEDE) };
+		this->headerExtension->length = 0u;
+
+		return true;
+	}
+
+	bool RtpPacket::SetTwoBytesHeaderExtension()
+	{
+		// If already set, return true.
+		if (HasTwoBytesExtensions())
+		{
+			return true;
+		}
+		// If it has One-Byte extensions, return false.
+		else if (HasOneByteExtensions())
+		{
+			return false;
+		}
+
+		// Set the header extension bit.
+		this->header->extension = 1u;
+
+		// Set the header extension pointing to the current payload.
+		this->headerExtension = reinterpret_cast<HeaderExtension*>(this->payload);
+
+		// Shift the payload 4 bytes (the length of the header extension).
+		std::memmove(this->payload + 4, this->payload, this->payloadLength + this->payloadPadding);
+		this->payload += 4;
+
+		// Increase size.
+		this->size += 4;
+
+		// Set the header extension id and length.
+		this->headerExtension->id     = uint16_t{ htons(0b0001000000000000) };
+		this->headerExtension->length = 0u;
+
+		return true;
+	}
+
 	void RtpPacket::MangleHeaderExtensionIds(const std::map<uint8_t, uint8_t>& idMapping)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -286,6 +286,8 @@ namespace RTC
 			return false;
 		}
 
+		MS_ERROR("---------- YES 1 !!!");
+
 		// Set the header extension bit.
 		this->header->extension = 1u;
 
@@ -296,10 +298,10 @@ namespace RTC
 		std::memmove(this->payload + 4, this->payload, this->payloadLength + this->payloadPadding);
 		this->payload += 4;
 
-		// Increase size.
+		// Increase packet total size.
 		this->size += 4;
 
-		// Set the header extension id and length.
+		// Set the header extension id with length 0.
 		this->headerExtension->id     = uint16_t{ htons(0xBEDE) };
 		this->headerExtension->length = 0u;
 
@@ -319,6 +321,8 @@ namespace RTC
 			return false;
 		}
 
+		MS_ERROR("---------- YES 2 !!!");
+
 		// Set the header extension bit.
 		this->header->extension = 1u;
 
@@ -332,7 +336,7 @@ namespace RTC
 		// Increase size.
 		this->size += 4;
 
-		// Set the header extension id and length.
+		// Set the header extension id with length 0.
 		this->headerExtension->id     = uint16_t{ htons(0b0001000000000000) };
 		this->headerExtension->length = 0u;
 
@@ -435,26 +439,41 @@ namespace RTC
 
 		// Copy payload.
 
-		uint8_t* newPayload{ nullptr };
+		// Set the payload pointer.
+		uint8_t* newPayload{ ptr };
 
-		if (this->payload != nullptr)
+		if (this->payloadLength != 0)
 		{
-			numBytes = GetPayloadLength();
+			numBytes = this->payloadLength;
 			std::memcpy(ptr, this->payload, numBytes);
-
-			// Set the payload pointer.
-			newPayload = ptr;
 
 			// Update pointer.
 			ptr += numBytes;
+		}
+		else
+		{
+			MS_ERROR("----- OH!! hay this->payload");
 		}
 
 		// Copy payload padding.
 
 		if (this->payloadPadding != 0u)
 		{
+			MS_ERROR("----- OH!! this->payloadPadding:%" PRIu8, this->payloadPadding);
+
 			*(ptr + static_cast<size_t>(this->payloadPadding) - 1) = this->payloadPadding;
 			ptr += size_t{ this->payloadPadding };
+		}
+		else
+		{
+			MS_ERROR("----- OH!! this->payloadPadding == 0");
+		}
+
+		if (static_cast<size_t>(ptr - buffer) != this->size)
+		{
+			MS_ERROR(
+				"----- OH!! (ptr - buffer):%zu, this->size:%zu, this->headerExtension->length:%" PRIu16 ", GetHeaderExtensionLength():%zu",
+				static_cast<size_t>(ptr - buffer), this->size, this->headerExtension->length, GetHeaderExtensionLength());
 		}
 
 		MS_ASSERT(static_cast<size_t>(ptr - buffer) == this->size, "ptr - buffer == this->size");

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -444,6 +444,8 @@ namespace RTC
 
 		if (this->payloadLength != 0)
 		{
+			MS_ERROR("----- OH!! this->payloadLength != 0");
+
 			numBytes = this->payloadLength;
 			std::memcpy(ptr, this->payload, numBytes);
 
@@ -452,7 +454,7 @@ namespace RTC
 		}
 		else
 		{
-			MS_ERROR("----- OH!! hay this->payload");
+			MS_ERROR("----- OH!! this->payloadLength == 0");
 		}
 
 		// Copy payload padding.

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -48,7 +48,7 @@ namespace RTC
 		ExtensionHeader* extensionHeader{ nullptr };
 		size_t extensionValueSize{ 0 };
 
-		if (header->extension != 0u)
+		if (header->extension == 1u)
 		{
 			// The extension header is at least 4 bytes.
 			if (len < static_cast<size_t>(ptr - data) + 4)

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -570,7 +570,11 @@ namespace RTC
 					break;
 				}
 
-				// Store the One-Byte extension element in a map. Ignore if 0.
+				// id=15 in One-Byte extensions means "stop parsing here".
+				if (id == 15u)
+					break;
+
+				// Store the One-Byte extension element in a map. Ignore if 0 (padding).
 				if (id != 0u)
 					this->oneByteExtensions[id] = reinterpret_cast<OneByteExtension*>(ptr);
 

--- a/worker/src/RTC/TcpConnection.cpp
+++ b/worker/src/RTC/TcpConnection.cpp
@@ -4,10 +4,15 @@
 #include "RTC/TcpConnection.hpp"
 #include "Logger.hpp"
 #include "Utils.hpp"
-#include <cstring> // std::memmove()
+#include <cstring> // std::memmove(), std::memcpy()
 
 namespace RTC
 {
+	/* Static. */
+
+	static constexpr size_t ReadBufferSize{ 65536 };
+	static uint8_t ReadBuffer[ReadBufferSize];
+
 	/* Instance methods. */
 
 	TcpConnection::TcpConnection(Listener* listener, size_t bufferSize)
@@ -67,7 +72,12 @@ namespace RTC
 				if (packetLen != 0)
 				{
 					this->recvBytes += packetLen;
-					this->listener->OnPacketRecv(this, packet, packetLen);
+
+					// Copy the received packet into the static buffer so it can be expanded
+					// later.
+					std::memcpy(ReadBuffer, packet, packetLen);
+
+					this->listener->OnPacketRecv(this, ReadBuffer, packetLen);
 				}
 
 				// If there is no more space available in the buffer and that is because

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -507,6 +507,20 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		uint8_t value1[] = { 0x01, 0x02, 0x03, 0x04 };
 
+		// This must be ignored due to id=0.
+		extensions.emplace_back(
+		  0,     // id
+		  4,     // len
+		  value1 // value
+		);
+
+		// This must be ignored due to id>14.
+		extensions.emplace_back(
+		  15,    // id
+		  4,     // len
+		  value1 // value
+		);
+
 		extensions.emplace_back(
 		  1,     // id
 		  4,     // len
@@ -539,7 +553,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		uint8_t value3[] = { 0x01, 0x02, 0x03, 0x04 };
 
 		extensions.emplace_back(
-		  2,     // id
+		  14,    // id
 		  4,     // len
 		  value3 // value
 		);
@@ -616,6 +630,13 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		uint8_t value1[] = { 0x01, 0x02, 0x03, 0x04 };
 
+		// This must be ignored due to id=0.
+		extensions.emplace_back(
+		  0,     // id
+		  4,     // len
+		  value1 // value
+		);
+
 		extensions.emplace_back(
 		  1,     // id
 		  4,     // len
@@ -625,7 +646,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		uint8_t value2[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11 };
 
 		extensions.emplace_back(
-		  2,     // id
+		  22,    // id
 		  11,    // len
 		  value2 // value
 		);
@@ -648,7 +669,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		uint8_t value3[] = { 0x01, 0x02, 0x03, 0x04 };
 
 		extensions.emplace_back(
-		  2,     // id
+		  24,    // id
 		  4,     // len
 		  value3 // value
 		);

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -29,13 +29,13 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			FAIL("not a RTP packet");
 
 		REQUIRE(packet->HasMarker() == false);
-		REQUIRE(packet->HasExtensionHeader() == true);
+		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetPayloadType() == 111);
 		REQUIRE(packet->GetSequenceNumber() == 23617);
 		REQUIRE(packet->GetTimestamp() == 1660241882);
 		REQUIRE(packet->GetSsrc() == 2674985186);
-		REQUIRE(packet->GetExtensionHeaderId() == 0xBEDE);
-		REQUIRE(packet->GetExtensionHeaderLength() == 4);
+		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
+		REQUIRE(packet->GetHeaderExtensionLength() == 4);
 		REQUIRE(packet->HasOneByteExtensions());
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 
@@ -63,13 +63,13 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			FAIL("not a RTP packet");
 
 		REQUIRE(packet->HasMarker() == false);
-		REQUIRE(packet->HasExtensionHeader() == false);
+		REQUIRE(packet->HasHeaderExtension() == false);
 		REQUIRE(packet->GetPayloadType() == 100);
 		REQUIRE(packet->GetSequenceNumber() == 28478);
 		REQUIRE(packet->GetTimestamp() == 172320136);
 		REQUIRE(packet->GetSsrc() == 3316375386);
-		REQUIRE(packet->GetExtensionHeaderId() == 0);
-		REQUIRE(packet->GetExtensionHeaderLength() == 0);
+		REQUIRE(packet->GetHeaderExtensionId() == 0);
+		REQUIRE(packet->GetHeaderExtensionLength() == 0);
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 
@@ -94,13 +94,13 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			FAIL("not a RTP packet");
 
 		REQUIRE(packet->HasMarker() == false);
-		REQUIRE(packet->HasExtensionHeader() == true);
+		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetPayloadType() == 111);
 		REQUIRE(packet->GetSequenceNumber() == 19354);
 		REQUIRE(packet->GetTimestamp() == 863466045);
 		REQUIRE(packet->GetSsrc() == 235797202);
-		REQUIRE(packet->GetExtensionHeaderId() == 0xBEDE);
-		REQUIRE(packet->GetExtensionHeaderLength() == 8);
+		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
+		REQUIRE(packet->GetHeaderExtensionLength() == 8);
 		REQUIRE(packet->HasOneByteExtensions());
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 
@@ -130,13 +130,13 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		delete packet;
 
 		REQUIRE(clonedPacket->HasMarker() == false);
-		REQUIRE(clonedPacket->HasExtensionHeader() == true);
+		REQUIRE(clonedPacket->HasHeaderExtension() == true);
 		REQUIRE(clonedPacket->GetPayloadType() == 111);
 		REQUIRE(clonedPacket->GetSequenceNumber() == 19354);
 		REQUIRE(clonedPacket->GetTimestamp() == 863466045);
 		REQUIRE(clonedPacket->GetSsrc() == 235797202);
-		REQUIRE(clonedPacket->GetExtensionHeaderId() == 0xBEDE);
-		REQUIRE(clonedPacket->GetExtensionHeaderLength() == 8);
+		REQUIRE(clonedPacket->GetHeaderExtensionId() == 0xBEDE);
+		REQUIRE(clonedPacket->GetHeaderExtensionLength() == 8);
 		REQUIRE(clonedPacket->HasOneByteExtensions());
 		REQUIRE(clonedPacket->HasTwoBytesExtensions() == false);
 
@@ -164,7 +164,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		idMapping[1] = 11;
 		idMapping[3] = 13;
 
-		clonedPacket->MangleExtensionHeaderIds(idMapping);
+		clonedPacket->MangleHeaderExtensionIds(idMapping);
 
 		clonedPacket->SetAudioLevelExtensionId(11);
 		extenValue = clonedPacket->GetExtension(11, extenLen);
@@ -193,7 +193,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		delete clonedPacket;
 	}
 
-	SECTION("create RtpPacket without extension header")
+	SECTION("create RtpPacket without header extension")
 	{
 		// clang-format off
 		uint8_t buffer[] =
@@ -210,7 +210,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			FAIL("not a RTP packet");
 
 		REQUIRE(packet->HasMarker() == false);
-		REQUIRE(packet->HasExtensionHeader() == false);
+		REQUIRE(packet->HasHeaderExtension() == false);
 		REQUIRE(packet->GetPayloadType() == 1);
 		REQUIRE(packet->GetSequenceNumber() == 8);
 		REQUIRE(packet->GetTimestamp() == 4);
@@ -221,7 +221,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		delete packet;
 	}
 
-	SECTION("create RtpPacket with One-Byte extension header")
+	SECTION("create RtpPacket with One-Byte header extension")
 	{
 		// clang-format off
 		uint8_t buffer[] =
@@ -229,7 +229,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			0b10010000, 0b00000001, 0, 8,
 			0, 0, 0, 4,
 			0, 0, 0, 5,
-			0xBE, 0xDE, 0, 3, // Extension header
+			0xBE, 0xDE, 0, 3, // Header Extension
 			0b00010000, 0xFF, 0b00100001, 0xFF,
 			0xFF, 0, 0, 0b00110011,
 			0xFF, 0xFF, 0xFF, 0xFF
@@ -242,20 +242,20 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			FAIL("not a RTP packet");
 
 		REQUIRE(packet->HasMarker() == false);
-		REQUIRE(packet->HasExtensionHeader() == true);
+		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetPayloadType() == 1);
 		REQUIRE(packet->GetSequenceNumber() == 8);
 		REQUIRE(packet->GetTimestamp() == 4);
 		REQUIRE(packet->GetSsrc() == 5);
-		REQUIRE(packet->GetExtensionHeaderId() == 0xBEDE);
-		REQUIRE(packet->GetExtensionHeaderLength() == 12);
+		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
+		REQUIRE(packet->GetHeaderExtensionLength() == 12);
 		REQUIRE(packet->HasOneByteExtensions());
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 
 		delete packet;
 	}
 
-	SECTION("create RtpPacket with Two-Bytes extension header")
+	SECTION("create RtpPacket with Two-Bytes header extension")
 	{
 		// clang-format off
 		uint8_t buffer[] =
@@ -263,7 +263,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			0b10010000, 0b00000001, 0, 8,
 			0, 0, 0, 4,
 			0, 0, 0, 5,
-			0b00010000, 0, 0, 4, // Extension header
+			0b00010000, 0, 0, 4, // Header Extension
 			0, 0, 1, 0,
 			2, 1, 0x42, 0,
 			3, 2, 0x11, 0x22,
@@ -280,12 +280,12 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			FAIL("not a RTP packet");
 
 		REQUIRE(packet->HasMarker() == false);
-		REQUIRE(packet->HasExtensionHeader() == true);
+		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetPayloadType() == 1);
 		REQUIRE(packet->GetSequenceNumber() == 8);
 		REQUIRE(packet->GetTimestamp() == 4);
 		REQUIRE(packet->GetSsrc() == 5);
-		REQUIRE(packet->GetExtensionHeaderLength() == 16);
+		REQUIRE(packet->GetHeaderExtensionLength() == 16);
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions());
 
@@ -323,7 +323,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			0b10010000, 0b00000001, 0, 8,
 			0, 0, 0, 4,
 			0, 0, 0, 5,
-			0b00010000, 0, 0, 3, // Extension header
+			0b00010000, 0, 0, 3, // Header Extension
 			1, 0, 2, 1,
 			0xFF, 0, 3, 4,
 			0xFF, 0xFF, 0xFF, 0xFF,
@@ -341,13 +341,13 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			FAIL("not a RTP packet");
 
 		REQUIRE(packet->HasMarker() == false);
-		REQUIRE(packet->HasExtensionHeader() == true);
+		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetPayloadType() == 1);
 		REQUIRE(packet->GetSequenceNumber() == 8);
 		REQUIRE(packet->GetTimestamp() == 4);
 		REQUIRE(packet->GetSsrc() == 5);
 		REQUIRE(packet->GetPayloadLength() == 4);
-		REQUIRE(packet->GetExtensionHeaderLength() == 12);
+		REQUIRE(packet->GetHeaderExtensionLength() == 12);
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions());
 
@@ -358,26 +358,26 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		rtxPacket->RtxEncode(rtxPayloadType, rtxSsrc, rtxSeq);
 
 		REQUIRE(rtxPacket->HasMarker() == false);
-		REQUIRE(rtxPacket->HasExtensionHeader() == true);
+		REQUIRE(rtxPacket->HasHeaderExtension() == true);
 		REQUIRE(rtxPacket->GetPayloadType() == rtxPayloadType);
 		REQUIRE(rtxPacket->GetSequenceNumber() == rtxSeq);
 		REQUIRE(rtxPacket->GetTimestamp() == 4);
 		REQUIRE(rtxPacket->GetSsrc() == rtxSsrc);
 		REQUIRE(rtxPacket->GetPayloadLength() == 6);
-		REQUIRE(rtxPacket->GetExtensionHeaderLength() == 12);
+		REQUIRE(rtxPacket->GetHeaderExtensionLength() == 12);
 		REQUIRE(rtxPacket->HasOneByteExtensions() == false);
 		REQUIRE(rtxPacket->HasTwoBytesExtensions());
 
 		rtxPacket->RtxDecode(1, 5);
 
 		REQUIRE(rtxPacket->HasMarker() == false);
-		REQUIRE(rtxPacket->HasExtensionHeader() == true);
+		REQUIRE(rtxPacket->HasHeaderExtension() == true);
 		REQUIRE(rtxPacket->GetPayloadType() == 1);
 		REQUIRE(rtxPacket->GetSequenceNumber() == 8);
 		REQUIRE(rtxPacket->GetTimestamp() == 4);
 		REQUIRE(rtxPacket->GetSsrc() == 5);
 		REQUIRE(rtxPacket->GetPayloadLength() == 4);
-		REQUIRE(rtxPacket->GetExtensionHeaderLength() == 12);
+		REQUIRE(rtxPacket->GetHeaderExtensionLength() == 12);
 		REQUIRE(rtxPacket->HasOneByteExtensions() == false);
 		REQUIRE(rtxPacket->HasTwoBytesExtensions());
 
@@ -393,7 +393,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			0b10110000, 0b00000001, 0, 8,
 			0, 0, 0, 4,
 			0, 0, 0, 5,
-			0xBE, 0xDE, 0, 3, // Extension header
+			0xBE, 0xDE, 0, 3, // Header Extension
 			0b00010000, 0xFF, 0b00100001, 0xFF,
 			0xFF, 0, 0, 0b00110011,
 			0xFF, 0xFF, 0xFF, 0xFF,
@@ -418,9 +418,9 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetSequenceNumber() == 8);
 		REQUIRE(packet->GetTimestamp() == 4);
 		REQUIRE(packet->GetSsrc() == 5);
-		REQUIRE(packet->HasExtensionHeader() == true);
-		REQUIRE(packet->GetExtensionHeaderId() == 0xBEDE);
-		REQUIRE(packet->GetExtensionHeaderLength() == 12);
+		REQUIRE(packet->HasHeaderExtension() == true);
+		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
+		REQUIRE(packet->GetHeaderExtensionLength() == 12);
 		REQUIRE(packet->HasOneByteExtensions());
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 8);
@@ -482,4 +482,38 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		delete packet;
 	}
+
+	// SECTION("add One-Byte header extensions")
+	// {
+	// 	// clang-format off
+	// 	uint8_t buffer[] =
+	// 	{
+	// 		0b10010000, 0b00000001, 0, 8,
+	// 		0, 0, 0, 4,
+	// 		0, 0, 0, 5,
+	// 		0xBE, 0xDE, 0, 3, // Header Extension
+	// 		0b00010000, 0xFF, 0b00100001, 0xFF,
+	// 		0xFF, 0, 0, 0b00110011,
+	// 		0xFF, 0xFF, 0xFF, 0xFF
+	// 	};
+	// 	// clang-format on
+
+	// 	RtpPacket* packet = RtpPacket::Parse(buffer, sizeof(buffer));
+
+	// 	if (!packet)
+	// 		FAIL("not a RTP packet");
+
+	// 	REQUIRE(packet->HasMarker() == false);
+	// 	REQUIRE(packet->HasHeaderExtension() == true);
+	// 	REQUIRE(packet->GetPayloadType() == 1);
+	// 	REQUIRE(packet->GetSequenceNumber() == 8);
+	// 	REQUIRE(packet->GetTimestamp() == 4);
+	// 	REQUIRE(packet->GetSsrc() == 5);
+	// 	REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
+	// 	REQUIRE(packet->GetHeaderExtensionLength() == 12);
+	// 	REQUIRE(packet->HasOneByteExtensions());
+	// 	REQUIRE(packet->HasTwoBytesExtensions() == false);
+
+	// 	delete packet;
+	// }
 }

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -10,6 +10,7 @@ using namespace RTC;
 
 static uint8_t buffer[65536];
 static uint8_t buffer2[65536];
+static uint8_t buffer3[65536];
 
 SCENARIO("parse RTP packets", "[parser][rtp]")
 {
@@ -540,7 +541,10 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(clonedPacket->GetPayload()[0] == 0x11);
 		REQUIRE(clonedPacket->GetPayload()[clonedPacket->GetPayloadLength() - 1] == 0xCC);
 
+		auto* clonedPacket2 = packet->Clone(buffer3);
+
 		delete clonedPacket;
+		delete clonedPacket2;
 	}
 
 	SECTION("add Two-Bytes header extensions")
@@ -600,6 +604,9 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(clonedPacket->GetPayload()[0] == 0x11);
 		REQUIRE(clonedPacket->GetPayload()[clonedPacket->GetPayloadLength() - 1] == 0xCC);
 
+		auto* clonedPacket2 = packet->Clone(buffer3);
+
 		delete clonedPacket;
+		delete clonedPacket2;
 	}
 }

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -643,6 +643,29 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 
+		extensions.clear();
+
+		uint8_t value3[] = { 0x01, 0x02, 0x03, 0x04 };
+
+		extensions.emplace_back(
+		  2,     // id
+		  4,     // len
+		  value3 // value
+		);
+
+		packet->SetExtensions(2, extensions);
+
+		REQUIRE(packet->GetSize() == 40);
+		REQUIRE(packet->HasHeaderExtension() == true);
+		REQUIRE(packet->GetHeaderExtensionId() == 0b0001000000000000);
+		REQUIRE(packet->GetHeaderExtensionLength() == 8);
+		REQUIRE(packet->HasOneByteExtensions() == false);
+		REQUIRE(packet->HasTwoBytesExtensions() == true);
+		REQUIRE(packet->GetPayloadLength() == 12);
+		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayload()[0] == 0x11);
+		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
+
 		delete packet;
 	}
 }


### PR DESCRIPTION
So we can now add RTP header extensions and decide which one should go in each packet (rather than just overwriting existing `ids` as before).