### PR TITLE
Remove non-existing fields from interface

### DIFF
--- a/src/DirectTransport.ts
+++ b/src/DirectTransport.ts
@@ -35,8 +35,6 @@ export type DirectTransportStat =
 	rtxRecvBitrate: number;
 	rtxBytesSent: number;
 	rtxSendBitrate: number;
-	probationBytesReceived: number;
-	probationRecvBitrate: number;
 	probationBytesSent: number;
 	probationSendBitrate: number;
 	availableOutgoingBitrate?: number;

--- a/src/PipeTransport.ts
+++ b/src/PipeTransport.ts
@@ -81,8 +81,6 @@ export type PipeTransportStat =
 	rtxRecvBitrate: number;
 	rtxBytesSent: number;
 	rtxSendBitrate: number;
-	probationBytesReceived: number;
-	probationRecvBitrate: number;
 	probationBytesSent: number;
 	probationSendBitrate: number;
 	availableOutgoingBitrate?: number;

--- a/src/PlainTransport.ts
+++ b/src/PlainTransport.ts
@@ -94,8 +94,6 @@ export type PlainTransportStat =
 	rtxRecvBitrate: number;
 	rtxBytesSent: number;
 	rtxSendBitrate: number;
-	probationBytesReceived: number;
-	probationRecvBitrate: number;
 	probationBytesSent: number;
 	probationSendBitrate: number;
 	availableOutgoingBitrate?: number;

--- a/src/WebRtcTransport.ts
+++ b/src/WebRtcTransport.ts
@@ -132,8 +132,6 @@ export type WebRtcTransportStat =
 	rtxRecvBitrate: number;
 	rtxBytesSent: number;
 	rtxSendBitrate: number;
-	probationBytesReceived: number;
-	probationRecvBitrate: number;
 	probationBytesSent: number;
 	probationSendBitrate: number;
 	availableOutgoingBitrate?: number;


### PR DESCRIPTION
These look to be copy-pasted, but do not actually exist