### PR TITLE
Remove ended SRTP streams from SrtpSession

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 
 ### 3.6.8 (WIP)
 
+* Fix SRTP leak due to streams not being removed when a `Producer` or `Consumer` is closed.
+  - PR #428 (fixes issues #426). 
+  - Credits to credits to @penguinol for reporting and initial work at PR #427.
 * Update `nlohmann::json` C++ dep to 3.8.0.
 
 

--- a/worker/include/RTC/DirectTransport.hpp
+++ b/worker/include/RTC/DirectTransport.hpp
@@ -23,6 +23,8 @@ namespace RTC
 		void SendRtcpPacket(RTC::RTCP::Packet* packet) override;
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;
+		void RecvStreamClosed(uint32_t ssrc) override;
+		void SendStreamClosed(uint32_t ssrc) override;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/PipeTransport.hpp
+++ b/worker/include/RTC/PipeTransport.hpp
@@ -39,6 +39,8 @@ namespace RTC
 		void SendRtcpPacket(RTC::RTCP::Packet* packet) override;
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;
+		void RecvStreamClosed(uint32_t ssrc) override;
+		void SendStreamClosed(uint32_t ssrc) override;
 		void OnPacketReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len);
 		void OnRtpDataReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len);
 		void OnRtcpDataReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len);

--- a/worker/include/RTC/PlainTransport.hpp
+++ b/worker/include/RTC/PlainTransport.hpp
@@ -41,6 +41,8 @@ namespace RTC
 		void SendRtcpPacket(RTC::RTCP::Packet* packet) override;
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;
+		void RecvStreamClosed(uint32_t ssrc) override;
+		void SendStreamClosed(uint32_t ssrc) override;
 		void OnPacketReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len);
 		void OnRtpDataReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len);
 		void OnRtcpDataReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len);

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -156,6 +156,8 @@ namespace RTC
 		virtual void SendRtcpPacket(RTC::RTCP::Packet* packet)                 = 0;
 		virtual void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) = 0;
 		virtual void SendSctpData(const uint8_t* data, size_t len)             = 0;
+		virtual void RecvStreamClosed(uint32_t ssrc)                           = 0;
+		virtual void SendStreamClosed(uint32_t ssrc)                           = 0;
 		void DistributeAvailableOutgoingBitrate();
 		void ComputeOutgoingDesiredBitrate(bool forceBitrate = false);
 		void EmitTraceEventProbationType(RTC::RtpPacket* packet) const;

--- a/worker/include/RTC/WebRtcTransport.hpp
+++ b/worker/include/RTC/WebRtcTransport.hpp
@@ -46,6 +46,8 @@ namespace RTC
 		void SendRtcpPacket(RTC::RTCP::Packet* packet) override;
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;
+		void RecvStreamClosed(uint32_t ssrc) override;
+		void SendStreamClosed(uint32_t ssrc) override;
 		void OnPacketReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len);
 		void OnStunDataReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len);
 		void OnDtlsDataReceived(const RTC::TransportTuple* tuple, const uint8_t* data, size_t len);

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -90,4 +90,18 @@ namespace RTC
 
 		// Do nothing.
 	}
+
+	void DirectTransport::RecvStreamClosed(uint32_t /*ssrc*/)
+	{
+		MS_TRACE();
+
+		// Do nothing.
+	}
+
+	void DirectTransport::SendStreamClosed(uint32_t /*ssrc*/)
+	{
+		MS_TRACE();
+
+		// Do nothing.
+	}
 } // namespace RTC

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -506,6 +506,26 @@ namespace RTC
 		RTC::Transport::DataSent(len);
 	}
 
+	void PipeTransport::RecvStreamClosed(uint32_t ssrc)
+	{
+		MS_TRACE();
+
+		if (this->srtpRecvSession)
+		{
+			this->srtpRecvSession->RemoveStream(ssrc);
+		}
+	}
+
+	void PipeTransport::SendStreamClosed(uint32_t ssrc)
+	{
+		MS_TRACE();
+
+		if (this->srtpSendSession)
+		{
+			this->srtpSendSession->RemoveStream(ssrc);
+		}
+	}
+
 	inline void PipeTransport::OnPacketReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -696,6 +696,26 @@ namespace RTC
 		RTC::Transport::DataSent(len);
 	}
 
+	void PlainTransport::RecvStreamClosed(uint32_t ssrc)
+	{
+		MS_TRACE();
+
+		if (this->srtpRecvSession)
+		{
+			this->srtpRecvSession->RemoveStream(ssrc);
+		}
+	}
+
+	void PlainTransport::SendStreamClosed(uint32_t ssrc)
+	{
+		MS_TRACE();
+
+		if (this->srtpSendSession)
+		{
+			this->srtpSendSession->RemoveStream(ssrc);
+		}
+	}
+
 	inline void PlainTransport::OnPacketReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1220,6 +1220,17 @@ namespace RTC
 				// Remove it from the map.
 				this->mapProducers.erase(producer->id);
 
+				// Tell the child class to clear associated SSRCs.
+				for (auto& kv : producer->GetRtpStreams())
+				{
+					auto* rtpStream = kv.first;
+
+					RecvStreamClosed(rtpStream->GetSsrc());
+
+					if (rtpStream->HasRtx())
+						RecvStreamClosed(rtpStream->GetRtxSsrc());
+				}
+
 				// Notify the listener.
 				this->listener->OnTransportProducerClosed(this, producer);
 
@@ -1244,11 +1255,17 @@ namespace RTC
 				for (auto ssrc : consumer->GetMediaSsrcs())
 				{
 					this->mapSsrcConsumer.erase(ssrc);
+
+					// Tell the child class to clear associated SSRCs.
+					SendStreamClosed(ssrc);
 				}
 
 				for (auto ssrc : consumer->GetRtxSsrcs())
 				{
 					this->mapRtxSsrcConsumer.erase(ssrc);
+
+					// Tell the child class to clear associated SSRCs.
+					SendStreamClosed(ssrc);
 				}
 
 				// Notify the listener.
@@ -2571,11 +2588,17 @@ namespace RTC
 		for (auto ssrc : consumer->GetMediaSsrcs())
 		{
 			this->mapSsrcConsumer.erase(ssrc);
+
+			// Tell the child class to clear associated SSRCs.
+			SendStreamClosed(ssrc);
 		}
 
 		for (auto ssrc : consumer->GetRtxSsrcs())
 		{
 			this->mapRtxSsrcConsumer.erase(ssrc);
+
+			// Tell the child class to clear associated SSRCs.
+			SendStreamClosed(ssrc);
 		}
 
 		// Notify the listener.

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -819,6 +819,26 @@ namespace RTC
 		this->dtlsTransport->SendApplicationData(data, len);
 	}
 
+	void WebRtcTransport::RecvStreamClosed(uint32_t ssrc)
+	{
+		MS_TRACE();
+
+		if (this->srtpRecvSession)
+		{
+			this->srtpRecvSession->RemoveStream(ssrc);
+		}
+	}
+
+	void WebRtcTransport::SendStreamClosed(uint32_t ssrc)
+	{
+		MS_TRACE();
+
+		if (this->srtpSendSession)
+		{
+			this->srtpSendSession->RemoveStream(ssrc);
+		}
+	}
+
 	inline void WebRtcTransport::OnPacketReceived(
 	  RTC::TransportTuple* tuple, const uint8_t* data, size_t len)
 	{


### PR DESCRIPTION
Fixes #426. 

This PR overrides #427 by simplifying the code. In summary, we don't want that `Transport` child classes are aware of `Producers` or `Consumers`.