### PR TITLE
Simulcast: proper RTP timestamp rewrite based on SenderReport NTP offset

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "npm run test:node && npm run test:worker",
     "test:node": "make -C worker && jest",
     "test:worker": "make test -C worker",
-    "coverage:node": "make -C worker && jest --coverage && opn coverage/lcov-report/index.html",
+    "coverage:node": "make -C worker && jest --coverage && open-cli coverage/lcov-report/index.html",
     "postinstall": "make -C worker"
   },
   "jest": {
@@ -55,7 +55,7 @@
     "gulp-clang-format": "^1.0.27",
     "jest": "^24.8.0",
     "jest-tobetype": "^1.2.3",
-    "opn-cli": "^4.1.0"
+    "open-cli": "^5.0.0"
   },
   "optionalDependencies": {
     "clang-tools-prebuilt": "^0.1.4"

--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -60,7 +60,8 @@ namespace RTC
 		virtual void ProducerRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc)    = 0;
 		virtual void ProducerNewRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) = 0;
 		virtual void ProducerRtpStreamScore(
-		  RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) = 0;
+		  RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore)       = 0;
+		virtual void ProducerSenderReport(RTC::RtpStream* rtpStream, bool first) = 0;
 		void ProducerClosed();
 		virtual void SetExternallyManagedBitrate();
 		virtual int16_t GetBitratePriority() const;

--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -60,8 +60,8 @@ namespace RTC
 		virtual void ProducerRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc)    = 0;
 		virtual void ProducerNewRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) = 0;
 		virtual void ProducerRtpStreamScore(
-		  RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore)       = 0;
-		virtual void ProducerSenderReport(RTC::RtpStream* rtpStream, bool first) = 0;
+		  RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore)           = 0;
+		virtual void ProducerRtcpSenderReport(RTC::RtpStream* rtpStream, bool first) = 0;
 		void ProducerClosed();
 		virtual void SetExternallyManagedBitrate();
 		virtual int16_t GetBitratePriority() const;

--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -21,7 +21,7 @@ namespace RTC
 		void ProducerRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerNewRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerRtpStreamScore(RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) override;
-		void ProducerSenderReport(RTC::RtpStream* rtpStream, bool first) override;
+		void ProducerRtcpSenderReport(RTC::RtpStream* rtpStream, bool first) override;
 		void SendRtpPacket(RTC::RtpPacket* packet) override;
 		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t now) override;
 		std::vector<RTC::RtpStreamSend*> GetRtpStreams() override;

--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -21,6 +21,7 @@ namespace RTC
 		void ProducerRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerNewRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerRtpStreamScore(RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) override;
+		void ProducerSenderReport(RTC::RtpStream* rtpStream, bool first) override;
 		void SendRtpPacket(RTC::RtpPacket* packet) override;
 		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t now) override;
 		std::vector<RTC::RtpStreamSend*> GetRtpStreams() override;

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -30,7 +30,7 @@ namespace RTC
 			  RTC::Producer* producer, RTC::RtpStream* rtpStream, uint32_t mappedSsrc) = 0;
 			virtual void OnProducerRtpStreamScore(
 			  RTC::Producer* producer, RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) = 0;
-			virtual void OnProducerSenderReport(
+			virtual void OnProducerRtcpSenderReport(
 			  RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first)                         = 0;
 			virtual void OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RtpPacket* packet) = 0;
 			virtual void OnProducerSendRtcpPacket(RTC::Producer* producer, RTC::RTCP::Packet* packet) = 0;

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -30,6 +30,8 @@ namespace RTC
 			  RTC::Producer* producer, RTC::RtpStream* rtpStream, uint32_t mappedSsrc) = 0;
 			virtual void OnProducerRtpStreamScore(
 			  RTC::Producer* producer, RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) = 0;
+			virtual void OnProducerSenderReport(
+			  RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first)                         = 0;
 			virtual void OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RtpPacket* packet) = 0;
 			virtual void OnProducerSendRtcpPacket(RTC::Producer* producer, RTC::RTCP::Packet* packet) = 0;
 			virtual void OnProducerNeedWorstRemoteFractionLost(

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -52,7 +52,7 @@ namespace RTC
 		  RTC::RtpStream* rtpStream,
 		  uint8_t score,
 		  uint8_t previousScore) override;
