### PR TITLE
Rate calculator optimization

### DIFF
--- a/worker/include/RTC/RateCalculator.hpp
+++ b/worker/include/RTC/RateCalculator.hpp
@@ -43,13 +43,13 @@ namespace RTC
 		void Reset(uint64_t nowMs)
 		{
 			this->buffer.reset(new BufferItem[this->windowItems]);
-			this->latestTime  = 0u;
-			this->latestIndex = -1;
-			this->oldestTime  = 0u;
-			this->oldestIndex = -1;
-			this->totalCount  = 0u;
-			this->lastRate    = 0u;
-			this->lastTime    = 0u;
+			this->newestTime      = 0u;
+			this->newestTimeIndex = -1;
+			this->oldestTimeIndex = 0u;
+			this->oldestIndex     = -1;
+			this->totalCount      = 0u;
+			this->lastRate        = 0u;
+			this->lastTime        = 0u;
 		}
 
 	private:
@@ -69,11 +69,11 @@ namespace RTC
 		// Buffer to keep data.
 		std::unique_ptr<BufferItem[]> buffer;
 		// Time (in milliseconds) for last item in the time window.
-		uint64_t latestTime{ 0u };
+		uint64_t newestTime{ 0u };
 		// Index for the last item in the time window.
-		int32_t latestIndex{ -1 };
+		int32_t newestTimeIndex{ -1 };
 		// Time (in milliseconds) for oldest item in the time window.
-		uint64_t oldestTime{ 0u };
+		uint64_t oldestTimeIndex{ 0u };
 		// Index for the oldest item in the time window.
 		int32_t oldestIndex{ -1 };
 		// Total count in the time window.

--- a/worker/include/RTC/RateCalculator.hpp
+++ b/worker/include/RTC/RateCalculator.hpp
@@ -17,7 +17,10 @@ namespace RTC
 		static constexpr uint16_t DefaultWindowItems{ 1000u };
 
 	public:
-		RateCalculator(size_t windowSize = DefaultWindowSize, float scale = DefaultBpsScale, uint16_t windowItems = DefaultWindowItems)
+		RateCalculator(
+		  size_t windowSize    = DefaultWindowSize,
+		  float scale          = DefaultBpsScale,
+		  uint16_t windowItems = DefaultWindowItems)
 		  : windowSize(windowSize), scale(scale), windowItems(windowItems)
 		{
 			Reset();

--- a/worker/include/RTC/RateCalculator.hpp
+++ b/worker/include/RTC/RateCalculator.hpp
@@ -14,10 +14,11 @@ namespace RTC
 	public:
 		static constexpr size_t DefaultWindowSize{ 1000u };
 		static constexpr float DefaultBpsScale{ 8000.0f };
+		static constexpr uint16_t DefaultWindowItems{ 1000u };
 
 	public:
-		RateCalculator(size_t windowSize = DefaultWindowSize, float scale = DefaultBpsScale)
-		  : windowSize(windowSize), scale(scale)
+		RateCalculator(size_t windowSize = DefaultWindowSize, float scale = DefaultBpsScale, uint16_t windowItems = DefaultWindowItems)
+		  : windowSize(windowSize), scale(scale), windowItems(windowItems)
 		{
 			Reset();
 		}
@@ -38,9 +39,11 @@ namespace RTC
 		void RemoveOldData(uint64_t nowMs);
 		void Reset(uint64_t nowMs)
 		{
-			this->buffer.reset(new BufferItem[this->windowSize]);
-			this->oldestTime  = nowMs - this->windowSize;
-			this->oldestIndex = 0u;
+			this->buffer.reset(new BufferItem[this->windowItems]);
+			this->latestTime  = 0u;
+			this->latestIndex = -1;
+			this->oldestTime  = 0u;
+			this->oldestIndex = -1;
 			this->totalCount  = 0u;
 			this->lastRate    = 0u;
 			this->lastTime    = 0u;
@@ -50,6 +53,7 @@ namespace RTC
 		struct BufferItem
 		{
 			size_t count{ 0u };
+			uint64_t time{ 0u };
 		};
 
 	private:
@@ -57,12 +61,18 @@ namespace RTC
 		size_t windowSize{ DefaultWindowSize };
 		// Scale in which the rate is represented.
 		float scale{ DefaultBpsScale };
+		// Window Size (number of items).
+		uint16_t windowItems{ DefaultWindowItems };
 		// Buffer to keep data.
 		std::unique_ptr<BufferItem[]> buffer;
+		// Time (in milliseconds) for last item in the time window.
+		uint64_t latestTime{ 0u };
+		// Index for the last item in the time window.
+		int32_t latestIndex{ -1 };
 		// Time (in milliseconds) for oldest item in the time window.
 		uint64_t oldestTime{ 0u };
 		// Index for the oldest item in the time window.
-		uint32_t oldestIndex{ 0u };
+		int32_t oldestIndex{ -1 };
 		// Total count in the time window.
 		size_t totalCount{ 0u };
 		// Total bytes transmitted.

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -41,7 +41,7 @@ namespace RTC
 				this->oldestIndex = 0;
 		}
 
-		// Update the latest item.
+		// Update the newest item.
 		BufferItem& item = buffer[this->newestTimeIndex];
 		item.count += size;
 		item.time        = nowMs;

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -83,7 +83,7 @@ namespace RTC
 
 		uint64_t newOldestTime = nowMs - this->windowSize;
 
-		// Oldest item already removed
+		// Oldest item already removed.
 		if (newOldestTime <= this->oldestTime)
 			return;
 

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -20,11 +20,11 @@ namespace RTC
 
 		RemoveOldData(nowMs);
 
-		// Increase the index
+		// Increase the index.
 		if (++this->latestIndex >= this->windowItems)
 			this->latestIndex = 0;
 
-		// Latest index overlaps with the oldest one, remove it
+		// Latest index overlaps with the oldest one, remove it.
 		if (this->latestIndex == this->oldestIndex && this->oldestIndex != -1)
 		{
 			BufferItem& oldestItem = buffer[this->oldestIndex];
@@ -41,7 +41,7 @@ namespace RTC
 		item.time        = nowMs;
 		this->latestTime = nowMs;
 
-		// Set the oldest item index and time, if not set
+		// Set the oldest item index and time, if not set.
 		if (this->oldestIndex < 0)
 		{
 			this->oldestIndex = this->latestIndex;

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -35,7 +35,7 @@ namespace RTC
 				this->oldestIndex = 0;
 		}
 
-		// Update the latest item
+		// Update the latest item.
 		BufferItem& item = buffer[this->latestIndex];
 		item.count += size;
 		item.time        = nowMs;

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -30,7 +30,7 @@ namespace RTC
 			BufferItem& oldestItem = buffer[this->oldestIndex];
 			this->totalCount -= oldestItem.count;
 			oldestItem.count = 0u;
-			oldestItem.time = 0u;
+			oldestItem.time  = 0u;
 			if (++this->oldestIndex >= this->windowItems)
 				this->oldestIndex = 0;
 		}
@@ -38,14 +38,14 @@ namespace RTC
 		// Update the latest item
 		BufferItem& item = buffer[this->latestIndex];
 		item.count += size;
-		item.time = nowMs;
+		item.time        = nowMs;
 		this->latestTime = nowMs;
 
 		// Set the oldest item index and time, if not set
 		if (this->oldestIndex < 0)
 		{
 			this->oldestIndex = this->latestIndex;
-			this->oldestTime = nowMs;
+			this->oldestTime  = nowMs;
 		}
 
 		this->totalCount += size;
@@ -100,15 +100,14 @@ namespace RTC
 			BufferItem& oldestItem = buffer[this->oldestIndex];
 			this->totalCount -= oldestItem.count;
 			oldestItem.count = 0u;
-			oldestItem.time = 0u;
+			oldestItem.time  = 0u;
 
 			if (++this->oldestIndex >= this->windowItems)
 				this->oldestIndex = 0;
 
 			const BufferItem& newOldestItem = buffer[this->oldestIndex];
-			this->oldestTime = newOldestItem.time;
+			this->oldestTime                = newOldestItem.time;
 		}
