### PR TITLE
Fix video lag after a long time (issue #372)

### DIFF
--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -84,6 +84,9 @@ namespace RTC
 			{
 				MS_DEBUG_DEV("trying to send a dropped input");
 
+				// TODO: TMP
+				MS_DUMP("trying to send a dropped input [input:%u]", input);
+
 				return false;
 			}
 
@@ -95,6 +98,9 @@ namespace RTC
 		}
 
 		output = input + base;
+
+		// TODO: TMP
+		MS_DUMP("result [input:%u, output:%u]", input, output);
 
 		T idelta = input - this->maxInput;
 		T odelta = output - this->maxOutput;

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -41,6 +41,9 @@ namespace RTC
 	template<typename T>
 	void SeqManager<T>::Sync(T input)
 	{
+		// TODO: TMP
+		MS_DUMP("[input:%u]", input);
+
 		// Update base.
 		this->base = this->maxOutput - input;
 
@@ -54,20 +57,39 @@ namespace RTC
 	template<typename T>
 	void SeqManager<T>::Drop(T input)
 	{
+		// TODO: TMP
+		MS_DUMP("[input:%u]", input);
+
 		// Mark as dropped if 'input' is higher than anyone already processed.
 		if (SeqManager<T>::IsSeqHigherThan(input, this->maxInput))
+		{
+			// TODO: TMP
+			MS_DUMP("input dropped [input:%u]", input);
+
 			this->dropped.insert(input);
+		}
+		else
+		{
+			// TODO: TMP
+			MS_DUMP("input NOT dropped [input:%u]", input);
+		}
 	}
 
 	template<typename T>
 	void SeqManager<T>::Offset(T offset)
 	{
+		// TODO: TMP
+		MS_DUMP("[offset:%u]", offset);
+
 		this->base += offset;
 	}
 
 	template<typename T>
 	bool SeqManager<T>::Input(const T input, T& output)
 	{
+		// TODO: TMP
+		MS_DUMP("[input:%u]", input);
+
 		auto base = this->base;
 
 		// There are dropped inputs. Synchronize.

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -41,9 +41,6 @@ namespace RTC
 	template<typename T>
 	void SeqManager<T>::Sync(T input)
 	{
-		// TODO: TMP
-		MS_DUMP("[input:%u]", input);
-
 		// Update base.
 		this->base = this->maxOutput - input;
 
@@ -57,47 +54,34 @@ namespace RTC
 	template<typename T>
 	void SeqManager<T>::Drop(T input)
 	{
-		// TODO: TMP
-		MS_DUMP("[input:%u]", input);
-
 		// Mark as dropped if 'input' is higher than anyone already processed.
 		if (SeqManager<T>::IsSeqHigherThan(input, this->maxInput))
 		{
-			// TODO: TMP
-			MS_DUMP("input dropped [input:%u]", input);
-
 			this->dropped.insert(input);
-		}
-		else
-		{
-			// TODO: TMP
-			MS_DUMP("input NOT dropped [input:%u]", input);
 		}
 	}
 
 	template<typename T>
 	void SeqManager<T>::Offset(T offset)
 	{
-		// TODO: TMP
-		MS_DUMP("[offset:%u]", offset);
-
 		this->base += offset;
 	}
 
 	template<typename T>
 	bool SeqManager<T>::Input(const T input, T& output)
 	{
-		// TODO: TMP
-		MS_DUMP("[input:%u]", input);
-
 		auto base = this->base;
 
 		// There are dropped inputs. Synchronize.
 		if (!this->dropped.empty())
 		{
 			// Delete dropped inputs older than input - MaxValue/2.
-			auto it = this->dropped.lower_bound(input - MaxValue / 2);
+			size_t droppedSize = this->dropped.size();
+			auto it            = this->dropped.lower_bound(input - MaxValue / 2);
+
 			this->dropped.erase(this->dropped.begin(), it);
+			this->base -= (droppedSize - this->dropped.size());
+			base = this->base;
 
 			// Check whether this input was dropped.
 			it = this->dropped.find(input);
@@ -105,9 +89,6 @@ namespace RTC
 			if (it != this->dropped.end())
 			{
 				MS_DEBUG_DEV("trying to send a dropped input");
-
-				// TODO: TMP
-				MS_DUMP("trying to send a dropped input [input:%u]", input);
 
 				return false;
 			}
@@ -120,9 +101,6 @@ namespace RTC
 		}
 
 		output = input + base;
-
-		// TODO: TMP
-		MS_DUMP("result [input:%u, output:%u]", input, output);
 
 		T idelta = input - this->maxInput;
 		T odelta = output - this->maxOutput;

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -46,236 +46,277 @@ void validate(SeqManager<uint16_t>& seqManager, std::vector<TestSeqManagerInput>
 
 SCENARIO("SeqManager", "[rtc]")
 {
-	SECTION("0 is greater than 65000")
-	{
-		REQUIRE(SeqManager<uint16_t>::IsSeqHigherThan(0, 65000) == true);
-	}
+	// SECTION("0 is greater than 65000")
+	// {
+	// 	REQUIRE(SeqManager<uint16_t>::IsSeqHigherThan(0, 65000) == true);
+	// }
 
-	SECTION("receive ordered numbers, no sync, no drop")
+	// SECTION("receive ordered numbers, no sync, no drop")
+	// {
+	// 	// clang-format off
+	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	{
+	// 		{  0,  0, false, false },
+	// 		{  1,  1, false, false },
+	// 		{  2,  2, false, false },
+	// 		{  3,  3, false, false },
+	// 		{  4,  4, false, false },
+	// 		{  5,  5, false, false },
+	// 		{  6,  6, false, false },
+	// 		{  7,  7, false, false },
+	// 		{  8,  8, false, false },
+	// 		{  9,  9, false, false },
+	// 		{ 10, 10, false, false },
+	// 		{ 11, 11, false, false }
+	// 	};
+	// 	// clang-format on
+
+	// 	SeqManager<uint16_t> seqManager;
+	// 	validate(seqManager, inputs);
+	// }
+
+	// SECTION("receive ordered numbers, sync, no drop")
+	// {
+	// 	// clang-format off
+	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	{
+	// 		{  0, 0, false, false },
+	// 		{  1, 1, false, false },
+	// 		{  2, 2, false, false },
+	// 		{ 80, 3, true, false },
+	// 		{ 81, 4, false, false },
+	// 		{ 82, 5, false, false },
+	// 		{ 83, 6, false, false },
+	// 		{ 84, 7, false, false }
+	// 	};
+	// 	// clang-format on
+
+	// 	SeqManager<uint16_t> seqManager;
+	// 	validate(seqManager, inputs);
+	// }
+
+	// SECTION("receive ordered numbers, sync, drop")
+	// {
+	// 	// clang-format off
+	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	{
+	// 		{  0,  0, false, false },
+	// 		{  1,  1, false, false },
+	// 		{  2,  2, false, false },
+	// 		{  3,  3, false, false },
+	// 		{  4,  4,  true, false }, // sync.
+	// 		{  5,  5, false, false },
+	// 		{  6,  6, false, false },
+	// 		{  7,  7,  true, false }, // sync.
+	// 		{  8,  0, false,  true }, // drop.
+	// 		{  9,  8, false, false },
+	// 		{ 11,  0, false,  true }, // drop.
+	// 		{ 10,  9, false, false },
+	// 		{ 12, 10, false, false },
+	// 	};
+	// 	// clang-format on
+
+	// 	SeqManager<uint16_t> seqManager;
+	// 	validate(seqManager, inputs);
+	// }
+
+	// SECTION("receive ordered wrapped numbers")
+	// {
+	// 	// clang-format off
+	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	{
+	// 		{ 65533, 65533, false, false },
+	// 		{ 65534, 65534, false, false },
+	// 		{ 65535, 65535, false, false },
+	// 		{     0,     0, false, false },
+	// 		{     1,     1, false, false }
+	// 	};
+	// 	// clang-format on
+
+	// 	SeqManager<uint16_t> seqManager;
+	// 	validate(seqManager, inputs);
+	// }
+
+	// SECTION("receive sequence numbers with a big jump")
+	// {
+	// 	// clang-format off
+	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	{
+	// 		{    0,   0, false, false },
+	// 		{    1,   1, false, false },
+	// 		{ 1000, 1000, false, false },
+	// 		{ 1001, 1001, false, false }
+	// 	};
+	// 	// clang-format on
+
+	// 	SeqManager<uint16_t> seqManager;
+	// 	validate(seqManager, inputs);
+	// }
+
+	// SECTION("receive mixed numbers with a big jump, drop before jump")
+	// {
+	// 	// clang-format off
+	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	{
+	// 		{   0,   0, false, false },
+	// 		{   1,   0, false,  true }, // drop.
+	// 		{ 100,  99, false, false },
+	// 		{ 100,  99, false, false },
+	// 		{ 103,   0, false,  true }, // drop.
+	// 		{ 101, 100, false, false }
+	// 	};
+	// 	// clang-format on
+
+	// 	SeqManager<uint16_t> seqManager;
+	// 	validate(seqManager, inputs);
+	// }
+
+	// SECTION("receive mixed numbers with a big jump, drop after jump")
+	// {
+	// 	// clang-format off
+	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	{
+	// 		{   0,   0, false, false },
+	// 		{   1,   1, false, false },
+	// 		{ 100,   0, false,  true }, // drop.
+	// 		{ 103,   0, false,  true }, // drop.
+	// 		{ 101, 100, false, false }
+	// 	};
+	// 	// clang-format on
+
+	// 	SeqManager<uint16_t> seqManager;
+	// 	validate(seqManager, inputs);
+	// }
+
+	// SECTION("drop, receive numbers newer and older than the one dropped")
+	// {
+	// 	// clang-format off
+	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	{
+	// 		{ 0, 0, false, false },
+	// 		{ 2, 0, false,  true }, // drop.
+	// 		{ 3, 2, false, false },
+	// 		{ 4, 3, false, false },
+	// 		{ 1, 1, false, false }
+	// 	};
+	// 	// clang-format on
+
+	// 	SeqManager<uint16_t> seqManager;
+	// 	validate(seqManager, inputs);
+	// }
+
+	// SECTION("receive mixed numbers, sync, drop")
+	// {
+	// 	// clang-format off
+	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	{
+	// 		{     0,  0, false, false },
+	// 		{     1,  1, false, false },
+	// 		{     2,  2, false, false },
+	// 		{     3,  3, false, false },
+	// 		{     7,  7, false, false },
+	// 		{     6,  0, false,  true }, // drop.
+	// 		{     8,  8, false, false },
+	// 		{    10, 10, false, false },
+	// 		{     9,  9, false, false },
+	// 		{    11, 11, false, false },
+	// 		{     0, 12,  true, false }, // sync.
+	// 		{     2, 14, false, false },
+	// 		{     3, 15, false, false },
+	// 		{     4, 16, false, false },
+	// 		{     5, 17, false, false },
+	// 		{     6, 18, false, false },
+	// 		{     7, 19, false, false },
+	// 		{     8, 20, false, false },
+	// 		{     9, 21, false, false },
+	// 		{    10, 22, false, false },
+	// 		{     9,  0, false,  true }, // drop.
+	// 		{    61, 23,  true, false }, // sync.
+	// 		{    62, 24, false, false },
+	// 		{    63, 25, false, false },
+	// 		{    64, 26, false, false },
+	// 		{    65, 27, false, false },
+	// 		{    11, 28,  true, false }, // sync.
+	// 		{    12, 29, false, false },
+	// 		{    13, 30, false, false },
+	// 		{    14, 31, false, false },
+	// 		{    15, 32, false, false },
+	// 		{     1, 33,  true, false }, // sync.
+	// 		{     2, 34, false, false },
+	// 		{     3, 35, false, false },
+	// 		{     4, 36, false, false },
+	// 		{     5, 37, false, false },
+	// 		{ 65533, 38,  true, false }, // sync.
+	// 		{ 65534, 39, false, false },
+	// 		{ 65535, 40, false, false },
+	// 		{     0, 41,  true, false }, // sync.
+	// 		{     1, 42, false, false },
+	// 		{     3,  0, false,  true }, // drop.
+	// 		{     4, 44, false, false },
+	// 		{     5, 45, false, false },
+	// 		{     6, 46, false, false },
+	// 		{     7, 47, false, false }
+	// 	};
+	// 	// clang-format on
+
+	// 	SeqManager<uint16_t> seqManager;
+	// 	validate(seqManager, inputs);
+	// }
+
+	// SECTION("receive ordered numbers, sync, no drop, increase input")
+	// {
+	// 	// clang-format off
+	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	{
+	// 		{  0,  0, false, false     },
+	// 		{  1,  1, false, false     },
+	// 		{  2,  2, false, false     },
+	// 		{ 80, 23,  true, false, 20 },
+	// 		{ 81, 24, false, false     },
+	// 		{ 82, 25, false, false     },
+	// 		{ 83, 26, false, false     },
+	// 		{ 84, 27, false, false     }
+	// 	};
+	// 	// clang-format on
+
+	// 	SeqManager<uint16_t> seqManager;
+	// 	validate(seqManager, inputs);
+	// }
+
+	SECTION("drop many inputs at the beginning")
 	{
 		// clang-format off
 		std::vector<TestSeqManagerInput> inputs =
 		{
-			{  0,  0, false, false },
-			{  1,  1, false, false },
-			{  2,  2, false, false },
-			{  3,  3, false, false },
-			{  4,  4, false, false },
-			{  5,  5, false, false },
-			{  6,  6, false, false },
-			{  7,  7, false, false },
-			{  8,  8, false, false },
-			{  9,  9, false, false },
-			{ 10, 10, false, false },
-			{ 11, 11, false, false }
-		};
-		// clang-format on
-
-		SeqManager<uint16_t> seqManager;
-		validate(seqManager, inputs);
-	}
-
-	SECTION("receive ordered numbers, sync, no drop")
-	{
-		// clang-format off
-		std::vector<TestSeqManagerInput> inputs =
-		{
-			{  0, 0, false, false },
-			{  1, 1, false, false },
-			{  2, 2, false, false },
-			{ 80, 3, true, false },
-			{ 81, 4, false, false },
-			{ 82, 5, false, false },
-			{ 83, 6, false, false },
-			{ 84, 7, false, false }
-		};
-		// clang-format on
-
-		SeqManager<uint16_t> seqManager;
-		validate(seqManager, inputs);
-	}
-
-	SECTION("receive ordered numbers, sync, drop")
-	{
-		// clang-format off
-		std::vector<TestSeqManagerInput> inputs =
-		{
-			{  0,  0, false, false },
-			{  1,  1, false, false },
-			{  2,  2, false, false },
-			{  3,  3, false, false },
-			{  4,  4,  true, false }, // sync.
-			{  5,  5, false, false },
-			{  6,  6, false, false },
-			{  7,  7,  true, false }, // sync.
-			{  8,  0, false,  true }, // drop.
-			{  9,  8, false, false },
-			{ 11,  0, false,  true }, // drop.
-			{ 10,  9, false, false },
-			{ 12, 10, false, false },
-		};
-		// clang-format on
-
-		SeqManager<uint16_t> seqManager;
-		validate(seqManager, inputs);
-	}
-
-	SECTION("receive ordered wrapped numbers")
-	{
-		// clang-format off
-		std::vector<TestSeqManagerInput> inputs =
-		{
-			{ 65533, 65533, false, false },
-			{ 65534, 65534, false, false },
-			{ 65535, 65535, false, false },
-			{     0,     0, false, false },
-			{     1,     1, false, false }
-		};
-		// clang-format on
-
-		SeqManager<uint16_t> seqManager;
-		validate(seqManager, inputs);
-	}
-
-	SECTION("receive sequence numbers with a big jump")
-	{
-		// clang-format off
-		std::vector<TestSeqManagerInput> inputs =
-		{
-			{    0,   0, false, false },
-			{    1,   1, false, false },
-			{ 1000, 1000, false, false },
-			{ 1001, 1001, false, false }
-		};
-		// clang-format on
-
-		SeqManager<uint16_t> seqManager;
-		validate(seqManager, inputs);
-	}
-
-	SECTION("receive mixed numbers with a big jump, drop before jump")
-	{
-		// clang-format off
-		std::vector<TestSeqManagerInput> inputs =
-		{
-			{   0,   0, false, false },
-			{   1,   0, false,  true }, // drop.
-			{ 100,  99, false, false },
-			{ 100,  99, false, false },
-			{ 103,   0, false,  true }, // drop.
-			{ 101, 100, false, false }
-		};
-		// clang-format on
-
-		SeqManager<uint16_t> seqManager;
-		validate(seqManager, inputs);
-	}
-
-	SECTION("receive mixed numbers with a big jump, drop after jump")
-	{
-		// clang-format off
-		std::vector<TestSeqManagerInput> inputs =
-		{
-			{   0,   0, false, false },
-			{   1,   1, false, false },
-			{ 100,   0, false,  true }, // drop.
-			{ 103,   0, false,  true }, // drop.
-			{ 101, 100, false, false }
-		};
-		// clang-format on
-
-		SeqManager<uint16_t> seqManager;
-		validate(seqManager, inputs);
-	}
-
-	SECTION("drop, receive numbers newer and older than the one dropped")
-	{
-		// clang-format off
-		std::vector<TestSeqManagerInput> inputs =
-		{
-			{ 0, 0, false, false },
-			{ 2, 0, false,  true }, // drop.
-			{ 3, 2, false, false },
-			{ 4, 3, false, false },
-			{ 1, 1, false, false }
-		};
-		// clang-format on
-
-		SeqManager<uint16_t> seqManager;
-		validate(seqManager, inputs);
-	}
-
-	SECTION("receive mixed numbers, sync, drop")
-	{
-		// clang-format off
-		std::vector<TestSeqManagerInput> inputs =
-		{
-			{     0,  0, false, false },
-			{     1,  1, false, false },
-			{     2,  2, false, false },
-			{     3,  3, false, false },
-			{     7,  7, false, false },
-			{     6,  0, false,  true }, // drop.
-			{     8,  8, false, false },
-			{    10, 10, false, false },
-			{     9,  9, false, false },
-			{    11, 11, false, false },
-			{     0, 12,  true, false }, // sync.
-			{     2, 14, false, false },
-			{     3, 15, false, false },
-			{     4, 16, false, false },
-			{     5, 17, false, false },
-			{     6, 18, false, false },
-			{     7, 19, false, false },
-			{     8, 20, false, false },
-			{     9, 21, false, false },
-			{    10, 22, false, false },
-			{     9,  0, false,  true }, // drop.
-			{    61, 23,  true, false }, // sync.
-			{    62, 24, false, false },
-			{    63, 25, false, false },
-			{    64, 26, false, false },
-			{    65, 27, false, false },
-			{    11, 28,  true, false }, // sync.
-			{    12, 29, false, false },
-			{    13, 30, false, false },
-			{    14, 31, false, false },
-			{    15, 32, false, false },
-			{     1, 33,  true, false }, // sync.
-			{     2, 34, false, false },
-			{     3, 35, false, false },
-			{     4, 36, false, false },
-			{     5, 37, false, false },
-			{ 65533, 38,  true, false }, // sync.
-			{ 65534, 39, false, false },
-			{ 65535, 40, false, false },
-			{     0, 41,  true, false }, // sync.
-			{     1, 42, false, false },
-			{     3,  0, false,  true }, // drop.
-			{     4, 44, false, false },
-			{     5, 45, false, false },
-			{     6, 46, false, false },
-			{     7, 47, false, false }
-		};
-		// clang-format on
-
-		SeqManager<uint16_t> seqManager;
-		validate(seqManager, inputs);
-	}
-
-	SECTION("receive ordered numbers, sync, no drop, increase input")
-	{
-		// clang-format off
-		std::vector<TestSeqManagerInput> inputs =
-		{
-			{  0,  0, false, false     },
-			{  1,  1, false, false     },
-			{  2,  2, false, false     },
-			{ 80, 23,  true, false, 20 },
-			{ 81, 24, false, false     },
-			{ 82, 25, false, false     },
-			{ 83, 26, false, false     },
-			{ 84, 27, false, false     }
+			{   1,   1,   false, false },
+			{   2,   0,   false, true  },
+			{   3,   0,   false, true  },
+			{   4,   0,   false, true  },
+			{   5,   0,   false, true  },
+			{   6,   0,   false, true  },
+			{   7,   0,   false, true  },
+			{   8,   0,   false, true  },
+			{   9,   0,   false, true  },
+			{   120, 112, false, false },
+			{   121, 113, false, false },
+			{   122, 114, false, false },
+			{   123, 115, false, false },
+			{   124, 116, false, false },
+			{   125, 117, false, false },
+			{   126, 118, false, false },
+			{   127, 119, false, false },
+			{   128, 120, false, false },
+			{   129, 121, false, false },
+			{   130, 122, false, false },
+			// {   132, 123, false, false },
+			// {   132, 124, false, false },
+			// {   133, 125, false, false },
+			// {   134, 126, false, false },
+			// {   135, 127, false, false },
+			// {   136, 128, false, false },
+			// {   137, 129, false, false },
+			// {   138, 130, false, false },
+			// {   139, 131, false, false }
 		};
 		// clang-format on
 

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -1,6 +1,7 @@
 #include "common.hpp"
 #include "RTC/SeqManager.hpp"
 #include <catch.hpp>
+#include <string>
 #include <vector>
 
 using namespace RTC;
@@ -40,6 +41,8 @@ void validate(SeqManager<T>& seqManager, std::vector<TestSeqManagerInput<T>>& in
 			T output;
 
 			seqManager.Input(element.input, output);
+
+			// Covert to string because otherwise Catch will print uint8_t as char.
 			REQUIRE(std::to_string(output) == std::to_string(element.output));
 		}
 	}
@@ -47,277 +50,277 @@ void validate(SeqManager<T>& seqManager, std::vector<TestSeqManagerInput<T>>& in
 
 SCENARIO("SeqManager", "[rtc]")
 {
-	// SECTION("0 is greater than 65000")
-	// {
-	// 	REQUIRE(SeqManager<uint16_t>::IsSeqHigherThan(0, 65000) == true);
-	// }
+	SECTION("0 is greater than 65000")
+	{
+		REQUIRE(SeqManager<uint16_t>::IsSeqHigherThan(0, 65000) == true);
+	}
 
-	// SECTION("receive ordered numbers, no sync, no drop")
-	// {
-	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
-	// 	{
-	// 		{  0,  0, false, false },
-	// 		{  1,  1, false, false },
-	// 		{  2,  2, false, false },
-	// 		{  3,  3, false, false },
-	// 		{  4,  4, false, false },
-	// 		{  5,  5, false, false },
-	// 		{  6,  6, false, false },
-	// 		{  7,  7, false, false },
-	// 		{  8,  8, false, false },
-	// 		{  9,  9, false, false },
-	// 		{ 10, 10, false, false },
-	// 		{ 11, 11, false, false }
-	// 	};
-	// 	// clang-format on
+	SECTION("receive ordered numbers, no sync, no drop")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{  0,  0, false, false },
+			{  1,  1, false, false },
+			{  2,  2, false, false },
+			{  3,  3, false, false },
+			{  4,  4, false, false },
+			{  5,  5, false, false },
+			{  6,  6, false, false },
+			{  7,  7, false, false },
+			{  8,  8, false, false },
+			{  9,  9, false, false },
+			{ 10, 10, false, false },
+			{ 11, 11, false, false }
+		};
+		// clang-format on
 
-	// 	SeqManager<uint16_t> seqManager;
-	// 	validate(seqManager, inputs);
-	// }
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
 
-	// SECTION("receive ordered numbers, sync, no drop")
-	// {
-	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
-	// 	{
-	// 		{  0, 0, false, false },
-	// 		{  1, 1, false, false },
-	// 		{  2, 2, false, false },
-	// 		{ 80, 3, true, false },
-	// 		{ 81, 4, false, false },
-	// 		{ 82, 5, false, false },
-	// 		{ 83, 6, false, false },
-	// 		{ 84, 7, false, false }
-	// 	};
-	// 	// clang-format on
+	SECTION("receive ordered numbers, sync, no drop")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{  0, 0, false, false },
+			{  1, 1, false, false },
+			{  2, 2, false, false },
+			{ 80, 3,  true, false },
+			{ 81, 4, false, false },
+			{ 82, 5, false, false },
+			{ 83, 6, false, false },
+			{ 84, 7, false, false }
+		};
+		// clang-format on
 
-	// 	SeqManager<uint16_t> seqManager;
-	// 	validate(seqManager, inputs);
-	// }
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
 
-	// SECTION("receive ordered numbers, sync, drop")
-	// {
-	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
-	// 	{
-	// 		{  0,  0, false, false },
-	// 		{  1,  1, false, false },
-	// 		{  2,  2, false, false },
-	// 		{  3,  3, false, false },
-	// 		{  4,  4,  true, false }, // sync.
-	// 		{  5,  5, false, false },
-	// 		{  6,  6, false, false },
-	// 		{  7,  7,  true, false }, // sync.
-	// 		{  8,  0, false,  true }, // drop.
-	// 		{  9,  8, false, false },
-	// 		{ 11,  0, false,  true }, // drop.
-	// 		{ 10,  9, false, false },
-	// 		{ 12, 10, false, false },
-	// 	};
-	// 	// clang-format on
+	SECTION("receive ordered numbers, sync, drop")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{  0,  0, false, false },
+			{  1,  1, false, false },
+			{  2,  2, false, false },
+			{  3,  3, false, false },
+			{  4,  4,  true, false }, // sync.
+			{  5,  5, false, false },
+			{  6,  6, false, false },
+			{  7,  7,  true, false }, // sync.
+			{  8,  0, false,  true }, // drop.
+			{  9,  8, false, false },
+			{ 11,  0, false,  true }, // drop.
+			{ 10,  9, false, false },
+			{ 12, 10, false, false },
+		};
+		// clang-format on
 
-	// 	SeqManager<uint16_t> seqManager;
-	// 	validate(seqManager, inputs);
-	// }
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
 
-	// SECTION("receive ordered wrapped numbers")
-	// {
-	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
-	// 	{
-	// 		{ 65533, 65533, false, false },
-	// 		{ 65534, 65534, false, false },
-	// 		{ 65535, 65535, false, false },
-	// 		{     0,     0, false, false },
-	// 		{     1,     1, false, false }
-	// 	};
-	// 	// clang-format on
+	SECTION("receive ordered wrapped numbers")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{ 65533, 65533, false, false },
+			{ 65534, 65534, false, false },
+			{ 65535, 65535, false, false },
+			{     0,     0, false, false },
+			{     1,     1, false, false }
+		};
+		// clang-format on
 
-	// 	SeqManager<uint16_t> seqManager;
-	// 	validate(seqManager, inputs);
-	// }
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
 
-	// SECTION("receive sequence numbers with a big jump")
-	// {
-	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
-	// 	{
-	// 		{    0,   0, false, false },
-	// 		{    1,   1, false, false },
-	// 		{ 1000, 1000, false, false },
-	// 		{ 1001, 1001, false, false }
-	// 	};
-	// 	// clang-format on
+	SECTION("receive sequence numbers with a big jump")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{    0,    0, false, false },
+			{    1,    1, false, false },
+			{ 1000, 1000, false, false },
+			{ 1001, 1001, false, false }
+		};
+		// clang-format on
 
-	// 	SeqManager<uint16_t> seqManager;
-	// 	validate(seqManager, inputs);
-	// }
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
 
-	// SECTION("receive mixed numbers with a big jump, drop before jump")
-	// {
-	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
-	// 	{
-	// 		{   0,   0, false, false },
-	// 		{   1,   0, false,  true }, // drop.
-	// 		{ 100,  99, false, false },
-	// 		{ 100,  99, false, false },
-	// 		{ 103,   0, false,  true }, // drop.
-	// 		{ 101, 100, false, false }
-	// 	};
-	// 	// clang-format on
+	SECTION("receive mixed numbers with a big jump, drop before jump")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{   0,   0, false, false },
+			{   1,   0, false,  true }, // drop.
+			{ 100,  99, false, false },
+			{ 100,  99, false, false },
+			{ 103,   0, false,  true }, // drop.
+			{ 101, 100, false, false }
+		};
+		// clang-format on
 
-	// 	SeqManager<uint16_t> seqManager;
-	// 	validate(seqManager, inputs);
-	// }
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
 
-	// SECTION("receive mixed numbers with a big jump, drop after jump")
-	// {
-	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
-	// 	{
-	// 		{   0,   0, false, false },
-	// 		{   1,   1, false, false },
-	// 		{ 100,   0, false,  true }, // drop.
-	// 		{ 103,   0, false,  true }, // drop.
-	// 		{ 101, 100, false, false }
-	// 	};
-	// 	// clang-format on
+	SECTION("receive mixed numbers with a big jump, drop after jump")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{   0,   0, false, false },
+			{   1,   1, false, false },
+			{ 100,   0, false,  true }, // drop.
+			{ 103,   0, false,  true }, // drop.
+			{ 101, 100, false, false }
+		};
+		// clang-format on
 
-	// 	SeqManager<uint16_t> seqManager;
-	// 	validate(seqManager, inputs);
-	// }
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
 
-	// SECTION("drop, receive numbers newer and older than the one dropped")
-	// {
-	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
-	// 	{
-	// 		{ 0, 0, false, false },
-	// 		{ 2, 0, false,  true }, // drop.
-	// 		{ 3, 2, false, false },
-	// 		{ 4, 3, false, false },
-	// 		{ 1, 1, false, false }
-	// 	};
-	// 	// clang-format on
+	SECTION("drop, receive numbers newer and older than the one dropped")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{ 0, 0, false, false },
+			{ 2, 0, false,  true }, // drop.
+			{ 3, 2, false, false },
+			{ 4, 3, false, false },
+			{ 1, 1, false, false }
+		};
+		// clang-format on
 
-	// 	SeqManager<uint16_t> seqManager;
-	// 	validate(seqManager, inputs);
-	// }
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
 
-	// SECTION("receive mixed numbers, sync, drop")
-	// {
-	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
-	// 	{
-	// 		{     0,  0, false, false },
-	// 		{     1,  1, false, false },
-	// 		{     2,  2, false, false },
-	// 		{     3,  3, false, false },
-	// 		{     7,  7, false, false },
-	// 		{     6,  0, false,  true }, // drop.
-	// 		{     8,  8, false, false },
-	// 		{    10, 10, false, false },
-	// 		{     9,  9, false, false },
-	// 		{    11, 11, false, false },
-	// 		{     0, 12,  true, false }, // sync.
-	// 		{     2, 14, false, false },
-	// 		{     3, 15, false, false },
-	// 		{     4, 16, false, false },
-	// 		{     5, 17, false, false },
-	// 		{     6, 18, false, false },
-	// 		{     7, 19, false, false },
-	// 		{     8, 20, false, false },
-	// 		{     9, 21, false, false },
-	// 		{    10, 22, false, false },
-	// 		{     9,  0, false,  true }, // drop.
-	// 		{    61, 23,  true, false }, // sync.
-	// 		{    62, 24, false, false },
-	// 		{    63, 25, false, false },
-	// 		{    64, 26, false, false },
-	// 		{    65, 27, false, false },
-	// 		{    11, 28,  true, false }, // sync.
-	// 		{    12, 29, false, false },
-	// 		{    13, 30, false, false },
-	// 		{    14, 31, false, false },
-	// 		{    15, 32, false, false },
-	// 		{     1, 33,  true, false }, // sync.
-	// 		{     2, 34, false, false },
-	// 		{     3, 35, false, false },
-	// 		{     4, 36, false, false },
-	// 		{     5, 37, false, false },
-	// 		{ 65533, 38,  true, false }, // sync.
-	// 		{ 65534, 39, false, false },
-	// 		{ 65535, 40, false, false },
-	// 		{     0, 41,  true, false }, // sync.
-	// 		{     1, 42, false, false },
-	// 		{     3,  0, false,  true }, // drop.
-	// 		{     4, 44, false, false },
-	// 		{     5, 45, false, false },
-	// 		{     6, 46, false, false },
-	// 		{     7, 47, false, false }
-	// 	};
-	// 	// clang-format on
+	SECTION("receive mixed numbers, sync, drop")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{     0,  0, false, false },
+			{     1,  1, false, false },
+			{     2,  2, false, false },
+			{     3,  3, false, false },
+			{     7,  7, false, false },
+			{     6,  0, false,  true }, // drop.
+			{     8,  8, false, false },
+			{    10, 10, false, false },
+			{     9,  9, false, false },
+			{    11, 11, false, false },
+			{     0, 12,  true, false }, // sync.
+			{     2, 14, false, false },
+			{     3, 15, false, false },
+			{     4, 16, false, false },
+			{     5, 17, false, false },
+			{     6, 18, false, false },
+			{     7, 19, false, false },
+			{     8, 20, false, false },
+			{     9, 21, false, false },
+			{    10, 22, false, false },
+			{     9,  0, false,  true }, // drop.
+			{    61, 23,  true, false }, // sync.
+			{    62, 24, false, false },
+			{    63, 25, false, false },
+			{    64, 26, false, false },
+			{    65, 27, false, false },
+			{    11, 28,  true, false }, // sync.
+			{    12, 29, false, false },
+			{    13, 30, false, false },
+			{    14, 31, false, false },
+			{    15, 32, false, false },
+			{     1, 33,  true, false }, // sync.
+			{     2, 34, false, false },
+			{     3, 35, false, false },
+			{     4, 36, false, false },
+			{     5, 37, false, false },
+			{ 65533, 38,  true, false }, // sync.
+			{ 65534, 39, false, false },
+			{ 65535, 40, false, false },
+			{     0, 41,  true, false }, // sync.
+			{     1, 42, false, false },
+			{     3,  0, false,  true }, // drop.
+			{     4, 44, false, false },
+			{     5, 45, false, false },
+			{     6, 46, false, false },
+			{     7, 47, false, false }
+		};
+		// clang-format on
 
-	// 	SeqManager<uint16_t> seqManager;
-	// 	validate(seqManager, inputs);
-	// }
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
 
-	// SECTION("receive ordered numbers, sync, no drop, increase input")
-	// {
-	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
-	// 	{
-	// 		{  0,  0, false, false     },
-	// 		{  1,  1, false, false     },
-	// 		{  2,  2, false, false     },
-	// 		{ 80, 23,  true, false, 20 },
-	// 		{ 81, 24, false, false     },
-	// 		{ 82, 25, false, false     },
-	// 		{ 83, 26, false, false     },
-	// 		{ 84, 27, false, false     }
-	// 	};
-	// 	// clang-format on
+	SECTION("receive ordered numbers, sync, no drop, increase input")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{  0,  0, false, false     },
+			{  1,  1, false, false     },
+			{  2,  2, false, false     },
+			{ 80, 23,  true, false, 20 },
+			{ 81, 24, false, false     },
+			{ 82, 25, false, false     },
+			{ 83, 26, false, false     },
+			{ 84, 27, false, false     }
+		};
+		// clang-format on
 
-	// 	SeqManager<uint16_t> seqManager;
-	// 	validate(seqManager, inputs);
-	// }
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
 
 	SECTION("drop many inputs at the beginning (using uint16_t)")
 	{
 		// clang-format off
 		std::vector<TestSeqManagerInput<uint16_t>> inputs =
 		{
-			{   1,   1,   false, false },
-			{   2,   0,   false, true  },
-			{   3,   0,   false, true  },
-			{   4,   0,   false, true  },
-			{   5,   0,   false, true  },
-			{   6,   0,   false, true  },
-			{   7,   0,   false, true  },
-			{   8,   0,   false, true  },
-			{   9,   0,   false, true  },
-			{   120, 112, false, false },
-			{   121, 113, false, false },
-			{   122, 114, false, false },
-			{   123, 115, false, false },
-			{   124, 116, false, false },
-			{   125, 117, false, false },
-			{   126, 118, false, false },
-			{   127, 119, false, false },
-			{   128, 120, false, false },
-			{   129, 121, false, false },
-			{   130, 122, false, false },
-			{   131, 123, false, false },
-			{   132, 124, false, false },
-			{   133, 125, false, false },
-			{   134, 126, false, false },
-			{   135, 127, false, false },
-			{   136, 128, false, false },
-			{   137, 129, false, false },
-			{   138, 130, false, false },
-			{   139, 131, false, false }
+			{   1,   1, false, false },
+			{   2,   0, false,  true }, // drop.
+			{   3,   0, false,  true }, // drop.
+			{   4,   0, false,  true }, // drop.
+			{   5,   0, false,  true }, // drop.
+			{   6,   0, false,  true }, // drop.
+			{   7,   0, false,  true }, // drop.
+			{   8,   0, false,  true }, // drop.
+			{   9,   0, false,  true }, // drop.
+			{ 120, 112, false, false },
+			{ 121, 113, false, false },
+			{ 122, 114, false, false },
+			{ 123, 115, false, false },
+			{ 124, 116, false, false },
+			{ 125, 117, false, false },
+			{ 126, 118, false, false },
+			{ 127, 119, false, false },
+			{ 128, 120, false, false },
+			{ 129, 121, false, false },
+			{ 130, 122, false, false },
+			{ 131, 123, false, false },
+			{ 132, 124, false, false },
+			{ 133, 125, false, false },
+			{ 134, 126, false, false },
+			{ 135, 127, false, false },
+			{ 136, 128, false, false },
+			{ 137, 129, false, false },
+			{ 138, 130, false, false },
+			{ 139, 131, false, false }
 		};
 		// clang-format on
 
@@ -330,39 +333,73 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format off
 		std::vector<TestSeqManagerInput<uint8_t>> inputs =
 		{
-			{   1,   1,   false, false },
-			{   2,   0,   false, true  },
-			{   3,   0,   false, true  },
-			{   4,   0,   false, true  },
-			{   5,   0,   false, true  },
-			{   6,   0,   false, true  },
-			{   7,   0,   false, true  },
-			{   8,   0,   false, true  },
-			{   9,   0,   false, true  },
-			{   120, 112, false, false },
-			{   121, 113, false, false },
-			{   122, 114, false, false },
-			{   123, 115, false, false },
-			{   124, 116, false, false },
-			{   125, 117, false, false },
-			{   126, 118, false, false },
-			{   127, 119, false, false },
-			{   128, 120, false, false },
-			{   129, 121, false, false },
-			{   130, 122, false, false },
-			{   131, 123, false, false },
-			{   132, 124, false, false },
-			{   133, 125, false, false },
-			{   134, 126, false, false },
-			{   135, 127, false, false },
-			{   136, 128, false, false },
-			{   137, 129, false, false },
-			{   138, 130, false, false },
-			{   139, 131, false, false }
+			{   1,   1, false, false },
+			{   2,   0, false,  true }, // drop.
+			{   3,   0, false,  true }, // drop.
+			{   4,   0, false,  true }, // drop.
+			{   5,   0, false,  true }, // drop.
+			{   6,   0, false,  true }, // drop.
+			{   7,   0, false,  true }, // drop.
+			{   8,   0, false,  true }, // drop.
+			{   9,   0, false,  true }, // drop.
+			{ 120, 112, false, false },
+			{ 121, 113, false, false },
+			{ 122, 114, false, false },
+			{ 123, 115, false, false },
+			{ 124, 116, false, false },
+			{ 125, 117, false, false },
+			{ 126, 118, false, false },
+			{ 127, 119, false, false },
+			{ 128, 120, false, false },
+			{ 129, 121, false, false },
+			{ 130, 122, false, false },
+			{ 131, 123, false, false },
+			{ 132, 124, false, false },
+			{ 133, 125, false, false },
+			{ 134, 126, false, false },
+			{ 135, 127, false, false },
+			{ 136, 128, false, false },
+			{ 137, 129, false, false },
+			{ 138, 130, false, false },
+			{ 139, 131, false, false }
 		};
 		// clang-format on
 
 		SeqManager<uint8_t> seqManager;
+		validate(seqManager, inputs);
+	}
+
+	SECTION("drop many inputs at the beginning (using uint16_t with high values)")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{     1,     1, false, false },
+			{     2,     0, false,  true }, // drop.
+			{     3,     0, false,  true }, // drop.
+			{     4,     0, false,  true }, // drop.
+			{     5,     0, false,  true }, // drop.
+			{     6,     0, false,  true }, // drop.
+			{     7,     0, false,  true }, // drop.
+			{     8,     0, false,  true }, // drop.
+			{     9,     0, false,  true }, // drop.
+			{ 32768, 32760, false, false },
+			{ 32769, 32761, false, false },
+			{ 32770, 32762, false, false },
+			{ 32771, 32763, false, false },
+			{ 32772, 32764, false, false },
+			{ 32773, 32765, false, false },
+			{ 32774, 32766, false, false },
+			{ 32775, 32767, false, false },
+			{ 32776, 32768, false, false },
+			{ 32777, 32769, false, false },
+			{ 32778, 32770, false, false },
+			{ 32779, 32771, false, false },
+			{ 32780, 32772, false, false }
+		};
+		// clang-format on
+
+		SeqManager<uint16_t> seqManager;
 		validate(seqManager, inputs);
 	}
 }

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -5,22 +5,23 @@
 
 using namespace RTC;
 
+template<typename T>
 struct TestSeqManagerInput
 {
-	TestSeqManagerInput(
-	  uint16_t input, uint16_t output, bool sync = false, bool drop = false, uint16_t offset = 0)
+	TestSeqManagerInput(T input, T output, bool sync = false, bool drop = false, T offset = 0)
 	  : input(input), output(output), sync(sync), drop(drop), offset(offset)
 	{
 	}
 
-	uint16_t input{ 0 };
-	uint16_t output{ 0 };
+	T input{ 0 };
+	T output{ 0 };
 	bool sync{ false };
 	bool drop{ false };
-	uint16_t offset{ 0 };
+	T offset{ 0 };
 };
 
-void validate(SeqManager<uint16_t>& seqManager, std::vector<TestSeqManagerInput>& inputs)
+template<typename T>
+void validate(SeqManager<T>& seqManager, std::vector<TestSeqManagerInput<T>>& inputs)
 {
 	for (auto& element : inputs)
 	{
@@ -36,10 +37,10 @@ void validate(SeqManager<uint16_t>& seqManager, std::vector<TestSeqManagerInput>
 		}
 		else
 		{
-			uint16_t output;
+			T output;
 
 			seqManager.Input(element.input, output);
-			REQUIRE(output == element.output);
+			REQUIRE(std::to_string(output) == std::to_string(element.output));
 		}
 	}
 }
@@ -54,7 +55,7 @@ SCENARIO("SeqManager", "[rtc]")
 	// SECTION("receive ordered numbers, no sync, no drop")
 	// {
 	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
 	// 	{
 	// 		{  0,  0, false, false },
 	// 		{  1,  1, false, false },
@@ -78,7 +79,7 @@ SCENARIO("SeqManager", "[rtc]")
 	// SECTION("receive ordered numbers, sync, no drop")
 	// {
 	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
 	// 	{
 	// 		{  0, 0, false, false },
 	// 		{  1, 1, false, false },
@@ -98,7 +99,7 @@ SCENARIO("SeqManager", "[rtc]")
 	// SECTION("receive ordered numbers, sync, drop")
 	// {
 	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
 	// 	{
 	// 		{  0,  0, false, false },
 	// 		{  1,  1, false, false },
@@ -123,7 +124,7 @@ SCENARIO("SeqManager", "[rtc]")
 	// SECTION("receive ordered wrapped numbers")
 	// {
 	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
 	// 	{
 	// 		{ 65533, 65533, false, false },
 	// 		{ 65534, 65534, false, false },
@@ -140,7 +141,7 @@ SCENARIO("SeqManager", "[rtc]")
 	// SECTION("receive sequence numbers with a big jump")
 	// {
 	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
 	// 	{
 	// 		{    0,   0, false, false },
 	// 		{    1,   1, false, false },
@@ -156,7 +157,7 @@ SCENARIO("SeqManager", "[rtc]")
 	// SECTION("receive mixed numbers with a big jump, drop before jump")
 	// {
 	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
 	// 	{
 	// 		{   0,   0, false, false },
 	// 		{   1,   0, false,  true }, // drop.
@@ -174,7 +175,7 @@ SCENARIO("SeqManager", "[rtc]")
 	// SECTION("receive mixed numbers with a big jump, drop after jump")
 	// {
 	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
 	// 	{
 	// 		{   0,   0, false, false },
 	// 		{   1,   1, false, false },
@@ -191,7 +192,7 @@ SCENARIO("SeqManager", "[rtc]")
 	// SECTION("drop, receive numbers newer and older than the one dropped")
 	// {
 	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
 	// 	{
 	// 		{ 0, 0, false, false },
 	// 		{ 2, 0, false,  true }, // drop.
@@ -208,7 +209,7 @@ SCENARIO("SeqManager", "[rtc]")
 	// SECTION("receive mixed numbers, sync, drop")
 	// {
 	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
 	// 	{
 	// 		{     0,  0, false, false },
 	// 		{     1,  1, false, false },
@@ -266,7 +267,7 @@ SCENARIO("SeqManager", "[rtc]")
 	// SECTION("receive ordered numbers, sync, no drop, increase input")
 	// {
 	// 	// clang-format off
-	// 	std::vector<TestSeqManagerInput> inputs =
+	// 	std::vector<TestSeqManagerInput<uint16_t>> inputs =
 	// 	{
 	// 		{  0,  0, false, false     },
 	// 		{  1,  1, false, false     },
@@ -283,10 +284,10 @@ SCENARIO("SeqManager", "[rtc]")
 	// 	validate(seqManager, inputs);
 	// }
 
-	SECTION("drop many inputs at the beginning")
+	SECTION("drop many inputs at the beginning (using uint16_t)")
 	{
 		// clang-format off
-		std::vector<TestSeqManagerInput> inputs =
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
 		{
 			{   1,   1,   false, false },
 			{   2,   0,   false, true  },
@@ -321,6 +322,47 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format on
 
 		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
+
+	SECTION("drop many inputs at the beginning (using uint8_t)")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint8_t>> inputs =
+		{
+			{   1,   1,   false, false },
+			{   2,   0,   false, true  },
+			{   3,   0,   false, true  },
+			{   4,   0,   false, true  },
+			{   5,   0,   false, true  },
+			{   6,   0,   false, true  },
+			{   7,   0,   false, true  },
+			{   8,   0,   false, true  },
+			{   9,   0,   false, true  },
+			{   120, 112, false, false },
+			{   121, 113, false, false },
+			{   122, 114, false, false },
+			{   123, 115, false, false },
+			{   124, 116, false, false },
+			{   125, 117, false, false },
+			{   126, 118, false, false },
+			{   127, 119, false, false },
+			{   128, 120, false, false },
+			{   129, 121, false, false },
+			{   130, 122, false, false },
+			{   131, 123, false, false },
+			{   132, 124, false, false },
+			{   133, 125, false, false },
+			{   134, 126, false, false },
+			{   135, 127, false, false },
+			{   136, 128, false, false },
+			{   137, 129, false, false },
+			{   138, 130, false, false },
+			{   139, 131, false, false }
+		};
+		// clang-format on
+
+		SeqManager<uint8_t> seqManager;
 		validate(seqManager, inputs);
 	}
 }

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -308,15 +308,15 @@ SCENARIO("SeqManager", "[rtc]")
 			{   128, 120, false, false },
 			{   129, 121, false, false },
 			{   130, 122, false, false },
-			// {   132, 123, false, false },
-			// {   132, 124, false, false },
-			// {   133, 125, false, false },
-			// {   134, 126, false, false },
-			// {   135, 127, false, false },
-			// {   136, 128, false, false },
-			// {   137, 129, false, false },
-			// {   138, 130, false, false },
-			// {   139, 131, false, false }
+			{   131, 123, false, false },
+			{   132, 124, false, false },
+			{   133, 125, false, false },
+			{   134, 126, false, false },
+			{   135, 127, false, false },
+			{   136, 128, false, false },
+			{   137, 129, false, false },
+			{   138, 130, false, false },
+			{   139, 131, false, false }
 		};
 		// clang-format on
 


### PR DESCRIPTION
This issue produced video lag when using simulcast/SVC when staying at the low streams for 10-20 minutes.

A big thanks to @penguinol for reporting it and giving the solution in #372.