-		void OnTransportProducerSenderReport(
+		void OnTransportProducerRtcpSenderReport(
 		  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first) override;
 		void OnTransportProducerRtpPacketReceived(
 		  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpPacket* packet) override;

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -46,6 +46,14 @@ namespace RTC
 		  RTC::Producer* producer,
 		  RTC::RtpStream* rtpStream,
 		  uint32_t mappedSsrc) override;
+		void OnTransportProducerRtpStreamScore(
+		  RTC::Transport* transport,
+		  RTC::Producer* producer,
+		  RTC::RtpStream* rtpStream,
+		  uint8_t score,
+		  uint8_t previousScore) override;
+		void OnTransportProducerSenderReport(
+		  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first) override;
 		void OnTransportProducerRtpPacketReceived(
 		  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpPacket* packet) override;
 		void OnTransportNeedWorstRemoteFractionLost(
@@ -53,12 +61,6 @@ namespace RTC
 		  RTC::Producer* producer,
 		  uint32_t mappedSsrc,
 		  uint8_t& worstRemoteFractionLost) override;
-		void OnTransportProducerRtpStreamScore(
-		  RTC::Transport* transport,
-		  RTC::Producer* producer,
-		  RTC::RtpStream* rtpStream,
-		  uint8_t score,
-		  uint8_t previousScore) override;
 		void OnTransportNewConsumer(
 		  RTC::Transport* transport, RTC::Consumer* consumer, std::string& producerId) override;
 		void OnTransportConsumerClosed(RTC::Transport* transport, RTC::Consumer* consumer) override;

--- a/worker/include/RTC/RtpStream.hpp
+++ b/worker/include/RTC/RtpStream.hpp
@@ -79,6 +79,8 @@ namespace RTC
 		uint8_t GetFractionLost() const;
 		float GetLossPercentage() const;
 		uint64_t GetMaxPacketMs() const;
+		uint64_t GetSenderReportNtp() const;
+		uint32_t GetSenderReportTs() const;
 		uint8_t GetScore() const;
 
 	protected:
@@ -86,7 +88,7 @@ namespace RTC
 		void UpdateScore(uint8_t score);
 		void PacketRetransmitted(RTC::RtpPacket* packet);
 		void PacketRepaired(RTC::RtpPacket* packet);
-		uint32_t GetExpectedPackets();
+		uint32_t GetExpectedPackets() const;
 
 	private:
 		void InitSeq(uint16_t seq);
@@ -112,9 +114,11 @@ namespace RTC
 		size_t nackPacketCount{ 0 };
 		size_t pliCount{ 0 };
 		size_t firCount{ 0 };
-		size_t repairedPrior{ 0 };      // Packets repaired at last interval.
-		size_t retransmittedPrior{ 0 }; // Packets retransmitted at last interval.
-		uint32_t expectedPrior{ 0 };    // Packets expected at last interval.
+		size_t repairedPrior{ 0 };         // Packets repaired at last interval.
+		size_t retransmittedPrior{ 0 };    // Packets retransmitted at last interval.
+		uint32_t expectedPrior{ 0 };       // Packets expected at last interval.
+		uint64_t lastSenderReportNtp{ 0 }; // NTP timestamp in last Sender Report.
+		uint32_t lastSenderReporTs{ 0 };   // RTP timestamp in last Sender Report.
 
 	private:
 		// Score related.
@@ -206,14 +210,24 @@ namespace RTC
 		return this->maxPacketMs;
 	}
 
-	inline uint32_t RtpStream::GetExpectedPackets()
+	inline uint64_t RtpStream::GetSenderReportNtp() const
 	{
-		return (this->cycles + this->maxSeq) - this->baseSeq + 1;
+		return this->lastSenderReportNtp;
+	}
+
+	inline uint32_t RtpStream::GetSenderReportTs() const
+	{
+		return this->lastSenderReporTs;
 	}
 
 	inline uint8_t RtpStream::GetScore() const
 	{
 		return this->score;
+	}
+
+	inline uint32_t RtpStream::GetExpectedPackets() const
+	{
+		return (this->cycles + this->maxSeq) - this->baseSeq + 1;
 	}
 } // namespace RTC
 

--- a/worker/include/RTC/RtpStream.hpp
+++ b/worker/include/RTC/RtpStream.hpp
@@ -79,7 +79,7 @@ namespace RTC
 		uint8_t GetFractionLost() const;
 		float GetLossPercentage() const;
 		uint64_t GetMaxPacketMs() const;