-
 	}
 
 	void RtpDataCounter::Update(RTC::RtpPacket* packet)

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -27,6 +27,12 @@ namespace RTC
 		// Latest index overlaps with the oldest one, remove it.
 		if (this->latestIndex == this->oldestIndex && this->oldestIndex != -1)
 		{
+			MS_WARN_TAG(
+			  info,
+			  "calculation buffer full, windowSize:%" PRIu64 " ms windowItems:%" PRIu16,
+			  this->windowSize,
+			  this->windowItems);
+
 			BufferItem& oldestItem = buffer[this->oldestIndex];
 			this->totalCount -= oldestItem.count;
 			oldestItem.count = 0u;

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -24,7 +24,7 @@ namespace RTC
 		if (++this->newestTimeIndex >= this->windowItems)
 			this->newestTimeIndex = 0;
 
-		// Latest index overlaps with the oldest one, remove it.
+		// Newest index overlaps with the oldest one, remove it.
 		if (this->newestTimeIndex == this->oldestIndex && this->oldestIndex != -1)
 		{
 			MS_WARN_TAG(

--- a/worker/test/src/RTC/TestRateCalculator.cpp
+++ b/worker/test/src/RTC/TestRateCalculator.cpp
@@ -76,6 +76,29 @@ SCENARIO("Bitrate calculator", "[rtp][bitrate]")
 
 		validate(rate, nowMs, input);
 
-		REQUIRE(rate.GetRate(nowMs + 3000) == 0);
+		REQUIRE(rate.GetRate(nowMs + 3001) == 0);
+	}
+
+	SECTION("wrap")
+	{
+		RateCalculator rate(1000, 8000, 5);
+
+		// clang-format off
+		std::vector<data> input =
+		{
+			{ 1000, 1, 1*8 },
+			{ 1001, 1, 1*8 + 1*8 },
+			{ 1002, 1, 1*8 + 2*8 },
+			{ 1003, 1, 1*8 + 3*8 },
+			{ 1004, 1, 1*8 + 4*8 },
+			{ 1005, 1, 1*8 + (5-1)*8 }, // starts wrap here
+			{ 1006, 1, 1*8 + (6-2)*8 },
+			{ 1007, 1, 1*8 + (7-3)*8 },
+			{ 1008, 1, 1*8 + (8-4)*8 },
+			{ 1009, 1, 1*8 + (9-5)*8 },
+		};
+		// clang-format on
+
+		validate(rate, nowMs, input);
 	}
 }


### PR DESCRIPTION
In the current implementation of `RateCalculator` class, the `RemoveOldData` has an high CPU usage because it should iterate over an array where each item index represents a time moment with a resolution of 1ms. As a consequence, in most cases we have a sparse array. This PR changes the calculator algorithm, assigning each sample to an array position in a contiguous way, avoiding large iterations when removing the expired elements. The unit test has been modified accordingly.

Test is needed!
- [ ] no downsides 
- [ ] no bad corner cases
- [ ] no bugs

Callgrind outputs:
- v3:
![image](https://user-images.githubusercontent.com/283319/113173905-28856c80-924a-11eb-9d3d-2d91b84951f7.png)

- with optimization:
![image](https://user-images.githubusercontent.com/283319/113173968-3804b580-924a-11eb-8083-8d4b5fb8ba03.png)
