### PR TITLE
libwebrtc: BWE tweaks and debug logs

### DIFF
--- a/worker/deps/libwebrtc/libwebrtc/call/rtp_transport_controller_send.cc
+++ b/worker/deps/libwebrtc/libwebrtc/call/rtp_transport_controller_send.cc
@@ -144,7 +144,7 @@ void RtpTransportControllerSend::RegisterTargetTransferRateObserver(
 }
 
 void RtpTransportControllerSend::OnNetworkAvailability(bool network_available) {
-  MS_DEBUG_DEV("SignalNetworkState:%s", network_available ? "Up" : "Down");
+  MS_DEBUG_DEV("<<<<< network_available:%s", network_available ? "true" : "false");
 
   NetworkAvailability msg;
   msg.at_time = Timestamp::ms(DepLibUV::GetTimeMsInt64());
@@ -176,6 +176,8 @@ void RtpTransportControllerSend::EnablePeriodicAlrProbing(bool enable) {
 
 void RtpTransportControllerSend::OnSentPacket(
     const rtc::SentPacket& sent_packet, size_t size) {
+  MS_DEBUG_DEV("<<<<< size:%zu", size);
+
   absl::optional<SentPacket> packet_msg =
       transport_feedback_adapter_.ProcessSentPacket(sent_packet);
   if (packet_msg)
@@ -186,6 +188,8 @@ void RtpTransportControllerSend::OnSentPacket(
 
 void RtpTransportControllerSend::OnTransportOverheadChanged(
     size_t transport_overhead_bytes_per_packet) {
+  MS_DEBUG_DEV("<<<<< transport_overhead_bytes_per_packet:%zu", transport_overhead_bytes_per_packet);
+
   if (transport_overhead_bytes_per_packet >= kMaxOverheadBytes) {
     MS_ERROR("transport overhead exceeds: %zu", kMaxOverheadBytes);
     return;
@@ -193,6 +197,8 @@ void RtpTransportControllerSend::OnTransportOverheadChanged(
 }
 
 void RtpTransportControllerSend::OnReceivedEstimatedBitrate(uint32_t bitrate) {
+  MS_DEBUG_DEV("<<<<< bitrate:%zu", bitrate);
+
   RemoteBitrateReport msg;
   msg.receive_time = Timestamp::ms(DepLibUV::GetTimeMsInt64());
   msg.bandwidth = DataRate::bps(bitrate);
@@ -204,6 +210,8 @@ void RtpTransportControllerSend::OnReceivedRtcpReceiverReport(
     const ReportBlockList& report_blocks,
     int64_t rtt_ms,
     int64_t now_ms) {
+  MS_DEBUG_DEV("<<<<< rtt_ms:%" PRIi64, rtt_ms);
+
   OnReceivedRtcpReceiverReportBlocks(report_blocks, now_ms);
 
   RoundTripTimeUpdate report;
@@ -225,6 +233,8 @@ void RtpTransportControllerSend::OnAddPacket(
 
 void RtpTransportControllerSend::OnTransportFeedback(
     const RTC::RTCP::FeedbackRtpTransportPacket& feedback) {
+  MS_DEBUG_DEV("<<<<<");
+
   absl::optional<TransportPacketsFeedback> feedback_msg =
       transport_feedback_adapter_.ProcessTransportFeedback(
           feedback, Timestamp::ms(DepLibUV::GetTimeMsInt64()));
@@ -267,6 +277,8 @@ void RtpTransportControllerSend::MaybeCreateControllers() {
 }
 
 void RtpTransportControllerSend::UpdateControllerWithTimeInterval() {
+  MS_DEBUG_DEV("<<<<<");
+
   // RTC_DCHECK(controller_);
   MS_ASSERT(controller_, "controller not set");
 
@@ -277,6 +289,8 @@ void RtpTransportControllerSend::UpdateControllerWithTimeInterval() {
 }
 
 void RtpTransportControllerSend::UpdateStreamsConfig() {
+  MS_DEBUG_DEV("<<<<<");
+
   streams_config_.at_time = Timestamp::ms(DepLibUV::GetTimeMsInt64());
   if (controller_)
     PostUpdates(controller_->OnStreamsConfig(streams_config_));

--- a/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/rtp/transport_feedback_adapter.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/rtp/transport_feedback_adapter.cc
@@ -147,8 +147,15 @@ TransportFeedbackAdapter::ProcessTransportFeedback(
   for (const PacketFeedback& rtp_feedback : feedback_vector) {
     if (rtp_feedback.send_time_ms != PacketFeedback::kNoSendTime) {
       auto feedback = NetworkPacketFeedbackFromRtpPacketFeedback(rtp_feedback);
+      MS_DEBUG_DEV("feedback received for RTP packet: [seq_num: %" PRIi64 ", send_time:%" PRIi64 ", size: %lld, feedback.receive_time:%" PRIi64,
+          feedback.sent_packet.sequence_number,
+          feedback.sent_packet.send_time.ms(),
+          feedback.sent_packet.size.bytes(),
+          feedback.receive_time.ms());
+
       msg.packet_feedbacks.push_back(feedback);
     } else if (rtp_feedback.arrival_time_ms == PacketFeedback::kNotReceived) {
+      MS_DEBUG_DEV("--- rtp_feedback.arrival_time_ms == PacketFeedback::kNotReceived ---");
       msg.sendless_arrival_times.push_back(Timestamp::PlusInfinity());
     } else {
       msg.sendless_arrival_times.push_back(
@@ -164,6 +171,8 @@ TransportFeedbackAdapter::ProcessTransportFeedback(
   msg.feedback_time = feedback_receive_time;
   msg.prior_in_flight = prior_in_flight;
   msg.data_in_flight = GetOutstandingData();
+
+  MS_DEBUG_DEV("prior_in_flight:%lld, data_in_flight:%lld", msg.prior_in_flight.bytes(), msg.data_in_flight.bytes());
   return msg;
 }
 

--- a/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.cc
@@ -35,8 +35,8 @@ bool InterArrival::ComputeDeltas(uint32_t timestamp,
                                  int64_t arrival_time_ms,
                                  int64_t system_time_ms,
                                  size_t packet_size,
-                                 uint32_t* timestamp_delta,
-                                 int64_t* arrival_time_delta_ms,
+                                 uint32_t* timestamp_delta, // send_delta.
+                                 int64_t* arrival_time_delta_ms, // recv_delta.
                                  int* packet_size_delta) {
   MS_ASSERT(timestamp_delta != nullptr, "timestamp_delta is null");
   MS_ASSERT(arrival_time_delta_ms != nullptr, "arrival_time_delta_ms is null");
@@ -57,6 +57,9 @@ bool InterArrival::ComputeDeltas(uint32_t timestamp,
           current_timestamp_group_.timestamp - prev_timestamp_group_.timestamp;
       *arrival_time_delta_ms = current_timestamp_group_.complete_time_ms -
                                prev_timestamp_group_.complete_time_ms;
+      MS_DEBUG_DEV("timestamp previous/current [%" PRIu32 "/%" PRIu32"] complete time previous/current [%" PRIi64 "/%" PRIi64 "]",
+          prev_timestamp_group_.timestamp, current_timestamp_group_.timestamp,
+          prev_timestamp_group_.complete_time_ms, current_timestamp_group_.complete_time_ms);
       // Check system time differences to see if we have an unproportional jump
       // in arrival time. In that case reset the inter-arrival computations.
       int64_t system_time_delta_ms =
@@ -98,6 +101,8 @@ bool InterArrival::ComputeDeltas(uint32_t timestamp,
     current_timestamp_group_.timestamp = timestamp;
     current_timestamp_group_.first_arrival_ms = arrival_time_ms;
     current_timestamp_group_.size = 0;
+    MS_DEBUG_DEV("new timestamp group: first_timestamp:%" PRIu32 ", first_arrival_ms:%" PRIi64,
+        current_timestamp_group_.first_timestamp, current_timestamp_group_.first_arrival_ms);
   } else {
     current_timestamp_group_.timestamp =
         LatestTimestamp(current_timestamp_group_.timestamp, timestamp);

--- a/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/overuse_detector.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/overuse_detector.cc
@@ -8,9 +8,14 @@
  *  be found in the AUTHORS file in the root of the source tree.
  */
 
+#define MS_CLASS "webrtc::OveruseDetector"
+// #define MS_LOG_DEV_LEVEL 3
+
 #include "modules/remote_bitrate_estimator/overuse_detector.h"
 #include "modules/remote_bitrate_estimator/include/bwe_defines.h"
 #include "rtc_base/numerics/safe_minmax.h"
+
+#include "Logger.hpp"
 
 #include <math.h>
 #include <stdio.h>
@@ -102,6 +107,7 @@ BandwidthUsage OveruseDetector::Detect(double offset,
       if (offset >= prev_offset_) {
         time_over_using_ = 0;
         overuse_counter_ = 0;
+        MS_DEBUG_DEV("hypothesis_: BandwidthUsage::kBwOverusing");
         hypothesis_ = BandwidthUsage::kBwOverusing;
       }
     }

--- a/worker/src/DepLibWebRTC.cpp
+++ b/worker/src/DepLibWebRTC.cpp
@@ -7,8 +7,7 @@
 
 /* Static. */
 
-// TODO: Look for a proper value.
-static const char FieldTrials[]{ "WebRTC-Pacer-MinPacketLimitMs/Enabled,100/" };
+static constexpr char FieldTrials[] = "WebRTC-Bwe-AlrLimitedBackoff/Enabled/";
 
 /* Static methods. */
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2013,8 +2013,15 @@ namespace RTC
 							auto* remb = static_cast<RTC::RTCP::FeedbackPsRembPacket*>(afb);
 
 							// Pass it to the TCC client.
-							if (this->tccClient)
+							// clang-format off
+							if (
+								this->tccClient &&
+								this->tccClient->GetBweType() == RTC::BweType::REMB
+							)
+							// clang-format on
+							{
 								this->tccClient->ReceiveEstimatedBitrate(remb->GetBitrate());
+							}
 
 							break;
 						}

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -178,21 +178,20 @@ namespace RTC
 		this->bitrates.desiredBitrate          = desiredBitrate;
 		this->bitrates.effectiveDesiredBitrate = this->desiredBitrateTrend.GetValue();
 		this->bitrates.minBitrate              = MinBitrate;
+		// NOTE: Setting 'startBitrate' to 'availableBitrate' has proven to generate
+		// more stable values.
+		this->bitrates.startBitrate = std::max<uint32_t>(MinBitrate, this->bitrates.availableBitrate);
 
 		if (this->desiredBitrateTrend.GetValue() > 0u)
 		{
 			this->bitrates.maxBitrate = std::max<uint32_t>(
 			  this->initialAvailableBitrate,
 			  this->desiredBitrateTrend.GetValue() * MaxBitrateIncrementFactor);
-			this->bitrates.startBitrate = std::min<uint32_t>(
-			  this->bitrates.maxBitrate,
-			  std::max<uint32_t>(this->bitrates.availableBitrate, this->initialAvailableBitrate));
 			this->bitrates.maxPaddingBitrate = this->bitrates.maxBitrate * MaxPaddingBitrateFactor;
 		}
 		else
 		{
 			this->bitrates.maxBitrate        = this->initialAvailableBitrate;
-			this->bitrates.startBitrate      = this->initialAvailableBitrate;
 			this->bitrates.maxPaddingBitrate = 0u;
 		}
 


### PR DESCRIPTION
* Enabled WebRTC-Bwe-AlrLimitedBackoff/Enabled/ experiment.
  * It makes the down peaks smoother.
* Changed the trendline estimator to be more resilent upon sudden RTP delta increases/decreases.