### PR TITLE
Remove unnecessary files from gyp configs to fix linking issues

### DIFF
--- a/worker/deps/libuv/uv.gyp
+++ b/worker/deps/libuv/uv.gyp
@@ -245,7 +245,6 @@
             'libuv/src/unix/procfs-exepath.c',
             'libuv/src/unix/random-getrandom.c',
             'libuv/src/unix/random-sysctl-linux.c',
-            'libuv/src/unix/sysinfo-loadavg.c',
           ],
           'link_settings': {
             'libraries': [ '-ldl', '-lrt' ],
@@ -262,7 +261,6 @@
             'libuv/src/unix/procfs-exepath.c',
             'libuv/src/unix/random-getrandom.c',
             'libuv/src/unix/random-sysctl-linux.c',
-            'libuv/src/unix/sysinfo-loadavg.c',
           ],
           'link_settings': {
             'libraries': [ '-ldl' ],

--- a/worker/deps/libwebrtc/deps/abseil-cpp/abseil-cpp.gyp
+++ b/worker/deps/libwebrtc/deps/abseil-cpp/abseil-cpp.gyp
@@ -153,7 +153,6 @@
         'abseil-cpp/absl/synchronization/mutex.h',
         'abseil-cpp/absl/hash/internal/hash.cc',
         'abseil-cpp/absl/hash/internal/spy_hash_state.h',
-        'abseil-cpp/absl/hash/internal/print_hash_of.cc',
         'abseil-cpp/absl/hash/internal/city.h',
         'abseil-cpp/absl/hash/internal/city.cc',
         'abseil-cpp/absl/hash/internal/hash.h',


### PR DESCRIPTION
I was doing some hacking and found that linker is really unhappy about those files. Removing them doesn't change anything negatively, tests still pass, so I think this is a correct change.

The error looked like this:
```
  = note: /usr/bin/ld: /web/github/mediasoup/worker/out/Release/libuv.a(sysinfo-loadavg.o): in function `uv_loadavg':
          /web/github/mediasoup/worker/out/../deps/libuv/libuv/src/unix/sysinfo-loadavg.c:28: multiple definition of `uv_loadavg'; /web/github/mediasoup/worker/out/Release/libuv.a(linux-core.o):/web/github/mediasoup/worker/out/../deps/libuv/libuv/src/unix/linux-core.c:1132: first defined here
          /usr/bin/ld: /web/github/mediasoup/worker/out/Release/libabseil.a(print_hash_of.o): in function `main':
          /web/github/mediasoup/worker/out/../deps/libwebrtc/deps/abseil-cpp/abseil-cpp/absl/hash/internal/print_hash_of.cc:20: multiple definition of `main'; /web/github/mediasoup/target/debug/deps/mediasoup_sys-ad2c49156d6c0bb6.37125jqqwh13ju51.rcgu.o:37125jqqwh13ju51:(.text.main+0x0): first defined here
          collect2: error: ld returned 1 exit status
```