### PR TITLE
Added missing delete of the callbacks functions

### DIFF
--- a/worker/src/handles/UdpSocket.cpp
+++ b/worker/src/handles/UdpSocket.cpp
@@ -287,7 +287,11 @@ inline void UdpSocket::OnUvSend(int status, UdpSocket::onSendCallback* cb)
 	if (status == 0)
 	{
 		if (cb)
+		{
 			(*cb)(true);
+
+			delete cb;
+		}
 	}
 	else
 	{
@@ -296,6 +300,10 @@ inline void UdpSocket::OnUvSend(int status, UdpSocket::onSendCallback* cb)
 #endif
 
 		if (cb)
+		{
 			(*cb)(false);
+
+			delete cb;
+		}
 	}
 }


### PR DESCRIPTION
The delete operator is missing in the `OnUvSend` method, leading to a possible memory leak. 