### PR TITLE
Fix wrong lambda usage

### DIFF
--- a/worker/include/RTC/PipeTransport.hpp
+++ b/worker/include/RTC/PipeTransport.hpp
@@ -27,7 +27,7 @@ namespace RTC
 
 	private:
 		bool IsConnected() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone = [](bool) {}) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone = RTC::Transport::defaultOnSendHandler) override;
 		void SendRtcpPacket(RTC::RTCP::Packet* packet) override;
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;

--- a/worker/include/RTC/PipeTransport.hpp
+++ b/worker/include/RTC/PipeTransport.hpp
@@ -27,7 +27,7 @@ namespace RTC
 
 	private:
 		bool IsConnected() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone = RTC::Transport::defaultOnSendHandler) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, RTC::Transport::onSendHandler* onDone = nullptr) override;
 		void SendRtcpPacket(RTC::RTCP::Packet* packet) override;
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;

--- a/worker/include/RTC/PlainRtpTransport.hpp
+++ b/worker/include/RTC/PlainRtpTransport.hpp
@@ -27,7 +27,7 @@ namespace RTC
 
 	private:
 		bool IsConnected() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone = [](bool) {}) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone = RTC::Transport::defaultOnSendHandler) override;
 		void SendRtcpPacket(RTC::RTCP::Packet* packet) override;
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;

--- a/worker/include/RTC/PlainRtpTransport.hpp
+++ b/worker/include/RTC/PlainRtpTransport.hpp
@@ -27,7 +27,7 @@ namespace RTC
 
 	private:
 		bool IsConnected() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone = RTC::Transport::defaultOnSendHandler) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, RTC::Transport::onSendHandler* onDone = nullptr) override;
 		void SendRtcpPacket(RTC::RTCP::Packet* packet) override;
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;

--- a/worker/include/RTC/TcpConnection.hpp
+++ b/worker/include/RTC/TcpConnection.hpp
@@ -21,7 +21,7 @@ namespace RTC
 		~TcpConnection() override;
 
 	public:
-		void Send(const uint8_t* data, size_t len, onSendHandler& onDone);
+		void Send(const uint8_t* data, size_t len, ::TcpConnection::onSendHandler* onDone);
 		size_t GetRecvBytes() const;
 		size_t GetSentBytes() const;
 

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -41,7 +41,6 @@ namespace RTC
 	{
 	protected:
 		using onSendHandler = const std::function<void(bool sent)>;
-		static onSendHandler defaultOnSendHandler;
 
 	public:
 		class Listener
@@ -130,8 +129,8 @@ namespace RTC
 		RTC::DataProducer* GetDataProducerFromRequest(Channel::Request* request) const;
 		void SetNewDataConsumerIdFromRequest(Channel::Request* request, std::string& dataConsumerId) const;
 		RTC::DataConsumer* GetDataConsumerFromRequest(Channel::Request* request) const;
-		virtual bool IsConnected() const                                                        = 0;
-		virtual void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone = RTC::Transport::defaultOnSendHandler) = 0;
+		virtual bool IsConnected() const                                                    = 0;
+		virtual void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler* onDone = nullptr) = 0;
 		void HandleRtcpPacket(RTC::RTCP::Packet* packet);
 		void SendRtcp(uint64_t nowMs);
 		virtual void SendRtcpPacket(RTC::RTCP::Packet* packet)                 = 0;

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -39,6 +39,10 @@ namespace RTC
 	                  public RTC::SenderBandwidthEstimator::Listener,
 	                  public Timer::Listener
 	{
+	protected:
+		using onSendHandler = const std::function<void(bool sent)>;
+		static onSendHandler defaultOnSendHandler;
+
 	public:
 		class Listener
 		{
@@ -92,9 +96,6 @@ namespace RTC
 			  RTC::Transport* transport, RTC::DataConsumer* dataConsumer) = 0;
 		};
 
-	protected:
-		using onSendHandler = const std::function<void(bool sent)>;
-
 	public:
 		Transport(const std::string& id, Listener* listener, json& data);
 		virtual ~Transport();
@@ -130,7 +131,7 @@ namespace RTC
 		void SetNewDataConsumerIdFromRequest(Channel::Request* request, std::string& dataConsumerId) const;
 		RTC::DataConsumer* GetDataConsumerFromRequest(Channel::Request* request) const;
 		virtual bool IsConnected() const                                                        = 0;
