### PR TITLE
Mediasoup worker as a library: libmediasoup-worker

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -83,6 +83,12 @@ $ MEDIASOUP_WORKER_BIN="/home/xxx/src/foo/mediasoup-worker" node myapp.js
 ```
 
 
+### `make libmediasoup-worker`
+
+Builds the `libmediasoup-worker` static library at `worker/out/Release/`.
+
+`MEDIASOUP_MAX_CORES` and `MEDIASOUP_BUILDTYPE` environment variables from above still apply for static library build.
+
 ### `make clean`
 
 Cleans built objects and binaries.

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -16,7 +16,7 @@ DOCKER ?= docker
 
 .PHONY:	\
 	default clean clean-all xcode lint format test bear tidy \
-	fuzzer fuzzer-run-all docker-build docker-run
+	fuzzer fuzzer-run-all docker-build docker-run libmediasoup-worker
 
 default:
 ifeq ($(MEDIASOUP_WORKER_BIN),)
@@ -101,3 +101,7 @@ docker-run:
 		--cap-add SYS_PTRACE \
 		-v $(shell pwd)/../:/mediasoup \
 		mediasoup/docker:latest
+
+libmediasoup-worker:
+	$(PYTHON) ./scripts/configure.py --no-duplicate-basename-check -R libmediasoup-worker
+	$(MAKE) -j$(CORES) BUILDTYPE=$(MEDIASOUP_BUILDTYPE) -C out

--- a/worker/include/Channel/Notifier.hpp
+++ b/worker/include/Channel/Notifier.hpp
@@ -17,7 +17,7 @@ namespace Channel
 
 	public:
 		// Passed by argument.
-		static Channel::UnixStreamSocket* channel;
+		thread_local static Channel::UnixStreamSocket* channel;
 	};
 } // namespace Channel
 

--- a/worker/include/Channel/Request.hpp
+++ b/worker/include/Channel/Request.hpp
@@ -19,7 +19,8 @@ namespace Channel
 	public:
 		enum class MethodId
 		{
-			WORKER_DUMP = 1,
+			WORKER_CLOSE = 1,
+			WORKER_DUMP,
 			WORKER_GET_RESOURCE_USAGE,
 			WORKER_UPDATE_SETTINGS,
 			WORKER_CREATE_ROUTER,

--- a/worker/include/Channel/UnixStreamSocket.hpp
+++ b/worker/include/Channel/UnixStreamSocket.hpp
@@ -80,6 +80,7 @@ namespace Channel
 		// Others.
 		ConsumerSocket consumerSocket;
 		ProducerSocket producerSocket;
+		uint8_t* WriteBuffer;
 	};
 } // namespace Channel
 

--- a/worker/include/DepLibUV.hpp
+++ b/worker/include/DepLibUV.hpp
@@ -41,7 +41,7 @@ public:
 	}
 
 private:
-	static uv_loop_t* loop;
+	thread_local static uv_loop_t* loop;
 };
 
 #endif

--- a/worker/include/DepUsrSCTP.hpp
+++ b/worker/include/DepUsrSCTP.hpp
@@ -37,10 +37,10 @@ public:
 	static RTC::SctpAssociation* RetrieveSctpAssociation(uintptr_t id);
 
 private:
-	static Checker* checker;
-	static uint64_t numSctpAssociations;
-	static uintptr_t nextSctpAssociationId;
-	static std::unordered_map<uintptr_t, RTC::SctpAssociation*> mapIdSctpAssociation;
+	thread_local static Checker* checker;
+	thread_local static uint64_t numSctpAssociations;
+	thread_local static uintptr_t nextSctpAssociationId;
+	thread_local static std::unordered_map<uintptr_t, RTC::SctpAssociation*> mapIdSctpAssociation;
 };
 
 #endif

--- a/worker/include/DepUsrSCTP.hpp
+++ b/worker/include/DepUsrSCTP.hpp
@@ -38,9 +38,9 @@ public:
 
 private:
 	thread_local static Checker* checker;
-	thread_local static uint64_t numSctpAssociations;
-	thread_local static uintptr_t nextSctpAssociationId;
-	thread_local static std::unordered_map<uintptr_t, RTC::SctpAssociation*> mapIdSctpAssociation;
+	static uint64_t numSctpAssociations;
+	static uintptr_t nextSctpAssociationId;
+	static std::unordered_map<uintptr_t, RTC::SctpAssociation*> mapIdSctpAssociation;
 };
 
 #endif

--- a/worker/include/Logger.hpp
+++ b/worker/include/Logger.hpp
@@ -133,7 +133,7 @@ public:
 
 public:
 	static const int64_t pid;
-	static Channel::UnixStreamSocket* channel;
+	thread_local static Channel::UnixStreamSocket* channel;
 	static const size_t bufferSize {50000};
 	static char buffer[];
 };

--- a/worker/include/PayloadChannel/Notifier.hpp
+++ b/worker/include/PayloadChannel/Notifier.hpp
@@ -23,7 +23,7 @@ namespace PayloadChannel
 
 	public:
 		// Passed by argument.
-		static PayloadChannel::UnixStreamSocket* payloadChannel;
+		thread_local static PayloadChannel::UnixStreamSocket* payloadChannel;
 	};
 } // namespace PayloadChannel
 

--- a/worker/include/PayloadChannel/UnixStreamSocket.hpp
+++ b/worker/include/PayloadChannel/UnixStreamSocket.hpp
@@ -88,6 +88,7 @@ namespace PayloadChannel
 		ProducerSocket producerSocket;
 		PayloadChannel::Notification* ongoingNotification{ nullptr };
 		PayloadChannel::Request* ongoingRequest{ nullptr };
+		uint8_t* WriteBuffer;
 	};
 } // namespace PayloadChannel
 

--- a/worker/include/RTC/DtlsTransport.hpp
+++ b/worker/include/RTC/DtlsTransport.hpp
@@ -137,15 +137,15 @@ namespace RTC
 		static void GenerateFingerprints();
 
 	private:
-		static X509* certificate;
-		static EVP_PKEY* privateKey;
-		static SSL_CTX* sslCtx;
-		static uint8_t sslReadBuffer[];
-		static std::map<std::string, Role> string2Role;
-		static std::map<std::string, FingerprintAlgorithm> string2FingerprintAlgorithm;
-		static std::map<FingerprintAlgorithm, std::string> fingerprintAlgorithm2String;
-		static std::vector<Fingerprint> localFingerprints;
-		static std::vector<SrtpCryptoSuiteMapEntry> srtpCryptoSuites;
+		thread_local static X509* certificate;
+		thread_local static EVP_PKEY* privateKey;
+		thread_local static SSL_CTX* sslCtx;
+		thread_local static uint8_t sslReadBuffer[];
+		thread_local static std::map<std::string, Role> string2Role;
+		thread_local static std::map<std::string, FingerprintAlgorithm> string2FingerprintAlgorithm;
+		thread_local static std::map<FingerprintAlgorithm, std::string> fingerprintAlgorithm2String;
+		thread_local static std::vector<Fingerprint> localFingerprints;
+		thread_local static std::vector<SrtpCryptoSuiteMapEntry> srtpCryptoSuites;
 
 	public:
 		explicit DtlsTransport(Listener* listener);

--- a/worker/include/RTC/DtlsTransport.hpp
+++ b/worker/include/RTC/DtlsTransport.hpp
@@ -145,7 +145,7 @@ namespace RTC
 		static std::map<std::string, FingerprintAlgorithm> string2FingerprintAlgorithm;
 		static std::map<FingerprintAlgorithm, std::string> fingerprintAlgorithm2String;
 		thread_local static std::vector<Fingerprint> localFingerprints;
-		thread_local static std::vector<SrtpCryptoSuiteMapEntry> srtpCryptoSuites;
+		static std::vector<SrtpCryptoSuiteMapEntry> srtpCryptoSuites;
 
 	public:
 		explicit DtlsTransport(Listener* listener);

--- a/worker/include/RTC/DtlsTransport.hpp
+++ b/worker/include/RTC/DtlsTransport.hpp
@@ -141,9 +141,9 @@ namespace RTC
 		thread_local static EVP_PKEY* privateKey;
 		thread_local static SSL_CTX* sslCtx;
 		thread_local static uint8_t sslReadBuffer[];
-		thread_local static std::map<std::string, Role> string2Role;
-		thread_local static std::map<std::string, FingerprintAlgorithm> string2FingerprintAlgorithm;
-		thread_local static std::map<FingerprintAlgorithm, std::string> fingerprintAlgorithm2String;
+		static std::map<std::string, Role> string2Role;
+		static std::map<std::string, FingerprintAlgorithm> string2FingerprintAlgorithm;
+		static std::map<FingerprintAlgorithm, std::string> fingerprintAlgorithm2String;
 		thread_local static std::vector<Fingerprint> localFingerprints;
 		thread_local static std::vector<SrtpCryptoSuiteMapEntry> srtpCryptoSuites;
 

--- a/worker/include/Settings.hpp
+++ b/worker/include/Settings.hpp
@@ -51,7 +51,7 @@ private:
 	static void SetDtlsCertificateAndPrivateKeyFiles();
 
 public:
-	static struct Configuration configuration;
+	thread_local static struct Configuration configuration;
 
 private:
 	static std::map<std::string, LogLevel> string2LogLevel;

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -254,9 +254,9 @@ namespace Utils
 		static const uint8_t* GetHmacShA1(const std::string& key, const uint8_t* data, size_t len);
 
 	private:
-		static uint32_t seed;
-		static HMAC_CTX* hmacSha1Ctx;
-		static uint8_t hmacSha1Buffer[];
+		thread_local static uint32_t seed;
+		thread_local static HMAC_CTX* hmacSha1Ctx;
+		thread_local static uint8_t hmacSha1Buffer[];
 		static const uint32_t crc32Table[256];
 	};
 

--- a/worker/include/Worker.hpp
+++ b/worker/include/Worker.hpp
@@ -21,7 +21,7 @@ class Worker : public Channel::UnixStreamSocket::Listener,
 {
 public:
 	explicit Worker(
-	  Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamSocket* payloadChannel, bool handleSignals);
+	  Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamSocket* payloadChannel, bool processMode);
 	~Worker();
 
 private:

--- a/worker/include/Worker.hpp
+++ b/worker/include/Worker.hpp
@@ -20,10 +20,7 @@ class Worker : public Channel::UnixStreamSocket::Listener,
                public SignalsHandler::Listener
 {
 public:
-	explicit Worker(
-	  Channel::UnixStreamSocket* channel,
-	  PayloadChannel::UnixStreamSocket* payloadChannel,
-	  bool processMode);
+	explicit Worker(Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamSocket* payloadChannel);
 	~Worker();
 
 private:

--- a/worker/include/Worker.hpp
+++ b/worker/include/Worker.hpp
@@ -21,7 +21,9 @@ class Worker : public Channel::UnixStreamSocket::Listener,
 {
 public:
 	explicit Worker(
-	  Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamSocket* payloadChannel, bool processMode);
+	  Channel::UnixStreamSocket* channel,
+	  PayloadChannel::UnixStreamSocket* payloadChannel,
+	  bool processMode);
 	~Worker();
 
 private:

--- a/worker/include/Worker.hpp
+++ b/worker/include/Worker.hpp
@@ -20,7 +20,8 @@ class Worker : public Channel::UnixStreamSocket::Listener,
                public SignalsHandler::Listener
 {
 public:
-	explicit Worker(Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamSocket* payloadChannel);
+	explicit Worker(
+	  Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamSocket* payloadChannel, bool handleSignals);
 	~Worker();
 
 private:

--- a/worker/include/lib.hpp
+++ b/worker/include/lib.hpp
@@ -1,0 +1,10 @@
+extern "C" int run_worker(
+    int argc,
+    char* argv[],
+    const char* version,
+    bool processMode,
+    int consumerChannelFd,
+    int producerChannelFd,
+    int payloadConsumeChannelFd,
+    int payloadProduceChannelFd
+);

--- a/worker/include/lib.hpp
+++ b/worker/include/lib.hpp
@@ -1,10 +1,9 @@
 extern "C" int run_worker(
-    int argc,
-    char* argv[],
-    const char* version,
-    bool processMode,
-    int consumerChannelFd,
-    int producerChannelFd,
-    int payloadConsumeChannelFd,
-    int payloadProduceChannelFd
-);
+  int argc,
+  char* argv[],
+  const char* version,
+  bool processMode,
+  int consumerChannelFd,
+  int producerChannelFd,
+  int payloadConsumeChannelFd,
+  int payloadProduceChannelFd);

--- a/worker/include/lib.hpp
+++ b/worker/include/lib.hpp
@@ -2,7 +2,6 @@ extern "C" int run_worker(
   int argc,
   char* argv[],
   const char* version,
-  bool processMode,
   int consumerChannelFd,
   int producerChannelFd,
   int payloadConsumeChannelFd,

--- a/worker/mediasoup-worker.gyp
+++ b/worker/mediasoup-worker.gyp
@@ -333,6 +333,15 @@
       ]
     },
     {
+      'target_name': 'libmediasoup-worker',
+      'type': 'static_library',
+      'sources':
+      [
+        # C++ source files.
+        'src/lib.cpp'
+      ]
+    },
+    {
       'target_name': 'mediasoup-worker-test',
       'defines': [ 'MS_LOG_STD', 'MS_TEST' ],
       'sources':

--- a/worker/mediasoup-worker.gyp
+++ b/worker/mediasoup-worker.gyp
@@ -16,6 +16,7 @@
     'sources':
     [
       # C++ source files.
+      'src/lib.cpp',
       'src/DepLibSRTP.cpp',
       'src/DepLibUV.cpp',
       'src/DepLibWebRTC.cpp',
@@ -127,6 +128,7 @@
       'src/RTC/RTCP/XrDelaySinceLastRr.cpp',
       'src/RTC/RTCP/XrReceiverReferenceTime.cpp',
       # C++ include files.
+      'include/lib.hpp',
       'include/DepLibSRTP.hpp',
       'include/DepLibUV.hpp',
       'include/DepLibWebRTC.hpp',
@@ -334,12 +336,7 @@
     },
     {
       'target_name': 'libmediasoup-worker',
-      'type': 'static_library',
-      'sources':
-      [
-        # C++ source files.
-        'src/lib.cpp'
-      ]
+      'type': 'static_library'
     },
     {
       'target_name': 'mediasoup-worker-test',

--- a/worker/mediasoup-worker.gyp
+++ b/worker/mediasoup-worker.gyp
@@ -332,7 +332,8 @@
       [
         # C++ source files.
         'src/main.cpp'
-      ]
+      ],
+	  'defines': [ 'MS_EXECUTABLE' ]
     },
     {
       'target_name': 'libmediasoup-worker',

--- a/worker/src/Channel/Notifier.cpp
+++ b/worker/src/Channel/Notifier.cpp
@@ -8,7 +8,7 @@ namespace Channel
 {
 	/* Class variables. */
 
-	Channel::UnixStreamSocket* Notifier::channel{ nullptr };
+	thread_local Channel::UnixStreamSocket* Notifier::channel{ nullptr };
 
 	/* Static methods. */
 

--- a/worker/src/Channel/Request.cpp
+++ b/worker/src/Channel/Request.cpp
@@ -13,6 +13,7 @@ namespace Channel
 	// clang-format off
 	std::unordered_map<std::string, Request::MethodId> Request::string2MethodId =
 	{
+		{ "worker.close",                                Request::MethodId::WORKER_CLOSE                                     },
 		{ "worker.dump",                                 Request::MethodId::WORKER_DUMP                                      },
 		{ "worker.getResourceUsage",                     Request::MethodId::WORKER_GET_RESOURCE_USAGE                        },
 		{ "worker.updateSettings",                       Request::MethodId::WORKER_UPDATE_SETTINGS                           },

--- a/worker/src/Channel/UnixStreamSocket.cpp
+++ b/worker/src/Channel/UnixStreamSocket.cpp
@@ -87,7 +87,7 @@ namespace Channel
 
 		if (nsPayloadLen == 0)
 		{
-			nsNumLen       = 1;
+			nsNumLen             = 1;
 			this->WriteBuffer[0] = '0';
 			this->WriteBuffer[1] = ':';
 			this->WriteBuffer[2] = ',';

--- a/worker/src/Channel/UnixStreamSocket.cpp
+++ b/worker/src/Channel/UnixStreamSocket.cpp
@@ -19,18 +19,21 @@ namespace Channel
 	// netstring length for a 4194304 bytes payload.
 	static constexpr size_t NsMessageMaxLen{ 4194313 };
 	static constexpr size_t NsPayloadMaxLen{ 4194304 };
-	static uint8_t WriteBuffer[NsMessageMaxLen];
 
 	/* Instance methods. */
 	UnixStreamSocket::UnixStreamSocket(int consumerFd, int producerFd)
 	  : consumerSocket(consumerFd, NsMessageMaxLen, this), producerSocket(producerFd, NsMessageMaxLen)
 	{
 		MS_TRACE_STD();
+
+		this->WriteBuffer = (uint8_t*)std::malloc(NsMessageMaxLen);
 	}
 
 	UnixStreamSocket::~UnixStreamSocket()
 	{
 		MS_TRACE_STD();
+
+		std::free(this->WriteBuffer);
 	}
 
 	void UnixStreamSocket::SetListener(Listener* listener)
@@ -85,21 +88,21 @@ namespace Channel
 		if (nsPayloadLen == 0)
 		{
 			nsNumLen       = 1;
-			WriteBuffer[0] = '0';
-			WriteBuffer[1] = ':';
-			WriteBuffer[2] = ',';
+			this->WriteBuffer[0] = '0';
+			this->WriteBuffer[1] = ':';
+			this->WriteBuffer[2] = ',';
 		}
 		else
 		{
 			nsNumLen = static_cast<size_t>(std::ceil(std::log10(static_cast<double>(nsPayloadLen) + 1)));
-			std::sprintf(reinterpret_cast<char*>(WriteBuffer), "%zu:", nsPayloadLen);
-			std::memcpy(WriteBuffer + nsNumLen + 1, nsPayload, nsPayloadLen);
-			WriteBuffer[nsNumLen + nsPayloadLen + 1] = ',';
+			std::sprintf(reinterpret_cast<char*>(this->WriteBuffer), "%zu:", nsPayloadLen);
+			std::memcpy(this->WriteBuffer + nsNumLen + 1, nsPayload, nsPayloadLen);
+			this->WriteBuffer[nsNumLen + nsPayloadLen + 1] = ',';
 		}
 
 		size_t nsLen = nsNumLen + nsPayloadLen + 2;
 
-		this->producerSocket.Write(WriteBuffer, nsLen);
+		this->producerSocket.Write(this->WriteBuffer, nsLen);
 	}
 
 	void UnixStreamSocket::OnConsumerSocketMessage(

--- a/worker/src/Channel/UnixStreamSocket.cpp
+++ b/worker/src/Channel/UnixStreamSocket.cpp
@@ -26,7 +26,7 @@ namespace Channel
 	{
 		MS_TRACE_STD();
 
-		this->WriteBuffer = (uint8_t*)std::malloc(NsMessageMaxLen);
+		this->WriteBuffer = static_cast<uint8_t*>(std::malloc(NsMessageMaxLen));
 	}
 
 	UnixStreamSocket::~UnixStreamSocket()

--- a/worker/src/DepLibSRTP.cpp
+++ b/worker/src/DepLibSRTP.cpp
@@ -50,8 +50,9 @@ void DepLibSRTP::ClassInit()
 	MS_TRACE();
 
 	{
-		std::lock_guard<std::mutex> lock (globalSyncMutex);
-		if (globalInstances == 0) {
+		std::lock_guard<std::mutex> lock(globalSyncMutex);
+		if (globalInstances == 0)
+		{
 			MS_DEBUG_TAG(info, "libsrtp version: \"%s\"", srtp_get_version_string());
 
 			srtp_err_status_t err = srtp_init();
@@ -68,9 +69,10 @@ void DepLibSRTP::ClassDestroy()
 	MS_TRACE();
 
 	{
-		std::lock_guard<std::mutex> lock (globalSyncMutex);
+		std::lock_guard<std::mutex> lock(globalSyncMutex);
 		--globalInstances;
-		if (globalInstances == 0) {
+		if (globalInstances == 0)
+		{
 			srtp_shutdown();
 		}
 	}

--- a/worker/src/DepLibSRTP.cpp
+++ b/worker/src/DepLibSRTP.cpp
@@ -4,8 +4,12 @@
 #include "DepLibSRTP.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
+#include <mutex>
 
 /* Static variables. */
+
+static std::mutex globalSyncMutex;
+static size_t globalInstances = 0;
 
 // clang-format off
 std::vector<const char*> DepLibSRTP::errors =
@@ -45,17 +49,29 @@ void DepLibSRTP::ClassInit()
 {
 	MS_TRACE();
 
-	MS_DEBUG_TAG(info, "libsrtp version: \"%s\"", srtp_get_version_string());
+	{
+		std::lock_guard<std::mutex> lock (globalSyncMutex);
+		if (globalInstances == 0) {
+			MS_DEBUG_TAG(info, "libsrtp version: \"%s\"", srtp_get_version_string());
 
-	srtp_err_status_t err = srtp_init();
+			srtp_err_status_t err = srtp_init();
 
-	if (DepLibSRTP::IsError(err))
-		MS_THROW_ERROR("srtp_init() failed: %s", DepLibSRTP::GetErrorString(err));
+			if (DepLibSRTP::IsError(err))
+				MS_THROW_ERROR("srtp_init() failed: %s", DepLibSRTP::GetErrorString(err));
+		}
+		++globalInstances;
+	}
 }
 
 void DepLibSRTP::ClassDestroy()
 {
 	MS_TRACE();
 
-	srtp_shutdown();
+	{
+		std::lock_guard<std::mutex> lock (globalSyncMutex);
+		--globalInstances;
+		if (globalInstances == 0) {
+			srtp_shutdown();
+		}
+	}
 }

--- a/worker/src/DepLibSRTP.cpp
+++ b/worker/src/DepLibSRTP.cpp
@@ -51,6 +51,7 @@ void DepLibSRTP::ClassInit()
 
 	{
 		std::lock_guard<std::mutex> lock(globalSyncMutex);
+
 		if (globalInstances == 0)
 		{
 			MS_DEBUG_TAG(info, "libsrtp version: \"%s\"", srtp_get_version_string());
@@ -60,6 +61,7 @@ void DepLibSRTP::ClassInit()
 			if (DepLibSRTP::IsError(err))
 				MS_THROW_ERROR("srtp_init() failed: %s", DepLibSRTP::GetErrorString(err));
 		}
+
 		++globalInstances;
 	}
 }
@@ -71,6 +73,7 @@ void DepLibSRTP::ClassDestroy()
 	{
 		std::lock_guard<std::mutex> lock(globalSyncMutex);
 		--globalInstances;
+
 		if (globalInstances == 0)
 		{
 			srtp_shutdown();

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -7,7 +7,7 @@
 
 /* Static variables. */
 
-uv_loop_t* DepLibUV::loop{ nullptr };
+thread_local uv_loop_t* DepLibUV::loop{ nullptr };
 
 /* Static methods. */
 

--- a/worker/src/DepLibWebRTC.cpp
+++ b/worker/src/DepLibWebRTC.cpp
@@ -4,9 +4,11 @@
 #include "DepLibWebRTC.hpp"
 #include "Logger.hpp"
 #include "system_wrappers/source/field_trial.h" // webrtc::field_trial
+#include <mutex>
 
 /* Static. */
 
+static std::once_flag globalInitOnce;
 static constexpr char FieldTrials[] = "WebRTC-Bwe-AlrLimitedBackoff/Enabled/";
 
 /* Static methods. */
@@ -15,7 +17,9 @@ void DepLibWebRTC::ClassInit()
 {
 	MS_TRACE();
 
-	webrtc::field_trial::InitFieldTrialsFromString(FieldTrials);
+	std::call_once(globalInitOnce, []{
+		webrtc::field_trial::InitFieldTrialsFromString(FieldTrials);
+	});
 }
 
 void DepLibWebRTC::ClassDestroy()

--- a/worker/src/DepLibWebRTC.cpp
+++ b/worker/src/DepLibWebRTC.cpp
@@ -17,9 +17,7 @@ void DepLibWebRTC::ClassInit()
 {
 	MS_TRACE();
 
-	std::call_once(globalInitOnce, []{
-		webrtc::field_trial::InitFieldTrialsFromString(FieldTrials);
-	});
+	std::call_once(globalInitOnce, [] { webrtc::field_trial::InitFieldTrialsFromString(FieldTrials); });
 }
 
 void DepLibWebRTC::ClassDestroy()

--- a/worker/src/DepOpenSSL.cpp
+++ b/worker/src/DepOpenSSL.cpp
@@ -5,6 +5,11 @@
 #include "Logger.hpp"
 #include <openssl/crypto.h>
 #include <openssl/rand.h>
+#include <mutex>
+
+/* Static. */
+
+static std::once_flag globalInitOnce;
 
 /* Static methods. */
 
@@ -12,8 +17,10 @@ void DepOpenSSL::ClassInit()
 {
 	MS_TRACE();
 
-	MS_DEBUG_TAG(info, "openssl version: \"%s\"", OpenSSL_version(OPENSSL_VERSION));
+	std::call_once(globalInitOnce, []{
+		MS_DEBUG_TAG(info, "openssl version: \"%s\"", OpenSSL_version(OPENSSL_VERSION));
 
-	// Initialize some crypto stuff.
-	RAND_poll();
+		// Initialize some crypto stuff.
+		RAND_poll();
+	});
 }

--- a/worker/src/DepOpenSSL.cpp
+++ b/worker/src/DepOpenSSL.cpp
@@ -17,7 +17,7 @@ void DepOpenSSL::ClassInit()
 {
 	MS_TRACE();
 
-	std::call_once(globalInitOnce, []{
+	std::call_once(globalInitOnce, [] {
 		MS_DEBUG_TAG(info, "openssl version: \"%s\"", OpenSSL_version(OPENSSL_VERSION));
 
 		// Initialize some crypto stuff.

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -92,6 +92,9 @@ void DepUsrSCTP::ClassDestroy()
 		--globalInstances;
 		if (globalInstances == 0) {
 			usrsctp_finish();
+			numSctpAssociations = 0u;
+			nextSctpAssociationId = 0u;
+			DepUsrSCTP::mapIdSctpAssociation.clear();
 		}
 	}
 

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -66,8 +66,9 @@ void DepUsrSCTP::ClassInit()
 	MS_DEBUG_TAG(info, "usrsctp");
 
 	{
-		std::lock_guard<std::mutex> lock (globalSyncMutex);
-		if (globalInstances == 0) {
+		std::lock_guard<std::mutex> lock(globalSyncMutex);
+		if (globalInstances == 0)
+		{
 			usrsctp_init_nothreads(0, onSendSctpData, sctpDebug);
 
 			// Disable explicit congestion notifications (ecn).
@@ -88,13 +89,15 @@ void DepUsrSCTP::ClassDestroy()
 	MS_TRACE();
 
 	{
-		std::lock_guard<std::mutex> lock (globalSyncMutex);
+		std::lock_guard<std::mutex> lock(globalSyncMutex);
 		--globalInstances;
-		if (globalInstances == 0) {
+		if (globalInstances == 0)
+		{
 			usrsctp_finish();
-			// TODO: This cleanup currently causes assertion errors in DepUsrSCTP::DeregisterSctpAssociation()
-			// numSctpAssociations = 0u;
-			// nextSctpAssociationId = 0u;
+			// TODO: This cleanup currently causes assertion errors in
+			// DepUsrSCTP::DeregisterSctpAssociation()
+
+			// numSctpAssociations = 0u; nextSctpAssociationId = 0u;
 			// DepUsrSCTP::mapIdSctpAssociation.clear();
 		}
 	}
@@ -106,7 +109,7 @@ uintptr_t DepUsrSCTP::GetNextSctpAssociationId()
 {
 	MS_TRACE();
 
-	std::lock_guard<std::mutex> lock (globalSyncMutex);
+	std::lock_guard<std::mutex> lock(globalSyncMutex);
 
 	// NOTE: usrsctp_connect() fails with a value of 0.
 	if (DepUsrSCTP::nextSctpAssociationId == 0u)
@@ -130,7 +133,7 @@ void DepUsrSCTP::RegisterSctpAssociation(RTC::SctpAssociation* sctpAssociation)
 {
 	MS_TRACE();
 
-	std::lock_guard<std::mutex> lock (globalSyncMutex);
+	std::lock_guard<std::mutex> lock(globalSyncMutex);
 
 	auto it = DepUsrSCTP::mapIdSctpAssociation.find(sctpAssociation->id);
 
@@ -148,7 +151,7 @@ void DepUsrSCTP::DeregisterSctpAssociation(RTC::SctpAssociation* sctpAssociation
 {
 	MS_TRACE();
 
-	std::lock_guard<std::mutex> lock (globalSyncMutex);
+	std::lock_guard<std::mutex> lock(globalSyncMutex);
 
 	auto found = DepUsrSCTP::mapIdSctpAssociation.erase(sctpAssociation->id);
 
@@ -163,7 +166,7 @@ RTC::SctpAssociation* DepUsrSCTP::RetrieveSctpAssociation(uintptr_t id)
 {
 	MS_TRACE();
 
-	std::lock_guard<std::mutex> lock (globalSyncMutex);
+	std::lock_guard<std::mutex> lock(globalSyncMutex);
 
 	auto it = DepUsrSCTP::mapIdSctpAssociation.find(id);
 

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -92,9 +92,10 @@ void DepUsrSCTP::ClassDestroy()
 		--globalInstances;
 		if (globalInstances == 0) {
 			usrsctp_finish();
-			numSctpAssociations = 0u;
-			nextSctpAssociationId = 0u;
-			DepUsrSCTP::mapIdSctpAssociation.clear();
+			// TODO: This cleanup currently causes assertion errors in DepUsrSCTP::DeregisterSctpAssociation()
+			// numSctpAssociations = 0u;
+			// nextSctpAssociationId = 0u;
+			// DepUsrSCTP::mapIdSctpAssociation.clear();
 		}
 	}
 

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -49,10 +49,10 @@ inline static void sctpDebug(const char* format, ...)
 
 /* Static variables. */
 
-DepUsrSCTP::Checker* DepUsrSCTP::checker{ nullptr };
-uint64_t DepUsrSCTP::numSctpAssociations{ 0u };
-uintptr_t DepUsrSCTP::nextSctpAssociationId{ 0u };
-std::unordered_map<uintptr_t, RTC::SctpAssociation*> DepUsrSCTP::mapIdSctpAssociation;
+thread_local DepUsrSCTP::Checker* DepUsrSCTP::checker{ nullptr };
+thread_local uint64_t DepUsrSCTP::numSctpAssociations{ 0u };
+thread_local uintptr_t DepUsrSCTP::nextSctpAssociationId{ 0u };
+thread_local std::unordered_map<uintptr_t, RTC::SctpAssociation*> DepUsrSCTP::mapIdSctpAssociation;
 
 /* Static methods. */
 

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -67,6 +67,7 @@ void DepUsrSCTP::ClassInit()
 
 	{
 		std::lock_guard<std::mutex> lock(globalSyncMutex);
+
 		if (globalInstances == 0)
 		{
 			usrsctp_init_nothreads(0, onSendSctpData, sctpDebug);
@@ -78,6 +79,7 @@ void DepUsrSCTP::ClassInit()
 			usrsctp_sysctl_set_sctp_debug_on(SCTP_DEBUG_ALL);
 #endif
 		}
+
 		++globalInstances;
 	}
 
@@ -91,6 +93,7 @@ void DepUsrSCTP::ClassDestroy()
 	{
 		std::lock_guard<std::mutex> lock(globalSyncMutex);
 		--globalInstances;
+
 		if (globalInstances == 0)
 		{
 			usrsctp_finish();

--- a/worker/src/Logger.cpp
+++ b/worker/src/Logger.cpp
@@ -7,7 +7,7 @@
 /* Class variables. */
 
 const int64_t Logger::pid{ static_cast<int64_t>(uv_os_getpid()) };
-Channel::UnixStreamSocket* Logger::channel{ nullptr };
+thread_local Channel::UnixStreamSocket* Logger::channel{ nullptr };
 char Logger::buffer[Logger::bufferSize];
 
 /* Class methods. */

--- a/worker/src/PayloadChannel/Notifier.cpp
+++ b/worker/src/PayloadChannel/Notifier.cpp
@@ -8,7 +8,7 @@ namespace PayloadChannel
 {
 	/* Class variables. */
 
-	PayloadChannel::UnixStreamSocket* Notifier::payloadChannel{ nullptr };
+	thread_local PayloadChannel::UnixStreamSocket* Notifier::payloadChannel{ nullptr };
 
 	/* Static methods. */
 

--- a/worker/src/PayloadChannel/UnixStreamSocket.cpp
+++ b/worker/src/PayloadChannel/UnixStreamSocket.cpp
@@ -20,19 +20,21 @@ namespace PayloadChannel
 	// netstring length for a 4194304 bytes payload.
 	static constexpr size_t NsMessageMaxLen{ 4194313 };
 	static constexpr size_t NsPayloadMaxLen{ 4194304 };
-	static uint8_t WriteBuffer[NsMessageMaxLen];
 
 	/* Instance methods. */
 	UnixStreamSocket::UnixStreamSocket(int consumerFd, int producerFd)
 	  : consumerSocket(consumerFd, NsMessageMaxLen, this), producerSocket(producerFd, NsMessageMaxLen)
 	{
 		MS_TRACE();
+
+		this->WriteBuffer = (uint8_t*)std::malloc(NsMessageMaxLen);
 	}
 
 	UnixStreamSocket::~UnixStreamSocket()
 	{
 		MS_TRACE();
 
+		std::free(this->WriteBuffer);
 		delete this->ongoingNotification;
 	}
 
@@ -97,21 +99,21 @@ namespace PayloadChannel
 		if (nsPayloadLen == 0)
 		{
 			nsNumLen       = 1;
-			WriteBuffer[0] = '0';
-			WriteBuffer[1] = ':';
-			WriteBuffer[2] = ',';
+			this->WriteBuffer[0] = '0';
+			this->WriteBuffer[1] = ':';
+			this->WriteBuffer[2] = ',';
 		}
 		else
 		{
 			nsNumLen = static_cast<size_t>(std::ceil(std::log10(static_cast<double>(nsPayloadLen) + 1)));
-			std::sprintf(reinterpret_cast<char*>(WriteBuffer), "%zu:", nsPayloadLen);
-			std::memcpy(WriteBuffer + nsNumLen + 1, nsPayload, nsPayloadLen);
-			WriteBuffer[nsNumLen + nsPayloadLen + 1] = ',';
+			std::sprintf(reinterpret_cast<char*>(this->WriteBuffer), "%zu:", nsPayloadLen);
+			std::memcpy(this->WriteBuffer + nsNumLen + 1, nsPayload, nsPayloadLen);
+			this->WriteBuffer[nsNumLen + nsPayloadLen + 1] = ',';
 		}
 
 		size_t nsLen = nsNumLen + nsPayloadLen + 2;
 
-		this->producerSocket.Write(WriteBuffer, nsLen);
+		this->producerSocket.Write(this->WriteBuffer, nsLen);
 	}
 
 	void UnixStreamSocket::OnConsumerSocketMessage(

--- a/worker/src/PayloadChannel/UnixStreamSocket.cpp
+++ b/worker/src/PayloadChannel/UnixStreamSocket.cpp
@@ -98,7 +98,7 @@ namespace PayloadChannel
 
 		if (nsPayloadLen == 0)
 		{
-			nsNumLen       = 1;
+			nsNumLen             = 1;
 			this->WriteBuffer[0] = '0';
 			this->WriteBuffer[1] = ':';
 			this->WriteBuffer[2] = ',';

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -78,12 +78,12 @@ namespace RTC
 
 	/* Class variables. */
 
-	X509* DtlsTransport::certificate{ nullptr };
-	EVP_PKEY* DtlsTransport::privateKey{ nullptr };
-	SSL_CTX* DtlsTransport::sslCtx{ nullptr };
-	uint8_t DtlsTransport::sslReadBuffer[SslReadBufferSize];
+	thread_local X509* DtlsTransport::certificate{ nullptr };
+	thread_local EVP_PKEY* DtlsTransport::privateKey{ nullptr };
+	thread_local SSL_CTX* DtlsTransport::sslCtx{ nullptr };
+	thread_local uint8_t DtlsTransport::sslReadBuffer[SslReadBufferSize];
 	// clang-format off
-	std::map<std::string, DtlsTransport::FingerprintAlgorithm> DtlsTransport::string2FingerprintAlgorithm =
+	thread_local std::map<std::string, DtlsTransport::FingerprintAlgorithm> DtlsTransport::string2FingerprintAlgorithm =
 	{
 		{ "sha-1",   DtlsTransport::FingerprintAlgorithm::SHA1   },
 		{ "sha-224", DtlsTransport::FingerprintAlgorithm::SHA224 },
@@ -91,7 +91,7 @@ namespace RTC
 		{ "sha-384", DtlsTransport::FingerprintAlgorithm::SHA384 },
 		{ "sha-512", DtlsTransport::FingerprintAlgorithm::SHA512 }
 	};
-	std::map<DtlsTransport::FingerprintAlgorithm, std::string> DtlsTransport::fingerprintAlgorithm2String =
+	thread_local std::map<DtlsTransport::FingerprintAlgorithm, std::string> DtlsTransport::fingerprintAlgorithm2String =
 	{
 		{ DtlsTransport::FingerprintAlgorithm::SHA1,   "sha-1"   },
 		{ DtlsTransport::FingerprintAlgorithm::SHA224, "sha-224" },
@@ -99,14 +99,14 @@ namespace RTC
 		{ DtlsTransport::FingerprintAlgorithm::SHA384, "sha-384" },
 		{ DtlsTransport::FingerprintAlgorithm::SHA512, "sha-512" }
 	};
-	std::map<std::string, DtlsTransport::Role> DtlsTransport::string2Role =
+	thread_local std::map<std::string, DtlsTransport::Role> DtlsTransport::string2Role =
 	{
 		{ "auto",   DtlsTransport::Role::AUTO   },
 		{ "client", DtlsTransport::Role::CLIENT },
 		{ "server", DtlsTransport::Role::SERVER }
 	};
-	std::vector<DtlsTransport::Fingerprint> DtlsTransport::localFingerprints;
-	std::vector<DtlsTransport::SrtpCryptoSuiteMapEntry> DtlsTransport::srtpCryptoSuites =
+	thread_local std::vector<DtlsTransport::Fingerprint> DtlsTransport::localFingerprints;
+	thread_local std::vector<DtlsTransport::SrtpCryptoSuiteMapEntry> DtlsTransport::srtpCryptoSuites =
 	{
 		{ RTC::SrtpSession::CryptoSuite::AEAD_AES_256_GCM, "SRTP_AEAD_AES_256_GCM" },
 		{ RTC::SrtpSession::CryptoSuite::AEAD_AES_128_GCM, "SRTP_AEAD_AES_128_GCM" },

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -99,14 +99,14 @@ namespace RTC
 		{ DtlsTransport::FingerprintAlgorithm::SHA384, "sha-384" },
 		{ DtlsTransport::FingerprintAlgorithm::SHA512, "sha-512" }
 	};
-	thread_local std::map<std::string, DtlsTransport::Role> DtlsTransport::string2Role =
+	std::map<std::string, DtlsTransport::Role> DtlsTransport::string2Role =
 	{
 		{ "auto",   DtlsTransport::Role::AUTO   },
 		{ "client", DtlsTransport::Role::CLIENT },
 		{ "server", DtlsTransport::Role::SERVER }
 	};
-	thread_local std::vector<DtlsTransport::Fingerprint> DtlsTransport::localFingerprints;
-	thread_local std::vector<DtlsTransport::SrtpCryptoSuiteMapEntry> DtlsTransport::srtpCryptoSuites =
+	std::vector<DtlsTransport::Fingerprint> DtlsTransport::localFingerprints;
+	std::vector<DtlsTransport::SrtpCryptoSuiteMapEntry> DtlsTransport::srtpCryptoSuites =
 	{
 		{ RTC::SrtpSession::CryptoSuite::AEAD_AES_256_GCM, "SRTP_AEAD_AES_256_GCM" },
 		{ RTC::SrtpSession::CryptoSuite::AEAD_AES_128_GCM, "SRTP_AEAD_AES_128_GCM" },

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -83,7 +83,7 @@ namespace RTC
 	thread_local SSL_CTX* DtlsTransport::sslCtx{ nullptr };
 	thread_local uint8_t DtlsTransport::sslReadBuffer[SslReadBufferSize];
 	// clang-format off
-	thread_local std::map<std::string, DtlsTransport::FingerprintAlgorithm> DtlsTransport::string2FingerprintAlgorithm =
+	std::map<std::string, DtlsTransport::FingerprintAlgorithm> DtlsTransport::string2FingerprintAlgorithm =
 	{
 		{ "sha-1",   DtlsTransport::FingerprintAlgorithm::SHA1   },
 		{ "sha-224", DtlsTransport::FingerprintAlgorithm::SHA224 },
@@ -91,7 +91,7 @@ namespace RTC
 		{ "sha-384", DtlsTransport::FingerprintAlgorithm::SHA384 },
 		{ "sha-512", DtlsTransport::FingerprintAlgorithm::SHA512 }
 	};
-	thread_local std::map<DtlsTransport::FingerprintAlgorithm, std::string> DtlsTransport::fingerprintAlgorithm2String =
+	std::map<DtlsTransport::FingerprintAlgorithm, std::string> DtlsTransport::fingerprintAlgorithm2String =
 	{
 		{ DtlsTransport::FingerprintAlgorithm::SHA1,   "sha-1"   },
 		{ DtlsTransport::FingerprintAlgorithm::SHA224, "sha-224" },
@@ -105,7 +105,7 @@ namespace RTC
 		{ "client", DtlsTransport::Role::CLIENT },
 		{ "server", DtlsTransport::Role::SERVER }
 	};
-	std::vector<DtlsTransport::Fingerprint> DtlsTransport::localFingerprints;
+	thread_local std::vector<DtlsTransport::Fingerprint> DtlsTransport::localFingerprints;
 	std::vector<DtlsTransport::SrtpCryptoSuiteMapEntry> DtlsTransport::srtpCryptoSuites =
 	{
 		{ RTC::SrtpSession::CryptoSuite::AEAD_AES_256_GCM, "SRTP_AEAD_AES_256_GCM" },

--- a/worker/src/RTC/IceServer.cpp
+++ b/worker/src/RTC/IceServer.cpp
@@ -11,7 +11,7 @@ namespace RTC
 	/* Static. */
 
 	static constexpr size_t StunSerializeBufferSize{ 65536 };
-	static uint8_t StunSerializeBuffer[StunSerializeBufferSize];
+	thread_local static uint8_t StunSerializeBuffer[StunSerializeBufferSize];
 
 	/* Instance methods. */
 

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -12,7 +12,7 @@ namespace RTC
 
 	// 17: 16 bit mask + the initial sequence number.
 	static constexpr size_t MaxRequestedPackets{ 17 };
-	static std::vector<RTC::RtpStreamSend::StorageItem*> RetransmissionContainer(MaxRequestedPackets + 1);
+	thread_local static std::vector<RTC::RtpStreamSend::StorageItem*> RetransmissionContainer(MaxRequestedPackets + 1);
 	// Don't retransmit packets older than this (ms).
 	static constexpr uint32_t MaxRetransmissionDelay{ 2000 };
 	static constexpr uint32_t DefaultRtt{ 100 };

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -12,7 +12,8 @@ namespace RTC
 
 	// 17: 16 bit mask + the initial sequence number.
 	static constexpr size_t MaxRequestedPackets{ 17 };
-	thread_local static std::vector<RTC::RtpStreamSend::StorageItem*> RetransmissionContainer(MaxRequestedPackets + 1);
+	thread_local static std::vector<RTC::RtpStreamSend::StorageItem*> RetransmissionContainer(
+	  MaxRequestedPackets + 1);
 	// Don't retransmit packets older than this (ms).
 	static constexpr uint32_t MaxRetransmissionDelay{ 2000 };
 	static constexpr uint32_t DefaultRtt{ 100 };

--- a/worker/src/RTC/SrtpSession.cpp
+++ b/worker/src/RTC/SrtpSession.cpp
@@ -12,7 +12,7 @@ namespace RTC
 	/* Static. */
 
 	static constexpr size_t EncryptBufferSize{ 65536 };
-	static uint8_t EncryptBuffer[EncryptBufferSize];
+	thread_local static uint8_t EncryptBuffer[EncryptBufferSize];
 
 	/* Class methods. */
 

--- a/worker/src/RTC/TcpConnection.cpp
+++ b/worker/src/RTC/TcpConnection.cpp
@@ -11,7 +11,7 @@ namespace RTC
 	/* Static. */
 
 	static constexpr size_t ReadBufferSize{ 65536 };
-	static uint8_t ReadBuffer[ReadBufferSize];
+	thread_local static uint8_t ReadBuffer[ReadBufferSize];
 
 	/* Instance methods. */
 

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -9,8 +9,8 @@
 #include <cctype> // isprint()
 #include <cerrno>
 #include <iterator> // std::ostream_iterator
-#include <sstream>  // std::ostringstream
 #include <mutex>
+#include <sstream> // std::ostringstream
 extern "C"
 {
 #include <getopt.h>
@@ -68,7 +68,7 @@ void Settings::SetConfiguration(int argc, char* argv[])
 	/* Parse command line options. */
 
 	// getopt_long_only() is not thread-safe
-	std::lock_guard<std::mutex> lock (globalSyncMutex);
+	std::lock_guard<std::mutex> lock(globalSyncMutex);
 
 	optind = 1; // Set explicitly, otherwise subsequent runs will fail
 	opterr = 0; // Don't allow getopt to print error messages.

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -10,10 +10,15 @@
 #include <cerrno>
 #include <iterator> // std::ostream_iterator
 #include <sstream>  // std::ostringstream
+#include <mutex>
 extern "C"
 {
 #include <getopt.h>
 }
+
+/* Static. */
+
+static std::mutex globalSyncMutex;
 
 /* Class variables. */
 
@@ -62,6 +67,10 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 	/* Parse command line options. */
 
+	// getopt_long_only() is not thread-safe
+	std::lock_guard<std::mutex> lock (globalSyncMutex);
+
+	optind = 1; // Set explicitly, otherwise subsequent runs will fail
 	opterr = 0; // Don't allow getopt to print error messages.
 	while ((c = getopt_long_only(argc, argv, "", options, &optionIdx)) != -1)
 	{

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -17,7 +17,7 @@ extern "C"
 
 /* Class variables. */
 
-struct Settings::Configuration Settings::configuration;
+thread_local struct Settings::Configuration Settings::configuration;
 // clang-format off
 std::map<std::string, LogLevel> Settings::string2LogLevel =
 {

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -70,7 +70,7 @@ void Settings::SetConfiguration(int argc, char* argv[])
 	// getopt_long_only() is not thread-safe
 	std::lock_guard<std::mutex> lock(globalSyncMutex);
 
-	optind = 1; // Set explicitly, otherwise subsequent runs will fail
+	optind = 1; // Set explicitly, otherwise subsequent runs will fail.
 	opterr = 0; // Don't allow getopt to print error messages.
 	while ((c = getopt_long_only(argc, argv, "", options, &optionIdx)) != -1)
 	{

--- a/worker/src/Utils/Crypto.cpp
+++ b/worker/src/Utils/Crypto.cpp
@@ -9,9 +9,9 @@ namespace Utils
 {
 	/* Static variables. */
 
-	uint32_t Crypto::seed;
-	HMAC_CTX* Crypto::hmacSha1Ctx{ nullptr };
-	uint8_t Crypto::hmacSha1Buffer[20]; // SHA-1 result is 20 bytes long.
+	thread_local uint32_t Crypto::seed;
+	thread_local HMAC_CTX* Crypto::hmacSha1Ctx{ nullptr };
+	thread_local uint8_t Crypto::hmacSha1Buffer[20]; // SHA-1 result is 20 bytes long.
 	// clang-format off
 	const uint32_t Crypto::crc32Table[] =
 	{

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -10,10 +10,7 @@
 
 /* Instance methods. */
 
-Worker::Worker(
-  ::Channel::UnixStreamSocket* channel,
-  PayloadChannel::UnixStreamSocket* payloadChannel,
-  bool processMode)
+Worker::Worker(::Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamSocket* payloadChannel)
   : channel(channel), payloadChannel(payloadChannel)
 {
 	MS_TRACE();
@@ -27,12 +24,13 @@ Worker::Worker(
 	// Set the signals handler.
 	this->signalsHandler = new SignalsHandler(this);
 
-	if (processMode)
+#ifdef MS_EXECUTABLE
 	{
 		// Add signals to handle.
 		this->signalsHandler->AddSignal(SIGINT, "INT");
 		this->signalsHandler->AddSignal(SIGTERM, "TERM");
 	}
+#endif
 
 	// Tell the Node process that we are running.
 	Channel::Notifier::Emit(std::to_string(Logger::pid), "running");

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -11,7 +11,9 @@
 /* Instance methods. */
 
 Worker::Worker(
-  ::Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamSocket* payloadChannel, bool processMode)
+  ::Channel::UnixStreamSocket* channel,
+  PayloadChannel::UnixStreamSocket* payloadChannel,
+  bool processMode)
   : channel(channel), payloadChannel(payloadChannel)
 {
 	MS_TRACE();

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -11,7 +11,7 @@
 /* Instance methods. */
 
 Worker::Worker(
-  ::Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamSocket* payloadChannel, bool handleSignals)
+  ::Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamSocket* payloadChannel, bool processMode)
   : channel(channel), payloadChannel(payloadChannel)
 {
 	MS_TRACE();
@@ -25,7 +25,7 @@ Worker::Worker(
 	// Set the signals handler.
 	this->signalsHandler = new SignalsHandler(this);
 
-	if (handleSignals)
+	if (processMode)
 	{
 		// Add signals to handle.
 		this->signalsHandler->AddSignal(SIGINT, "INT");

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -10,7 +10,8 @@
 
 /* Instance methods. */
 
-Worker::Worker(::Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamSocket* payloadChannel)
+Worker::Worker(
+  ::Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamSocket* payloadChannel, bool handleSignals)
   : channel(channel), payloadChannel(payloadChannel)
 {
 	MS_TRACE();
@@ -24,9 +25,12 @@ Worker::Worker(::Channel::UnixStreamSocket* channel, PayloadChannel::UnixStreamS
 	// Set the signals handler.
 	this->signalsHandler = new SignalsHandler(this);
 
-	// Add signals to handle.
-	this->signalsHandler->AddSignal(SIGINT, "INT");
-	this->signalsHandler->AddSignal(SIGTERM, "TERM");
+	if (handleSignals)
+	{
+		// Add signals to handle.
+		this->signalsHandler->AddSignal(SIGINT, "INT");
+		this->signalsHandler->AddSignal(SIGTERM, "TERM");
+	}
 
 	// Tell the Node process that we are running.
 	Channel::Notifier::Emit(std::to_string(Logger::pid), "running");

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -197,6 +197,18 @@ inline void Worker::OnChannelRequest(Channel::UnixStreamSocket* /*channel*/, Cha
 
 	switch (request->methodId)
 	{
+		case Channel::Request::MethodId::WORKER_CLOSE:
+		{
+			if (this->closed)
+				return;
+
+			MS_DEBUG_DEV("Worker close request, stopping");
+
+			Close();
+
+			break;
+		}
+
 		case Channel::Request::MethodId::WORKER_DUMP:
 		{
 			json data = json::object();

--- a/worker/src/handles/TcpConnection.cpp
+++ b/worker/src/handles/TcpConnection.cpp
@@ -108,7 +108,7 @@ void TcpConnection::Close()
 		err       = uv_shutdown(
       req, reinterpret_cast<uv_stream_t*>(this->uvHandle), static_cast<uv_shutdown_cb>(onShutdown));
 
-		if (err != 0)
+		if (err != 0 && err != UV_ENOTCONN)
 			MS_ABORT("uv_shutdown() failed: %s", uv_strerror(err));
 	}
 	// Otherwise directly close the socket.

--- a/worker/src/handles/TcpConnection.cpp
+++ b/worker/src/handles/TcpConnection.cpp
@@ -108,7 +108,7 @@ void TcpConnection::Close()
 		err       = uv_shutdown(
       req, reinterpret_cast<uv_stream_t*>(this->uvHandle), static_cast<uv_shutdown_cb>(onShutdown));
 
-		if (err != 0 && err != UV_ENOTCONN)
+		if (err != 0)
 			MS_ABORT("uv_shutdown() failed: %s", uv_strerror(err));
 	}
 	// Otherwise directly close the socket.

--- a/worker/src/handles/UdpSocket.cpp
+++ b/worker/src/handles/UdpSocket.cpp
@@ -10,7 +10,7 @@
 /* Static. */
 
 static constexpr size_t ReadBufferSize{ 65536 };
-static uint8_t ReadBuffer[ReadBufferSize];
+thread_local static uint8_t ReadBuffer[ReadBufferSize];
 
 /* Static methods for UV callbacks. */
 

--- a/worker/src/handles/UnixStreamSocket.cpp
+++ b/worker/src/handles/UnixStreamSocket.cpp
@@ -151,7 +151,7 @@ void UnixStreamSocket::Close()
 		err       = uv_shutdown(
       req, reinterpret_cast<uv_stream_t*>(this->uvHandle), static_cast<uv_shutdown_cb>(onShutdown));
 
-		if (err != 0)
+		if (err != 0 && err != UV_ENOTCONN)
 			MS_ABORT("uv_shutdown() failed: %s", uv_strerror(err));
 	}
 	// Otherwise directly close the socket.

--- a/worker/src/handles/UnixStreamSocket.cpp
+++ b/worker/src/handles/UnixStreamSocket.cpp
@@ -143,7 +143,7 @@ void UnixStreamSocket::Close()
 	}
 
 	// If there is no error and the peer didn't close its pipe side then close gracefully.
-	if (!this->hasError && !this->isClosedByPeer)
+	if (this->role == UnixStreamSocket::Role::PRODUCER && !this->hasError && !this->isClosedByPeer)
 	{
 		// Use uv_shutdown() so pending data to be written will be sent to the peer before closing.
 		auto req  = new uv_shutdown_t;
@@ -151,7 +151,7 @@ void UnixStreamSocket::Close()
 		err       = uv_shutdown(
       req, reinterpret_cast<uv_stream_t*>(this->uvHandle), static_cast<uv_shutdown_cb>(onShutdown));
 
-		if (err != 0 && err != UV_ENOTCONN)
+		if (err != 0)
 			MS_ABORT("uv_shutdown() failed: %s", uv_strerror(err));
 	}
 	// Otherwise directly close the socket.

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -27,7 +27,9 @@
 #include <string>
 #include <mutex>
 
-std::once_flag globalInitOnce;
+/* Static. */
+
+static std::once_flag globalInitOnce;
 
 extern "C" int run(
     int argc,

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -25,11 +25,6 @@
 #include <iostream> // std::cerr, std::endl
 #include <map>
 #include <string>
-#include <mutex>
-
-/* Static. */
-
-static std::once_flag globalInitOnce;
 
 extern "C" int run_worker(
     int argc,
@@ -117,15 +112,11 @@ extern "C" int run_worker(
 
 	try
 	{
-		std::call_once(globalInitOnce, []{
-			// Initialize global static stuff once.
-			DepOpenSSL::ClassInit();
-			DepLibSRTP::ClassInit();
-			DepLibWebRTC::ClassInit();
-		});
-
 		// Initialize static stuff.
+		DepOpenSSL::ClassInit();
+		DepLibSRTP::ClassInit();
 		DepUsrSCTP::ClassInit();
+		DepLibWebRTC::ClassInit();
 		Utils::Crypto::ClassInit();
 		RTC::DtlsTransport::ClassInit();
 		RTC::SrtpSession::ClassInit();
@@ -137,7 +128,9 @@ extern "C" int run_worker(
 
 		// Free static stuff.
 		DepLibUV::ClassDestroy();
+		DepLibSRTP::ClassDestroy();
 		Utils::Crypto::ClassDestroy();
+		DepLibWebRTC::ClassDestroy();
 		RTC::DtlsTransport::ClassDestroy();
 		DepUsrSCTP::ClassDestroy();
 

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -31,7 +31,7 @@
 
 static std::once_flag globalInitOnce;
 
-extern "C" int run(
+extern "C" int run_worker(
     int argc,
     char* argv[],
     char* version,

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -29,15 +29,14 @@
 void IgnoreSignals();
 
 extern "C" int run_worker(
-    int argc,
-    char* argv[],
-    const char* version,
-    bool processMode,
-    int consumerChannelFd,
-    int producerChannelFd,
-    int payloadConsumeChannelFd,
-    int payloadProduceChannelFd
-)
+  int argc,
+  char* argv[],
+  const char* version,
+  bool processMode,
+  int consumerChannelFd,
+  int producerChannelFd,
+  int payloadConsumeChannelFd,
+  int payloadProduceChannelFd)
 {
 	// Initialize libuv stuff (we need it for the Channel).
 	DepLibUV::ClassInit();
@@ -126,7 +125,8 @@ extern "C" int run_worker(
 		Channel::Notifier::ClassInit(channel);
 		PayloadChannel::Notifier::ClassInit(payloadChannel);
 
-		if (processMode) {
+		if (processMode)
+		{
 			// Ignore some signals.
 			IgnoreSignals();
 		}

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -32,7 +32,6 @@ extern "C" int run_worker(
   int argc,
   char* argv[],
   const char* version,
-  bool processMode,
   int consumerChannelFd,
   int producerChannelFd,
   int payloadConsumeChannelFd,
@@ -125,14 +124,15 @@ extern "C" int run_worker(
 		Channel::Notifier::ClassInit(channel);
 		PayloadChannel::Notifier::ClassInit(payloadChannel);
 
-		if (processMode)
+#ifdef MS_EXECUTABLE
 		{
 			// Ignore some signals.
 			IgnoreSignals();
 		}
+#endif
 
 		// Run the Worker.
-		Worker worker(channel, payloadChannel, processMode);
+		Worker worker(channel, payloadChannel);
 
 		// Free static stuff.
 		DepLibUV::ClassDestroy();

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -1,0 +1,149 @@
+#define MS_CLASS "mediasoup-worker"
+// #define MS_LOG_DEV_LEVEL 3
+
+#include "common.hpp"
+#include "DepLibSRTP.hpp"
+#include "DepLibUV.hpp"
+#include "DepLibWebRTC.hpp"
+#include "DepOpenSSL.hpp"
+#include "DepUsrSCTP.hpp"
+#include "Logger.hpp"
+#include "MediaSoupErrors.hpp"
+#include "Settings.hpp"
+#include "Utils.hpp"
+#include "Worker.hpp"
+#include "Channel/Notifier.hpp"
+#include "Channel/UnixStreamSocket.hpp"
+#include "PayloadChannel/Notifier.hpp"
+#include "PayloadChannel/UnixStreamSocket.hpp"
+#include "RTC/DtlsTransport.hpp"
+#include "RTC/SrtpSession.hpp"
+#include <uv.h>
+#include <cerrno>
+#include <csignal>  // sigaction()
+#include <cstdlib>  // std::_Exit(), std::genenv()
+#include <iostream> // std::cerr, std::endl
+#include <map>
+#include <string>
+
+extern "C" int run(
+    int argc,
+    char* argv[],
+    char* version,
+    int consumerChannelFd,
+    int producerChannelFd,
+    int payloadConsumeChannelFd,
+    int payloadProduceChannelFd
+)
+{
+	// Initialize libuv stuff (we need it for the Channel).
+	DepLibUV::ClassInit();
+
+	// Channel socket (it will be handled and deleted by the Worker).
+	Channel::UnixStreamSocket* channel{ nullptr };
+
+	// PayloadChannel socket (it will be handled and deleted by the Worker).
+	PayloadChannel::UnixStreamSocket* payloadChannel{ nullptr };
+
+	try
+	{
+		channel = new Channel::UnixStreamSocket(consumerChannelFd, producerChannelFd);
+	}
+	catch (const MediaSoupError& error)
+	{
+		MS_ERROR_STD("error creating the Channel: %s", error.what());
+
+		return 1;
+	}
+
+	try
+	{
+		payloadChannel =
+		  new PayloadChannel::UnixStreamSocket(payloadConsumeChannelFd, payloadProduceChannelFd);
+	}
+	catch (const MediaSoupError& error)
+	{
+		MS_ERROR_STD("error creating the RTC Channel: %s", error.what());
+
+		return 1;
+	}
+
+	// Initialize the Logger.
+	Logger::ClassInit(channel);
+
+	try
+	{
+		Settings::SetConfiguration(argc, argv);
+	}
+	catch (const MediaSoupTypeError& error)
+	{
+		MS_ERROR_STD("settings error: %s", error.what());
+
+		// 42 is a custom exit code to notify "settings error" to the Node library.
+		return 42;
+	}
+	catch (const MediaSoupError& error)
+	{
+		MS_ERROR_STD("unexpected settings error: %s", error.what());
+
+		return 1;
+	}
+
+	MS_DEBUG_TAG(info, "starting mediasoup-worker process [version:%s]", version);
+
+#if defined(MS_LITTLE_ENDIAN)
+	MS_DEBUG_TAG(info, "little-endian CPU detected");
+#elif defined(MS_BIG_ENDIAN)
+	MS_DEBUG_TAG(info, "big-endian CPU detected");
+#else
+	MS_WARN_TAG(info, "cannot determine whether little-endian or big-endian");
+#endif
+
+#if defined(INTPTR_MAX) && defined(INT32_MAX) && (INTPTR_MAX == INT32_MAX)
+	MS_DEBUG_TAG(info, "32 bits architecture detected");
+#elif defined(INTPTR_MAX) && defined(INT64_MAX) && (INTPTR_MAX == INT64_MAX)
+	MS_DEBUG_TAG(info, "64 bits architecture detected");
+#else
+	MS_WARN_TAG(info, "cannot determine 32 or 64 bits architecture");
+#endif
+
+	Settings::PrintConfiguration();
+	DepLibUV::PrintVersion();
+
+	try
+	{
+		// Initialize static stuff.
+		DepOpenSSL::ClassInit();
+		DepLibSRTP::ClassInit();
+		DepUsrSCTP::ClassInit();
+		DepLibWebRTC::ClassInit();
+		Utils::Crypto::ClassInit();
+		RTC::DtlsTransport::ClassInit();
+		RTC::SrtpSession::ClassInit();
+		Channel::Notifier::ClassInit(channel);
+		PayloadChannel::Notifier::ClassInit(payloadChannel);
+
+		// Run the Worker.
+		Worker worker(channel, payloadChannel);
+
+		// Free static stuff.
+		DepLibUV::ClassDestroy();
+		DepLibSRTP::ClassDestroy();
+		Utils::Crypto::ClassDestroy();
+		DepLibWebRTC::ClassDestroy();
+		RTC::DtlsTransport::ClassDestroy();
+		DepUsrSCTP::ClassDestroy();
+
+		// Wait a bit so peding messages to stdout/Channel arrive to the Node
+		// process.
+		uv_sleep(200);
+
+		return 0;
+	}
+	catch (const MediaSoupError& error)
+	{
+		MS_ERROR_STD("failure exit: %s", error.what());
+
+		return 1;
+	}
+}

--- a/worker/src/main.cpp
+++ b/worker/src/main.cpp
@@ -136,7 +136,7 @@ int main(int argc, char* argv[])
 		IgnoreSignals();
 
 		// Run the Worker.
-		Worker worker(channel, payloadChannel);
+		Worker worker(channel, payloadChannel, true);
 
 		// Free static stuff.
 		DepLibUV::ClassDestroy();

--- a/worker/src/main.cpp
+++ b/worker/src/main.cpp
@@ -27,7 +27,6 @@ int main(int argc, char* argv[])
 	  argc,
 	  argv,
 	  version.c_str(),
-	  true,
 	  ConsumerChannelFd,
 	  ProducerChannelFd,
 	  PayloadConsumerChannelFd,

--- a/worker/src/main.cpp
+++ b/worker/src/main.cpp
@@ -1,37 +1,15 @@
 #define MS_CLASS "mediasoup-worker"
 // #define MS_LOG_DEV_LEVEL 3
 
-#include "common.hpp"
-#include "DepLibSRTP.hpp"
-#include "DepLibUV.hpp"
-#include "DepLibWebRTC.hpp"
-#include "DepOpenSSL.hpp"
-#include "DepUsrSCTP.hpp"
-#include "Logger.hpp"
+#include "lib.hpp"
 #include "MediaSoupErrors.hpp"
-#include "Settings.hpp"
-#include "Utils.hpp"
-#include "Worker.hpp"
-#include "Channel/Notifier.hpp"
-#include "Channel/UnixStreamSocket.hpp"
-#include "PayloadChannel/Notifier.hpp"
-#include "PayloadChannel/UnixStreamSocket.hpp"
-#include "RTC/DtlsTransport.hpp"
-#include "RTC/SrtpSession.hpp"
-#include <uv.h>
-#include <cerrno>
-#include <csignal>  // sigaction()
 #include <cstdlib>  // std::_Exit(), std::genenv()
-#include <iostream> // std::cerr, std::endl
-#include <map>
 #include <string>
 
 static constexpr int ConsumerChannelFd{ 3 };
 static constexpr int ProducerChannelFd{ 4 };
 static constexpr int PayloadConsumerChannelFd{ 5 };
 static constexpr int PayloadProducerChannelFd{ 6 };
-
-void IgnoreSignals();
 
 int main(int argc, char* argv[])
 {
@@ -45,156 +23,24 @@ int main(int argc, char* argv[])
 
 	std::string version = std::getenv("MEDIASOUP_VERSION");
 
-	// Initialize libuv stuff (we need it for the Channel).
-	DepLibUV::ClassInit();
+	auto statusCode = run_worker(
+	  argc,
+	  argv,
+	  version.c_str(),
+	  true,
+	  ConsumerChannelFd,
+	  ProducerChannelFd,
+	  PayloadConsumerChannelFd,
+	  PayloadProducerChannelFd
+	);
 
-	// Channel socket (it will be handled and deleted by the Worker).
-	Channel::UnixStreamSocket* channel{ nullptr };
-
-	// PayloadChannel socket (it will be handled and deleted by the Worker).
-	PayloadChannel::UnixStreamSocket* payloadChannel{ nullptr };
-
-	try
+	switch (statusCode)
 	{
-		channel = new Channel::UnixStreamSocket(ConsumerChannelFd, ProducerChannelFd);
+		case 0:
+			std::_Exit(EXIT_SUCCESS);
+		case 1:
+			std::_Exit(EXIT_FAILURE);
+		case 42:
+			std::_Exit(42);
 	}
-	catch (const MediaSoupError& error)
-	{
-		MS_ERROR_STD("error creating the Channel: %s", error.what());
-
-		std::_Exit(EXIT_FAILURE);
-	}
-
-	try
-	{
-		payloadChannel =
-		  new PayloadChannel::UnixStreamSocket(PayloadConsumerChannelFd, PayloadProducerChannelFd);
-	}
-	catch (const MediaSoupError& error)
-	{
-		MS_ERROR_STD("error creating the RTC Channel: %s", error.what());
-
-		std::_Exit(EXIT_FAILURE);
-	}
-
-	// Initialize the Logger.
-	Logger::ClassInit(channel);
-
-	try
-	{
-		Settings::SetConfiguration(argc, argv);
-	}
-	catch (const MediaSoupTypeError& error)
-	{
-		MS_ERROR_STD("settings error: %s", error.what());
-
-		// 42 is a custom exit code to notify "settings error" to the Node library.
-		std::_Exit(42);
-	}
-	catch (const MediaSoupError& error)
-	{
-		MS_ERROR_STD("unexpected settings error: %s", error.what());
-
-		std::_Exit(EXIT_FAILURE);
-	}
-
-	MS_DEBUG_TAG(info, "starting mediasoup-worker process [version:%s]", version.c_str());
-
-#if defined(MS_LITTLE_ENDIAN)
-	MS_DEBUG_TAG(info, "little-endian CPU detected");
-#elif defined(MS_BIG_ENDIAN)
-	MS_DEBUG_TAG(info, "big-endian CPU detected");
-#else
-	MS_WARN_TAG(info, "cannot determine whether little-endian or big-endian");
-#endif
-
-#if defined(INTPTR_MAX) && defined(INT32_MAX) && (INTPTR_MAX == INT32_MAX)
-	MS_DEBUG_TAG(info, "32 bits architecture detected");
-#elif defined(INTPTR_MAX) && defined(INT64_MAX) && (INTPTR_MAX == INT64_MAX)
-	MS_DEBUG_TAG(info, "64 bits architecture detected");
-#else
-	MS_WARN_TAG(info, "cannot determine 32 or 64 bits architecture");
-#endif
-
-	Settings::PrintConfiguration();
-	DepLibUV::PrintVersion();
-
-	try
-	{
-		// Initialize static stuff.
-		DepOpenSSL::ClassInit();
-		DepLibSRTP::ClassInit();
-		DepUsrSCTP::ClassInit();
-		DepLibWebRTC::ClassInit();
-		Utils::Crypto::ClassInit();
-		RTC::DtlsTransport::ClassInit();
-		RTC::SrtpSession::ClassInit();
-		Channel::Notifier::ClassInit(channel);
-		PayloadChannel::Notifier::ClassInit(payloadChannel);
-
-		// Ignore some signals.
-		IgnoreSignals();
-
-		// Run the Worker.
-		Worker worker(channel, payloadChannel, true);
-
-		// Free static stuff.
-		DepLibUV::ClassDestroy();
-		DepLibSRTP::ClassDestroy();
-		Utils::Crypto::ClassDestroy();
-		DepLibWebRTC::ClassDestroy();
-		RTC::DtlsTransport::ClassDestroy();
-		DepUsrSCTP::ClassDestroy();
-
-		// Wait a bit so peding messages to stdout/Channel arrive to the Node
-		// process.
-		uv_sleep(200);
-
-		std::_Exit(EXIT_SUCCESS);
-	}
-	catch (const MediaSoupError& error)
-	{
-		MS_ERROR_STD("failure exit: %s", error.what());
-
-		std::_Exit(EXIT_FAILURE);
-	}
-}
-
-void IgnoreSignals()
-{
-#ifndef _WIN32
-	MS_TRACE();
-
-	int err;
-	struct sigaction act; // NOLINT(cppcoreguidelines-pro-type-member-init)
-
-	// clang-format off
-	std::map<std::string, int> ignoredSignals =
-	{
-		{ "PIPE", SIGPIPE },
-		{ "HUP",  SIGHUP  },
-		{ "ALRM", SIGALRM },
-		{ "USR1", SIGUSR1 },
-		{ "USR2", SIGUSR2 }
-	};
-	// clang-format on
-
-	act.sa_handler = SIG_IGN; // NOLINT(cppcoreguidelines-pro-type-cstyle-cast)
-	act.sa_flags   = 0;
-	err            = sigfillset(&act.sa_mask);
-
-	if (err != 0)
-		MS_THROW_ERROR("sigfillset() failed: %s", std::strerror(errno));
-
-	for (auto& kv : ignoredSignals)
-	{
-		const auto& sigName = kv.first;
-		int sigId           = kv.second;
-
-		err = sigaction(sigId, &act, nullptr);
-
-		if (err != 0)
-			MS_THROW_ERROR("sigaction() failed for signal %s: %s", sigName.c_str(), std::strerror(errno));
-	}
-#endif
 }

--- a/worker/src/main.cpp
+++ b/worker/src/main.cpp
@@ -1,9 +1,9 @@
 #define MS_CLASS "mediasoup-worker"
 // #define MS_LOG_DEV_LEVEL 3
 
-#include "lib.hpp"
 #include "MediaSoupErrors.hpp"
-#include <cstdlib>  // std::_Exit(), std::genenv()
+#include "lib.hpp"
+#include <cstdlib> // std::_Exit(), std::genenv()
 #include <string>
 
 static constexpr int ConsumerChannelFd{ 3 };
@@ -31,8 +31,7 @@ int main(int argc, char* argv[])
 	  ConsumerChannelFd,
 	  ProducerChannelFd,
 	  PayloadConsumerChannelFd,
-	  PayloadProducerChannelFd
-	);
+	  PayloadProducerChannelFd);
 
 	switch (statusCode)
 	{


### PR DESCRIPTION
#### Motivation:
There is an ergonomic issue with #518 that requires user to build worker separately and then specifying a path to its executable during instantiation. Ideally worker would also be a library, which would allow it to be packaged into Rust crate and seamlessly installed as any other dependency.

I worked on achieving this in my fork and succeeded in doing so, this PR is a distilled worker-specific set of changes without anything Rust-specific in order to separate review process for each. I also think this could be useful for those using worker in other languages.

#### This PR contains a few things:
* adds `libmediasoup-worker` static library build, which is the almost identical to `mediasoup-worker`, but presents itself as a library instead of an executable
* regular executable `mediasoup-worker` now shares code with `libmediasoup-worker`
* `mediasoup-worker`'s internals are now aware of multiple threads, namely:
  * truly global resources are guarded by mutexes
  * data specific to worker instance are made thread-local
  * above allows to have multiple concurrent workers running each in their own thread withing parent application
* `worker.close` message added such that it is possible to stop worker that is running in the thread and can't be controlled with signals
* with a thin wrapper above library can be turned into Rust crate (build script as of right now: https://github.com/nazar-pc/mediasoup/blob/a67a5ad535315979e273644a9f215ac24c79e451/worker/build.rs)

API of the introduced `run_worker()` is intentionally very close to `int main(argc, argv)` of the executable itself, more convenient API can be created later if ever needed. PR wasn't squashed to simplify review process.

P.S. This needs careful review and probably some more extensive testing, but it seems to work from my testing so far, passes all TypeScript, C++ and Rust tests in my fork. The primary concern is around data channels as usrsctp internals are really hard to understand and are not documented.