### PR TITLE
Add missing `delete cb` that otherwise would leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### 3.6.33 (WIP)
 
+* Add missing `delete cb` that otherwise would leak (PR #527 based on PR #526 by @vpalmisano).
 * `router.pipeToRouter()`: Fix possible inconsistency in `pipeProducer.paused` status (as discussed in this [thread](https://mediasoup.discourse.group/t/concurrency-architecture/2515/) in the mediasoup forum).
 * Update `nlohmann/json` to 3.9.1.
 * Update `usrsctp`.

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -186,7 +186,6 @@ namespace RTC
 		if (cb)
 		{
 			(*cb)(true);
-
 			delete cb;
 		}
 

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -428,7 +428,6 @@ namespace RTC
 			if (cb)
 			{
 				(*cb)(false);
-
 				delete cb;
 			}
 
@@ -443,7 +442,6 @@ namespace RTC
 			if (cb)
 			{
 				(*cb)(false);
-
 				delete cb;
 			}
 

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -612,7 +612,6 @@ namespace RTC
 			if (cb)
 			{
 				(*cb)(false);
-
 				delete cb;
 			}
 
@@ -627,7 +626,6 @@ namespace RTC
 			if (cb)
 			{
 				(*cb)(false);
-
 				delete cb;
 			}
 

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -449,14 +449,12 @@ namespace RTC
 			if (cb)
 			{
 				(*cb)(false);
-
 				delete cb;
 			}
 		}
 		else if (cb)
 		{
 			(*cb)(true);
-
 			delete cb;
 		}
 

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -703,7 +703,6 @@ namespace RTC
 			if (cb)
 			{
 				(*cb)(false);
-
 				delete cb;
 			}
 
@@ -718,7 +717,6 @@ namespace RTC
 			if (cb)
 			{
 				(*cb)(false);
-
 				delete cb;
 			}
 
@@ -733,7 +731,6 @@ namespace RTC
 			if (cb)
 			{
 				(*cb)(false);
-
 				delete cb;
 			}
 

--- a/worker/src/handles/TcpConnection.cpp
+++ b/worker/src/handles/TcpConnection.cpp
@@ -183,7 +183,6 @@ void TcpConnection::Write(const uint8_t* data, size_t len, TcpConnection::onSend
 		if (cb)
 		{
 			(*cb)(false);
-
 			delete cb;
 		}
 
@@ -195,7 +194,6 @@ void TcpConnection::Write(const uint8_t* data, size_t len, TcpConnection::onSend
 		if (cb)
 		{
 			(*cb)(false);
-
 			delete cb;
 		}
 
@@ -217,7 +215,6 @@ void TcpConnection::Write(const uint8_t* data, size_t len, TcpConnection::onSend
 		if (cb)
 		{
 			(*cb)(true);
-
 			delete cb;
 		}
 
@@ -281,7 +278,6 @@ void TcpConnection::Write(
 		if (cb)
 		{
 			(*cb)(false);
-
 			delete cb;
 		}
 
@@ -293,7 +289,6 @@ void TcpConnection::Write(
 		if (cb)
 		{
 			(*cb)(false);
-
 			delete cb;
 		}
 
@@ -321,7 +316,6 @@ void TcpConnection::Write(
 		if (cb)
 		{
 			(*cb)(true);
-
 			delete cb;
 		}
 
@@ -502,7 +496,10 @@ inline void TcpConnection::OnUvWrite(int status, TcpConnection::onSendCallback* 
 	if (status == 0)
 	{
 		if (cb)
+		{
 			(*cb)(true);
+			delete cb;
+		}
 	}
 	else
 	{
@@ -512,7 +509,10 @@ inline void TcpConnection::OnUvWrite(int status, TcpConnection::onSendCallback* 
 		MS_WARN_DEV("write error, closing the connection: %s", uv_strerror(status));
 
 		if (cb)
+		{
 			(*cb)(false);
+			delete cb;
+		}
 
 		Close();
 

--- a/worker/src/handles/UdpSocket.cpp
+++ b/worker/src/handles/UdpSocket.cpp
@@ -126,7 +126,10 @@ void UdpSocket::Send(
 	if (this->closed)
 	{
 		if (cb)
+		{
 			(*cb)(false);
+			delete cb;
+		}
 
 		return;
 	}
@@ -134,7 +137,10 @@ void UdpSocket::Send(
 	if (len == 0)
 	{
 		if (cb)
+		{
 			(*cb)(false);
+			delete cb;
+		}
 
 		return;
 	}
@@ -154,7 +160,6 @@ void UdpSocket::Send(
 		if (cb)
 		{
 			(*cb)(true);
-
 			delete cb;
 		}
 
@@ -170,7 +175,6 @@ void UdpSocket::Send(
 		if (cb)
 		{
 			(*cb)(false);
-
 			delete cb;
 		}
 
@@ -287,7 +291,10 @@ inline void UdpSocket::OnUvSend(int status, UdpSocket::onSendCallback* cb)
 	if (status == 0)
 	{
 		if (cb)
+		{
 			(*cb)(true);
+			delete cb;
+		}
 	}
 	else
 	{
@@ -296,6 +303,9 @@ inline void UdpSocket::OnUvSend(int status, UdpSocket::onSendCallback* cb)
 #endif
 
 		if (cb)
+		{
 			(*cb)(false);
+			delete cb;
+		}
 	}
 }


### PR DESCRIPTION
Based on PR #526 by @vpalmisano. Also apply to TCP.

To ensure we don't miss anything:

```
~/src/v3-mediasoup/worker/src on add-missing-delete-cb
$ ack -A 2 "\(\*cb\)\("

handles/TcpConnection.cpp
185:			(*cb)(false);
186-			delete cb;
187-		}
--
196:			(*cb)(false);
197-			delete cb;
198-		}
--
217:			(*cb)(true);
218-			delete cb;
219-		}
--
259:			(*cb)(false);
260-
261-		// Delete the UvWriteData struct (it will delete the store and cb too).
--
280:			(*cb)(false);
281-			delete cb;
282-		}
--
291:			(*cb)(false);
292-			delete cb;
293-		}
--
318:			(*cb)(true);
319-			delete cb;
320-		}
--
376:			(*cb)(false);
377-
378-		// Delete the UvWriteData struct (it will delete the store and cb too).
--
500:			(*cb)(true);
501-			delete cb;
502-		}
--
513:			(*cb)(false);
514-			delete cb;
515-		}

handles/UdpSocket.cpp
130:			(*cb)(false);
131-			delete cb;
132-		}
--
141:			(*cb)(false);
142-			delete cb;
143-		}
--
162:			(*cb)(true);
163-			delete cb;
164-		}
--
177:			(*cb)(false);
178-			delete cb;
179-		}
--
207:			(*cb)(false);
208-
209-		// Delete the UvSendData struct (it will delete the store and cb too).
--
295:			(*cb)(true);
296-			delete cb;
297-		}
--
307:			(*cb)(false);
308-			delete cb;
309-		}

RTC/SctpAssociation.cpp
451:				(*cb)(false);
452-				delete cb;
453-			}
--
457:			(*cb)(true);
458-			delete cb;
459-		}

RTC/PlainTransport.cpp
614:				(*cb)(false);
615-				delete cb;
616-			}
--
628:				(*cb)(false);
629-				delete cb;
630-			}

RTC/DirectTransport.cpp
188:			(*cb)(true);
189-			delete cb;
190-		}

RTC/WebRtcTransport.cpp
705:				(*cb)(false);
706-				delete cb;
707-			}
--
719:				(*cb)(false);
720-				delete cb;
721-			}
--
733:				(*cb)(false);
734-				delete cb;
735-			}

RTC/PipeTransport.cpp
430:				(*cb)(false);
431-				delete cb;
432-			}
--
444:				(*cb)(false);
445-				delete cb;
446-			}
```