### PR TITLE
Added possibility to use LD_LIBRARY_PATH

### DIFF
--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -269,7 +269,8 @@ export class Worker extends EnhancedEventEmitter
 			{
 				env :
 				{
-					MEDIASOUP_VERSION : '__MEDIASOUP_VERSION__'
+					MEDIASOUP_VERSION : '__MEDIASOUP_VERSION__',
+					LD_LIBRARY_PATH: process.env["LD_LIBRARY_PATH"]
 				},
 
 				detached : false,

--- a/src/Worker.ts
+++ b/src/Worker.ts
@@ -270,7 +270,7 @@ export class Worker extends EnhancedEventEmitter
 				env :
 				{
 					MEDIASOUP_VERSION : '__MEDIASOUP_VERSION__',
-					LD_LIBRARY_PATH: process.env["LD_LIBRARY_PATH"]
+					LD_LIBRARY_PATH   : process.env['LD_LIBRARY_PATH']
 				},
 
 				detached : false,


### PR DESCRIPTION
Suggested quick fix allows to compile _mediasoup_ with non-standard or upgraded libs (e. g. I use it for running _mediasoup_ on _CentOS 7_ , which has deprecated _gcc_ (and, correspondent "_RuntimeError: gcc <= 4.8 not supported, please upgrade your gcc_" error), and, therefore it's required to manually compile and install a new _gcc-10.2.0_). So, preliminary setting _LD_LIBRARY_PATH_ (e. g. `LD_LIBRARY_PATH=/home/vyermolenko/build/gcc-10.2.0/lib64/:$LD_LIBRARY_PATH`) resolves the problem with this fix.