-		virtual void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone = [](bool) {}) = 0;
+		virtual void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone = RTC::Transport::defaultOnSendHandler) = 0;
 		void HandleRtcpPacket(RTC::RTCP::Packet* packet);
 		void SendRtcp(uint64_t nowMs);
 		virtual void SendRtcpPacket(RTC::RTCP::Packet* packet)                 = 0;

--- a/worker/include/RTC/TransportTuple.hpp
+++ b/worker/include/RTC/TransportTuple.hpp
@@ -14,15 +14,16 @@ namespace RTC
 {
 	class TransportTuple
 	{
+	protected:
+		using onSendHandler = const std::function<void(bool sent)>;
+		static onSendHandler defaultOnSendHandler;
+
 	public:
 		enum class Protocol
 		{
 			UDP = 1,
 			TCP
 		};
-
-	protected:
-		using onSendHandler = const std::function<void(bool sent)>;
 
 	public:
 		TransportTuple(RTC::UdpSocket* udpSocket, const struct sockaddr* udpRemoteAddr);
@@ -35,7 +36,7 @@ namespace RTC
 		void StoreUdpRemoteAddress();
 		bool Compare(const TransportTuple* tuple) const;
 		void SetLocalAnnouncedIp(std::string& localAnnouncedIp);
-		void Send(const uint8_t* data, size_t len, onSendHandler& onDone = [](bool) {});
+		void Send(const uint8_t* data, size_t len, onSendHandler& onDone = RTC::TransportTuple::defaultOnSendHandler);
 		Protocol GetProtocol() const;
 		const struct sockaddr* GetLocalAddress() const;
 		const struct sockaddr* GetRemoteAddress() const;

--- a/worker/include/RTC/TransportTuple.hpp
+++ b/worker/include/RTC/TransportTuple.hpp
@@ -16,7 +16,6 @@ namespace RTC
 	{
 	protected:
 		using onSendHandler = const std::function<void(bool sent)>;
-		static onSendHandler defaultOnSendHandler;
 
 	public:
 		enum class Protocol
@@ -36,7 +35,7 @@ namespace RTC
 		void StoreUdpRemoteAddress();
 		bool Compare(const TransportTuple* tuple) const;
 		void SetLocalAnnouncedIp(std::string& localAnnouncedIp);
-		void Send(const uint8_t* data, size_t len, onSendHandler& onDone = RTC::TransportTuple::defaultOnSendHandler);
+		void Send(const uint8_t* data, size_t len, RTC::TransportTuple::onSendHandler* onDone = nullptr);
 		Protocol GetProtocol() const;
 		const struct sockaddr* GetLocalAddress() const;
 		const struct sockaddr* GetRemoteAddress() const;
@@ -112,7 +111,7 @@ namespace RTC
 	}
 
 	inline void TransportTuple::Send(
-	  const uint8_t* data, size_t len, const std::function<void(bool sent)>& onDone)
+	  const uint8_t* data, size_t len, RTC::TransportTuple::onSendHandler* onDone)
 	{
 		if (this->protocol == Protocol::UDP)
 			this->udpSocket->Send(data, len, this->udpRemoteAddr, onDone);

--- a/worker/include/RTC/WebRtcTransport.hpp
+++ b/worker/include/RTC/WebRtcTransport.hpp
@@ -41,7 +41,7 @@ namespace RTC
 	private:
 		bool IsConnected() const override;
 		void MayRunDtlsTransport();
-		void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone = RTC::Transport::defaultOnSendHandler) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, RTC::Transport::onSendHandler* onDone = nullptr) override;
 		void SendRtcpPacket(RTC::RTCP::Packet* packet) override;
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;

--- a/worker/include/RTC/WebRtcTransport.hpp
+++ b/worker/include/RTC/WebRtcTransport.hpp
@@ -41,7 +41,7 @@ namespace RTC
 	private:
 		bool IsConnected() const override;
 		void MayRunDtlsTransport();
-		void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone = [](bool) {}) override;
+		void SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone = RTC::Transport::defaultOnSendHandler) override;
 		void SendRtcpPacket(RTC::RTCP::Packet* packet) override;
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;

