### PR TITLE
add MEDIASOUP_MAX_CORES to limit NUM_CORES during build

### DIFF
--- a/worker/scripts/cpu_cores.sh
+++ b/worker/scripts/cpu_cores.sh
@@ -11,4 +11,8 @@ case "${OS}" in
 	*)        NUM_CORES=1;;
 esac
 
+if [ -n "${MEDIASOUP_MAX_CORES}" ]; then
+	NUM_CORES=$((MEDIASOUP_MAX_CORES>NUM_CORES ? NUM_CORES : MEDIASOUP_MAX_CORES))
+fi
+
 echo ${NUM_CORES}


### PR DESCRIPTION
Thanks so much for mediasoup. It's absolutely the best & your dedication to the community is amazing. OSS is hard & thankless, so thank you.

When building in a virtual CI environment, `nproc` could return a very large number of cores. This may cause the kernel to run out of memory when building. While #448 may be a more desirable longterm solution, I understand the additional maintenance cost isn't trivial.

This PR allows folks to set a max number of cores to use.
It works like this: `MEDIASOUP_MAX_CORES=8 yarn`.
I namespaced the variable because it's possible that other packages might do similar things.

This is hard to test, so I'm including 2 circleCI builds as proof (see "Install Dependencies"):
- before: https://app.circleci.com/pipelines/github/ParabolInc/parabol/724/workflows/9b919a23-f992-419c-a273-ea467290f3ad/jobs/9604
- after: https://app.circleci.com/pipelines/github/ParabolInc/parabol/735/workflows/a6fd256e-a967-4f74-bd04-d13bc0d54672/jobs/9616
