### PR TITLE
SimulcastConsumer: apply a 33ms offset to intra layer RTP packet

### DIFF
--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -783,7 +783,10 @@ namespace RTC
 				// outgoing packet matches the highest seen in the previous stream. Fix it.
 				else if (tsExtraOffset == 0u)
 				{
-					tsExtraOffset = 1u;
+					// Apply an expected offset for a new frame in a 30fps stream.
+					static const uint8_t MsOffset{ 33u }; // (1 / 30 * 1000).
+
+					tsExtraOffset = MsOffset * this->rtpStream->GetClockRate() / 1000;
 				}
 
 				if (tsExtraOffset > 0u)


### PR DESCRIPTION
Apply a RTP Timestamp offset to the first packet upon spatial layer change to indicate decoders this packet contains a new frame.