--- a/worker/include/handles/UdpSocket.hpp
+++ b/worker/include/handles/UdpSocket.hpp
@@ -15,7 +15,7 @@ public:
 	struct UvSendData
 	{
 		uv_udp_send_t req;
-		onSendHandler* onDone;
+		UdpSocket::onSendHandler* onDone{ nullptr };
 		uint8_t store[1];
 	};
 
@@ -31,7 +31,8 @@ public:
 public:
 	void Close();
 	virtual void Dump() const;
-	void Send(const uint8_t* data, size_t len, const struct sockaddr* addr, onSendHandler& onDone);
+	void Send(
+	  const uint8_t* data, size_t len, const struct sockaddr* addr, UdpSocket::onSendHandler* onDone);
 	const struct sockaddr* GetLocalAddress() const;
 	int GetLocalFamily() const;
 	const std::string& GetLocalIp() const;
@@ -46,7 +47,7 @@ private:
 public:
 	void OnUvRecvAlloc(size_t suggestedSize, uv_buf_t* buf);
 	void OnUvRecv(ssize_t nread, const uv_buf_t* buf, const struct sockaddr* addr, unsigned int flags);
-	void OnUvSend(int status, onSendHandler& onDone);
+	void OnUvSend(int status, UdpSocket::onSendHandler* onDone);
 
 	/* Pure virtual methods that must be implemented by the subclass. */
 protected:

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -246,13 +246,18 @@ namespace RTC
 		return this->tuple != nullptr;
 	}
 
-	void PipeTransport::SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone)
+	void PipeTransport::SendRtpPacket(RTC::RtpPacket* packet, RTC::Transport::onSendHandler* onDone)
 	{
 		MS_TRACE();
 
 		if (!IsConnected())
 		{
-			onDone(false);
+			if (onDone)
+			{
+				(*onDone)(false);
+
+				delete onDone;
+			}
 
 			return;
 		}

--- a/worker/src/RTC/PlainRtpTransport.cpp
+++ b/worker/src/RTC/PlainRtpTransport.cpp
@@ -417,13 +417,18 @@ namespace RTC
 		return this->tuple != nullptr;
 	}
 
-	void PlainRtpTransport::SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone)
+	void PlainRtpTransport::SendRtpPacket(RTC::RtpPacket* packet, RTC::Transport::onSendHandler* onDone)
 	{
 		MS_TRACE();
 
 		if (!IsConnected())
 		{
-			onDone(false);
+			if (onDone)
+			{
+				(*onDone)(false);
+
+				delete onDone;
+			}
 
 			return;
 		}

--- a/worker/src/RTC/TcpConnection.cpp
+++ b/worker/src/RTC/TcpConnection.cpp
@@ -154,7 +154,7 @@ namespace RTC
 		}
 	}
 
-	void TcpConnection::Send(const uint8_t* data, size_t len, onSendHandler& onDone)
+	void TcpConnection::Send(const uint8_t* data, size_t len, ::TcpConnection::onSendHandler* onDone)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -25,6 +25,10 @@
 
 namespace RTC
 {
+	/* Class variables. */
+
+	Transport::onSendHandler Transport::defaultOnSendHandler{ [](bool) {} };
+
 	/* Instance methods. */
 
 	Transport::Transport(const std::string& id, Listener* listener, json& data)
@@ -2461,6 +2465,9 @@ namespace RTC
 	  const webrtc::PacedPacketInfo& pacingInfo)
 	{
 		MS_TRACE();
+
+			// TODO: REMOVE
+			return;
 
 		// Update abs-send-time if present.
 		packet->UpdateAbsSendTime(DepLibUV::GetTimeMs());

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2166,7 +2166,7 @@ namespace RTC
 			// });
 
 			// THIS CRASHES ALWAYS
-			const onSendHandler onDone = [tccClient, &packetInfo](bool sent) {
+			onSendHandler onDone = [tccClient, &packetInfo](bool sent) {
 				MS_ERROR(
 					"---- onDone [wideSeq:%" PRIu16 ", sent:%s]",
 					packetInfo.transport_sequence_number, sent ? "true" : "false");

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2160,10 +2160,25 @@ namespace RTC
 				}
 			});
 #else
