### PR TITLE
Add mips64 to support the platform of loongnix

### DIFF
--- a/worker/scripts/configure.py
+++ b/worker/scripts/configure.py
@@ -28,6 +28,7 @@ def host_arch():
     if machine == 'i386': return 'ia32'
     if machine == 'x86_64': return 'x64'
     if machine == 'aarch64': return 'arm64'
+    if machine == 'mips64': return 'mips64el'
     if machine.startswith('arm'): return 'arm'
     if machine.startswith('mips'): return 'mips'
     return machine  # Return as-is and hope for the best.


### PR DESCRIPTION
	mips64 based on loongnix-Server release.
	npm install fails:

	cc: error: unrecognized command line option ‘-m64’
	make[1]: *** [/home/xxx/node_modules/mediasoup/worker/out/Release/obj.target/openssl/deps/openssl/openssl/ssl/bio_ssl.o] error 1