-		uint64_t GetSenderReportNtp() const;
+		uint64_t GetSenderReportNtpMs() const;
 		uint32_t GetSenderReportTs() const;
 		uint8_t GetScore() const;
 
@@ -114,11 +114,11 @@ namespace RTC
 		size_t nackPacketCount{ 0 };
 		size_t pliCount{ 0 };
 		size_t firCount{ 0 };
-		size_t repairedPrior{ 0 };         // Packets repaired at last interval.
-		size_t retransmittedPrior{ 0 };    // Packets retransmitted at last interval.
-		uint32_t expectedPrior{ 0 };       // Packets expected at last interval.
-		uint64_t lastSenderReportNtp{ 0 }; // NTP timestamp in last Sender Report.
-		uint32_t lastSenderReporTs{ 0 };   // RTP timestamp in last Sender Report.
+		size_t repairedPrior{ 0 };           // Packets repaired at last interval.
+		size_t retransmittedPrior{ 0 };      // Packets retransmitted at last interval.
+		uint32_t expectedPrior{ 0 };         // Packets expected at last interval.
+		uint64_t lastSenderReportNtpMs{ 0 }; // NTP timestamp in last Sender Report (in ms).
+		uint32_t lastSenderReporTs{ 0 };     // RTP timestamp in last Sender Report.
 
 	private:
 		// Score related.
@@ -210,9 +210,9 @@ namespace RTC
 		return this->maxPacketMs;
 	}
 
-	inline uint64_t RtpStream::GetSenderReportNtp() const
+	inline uint64_t RtpStream::GetSenderReportNtpMs() const
 	{
-		return this->lastSenderReportNtp;
+		return this->lastSenderReportNtpMs;
 	}
 
 	inline uint32_t RtpStream::GetSenderReportTs() const

--- a/worker/include/RTC/RtpStream.hpp
+++ b/worker/include/RTC/RtpStream.hpp
@@ -79,6 +79,7 @@ namespace RTC
 		uint8_t GetFractionLost() const;
 		float GetLossPercentage() const;
 		uint64_t GetMaxPacketMs() const;
+		uint32_t GetMaxPacketTs() const;
 		uint64_t GetSenderReportNtpMs() const;
 		uint32_t GetSenderReportTs() const;
 		uint8_t GetScore() const;
@@ -208,6 +209,11 @@ namespace RTC
 	inline uint64_t RtpStream::GetMaxPacketMs() const
 	{
 		return this->maxPacketMs;
+	}
+
+	inline uint32_t RtpStream::GetMaxPacketTs() const
+	{
+		return this->maxPacketTs;
 	}
 
 	inline uint64_t RtpStream::GetSenderReportNtpMs() const

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -22,7 +22,7 @@ namespace RTC
 		void ProducerRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerNewRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerRtpStreamScore(RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) override;
-		void ProducerSenderReport(RTC::RtpStream* rtpStream, bool first) override;
+		void ProducerRtcpSenderReport(RTC::RtpStream* rtpStream, bool first) override;
 		void SendRtpPacket(RTC::RtpPacket* packet) override;
 		std::vector<RTC::RtpStreamSend*> GetRtpStreams() override;
 		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t now) override;

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -22,6 +22,7 @@ namespace RTC
 		void ProducerRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerNewRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerRtpStreamScore(RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) override;
+		void ProducerSenderReport(RTC::RtpStream* rtpStream, bool first) override;
 		void SendRtpPacket(RTC::RtpPacket* packet) override;
 		std::vector<RTC::RtpStreamSend*> GetRtpStreams() override;
 		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t now) override;

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -73,7 +73,6 @@ namespace RTC
 		bool keyFrameSupported{ false };
 		bool syncRequired{ false };
 		RTC::SeqManager<uint16_t> rtpSeqManager;
-		RTC::SeqManager<uint32_t> rtpTimestampManager;
 		int16_t preferredSpatialLayer{ -1 };
 		int16_t preferredTemporalLayer{ -1 };
 		int16_t provisionalTargetSpatialLayer{ -1 };
@@ -85,6 +84,7 @@ namespace RTC
 		int16_t tsReferenceSpatialLayer{ -1 }; // Used for RTP TS sync.
 		std::unique_ptr<RTC::Codecs::EncodingContext> encodingContext;
 		bool externallyManagedBitrate{ false };
