### PR TITLE
Make static variables in worker be in thread-local storage

### DIFF
--- a/worker/include/DepLibUV.hpp
+++ b/worker/include/DepLibUV.hpp
@@ -41,7 +41,7 @@ public:
 	}
 
 private:
-	static uv_loop_t* loop;
+	thread_local static uv_loop_t* loop;
 };
 
 #endif

--- a/worker/include/DepUsrSCTP.hpp
+++ b/worker/include/DepUsrSCTP.hpp
@@ -37,10 +37,10 @@ public:
 	static RTC::SctpAssociation* RetrieveSctpAssociation(uintptr_t id);
 
 private:
-	static Checker* checker;
-	static uint64_t numSctpAssociations;
-	static uintptr_t nextSctpAssociationId;
-	static std::unordered_map<uintptr_t, RTC::SctpAssociation*> mapIdSctpAssociation;
+	thread_local static Checker* checker;
+	thread_local static uint64_t numSctpAssociations;
+	thread_local static uintptr_t nextSctpAssociationId;
+	thread_local static std::unordered_map<uintptr_t, RTC::SctpAssociation*> mapIdSctpAssociation;
 };
 
 #endif

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -7,7 +7,7 @@
 
 /* Static variables. */
 
-uv_loop_t* DepLibUV::loop{ nullptr };
+thread_local uv_loop_t* DepLibUV::loop{ nullptr };
 
 /* Static methods. */
 

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -49,10 +49,10 @@ inline static void sctpDebug(const char* format, ...)
 
 /* Static variables. */
 
-DepUsrSCTP::Checker* DepUsrSCTP::checker{ nullptr };
-uint64_t DepUsrSCTP::numSctpAssociations{ 0u };
-uintptr_t DepUsrSCTP::nextSctpAssociationId{ 0u };
-std::unordered_map<uintptr_t, RTC::SctpAssociation*> DepUsrSCTP::mapIdSctpAssociation;
+thread_local DepUsrSCTP::Checker* DepUsrSCTP::checker{ nullptr };
+thread_local uint64_t DepUsrSCTP::numSctpAssociations{ 0u };
+thread_local uintptr_t DepUsrSCTP::nextSctpAssociationId{ 0u };
+thread_local std::unordered_map<uintptr_t, RTC::SctpAssociation*> DepUsrSCTP::mapIdSctpAssociation;
 
 /* Static methods. */
 


### PR DESCRIPTION
This is another necessary change towards ability to run worker in a thread instead of own whole process.

Tests pass, but I'm a bit worried about "SCTP iterator" thread that is still being created, see https://github.com/sctplab/usrsctp/pull/472