### PR TITLE
SctpAssociation: increase sctpBufferedAmount before sending any data

### DIFF
--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -425,20 +425,21 @@ namespace RTC
 			}
 		}
 
+		this->sctpBufferedAmount += len;
+
 		int ret = usrsctp_sendv(
 		  this->socket, msg, len, nullptr, 0, &spa, static_cast<socklen_t>(sizeof(spa)), SCTP_SENDV_SPA, 0);
 
 		if (ret > 0)
 		{
 			// NOTE: 'usrsctp_sendv' returns the number of bytes sent.
-			// Don't decrese such value to sctpBufferedAmount since nothing is sent
-			// at this point.
-			this->sctpBufferedAmount += len;
 			this->listener->OnSctpAssociationBufferedAmount(this, this->sctpBufferedAmount);
 		}
 
 		if (ret < 0)
 		{
+			this->sctpBufferedAmount -= ret;
+
 			MS_WARN_TAG(
 			  sctp,
 			  "error sending SCTP message [sid:%" PRIu16 ", ppid:%" PRIu32 ", message size:%zu]: %s",


### PR DESCRIPTION
Prevents increasing the value 'after' send_cb is called before returning
from usrsctp_sendv.