+		uint32_t tsOffset{ 0 }; // RTP Timestamp offset.
 	};
 
 	/* Inline methods. */

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -85,6 +85,8 @@ namespace RTC
 		std::unique_ptr<RTC::Codecs::EncodingContext> encodingContext;
 		bool externallyManagedBitrate{ false };
 		uint32_t tsOffset{ 0 }; // RTP Timestamp offset.
+		uint32_t tsExtraOffset{ 0 };
+		uint32_t lastIncreasedOriginalTs{ 0 };
 	};
 
 	/* Inline methods. */

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -56,6 +56,7 @@ namespace RTC
 		void EmitLayersChange() const;
 		RTC::RtpStream* GetProducerCurrentRtpStream() const;
 		RTC::RtpStream* GetProducerTargetRtpStream() const;
+		RTC::RtpStream* GetProducerTsReferenceRtpStream() const;
 
 		/* Pure virtual methods inherited from RtpStreamSend::Listener. */
 	public:
@@ -81,6 +82,7 @@ namespace RTC
 		int16_t targetTemporalLayer{ -1 };
 		int16_t currentSpatialLayer{ -1 };
 		int16_t currentTemporalLayer{ -1 };
+		int16_t tsReferenceSpatialLayer{ -1 }; // Used for RTP TS sync.
 		std::unique_ptr<RTC::Codecs::EncodingContext> encodingContext;
 		bool externallyManagedBitrate{ false };
 	};

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -23,6 +23,7 @@ namespace RTC
 		void ProducerRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerNewRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerRtpStreamScore(RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) override;
+		void ProducerSenderReport(RTC::RtpStream* rtpStream, bool first) override;
 		void SetExternallyManagedBitrate() override;
 		int16_t GetBitratePriority() const override;
 		uint32_t UseAvailableBitrate(uint32_t bitrate) override;
@@ -50,6 +51,7 @@ namespace RTC
 		bool RecalculateTargetLayers(int16_t& newTargetSpatialLayer, int16_t& newTargetTemporalLayer) const;
 		void UpdateTargetLayers(int16_t newTargetSpatialLayer, int16_t newTargetTemporalLayer);
 		void UpdateCurrentLayers();
+		bool CanSwitchToSpatialLayer(int16_t spatialLayer) const;
 		void EmitScore() const;
 		void EmitLayersChange() const;
 		RTC::RtpStream* GetProducerCurrentRtpStream() const;

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -23,7 +23,7 @@ namespace RTC
 		void ProducerRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerNewRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerRtpStreamScore(RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) override;
-		void ProducerSenderReport(RTC::RtpStream* rtpStream, bool first) override;
+		void ProducerRtcpSenderReport(RTC::RtpStream* rtpStream, bool first) override;
 		void SetExternallyManagedBitrate() override;
 		int16_t GetBitratePriority() const override;
 		uint32_t UseAvailableBitrate(uint32_t bitrate) override;

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -44,6 +44,8 @@ namespace RTC
 			  RTC::RtpStream* rtpStream,
 			  uint8_t score,
 			  uint8_t previousScore) = 0;
+			virtual void OnTransportProducerSenderReport(
+			  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first) = 0;
 			virtual void OnTransportProducerRtpPacketReceived(
 			  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpPacket* packet) = 0;
 			virtual void OnTransportNeedWorstRemoteFractionLost(
@@ -112,6 +114,7 @@ namespace RTC
 		  RTC::Producer* producer, RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void OnProducerRtpStreamScore(
 		  RTC::Producer* producer, RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) override;
+		void OnProducerSenderReport(RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first) override;
 		void OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RtpPacket* packet) override;
 		void OnProducerSendRtcpPacket(RTC::Producer* producer, RTC::RTCP::Packet* packet) override;
 		void OnProducerNeedWorstRemoteFractionLost(

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -44,7 +44,7 @@ namespace RTC
 			  RTC::RtpStream* rtpStream,
 			  uint8_t score,
 			  uint8_t previousScore) = 0;
