### PR TITLE
ConsumerOptions.rtpCapabilities field is not optional

### DIFF
--- a/src/Consumer.ts
+++ b/src/Consumer.ts
@@ -18,7 +18,7 @@ export type ConsumerOptions =
 	/**
 	 * RTP capabilities of the consuming endpoint.
 	 */
-	rtpCapabilities?: RtpCapabilities;
+	rtpCapabilities: RtpCapabilities;
 
 	/**
 	 * Whether the Consumer must start in paused mode. Default false.


### PR DESCRIPTION
It is also not optional according to documentation