-			SendRtpPacket(packet, [tccClient, &packetInfo](bool sent) {
+			// SendRtpPacket(packet, [tccClient, &packetInfo](bool sent) {
+			// 	if (sent)
+			// 		tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMs());
+			// });
+
+			// THIS CRASHES ALWAYS
+			const onSendHandler onDone = [tccClient, &packetInfo](bool sent) {
+				MS_ERROR(
+					"---- onDone [wideSeq:%" PRIu16 ", sent:%s]",
+					packetInfo.transport_sequence_number, sent ? "true" : "false");
+
 				if (sent)
 					tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMs());
-			});
+			};
+
+			// TODO: REMOVE
+			MS_ERROR("---- onDone addr:%p", &onDone);
+
+			SendRtpPacket(packet, onDone);
 #endif
 		}
 		else

--- a/worker/src/RTC/TransportTuple.cpp
+++ b/worker/src/RTC/TransportTuple.cpp
@@ -8,6 +8,10 @@
 
 namespace RTC
 {
+	/* Class variables. */
+
+	TransportTuple::onSendHandler TransportTuple::defaultOnSendHandler{ [](bool) {} };
+
 	/* Instance methods. */
 
 	void TransportTuple::FillJson(json& jsonObject) const

--- a/worker/src/RTC/TransportTuple.cpp
+++ b/worker/src/RTC/TransportTuple.cpp
@@ -8,10 +8,6 @@
 
 namespace RTC
 {
-	/* Class variables. */
-
-	TransportTuple::onSendHandler TransportTuple::defaultOnSendHandler{ [](bool) {} };
-
 	/* Instance methods. */
 
 	void TransportTuple::FillJson(json& jsonObject) const

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -702,16 +702,18 @@ namespace RTC
 		}
 	}
 
