### PR TITLE
RtpStreamRecv: Enhance jitter calculation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update `nlohmann/json` to 3.9.1.
 * Update `usrsctp`.
 * Update NPM deps.
+* Enhance Jitter calculation.
 
 
 ### 3.6.32

--- a/worker/include/RTC/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RtpStreamRecv.hpp
@@ -96,7 +96,7 @@ namespace RTC
 		                                   // sender report.
 		uint64_t lastSrReceived{ 0u };     // Wallclock time representing the most recent
 		                                   // sender report arrival.
-		uint32_t transit{ 0u };            // Relative transit time for prev packet.
+		int32_t transit{ 0u };             // Relative transit time for prev packet.
 		uint32_t jitter{ 0u };
 		uint8_t firSeqNumber{ 0u };
 		uint32_t reportedPacketLost{ 0u };

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -623,6 +623,10 @@ namespace RTC
 
 		if (this->params.useNack)
 			this->nackGenerator->Reset();
+
+		// Reset jitter.
+		this->transit = 0;
+		this->jitter = 0;
 	}
 
 	void RtpStreamRecv::Resume()
@@ -643,6 +647,14 @@ namespace RTC
 		auto transit =
 		  static_cast<int>(DepLibUV::GetTimeMs() - (rtpTimestamp * 1000 / this->params.clockRate));
 		int d = transit - this->transit;
+
+		// First transit calculation, save and return.
+		if (this->transit == 0)
+		{
+			this->transit = transit;
+
+			return;
+		}
 
 		this->transit = transit;
 


### PR DESCRIPTION
* Don't set any value until at least two packets have arrived.
* Reset the value when pausing.
* Relative transit time variable is signed by definition:
  https://tools.ietf.org/html/rfc3550#appendix-A.8