-			virtual void OnTransportProducerSenderReport(
+			virtual void OnTransportProducerRtcpSenderReport(
 			  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first) = 0;
 			virtual void OnTransportProducerRtpPacketReceived(
 			  RTC::Transport* transport, RTC::Producer* producer, RTC::RtpPacket* packet) = 0;
@@ -114,7 +114,8 @@ namespace RTC
 		  RTC::Producer* producer, RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void OnProducerRtpStreamScore(
 		  RTC::Producer* producer, RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) override;
-		void OnProducerSenderReport(RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first) override;
+		void OnProducerRtcpSenderReport(
+		  RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first) override;
 		void OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RtpPacket* packet) override;
 		void OnProducerSendRtcpPacket(RTC::Producer* producer, RTC::RTCP::Packet* packet) override;
 		void OnProducerNeedWorstRemoteFractionLost(

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -308,7 +308,7 @@ namespace Utils
 
 	inline Time::Ntp Time::TimeMs2Ntp(uint64_t ms)
 	{
-		Time::Ntp ntp;
+		Time::Ntp ntp; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 		ntp.seconds = ms / 1000;
 		ntp.fractions =

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -3,6 +3,7 @@
 
 #include "common.hpp"
 #include <openssl/hmac.h>
+#include <cmath>
 #include <cstring> // std::memcmp(), std::memcpy()
 #include <string>
 
@@ -300,19 +301,30 @@ namespace Utils
 		};
 
 		static Time::Ntp TimeMs2Ntp(uint64_t ms);
+		static uint64_t Ntp2TimeMs(Time::Ntp ntp);
 		static bool IsNewerTimestamp(uint32_t timestamp, uint32_t prevTimestamp);
 		static uint32_t LatestTimestamp(uint32_t timestamp1, uint32_t timestamp2);
 	};
 
 	inline Time::Ntp Time::TimeMs2Ntp(uint64_t ms)
 	{
-		Ntp ntp;
+		Time::Ntp ntp;
 
 		ntp.seconds = ms / 1000;
 		ntp.fractions =
-		  static_cast<uint32_t>(static_cast<double>(ms % 1000) / 1000 * Utils::Time::NtpFractionalUnit);
+		  static_cast<uint32_t>((static_cast<double>(ms % 1000) / 1000) * NtpFractionalUnit);
 
 		return ntp;
+	}
+
+	inline uint64_t Time::Ntp2TimeMs(Time::Ntp ntp)
+	{
+		// clang-format off
+		return (
+			static_cast<uint64_t>(ntp.seconds) * 1000 +
+			static_cast<uint64_t>(std::round((static_cast<double>(ntp.fractions) * 1000) / NtpFractionalUnit))
+		);
+		// clang-format on
 	}
 
 	inline bool Time::IsNewerTimestamp(uint32_t timestamp, uint32_t prevTimestamp)

--- a/worker/mediasoup-worker.gyp
+++ b/worker/mediasoup-worker.gyp
@@ -308,6 +308,7 @@
         'test/src/Utils/TestBits.cpp',
         'test/src/Utils/TestIP.cpp',
         'test/src/Utils/TestString.cpp',
+        'test/src/Utils/TestTime.cpp',
         # C++ include files.
         'test/include/catch.hpp',
         'test/include/helpers.hpp'

--- a/worker/src/RTC/Codecs/VP8.cpp
+++ b/worker/src/RTC/Codecs/VP8.cpp
@@ -180,8 +180,8 @@ namespace RTC
 			// Check whether pictureId and tl0PictureIndex sync is required.
 			if (context->syncRequired)
 			{
-				context->pictureIdManager.Sync(this->payloadDescriptor->pictureId);
-				context->tl0PictureIndexManager.Sync(this->payloadDescriptor->tl0PictureIndex);
+				context->pictureIdManager.Sync(this->payloadDescriptor->pictureId - 1);
+				context->tl0PictureIndexManager.Sync(this->payloadDescriptor->tl0PictureIndex - 1);
 				context->syncRequired = false;
 			}
 

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -126,7 +126,7 @@ namespace RTC
 		// Do nothing.
 	}
 
-	void PipeConsumer::ProducerSenderReport(RTC::RtpStream* /*rtpStream*/, bool /*first*/)
+	void PipeConsumer::ProducerRtcpSenderReport(RTC::RtpStream* /*rtpStream*/, bool /*first*/)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -169,7 +169,7 @@ namespace RTC
 			if (packet->IsKeyFrame())
 				MS_DEBUG_TAG(rtp, "sync key frame received");
 
-			rtpSeqManager.Sync(packet->GetSequenceNumber());
+			rtpSeqManager.Sync(packet->GetSequenceNumber() - 1);
 
 			syncRequired = false;
 		}

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -126,6 +126,13 @@ namespace RTC
 		// Do nothing.
 	}
 