-	void WebRtcTransport::SendRtpPacket(RTC::RtpPacket* packet, onSendHandler& onDone)
+	void WebRtcTransport::SendRtpPacket(RTC::RtpPacket* packet, onSendHandler* onDone)
 	{
 		MS_TRACE();
 
-			// TODO: REMOVE
-			MS_ERROR("---- onDone addr:%p", &onDone);
-
 		if (!IsConnected())
 		{
-			onDone(false);
+			if (onDone)
+			{
+				(*onDone)(false);
+
+				delete onDone;
+			}
 
 			return;
 		}
@@ -721,7 +723,12 @@ namespace RTC
 		{
 			MS_WARN_DEV("ignoring RTP packet due to non sending SRTP session");
 
-			onDone(false);
+			if (onDone)
+			{
+				(*onDone)(false);
+
+				delete onDone;
+			}
 
 			return;
 		}
@@ -731,7 +738,12 @@ namespace RTC
 
 		if (!this->srtpSendSession->EncryptRtp(&data, &len))
 		{
-			onDone(false);
+			if (onDone)
+			{
+				(*onDone)(false);
+
+				delete onDone;
+			}
 
 			return;
 		}

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -706,6 +706,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
+			// TODO: REMOVE
+			MS_ERROR("---- onDone addr:%p", &onDone);
+
 		if (!IsConnected())
 		{
 			onDone(false);

--- a/worker/src/handles/UdpSocket.cpp
+++ b/worker/src/handles/UdpSocket.cpp
@@ -128,6 +128,9 @@ void UdpSocket::Send(const uint8_t* data, size_t len, const struct sockaddr* add
 {
 	MS_TRACE();
 
+		// TODO: REMOVE
+		MS_ERROR("---- onDone addr:%p", &onDone);
+
 	if (this->closed)
 	{
 		onDone(false);
@@ -146,40 +149,40 @@ void UdpSocket::Send(const uint8_t* data, size_t len, const struct sockaddr* add
 	// then build a uv_req_t and use uv_udp_send().
 
 	uv_buf_t buffer = uv_buf_init(reinterpret_cast<char*>(const_cast<uint8_t*>(data)), len);
-	int sent        = uv_udp_try_send(this->uvHandle, &buffer, 1, addr);
+	// int sent        = uv_udp_try_send(this->uvHandle, &buffer, 1, addr);
 
-	// Entire datagram was sent. Done.
-	if (sent == static_cast<int>(len))
-	{
-		// Update sent bytes.
-		this->sentBytes += sent;
+	// // Entire datagram was sent. Done.
+	// if (sent == static_cast<int>(len))
+	// {
+	// 	// Update sent bytes.
+	// 	this->sentBytes += sent;
 
-		onDone(true);
+	// 	onDone(true);
 
-		return;
-	}
-	if (sent >= 0)
-	{
-		MS_WARN_DEV("datagram truncated (just %d of %zu bytes were sent)", sent, len);
+	// 	return;
+	// }
+	// if (sent >= 0)
+	// {
+	// 	MS_WARN_DEV("datagram truncated (just %d of %zu bytes were sent)", sent, len);
 
-		// Update sent bytes.
-		this->sentBytes += sent;
+	// 	// Update sent bytes.
+	// 	this->sentBytes += sent;
 
-		onDone(false);
+	// 	onDone(false);
 
-		return;
-	}
-	// Error,
-	if (sent != UV_EAGAIN)
-	{
-		MS_WARN_DEV("uv_udp_try_send() failed: %s", uv_strerror(sent));
+	// 	return;
+	// }
+	// // Error,
+	// if (sent != UV_EAGAIN)
+	// {
+	// 	MS_WARN_DEV("uv_udp_try_send() failed: %s", uv_strerror(sent));
 
-		onDone(false);
+	// 	onDone(false);
 
-		return;
-	}
+	// 	return;
+	// }
+
 	// Otherwise UV_EAGAIN was returned so cannot send data at first time. Use uv_udp_send().
-
 	// MS_DEBUG_DEV("could not send the datagram at first time, using uv_udp_send() now");
 
 	// Allocate a special UvSendData struct pointer.

--- a/worker/src/handles/UdpSocket.cpp
+++ b/worker/src/handles/UdpSocket.cpp
@@ -18,10 +18,8 @@ inline static void onAlloc(uv_handle_t* handle, size_t suggestedSize, uv_buf_t* 
 {
 	auto* socket = static_cast<UdpSocket*>(handle->data);
 
-	if (socket == nullptr)
-		return;
-
-	socket->OnUvRecvAlloc(suggestedSize, buf);
+	if (socket)
+		socket->OnUvRecvAlloc(suggestedSize, buf);
 }
 
 inline static void onRecv(
@@ -29,10 +27,8 @@ inline static void onRecv(
 {
 	auto* socket = static_cast<UdpSocket*>(handle->data);
 
-	if (socket == nullptr)
-		return;
-
-	socket->OnUvRecv(nread, buf, addr, flags);
+	if (socket)
+		socket->OnUvRecv(nread, buf, addr, flags);
 }
 
 inline static void onSend(uv_udp_send_t* req, int status)
@@ -45,10 +41,10 @@ inline static void onSend(uv_udp_send_t* req, int status)
 	// Delete the UvSendData struct (which includes the uv_req_t and the store char[]).
 	std::free(sendData);
 
-	if (socket == nullptr)
-		return;
+	if (socket)
+		socket->OnUvSend(status, onDone);
 
-	socket->OnUvSend(status, *onDone);
+	delete onDone;
 }
 
 inline static void onClose(uv_handle_t* handle)
@@ -124,23 +120,23 @@ void UdpSocket::Dump() const
 	MS_DUMP("</UdpSocket>");
 }
 
-void UdpSocket::Send(const uint8_t* data, size_t len, const struct sockaddr* addr, onSendHandler& onDone)
+void UdpSocket::Send(
+  const uint8_t* data, size_t len, const struct sockaddr* addr, UdpSocket::onSendHandler* onDone)
 {
 	MS_TRACE();
 
-		// TODO: REMOVE
-		MS_ERROR("---- onDone addr:%p", &onDone);
-
 	if (this->closed)
 	{
-		onDone(false);
+		if (onDone)
+			(*onDone)(false);
 
 		return;
 	}
 
 	if (len == 0)
 	{
-		onDone(false);
+		if (onDone)
+			(*onDone)(false);
 
 		return;
 	}
@@ -149,38 +145,53 @@ void UdpSocket::Send(const uint8_t* data, size_t len, const struct sockaddr* add
 	// then build a uv_req_t and use uv_udp_send().
 
 	uv_buf_t buffer = uv_buf_init(reinterpret_cast<char*>(const_cast<uint8_t*>(data)), len);
-	// int sent        = uv_udp_try_send(this->uvHandle, &buffer, 1, addr);
+	int sent        = uv_udp_try_send(this->uvHandle, &buffer, 1, addr);
 
-	// // Entire datagram was sent. Done.
-	// if (sent == static_cast<int>(len))
-	// {
-	// 	// Update sent bytes.
-	// 	this->sentBytes += sent;
+	// Entire datagram was sent. Done.
+	if (sent == static_cast<int>(len))
+	{
+		// Update sent bytes.
+		this->sentBytes += sent;
 
-	// 	onDone(true);
+		if (onDone)
+		{
+			(*onDone)(true);
 
-	// 	return;
-	// }
-	// if (sent >= 0)
-	// {
-	// 	MS_WARN_DEV("datagram truncated (just %d of %zu bytes were sent)", sent, len);
+			delete onDone;
+		}
 
-	// 	// Update sent bytes.
-	// 	this->sentBytes += sent;
+		return;
+	}
+	if (sent >= 0)
+	{
+		MS_WARN_DEV("datagram truncated (just %d of %zu bytes were sent)", sent, len);
 
-	// 	onDone(false);
+		// Update sent bytes.
+		this->sentBytes += sent;
 
-	// 	return;
-	// }
-	// // Error,
-	// if (sent != UV_EAGAIN)
-	// {
-	// 	MS_WARN_DEV("uv_udp_try_send() failed: %s", uv_strerror(sent));
+		if (onDone)
+		{
+			(*onDone)(false);
 
-	// 	onDone(false);
+			delete onDone;
+		}
 
-	// 	return;
-	// }
+		return;
+	}
+	// Error,
+	if (sent != UV_EAGAIN)
+	{
+		MS_WARN_DEV("uv_udp_try_send() failed: %s", uv_strerror(sent));
+
+		if (onDone)
+		{
+			(*onDone)(false);
+
+			delete onDone;
+		}
+
+		return;
+	}
 
 	// Otherwise UV_EAGAIN was returned so cannot send data at first time. Use uv_udp_send().
 	// MS_DEBUG_DEV("could not send the datagram at first time, using uv_udp_send() now");
@@ -190,7 +201,7 @@ void UdpSocket::Send(const uint8_t* data, size_t len, const struct sockaddr* add
 
 	std::memcpy(sendData->store, data, len);
 	sendData->req.data = static_cast<void*>(sendData);
-	sendData->onDone   = &onDone;
+	sendData->onDone   = onDone;
 
 	buffer = uv_buf_init(reinterpret_cast<char*>(sendData->store), len);
 
@@ -205,7 +216,13 @@ void UdpSocket::Send(const uint8_t* data, size_t len, const struct sockaddr* add
 
 		// Delete the UvSendData struct (which includes the uv_req_t and the store char[]).
 		std::free(sendData);
-		onDone(false);
+
+		if (onDone)
+		{
+			(*onDone)(false);
+
+			delete onDone;
+		}
 	}
 	else
 	{
@@ -254,9 +271,6 @@ inline void UdpSocket::OnUvRecv(
 {
 	MS_TRACE();
 
-	if (this->closed)
-		return;
-
 	// NOTE: libuv calls twice to alloc & recv when a datagram is received, the
 	// second one with nread = 0 and addr = NULL. Ignore it.
 	if (nread == 0)
@@ -286,19 +300,14 @@ inline void UdpSocket::OnUvRecv(
 	}
 }
 
-inline void UdpSocket::OnUvSend(int status, onSendHandler& onDone)
+inline void UdpSocket::OnUvSend(int status, UdpSocket::onSendHandler* onDone)
 {
 	MS_TRACE();
 
-		// TODO: REMOVE
-		MS_ERROR("---- onDone addr:%p", &onDone);
-
-	if (this->closed)
-		return;
-
 	if (status == 0)
 	{
-		onDone(true);
+		if (onDone)
+			(*onDone)(true);
 	}
 	else
 	{
@@ -306,6 +315,7 @@ inline void UdpSocket::OnUvSend(int status, onSendHandler& onDone)
 		MS_DEBUG_DEV("send error: %s", uv_strerror(status));
 #endif
 
-		onDone(false);
+		if (onDone)
+			(*onDone)(false);
 	}
 }

--- a/worker/src/handles/UdpSocket.cpp
+++ b/worker/src/handles/UdpSocket.cpp
@@ -290,6 +290,9 @@ inline void UdpSocket::OnUvSend(int status, onSendHandler& onDone)
 {
 	MS_TRACE();
 
+		// TODO: REMOVE
+		MS_ERROR("---- onDone addr:%p", &onDone);
+
 	if (this->closed)
 		return;
 


### PR DESCRIPTION
Allocate a `new std::function` and delete when called. Fixes #333.