### PR TITLE
fix(worker): cpu cores detection using sh and default to 4

### DIFF
--- a/worker/Makefile
+++ b/worker/Makefile
@@ -6,7 +6,7 @@
 # with gyp and Python3.
 PYTHON ?= $(shell command -v python2 2> /dev/null || echo python)
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
-CORES ?= $(shell ${ROOT_DIR}/scripts/cpu_cores.sh)
+CORES ?= $(shell ${ROOT_DIR}/scripts/cpu_cores.sh || echo 4)
 MEDIASOUP_BUILDTYPE ?= Release
 GULP = ../node_modules/.bin/gulp
 LCOV = ./deps/lcov/bin/lcov

--- a/worker/scripts/cpu_cores.sh
+++ b/worker/scripts/cpu_cores.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 set -e
 


### PR DESCRIPTION
In case bash is missing from the system the `cpu_cores.sh` fails with an
error and returns empty string resulting in command like
`make -j BUILDTYPE=Release -C out` that uses unlimited jobs and could
lead to signifficant CPU and RAM usage during build

The cpu_cores.sh is now changed to using `sh` instead of `bash`, so it
should be more portable. Additionally if the cpu detection fails the
jobs default to 4, that should be safe enough.