### PR TITLE
RateCalculator: improve efficiency

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
   },
   "devDependencies": {
     "eslint": "^6.0.1",
-    "eslint-plugin-jest": "^22.9.0",
+    "eslint-plugin-jest": "^22.10.0",
     "gulp": "^4.0.2",
     "gulp-clang-format": "^1.0.27",
     "jest": "^24.8.0",

--- a/worker/include/RTC/RateCalculator.hpp
+++ b/worker/include/RTC/RateCalculator.hpp
@@ -35,18 +35,22 @@ namespace RTC
 	private:
 		std::unique_ptr<BufferItem[]> buffer;
 
+		// Window Size (in milliseconds).
+		size_t windowSize{ DefaultWindowSize };
+		// Scale in which the rate is represented.
+		float scale{ DefaultBpsScale };
 		// Time (in milliseconds) for oldest item in the time window.
 		uint64_t oldestTime{ 0 };
 		// Index for the oldest item in the time window.
 		uint32_t oldestIndex{ 0 };
 		// Total count in the time window.
 		size_t totalCount{ 0 };
-		// Window Size (in milliseconds).
-		size_t windowSize{ DefaultWindowSize };
-		// Scale in which the rate is represented.
-		const float scale{ DefaultBpsScale };
 		// Total bytes transmitted.
 		size_t bytes{ 0 };
+		// Last value calculated by GetRate().
+		uint32_t lastRate{ 0 };
+		// Last time GetRate() was called.
+		uint64_t lastTime{ 0 };
 	};
 
 	/* Inline instance methods. */
@@ -75,6 +79,8 @@ namespace RTC
 		this->totalCount  = 0;
 		this->oldestIndex = 0;
 		this->oldestTime  = now - this->windowSize;
+		this->lastRate    = 0;
+		this->lastTime    = 0;
 	}
 
 	class RtpDataCounter

--- a/worker/include/RTC/RateCalculator.hpp
+++ b/worker/include/RTC/RateCalculator.hpp
@@ -33,12 +33,12 @@ namespace RTC
 		};
 
 	private:
-		std::unique_ptr<BufferItem[]> buffer;
-
 		// Window Size (in milliseconds).
 		size_t windowSize{ DefaultWindowSize };
 		// Scale in which the rate is represented.
 		float scale{ DefaultBpsScale };
+		// Buffer to keep data.
+		std::unique_ptr<BufferItem[]> buffer;
 		// Time (in milliseconds) for oldest item in the time window.
 		uint64_t oldestTime{ 0 };
 		// Index for the oldest item in the time window.
@@ -76,9 +76,9 @@ namespace RTC
 	inline void RateCalculator::Reset(uint64_t now)
 	{
 		this->buffer.reset(new BufferItem[this->windowSize]);
-		this->totalCount  = 0;
-		this->oldestIndex = 0;
 		this->oldestTime  = now - this->windowSize;
+		this->oldestIndex = 0;
+		this->totalCount  = 0;
 		this->lastRate    = 0;
 		this->lastTime    = 0;
 	}

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -31,7 +31,7 @@ namespace RTC
 		this->totalCount += size;
 
 		// Reset lastRate and lastTime so GetRate() will calculate rate again even
-		// if caller with same now.
+		// if called with same now in the same loop iteration.
 		this->lastRate = 0;
 		this->lastTime = 0;
 	}

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -29,17 +29,28 @@ namespace RTC
 
 		this->buffer[index].count += size;
 		this->totalCount += size;
+
+		// Reset lastRate and lastTime so GetRate() will calculate rate again even
+		// if caller with same now.
+		this->lastRate = 0;
+		this->lastTime = 0;
 	}
 
 	uint32_t RateCalculator::GetRate(uint64_t now)
 	{
 		MS_TRACE();
 
+		if (now == this->lastTime)
+			return this->lastRate;
+
 		RemoveOldData(now);
 
 		float scale = this->scale / this->windowSize;
 
-		return static_cast<uint32_t>(std::trunc(this->totalCount * scale + 0.5f));
+		this->lastTime = now;
+		this->lastRate = static_cast<uint32_t>(std::trunc(this->totalCount * scale + 0.5f));
+
+		return this->lastRate;
 	}
 
 	inline void RateCalculator::RemoveOldData(uint64_t now)

--- a/worker/src/RTC/RembServer/RemoteBitrateEstimatorAbsSendTime.cpp
+++ b/worker/src/RTC/RembServer/RemoteBitrateEstimatorAbsSendTime.cpp
@@ -268,6 +268,9 @@ namespace RTC
 
 			this->incomingBitrate.Update(payloadSize, arrivalTimeMs);
 
+			// Update incoming bitrate.
+			incomingBitrate = this->incomingBitrate.GetRate(arrivalTimeMs);
+
 			if (this->firstPacketTimeMs == -1)
 				this->firstPacketTimeMs = nowMs;
 
@@ -349,9 +352,7 @@ namespace RTC
 					}
 					else if (this->detector.State() == BW_OVERUSING)
 					{
-						uint32_t incomingRate = this->incomingBitrate.GetRate(arrivalTimeMs);
-
-						if ((incomingRate != 0u) && this->remoteRate.TimeToReduceFurther(nowMs, incomingRate))
+						if ((incomingBitrate != 0u) && this->remoteRate.TimeToReduceFurther(nowMs, incomingBitrate))
 							updateEstimate = true;
 					}
 				}
@@ -362,9 +363,7 @@ namespace RTC
 					// We also have to update the estimate immediately if we are overusing
 					// and the target bitrate is too high compared to what we are receiving.
 					const RateControlInput input(
-					  this->detector.State(),
-					  this->incomingBitrate.GetRate(arrivalTimeMs),
-					  this->estimator->GetVarNoise());
+					  this->detector.State(), incomingBitrate, this->estimator->GetVarNoise());
 
 					this->remoteRate.Update(&input, nowMs);
 					targetBitrateBps = this->remoteRate.UpdateBandwidthEstimate(nowMs);


### PR DESCRIPTION
* Store `this->lastTime` and `this->lastRate` when calling `GetRate(now)` and return `this->lastRate` if `GetRate(now)` is called with `now == this->lastTime` (instead of calculating the rate again).
* Reset both `this->lastTime` and `this->lastRate` to 0 when calling `Reset()` or `Update()` (to allow that immediate new calls to `GetRate()` with same `now` trigger a new rate calculation).
* Avoid unnecessary calls to `GetRate()` in `RemoteBitrateEstimatorAbsSendTime` (even if no longer necessary with the changes above, but looks better).