+	void PipeConsumer::ProducerSenderReport(RTC::RtpStream* /*rtpStream*/, bool /*first*/)
+	{
+		MS_TRACE();
+
+		// Do nothing.
+	}
+
 	void PipeConsumer::SendRtpPacket(RTC::RtpPacket* packet)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -532,9 +532,12 @@ namespace RTC
 			return;
 		}
 
-		auto* rtpStream = it->second;
+		auto* rtpStream          = it->second;
+		bool isFirstSenderReport = rtpStream->GetSenderReportNtp() != 0;
 
 		rtpStream->ReceiveRtcpSenderReport(report);
+
+		this->listener->OnProducerSenderReport(this, rtpStream, isFirstSenderReport);
 	}
 
 	void Producer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t now)

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -532,12 +532,12 @@ namespace RTC
 			return;
 		}
 
-		auto* rtpStream          = it->second;
-		bool isFirstSenderReport = rtpStream->GetSenderReportNtp() != 0;
+		auto* rtpStream = it->second;
+		bool first      = rtpStream->GetSenderReportNtpMs() == 0;
 
 		rtpStream->ReceiveRtcpSenderReport(report);
 
-		this->listener->OnProducerSenderReport(this, rtpStream, isFirstSenderReport);
+		this->listener->OnProducerRtcpSenderReport(this, rtpStream, first);
 	}
 
 	void Producer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t now)

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -578,7 +578,7 @@ namespace RTC
 		}
 	}
 
-	inline void Router::OnTransportProducerSenderReport(
+	inline void Router::OnTransportProducerRtcpSenderReport(
 	  RTC::Transport* /*transport*/, RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first)
 	{
 		MS_TRACE();
@@ -587,7 +587,7 @@ namespace RTC
 
 		for (auto* consumer : consumers)
 		{
-			consumer->ProducerSenderReport(rtpStream, first);
+			consumer->ProducerRtcpSenderReport(rtpStream, first);
 		}
 	}
 

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -578,6 +578,19 @@ namespace RTC
 		}
 	}
 
+	inline void Router::OnTransportProducerSenderReport(
+	  RTC::Transport* /*transport*/, RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first)
+	{
+		MS_TRACE();
+
+		auto& consumers = this->mapProducerConsumers.at(producer);
+
+		for (auto* consumer : consumers)
+		{
+			consumer->ProducerSenderReport(rtpStream, first);
+		}
+	}
+
 	inline void Router::OnTransportProducerRtpPacketReceived(
 	  RTC::Transport* /*transport*/, RTC::Producer* producer, RTC::RtpPacket* packet)
 	{

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -428,7 +428,7 @@ namespace RTC
 		this->lastSrTimestamp += report->GetNtpFrac() >> 16;
 
 		// Update info about last Sender Report.
-		Utils::Time::Ntp ntp;
+		Utils::Time::Ntp ntp; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 		ntp.seconds   = report->GetNtpSec();
 		ntp.fractions = report->GetNtpFrac();

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -4,6 +4,7 @@
 #include "RTC/RtpStreamRecv.hpp"
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
+#include "Utils.hpp"
 #include "RTC/Codecs/Codecs.hpp"
 
 namespace RTC
@@ -425,6 +426,15 @@ namespace RTC
 		this->lastSrReceived  = DepLibUV::GetTime();
 		this->lastSrTimestamp = report->GetNtpSec() << 16;
 		this->lastSrTimestamp += report->GetNtpFrac() >> 16;
+
+		// Update info about last Sender Report.
+		Utils::Time::Ntp ntp;
+
+		ntp.seconds   = report->GetNtpSec();
+		ntp.fractions = report->GetNtpFrac();
+
+		this->lastSenderReportNtpMs = Utils::Time::Ntp2TimeMs(ntp);
+		this->lastSenderReporTs     = report->GetRtpTs();
 
 		// Update the score with the current RR.
 		UpdateScore();

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -179,9 +179,13 @@ namespace RTC
 		report->SetSsrc(GetSsrc());
 		report->SetPacketCount(this->transmissionCounter.GetPacketCount());
 		report->SetOctetCount(this->transmissionCounter.GetBytes());
-		report->SetRtpTs(this->maxPacketTs + diffTs);
 		report->SetNtpSec(ntp.seconds);
 		report->SetNtpFrac(ntp.fractions);
+		report->SetRtpTs(this->maxPacketTs + diffTs);
+
+		// Update info about last Sender Report.
+		this->lastSenderReportNtpMs = now;
+		this->lastSenderReporTs     = this->maxPacketTs + diffTs;
 
 		return report;
 	}

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -174,7 +174,7 @@ namespace RTC
 
 		// Calculate TS difference between now and maxPacketMs.
 		auto diffMs = now - this->maxPacketMs;
