### PR TITLE
Fix the usrsctp vulnerability by using a global map for SctpAssociations

### DIFF
--- a/worker/include/DepUsrSCTP.hpp
+++ b/worker/include/DepUsrSCTP.hpp
@@ -2,7 +2,9 @@
 #define MS_DEP_USRSCTP_HPP
 
 #include "common.hpp"
+#include "RTC/SctpAssociation.hpp"
 #include "handles/Timer.hpp"
+#include <unordered_map>
 
 class DepUsrSCTP
 {
@@ -29,12 +31,16 @@ private:
 public:
 	static void ClassInit();
 	static void ClassDestroy();
-	static void IncreaseSctpAssociations();
-	static void DecreaseSctpAssociations();
+	static uintptr_t GetNextSctpAssociationId();
+	static void RegisterSctpAssociation(RTC::SctpAssociation* sctpAssociation);
+	static void DeregisterSctpAssociation(RTC::SctpAssociation* sctpAssociation);
+	static RTC::SctpAssociation* RetrieveSctpAssociation(uintptr_t id);
 
 private:
 	static Checker* checker;
 	static uint64_t numSctpAssociations;
+	static uintptr_t nextSctpAssociationId;
+	static std::unordered_map<uintptr_t, RTC::SctpAssociation*> mapIdSctpAssociation;
 };
 
 #endif

--- a/worker/include/RTC/SctpAssociation.hpp
+++ b/worker/include/RTC/SctpAssociation.hpp
@@ -96,6 +96,9 @@ namespace RTC
 		  uint16_t streamId, uint16_t ssn, uint32_t ppid, int flags, const uint8_t* data, size_t len);
 		void OnUsrSctpReceiveSctpNotification(union sctp_notification* notification, size_t len);
 
+	public:
+		uintptr_t id{ 0u };
+
 	private:
 		// Passed by argument.
 		Listener* listener{ nullptr };

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -4,7 +4,6 @@
 #include "DepUsrSCTP.hpp"
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
-#include "RTC/SctpAssociation.hpp"
 #include <usrsctp.h>
 
 /* Static. */
@@ -15,10 +14,14 @@ static constexpr size_t CheckerInterval{ 10u }; // In ms.
 
 inline static int onSendSctpData(void* addr, void* data, size_t len, uint8_t /*tos*/, uint8_t /*setDf*/)
 {
-	auto* sctpAssociation = static_cast<RTC::SctpAssociation*>(addr);
+	auto* sctpAssociation = DepUsrSCTP::RetrieveSctpAssociation(reinterpret_cast<uintptr_t>(addr));
 
 	if (!sctpAssociation)
+	{
+		MS_WARN_TAG(sctp, "no SctpAssociation found");
+
 		return -1;
+	}
 
 	sctpAssociation->OnUsrSctpSendSctpData(data, len);
 
@@ -48,6 +51,8 @@ inline static void sctpDebug(const char* format, ...)
 
 DepUsrSCTP::Checker* DepUsrSCTP::checker{ nullptr };
 uint64_t DepUsrSCTP::numSctpAssociations{ 0u };
+uintptr_t DepUsrSCTP::nextSctpAssociationId{ 0u };
+std::unordered_map<uintptr_t, RTC::SctpAssociation*> DepUsrSCTP::mapIdSctpAssociation;
 
 /* Static methods. */
 
@@ -78,22 +83,67 @@ void DepUsrSCTP::ClassDestroy()
 	delete DepUsrSCTP::checker;
 }
 
-void DepUsrSCTP::IncreaseSctpAssociations()
+uintptr_t DepUsrSCTP::GetNextSctpAssociationId()
 {
 	MS_TRACE();
+
+	// NOTE: usrsctp_connect() fails with a value of 0.
+	if (DepUsrSCTP::nextSctpAssociationId == 0u)
+		++DepUsrSCTP::nextSctpAssociationId;
+
+	// In case we've wrapped around and need to find an empty spot from a removed
+	// SctpAssociation. Assumes we'll never be full.
+	while (DepUsrSCTP::mapIdSctpAssociation.find(DepUsrSCTP::nextSctpAssociationId) !=
+	       DepUsrSCTP::mapIdSctpAssociation.end())
+	{
+		++DepUsrSCTP::nextSctpAssociationId;
+
+		if (DepUsrSCTP::nextSctpAssociationId == 0u)
+			++DepUsrSCTP::nextSctpAssociationId;
+	}
+
+	return DepUsrSCTP::nextSctpAssociationId++;
+}
+
+void DepUsrSCTP::RegisterSctpAssociation(RTC::SctpAssociation* sctpAssociation)
+{
+	MS_TRACE();
+
+	auto it = DepUsrSCTP::mapIdSctpAssociation.find(sctpAssociation->id);
+
+	MS_ASSERT(
+	  it == DepUsrSCTP::mapIdSctpAssociation.end(),
+	  "given id already has an associated SctpAssociation");
+
+	DepUsrSCTP::mapIdSctpAssociation[sctpAssociation->id] = sctpAssociation;
 
 	if (++DepUsrSCTP::numSctpAssociations == 1u)
 		DepUsrSCTP::checker->Start();
 }
 
-void DepUsrSCTP::DecreaseSctpAssociations()
+void DepUsrSCTP::DeregisterSctpAssociation(RTC::SctpAssociation* sctpAssociation)
 {
 	MS_TRACE();
 
+	auto found = DepUsrSCTP::mapIdSctpAssociation.erase(sctpAssociation->id);
+
+	MS_ASSERT(found > 0, "SctpAssociation not found");
 	MS_ASSERT(DepUsrSCTP::numSctpAssociations > 0u, "numSctpAssociations was not higher than 0");
 
 	if (--DepUsrSCTP::numSctpAssociations == 0u)
 		DepUsrSCTP::checker->Stop();
+}
+
+RTC::SctpAssociation* DepUsrSCTP::RetrieveSctpAssociation(uintptr_t id)
+{
+	MS_TRACE();
+
+	auto it = DepUsrSCTP::mapIdSctpAssociation.find(id);
+
+	if (it == DepUsrSCTP::mapIdSctpAssociation.end())
+		return nullptr;
+
+	return it->second;
 }
 
 /* DepUsrSCTP::Checker instance methods. */

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -113,7 +113,7 @@ void DepUsrSCTP::RegisterSctpAssociation(RTC::SctpAssociation* sctpAssociation)
 
 	MS_ASSERT(
 	  it == DepUsrSCTP::mapIdSctpAssociation.end(),
-	  "given id already has an associated SctpAssociation");
+	  "the id of the SctpAssociation is already in the map");
 
 	DepUsrSCTP::mapIdSctpAssociation[sctpAssociation->id] = sctpAssociation;
 


### PR DESCRIPTION
instead of passing this pointer to usrsctp API

- Related commit in libwebrtc: https://webrtc-review.googlesource.com/c/src/+/176422/5/media/sctp/sctp_transport.cc
- Related commit in Janus: https://github.com/meetecho/janus-gateway/pull/2302/