### PR TITLE
Skip worker compilation

### DIFF
--- a/worker/Makefile
+++ b/worker/Makefile
@@ -13,18 +13,24 @@ MEDIASOUP_BUILDTYPE ?= Release
 	docker-build docker-run
 
 default:
-	$(PYTHON) ./scripts/configure.py -R mediasoup-worker
-	$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
+	ifeq ($(MEDIASOUP_WORKER_BIN),)
+		$(PYTHON) ./scripts/configure.py -R mediasoup-worker
+		$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
+	endif
 
 test:
-	$(PYTHON) ./scripts/configure.py -R mediasoup-worker-test
-	$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
-	./deps/lcov/bin/lcov --directory ./ --zerocounters
-	./out/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker-test --invisibles --use-colour=yes $(MEDIASOUP_TEST_TAGS)
+	ifeq ($(MEDIASOUP_WORKER_BIN),)
+		$(PYTHON) ./scripts/configure.py -R mediasoup-worker-test
+		$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
+		./deps/lcov/bin/lcov --directory ./ --zerocounters
+		./out/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker-test --invisibles --use-colour=yes $(MEDIASOUP_TEST_TAGS)
+	endif
 
 fuzzer:
-	$(PYTHON) ./scripts/configure.py -R mediasoup-worker-fuzzer
-	$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
+	ifeq ($(MEDIASOUP_WORKER_BIN),)
+		$(PYTHON) ./scripts/configure.py -R mediasoup-worker-fuzzer
+		$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
+	endif
 
 xcode:
 	$(PYTHON) ./scripts/configure.py --format=xcode

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -13,24 +13,24 @@ MEDIASOUP_BUILDTYPE ?= Release
 	docker-build docker-run
 
 default:
-	ifeq ($(MEDIASOUP_WORKER_BIN),)
+        ifeq ($(MEDIASOUP_WORKER_BIN),)
 		$(PYTHON) ./scripts/configure.py -R mediasoup-worker
 		$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
-	endif
+        endif
 
 test:
-	ifeq ($(MEDIASOUP_WORKER_BIN),)
+        ifeq ($(MEDIASOUP_WORKER_BIN),)
 		$(PYTHON) ./scripts/configure.py -R mediasoup-worker-test
 		$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
 		./deps/lcov/bin/lcov --directory ./ --zerocounters
 		./out/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker-test --invisibles --use-colour=yes $(MEDIASOUP_TEST_TAGS)
-	endif
+        endif
 
 fuzzer:
-	ifeq ($(MEDIASOUP_WORKER_BIN),)
+        ifeq ($(MEDIASOUP_WORKER_BIN),)
 		$(PYTHON) ./scripts/configure.py -R mediasoup-worker-fuzzer
 		$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
-	endif
+        endif
 
 xcode:
 	$(PYTHON) ./scripts/configure.py --format=xcode

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -13,24 +13,24 @@ MEDIASOUP_BUILDTYPE ?= Release
 	docker-build docker-run
 
 default:
-        ifeq ($(MEDIASOUP_WORKER_BIN),)
-		$(PYTHON) ./scripts/configure.py -R mediasoup-worker
-		$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
-        endif
+ifeq ($(MEDIASOUP_WORKER_BIN),)
+	$(PYTHON) ./scripts/configure.py -R mediasoup-worker
+	$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
+endif
 
 test:
-        ifeq ($(MEDIASOUP_WORKER_BIN),)
-		$(PYTHON) ./scripts/configure.py -R mediasoup-worker-test
-		$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
-		./deps/lcov/bin/lcov --directory ./ --zerocounters
-		./out/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker-test --invisibles --use-colour=yes $(MEDIASOUP_TEST_TAGS)
-        endif
+ifeq ($(MEDIASOUP_WORKER_BIN),)
+	$(PYTHON) ./scripts/configure.py -R mediasoup-worker-test
+	$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
+	./deps/lcov/bin/lcov --directory ./ --zerocounters
+	./out/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker-test --invisibles --use-colour=yes $(MEDIASOUP_TEST_TAGS)
+endif
 
 fuzzer:
-        ifeq ($(MEDIASOUP_WORKER_BIN),)
-		$(PYTHON) ./scripts/configure.py -R mediasoup-worker-fuzzer
-		$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
-        endif
+ifeq ($(MEDIASOUP_WORKER_BIN),)
+	$(PYTHON) ./scripts/configure.py -R mediasoup-worker-fuzzer
+	$(MAKE) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out
+endif
 
 xcode:
 	$(PYTHON) ./scripts/configure.py --format=xcode


### PR DESCRIPTION
Some systems do not have gcc >4.8 which is required, e.g. Centos. Thus `postinstall` of mediasoup fails. In order to avoid this, we can skip the worker compilation providing an environmental variable, like the `MEDIASOUP_WORKER_BIN` that is used in `mediasoup/lib/Worker.js`