### PR TITLE
Consumer: make IsActive() return true (even if Producer's score is 0) when DTX is enabled

### DIFF
--- a/worker/include/RTC/RtpStream.hpp
+++ b/worker/include/RTC/RtpStream.hpp
@@ -103,6 +103,10 @@ namespace RTC
 		{
 			return this->params.spatialLayers;
 		}
+		bool HasDtx() const
+		{
+			return this->params.useDtx;
+		}
 		uint8_t GetTemporalLayers() const
 		{
 			return this->params.temporalLayers;

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -28,7 +28,7 @@ namespace RTC
 			return (
 				RTC::Consumer::IsActive() &&
 				this->producerRtpStream &&
-				this->producerRtpStream->GetScore() > 0u
+				(this->producerRtpStream->GetScore() > 0u || this->producerRtpStream->HasDtx())
 			);
 			// clang-format on
 		}

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -42,7 +42,7 @@ namespace RTC
 					this->producerRtpStreams.end(),
 					[](const RTC::RtpStream* rtpStream)
 					{
-						return (rtpStream != nullptr && rtpStream->GetScore() > 0u);
+						return (rtpStream != nullptr && (rtpStream->GetScore() > 0u || rtpStream->HasDtx()));
 					}
 				)
 			);

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -39,7 +39,7 @@ namespace RTC
 			return (
 				RTC::Consumer::IsActive() &&
 				this->producerRtpStream &&
-				this->producerRtpStream->GetScore() > 0u
+				(this->producerRtpStream->GetScore() > 0u || this->producerRtpStream->HasDtx())
 			);
 			// clang-format on
 		}


### PR DESCRIPTION
- Should fix #532

Now, `Consumer::IsActive()` returns `true` in that case, which makes `RequestKeyFrame()` work. Although this requires a full review since we check `IsActive()` for many other things.