-		auto diffTs = diffMs * this->GetClockRate() / 1000;
+		auto diffTs = diffMs * GetClockRate() / 1000;
 
 		report->SetSsrc(GetSsrc());
 		report->SetPacketCount(this->transmissionCounter.GetPacketCount());

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -42,7 +42,7 @@ namespace RTC
 	void SeqManager<T>::Sync(T input)
 	{
 		// Update base.
-		this->base = this->maxOutput - input + 1;
+		this->base = this->maxOutput - input;
 
 		// Update maxInput.
 		this->maxInput = input;

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -124,7 +124,7 @@ namespace RTC
 		EmitScore();
 	}
 
-	void SimpleConsumer::ProducerSenderReport(RTC::RtpStream* /*rtpStream*/, bool /*first*/)
+	void SimpleConsumer::ProducerRtcpSenderReport(RTC::RtpStream* /*rtpStream*/, bool /*first*/)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -124,6 +124,13 @@ namespace RTC
 		EmitScore();
 	}
 
+	void SimpleConsumer::ProducerSenderReport(RTC::RtpStream* /*rtpStream*/, bool /*first*/)
+	{
+		MS_TRACE();
+
+		// Do nothing.
+	}
+
 	void SimpleConsumer::SendRtpPacket(RTC::RtpPacket* packet)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -163,7 +163,7 @@ namespace RTC
 			if (packet->IsKeyFrame())
 				MS_DEBUG_TAG(rtp, "sync key frame received");
 
-			this->rtpSeqManager.Sync(packet->GetSequenceNumber());
+			this->rtpSeqManager.Sync(packet->GetSequenceNumber() - 1);
 
 			this->syncRequired = false;
 		}

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -675,8 +675,8 @@ namespace RTC
 			if (!kk)
 			{
 				kk = true;
-				this->rtpSeqManager.Offset(packet->GetSequenceNumber() - 1);
-				this->rtpTimestampManager.Offset(packet->GetTimestamp() - 1);
+				// this->rtpSeqManager.Offset(packet->GetSequenceNumber() - 1);
+				// this->rtpTimestampManager.Offset(packet->GetTimestamp());
 			}
 
 			// If this is the RTP stream we use as TS reference, do NTP based RTP TS synchronization.

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -714,8 +714,8 @@ namespace RTC
 				// sending RTP packet.
 				this->tsOffset = newTs2 - ts1;
 
-				// NOTE: Usually wehn switching to a higher spatial layer, the resulting TS for the
-				// this keyframe mathes the TS of the latest packet sent. This may due due the encoder
+				// NOTE: Usually when switching to a higher spatial layer, the resulting TS for this
+				// keyframe mathes the TS of the latest packet sent. This may happen due due the encoder
 				// and the generation of a keyframe. If so, decrement the offset in 1.
 				if (packet->GetTimestamp() - this->tsOffset == this->rtpStream->GetMaxPacketTs())
 				{

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -661,7 +661,7 @@ namespace RTC
 				MS_DEBUG_TAG(rtp, "sync key frame received");
 
 			// Sync our RTP stream's sequence number.
-			this->rtpSeqManager.Sync(packet->GetSequenceNumber());
+			this->rtpSeqManager.Sync(packet->GetSequenceNumber() - 1);
 
 			// Sync our RTP stream's RTP timestamp.
 

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -714,9 +714,10 @@ namespace RTC
 				// sending RTP packet.
 				this->tsOffset = newTs2 - ts1;
 
-				// NOTE: Usually when switching to a higher spatial layer, the resulting TS for this
-				// keyframe mathes the TS of the latest packet sent. This may happen due due the encoder
-				// and the generation of a keyframe. If so, decrement the offset in 1.
+				// NOTE: When switching between spatial layers, the resulting TS for this
+				// keyframe may match the TS of the latest packet sent. This is legit
+				// since the encoder is encoding two (or more) different streams at the
+				// same time. If so, decrement the offset in 1.
 				if (packet->GetTimestamp() - this->tsOffset == this->rtpStream->GetMaxPacketTs())
 				{
 					// TODO: REMOVE

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -675,8 +675,8 @@ namespace RTC
 			if (!kk)
 			{
 				kk = true;
-				// this->rtpSeqManager.Offset(packet->GetSequenceNumber() - 1);
-				// this->rtpTimestampManager.Offset(packet->GetTimestamp());
+				this->rtpSeqManager.Offset(packet->GetSequenceNumber() - 1);
+				this->rtpTimestampManager.Offset(packet->GetTimestamp());
 			}
 
 			// If this is the RTP stream we use as TS reference, do NTP based RTP TS synchronization.
@@ -734,6 +734,11 @@ namespace RTC
 							diffTs,
 							tsOffset);
 			}
