### PR TITLE
Added const to arguments dealing with file descriptors

### DIFF
--- a/worker/include/Channel/UnixStreamSocket.hpp
+++ b/worker/include/Channel/UnixStreamSocket.hpp
@@ -19,7 +19,7 @@ namespace Channel
 		};
 
 	public:
-		ConsumerSocket(int fd, size_t bufferSize, Listener* listener);
+		ConsumerSocket(const int fd, size_t bufferSize, Listener* listener);
 		/* Pure virtual methods inherited from ::UnixStreamSocket. */
 	public:
 		void UserOnUnixStreamRead() override;
@@ -35,7 +35,7 @@ namespace Channel
 	class ProducerSocket : public ::UnixStreamSocket
 	{
 	public:
-		ProducerSocket(int fd, size_t bufferSize);
+		ProducerSocket(const int fd, size_t bufferSize);
 
 		/* Pure virtual methods inherited from ::UnixStreamSocket. */
 	public:
@@ -58,7 +58,7 @@ namespace Channel
 		};
 
 	public:
-		explicit UnixStreamSocket(int consumerFd, int producerFd);
+		explicit UnixStreamSocket(const int consumerFd, const int producerFd);
 		virtual ~UnixStreamSocket();
 
 	public:

--- a/worker/include/handles/UnixStreamSocket.hpp
+++ b/worker/include/handles/UnixStreamSocket.hpp
@@ -35,7 +35,7 @@ public:
 	};
 
 public:
-	UnixStreamSocket(int fd, size_t bufferSize, UnixStreamSocket::Role role);
+	UnixStreamSocket(const int fd, size_t bufferSize, UnixStreamSocket::Role role);
 	UnixStreamSocket& operator=(const UnixStreamSocket&) = delete;
 	UnixStreamSocket(const UnixStreamSocket&)            = delete;
 	virtual ~UnixStreamSocket();

--- a/worker/src/Channel/UnixStreamSocket.cpp
+++ b/worker/src/Channel/UnixStreamSocket.cpp
@@ -22,7 +22,7 @@ namespace Channel
 	static uint8_t WriteBuffer[NsMessageMaxLen];
 
 	/* Instance methods. */
-	UnixStreamSocket::UnixStreamSocket(int consumerFd, int producerFd)
+	UnixStreamSocket::UnixStreamSocket(const int consumerFd, const int producerFd)
 	  : consumerSocket(consumerFd, NsMessageMaxLen, this), producerSocket(producerFd, NsMessageMaxLen)
 	{
 		MS_TRACE_STD();
@@ -146,7 +146,7 @@ namespace Channel
 		this->listener->OnChannelClosed(this);
 	}
 
-	ConsumerSocket::ConsumerSocket(int fd, size_t bufferSize, Listener* listener)
+	ConsumerSocket::ConsumerSocket(const int fd, size_t bufferSize, Listener* listener)
 	  : ::UnixStreamSocket(fd, bufferSize, ::UnixStreamSocket::Role::CONSUMER), listener(listener)
 	{
 		MS_TRACE_STD();
@@ -285,7 +285,7 @@ namespace Channel
 		this->listener->OnConsumerSocketClosed(this);
 	}
 
-	ProducerSocket::ProducerSocket(int fd, size_t bufferSize)
+	ProducerSocket::ProducerSocket(const int fd, size_t bufferSize)
 	  : ::UnixStreamSocket(fd, bufferSize, ::UnixStreamSocket::Role::PRODUCER)
 	{
 		MS_TRACE_STD();

--- a/worker/src/handles/UnixStreamSocket.cpp
+++ b/worker/src/handles/UnixStreamSocket.cpp
@@ -61,7 +61,7 @@ inline static void onShutdown(uv_shutdown_t* req, int /*status*/)
 
 /* Instance methods. */
 
-UnixStreamSocket::UnixStreamSocket(int fd, size_t bufferSize, UnixStreamSocket::Role role)
+UnixStreamSocket::UnixStreamSocket(const int fd, size_t bufferSize, UnixStreamSocket::Role role)
   : bufferSize(bufferSize), role(role)
 {
 	MS_TRACE_STD();

--- a/worker/src/main.cpp
+++ b/worker/src/main.cpp
@@ -39,7 +39,6 @@ int main(int argc, char* argv[])
 	if (std::getenv("MEDIASOUP_VERSION") == nullptr)
 	{
 		MS_ERROR_STD("you don't seem to be my real father!");
-
 		std::_Exit(EXIT_FAILURE);
 	}
 

--- a/worker/src/main.cpp
+++ b/worker/src/main.cpp
@@ -39,6 +39,7 @@ int main(int argc, char* argv[])
 	if (std::getenv("MEDIASOUP_VERSION") == nullptr)
 	{
 		MS_ERROR_STD("you don't seem to be my real father!");
+		
 		std::_Exit(EXIT_FAILURE);
 	}
 


### PR DESCRIPTION
I was looking through the codebase, and I believe that the arguments I have changed from `int` to `const int` can be changed without issue. While unlikely to cause a bug, I see no reason why they couldn't be changed, since file descriptors do not change at runtime. Especially since the arguments passed in my `main.cpp` are declared with `constexpr`.

I did a test compilation and it worked for me. Please let me know if there is any issue with this that I haven't seen. Thank you!