+			// TMP.
+			else
+			{
+				MS_ERROR("sending reference Spatial layer!!");
+			}
 
 			if (this->encodingContext)
 				this->encodingContext->SyncRequired();
@@ -779,6 +784,13 @@ namespace RTC
 
 		if (isSyncPacket)
 		{
+			if (timestamp <= this->rtpStream->GetMaxPacketTs())
+			{
+				// TMP.
+				MS_ERROR("sending lower timestamp than before: timestamp:%" PRIu32 ", maxPacketTs:%" PRIu32,
+						timestamp, this->rtpStream->GetMaxPacketTs());
+			}
+
 			MS_DEBUG_TAG(
 			  rtp,
 			  "sending sync packet [ssrc:%" PRIu32 ", seq:%" PRIu16 ", ts:%" PRIu32

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -839,12 +839,12 @@ namespace RTC
 		this->listener->OnTransportProducerRtpStreamScore(this, producer, rtpStream, score, previousScore);
 	}
 
-	inline void Transport::OnProducerSenderReport(
+	inline void Transport::OnProducerRtcpSenderReport(
 	  RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first)
 	{
 		MS_TRACE();
 
-		this->listener->OnTransportProducerSenderReport(this, producer, rtpStream, first);
+		this->listener->OnTransportProducerRtcpSenderReport(this, producer, rtpStream, first);
 	}
 
 	inline void Transport::OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RtpPacket* packet)

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -839,6 +839,14 @@ namespace RTC
 		this->listener->OnTransportProducerRtpStreamScore(this, producer, rtpStream, score, previousScore);
 	}
 
+	inline void Transport::OnProducerSenderReport(
+	  RTC::Producer* producer, RTC::RtpStream* rtpStream, bool first)
+	{
+		MS_TRACE();
+
+		this->listener->OnTransportProducerSenderReport(this, producer, rtpStream, first);
+	}
+
 	inline void Transport::OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RtpPacket* packet)
 	{
 		MS_TRACE();

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -25,7 +25,7 @@ void validate(SeqManager<uint16_t>& seqManager, std::vector<TestSeqManagerInput>
 	for (auto& element : inputs)
 	{
 		if (element.sync)
-			seqManager.Sync(element.input);
+			seqManager.Sync(element.input - 1);
 
 		if (element.offset)
 			seqManager.Offset(element.offset);

--- a/worker/test/src/Utils/TestTime.cpp
+++ b/worker/test/src/Utils/TestTime.cpp
@@ -1,0 +1,18 @@
+#include "common.hpp"
+#include "DepLibUV.hpp"
+#include "Utils.hpp"
+#include "catch.hpp"
+
+using namespace Utils;
+
+SCENARIO("Utils::Time::TimeMs2Ntp() and Utils::Time::Ntp2TimeMs()")
+{
+	auto now  = DepLibUV::GetTime();
+	auto ntp  = Time::TimeMs2Ntp(now);
+	auto now2 = Time::Ntp2TimeMs(ntp);
+	auto ntp2 = Time::TimeMs2Ntp(now2);
+
+	REQUIRE(now2 == now);
+	REQUIRE(ntp2.seconds == ntp.seconds);
+	REQUIRE(ntp2.fractions == ntp.fractions);
+}


### PR DESCRIPTION
This avoids lipsync issues. This PR also takes into account cases in which the key frame of the switched stream has a RTP timestamp lower than the last sent and fixes it be gradually decreasing the sent timestamp.