### PR TITLE
SctpAssociation: provide 'sctpsendbufferfull' reason on send error

### DIFF
--- a/worker/include/RTC/DataConsumer.hpp
+++ b/worker/include/RTC/DataConsumer.hpp
@@ -13,7 +13,7 @@ namespace RTC
 	class DataConsumer
 	{
 	protected:
-		using onQueuedCallback = const std::function<void(bool queued)>;
+		using onQueuedCallback = const std::function<void(bool queued, bool sctpSendBufferFull)>;
 
 	public:
 		class Listener

--- a/worker/include/RTC/SctpAssociation.hpp
+++ b/worker/include/RTC/SctpAssociation.hpp
@@ -32,7 +32,7 @@ namespace RTC
 		};
 
 	protected:
-		using onQueuedCallback = const std::function<void(bool queued)>;
+		using onQueuedCallback = const std::function<void(bool queued, bool sctpSendBufferFull)>;
 
 	public:
 		class Listener

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -48,7 +48,7 @@ namespace RTC
 	{
 	protected:
 		using onSendCallback   = const std::function<void(bool sent)>;
-		using onQueuedCallback = const std::function<void(bool queued)>;
+		using onQueuedCallback = const std::function<void(bool queued, bool sctpSendBufferFull)>;
 
 	public:
 		class Listener

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -222,11 +222,11 @@ namespace RTC
 					return;
 				}
 
-				const auto* cb = new onQueuedCallback([&request](bool queued) {
+				const auto* cb = new onQueuedCallback([&request](bool queued, bool sctpSendBufferFull) {
 					if (queued)
 						request->Accept();
 					else
-						request->Error("message send failed");
+						request->Error(sctpSendBufferFull == true ? "sctpsendbufferfull" : "message send failed");
 				});
 
 				SendMessage(ppid, msg, len, cb);

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -446,21 +446,23 @@ namespace RTC
 			  len,
 			  std::strerror(errno));
 
+			bool sctpSendBufferFull = errno == EWOULDBLOCK || errno == EAGAIN;
+
 			if (cb)
 			{
-				(*cb)(false);
+				(*cb)(false, sctpSendBufferFull);
 				delete cb;
+			}
+
+			if (sctpSendBufferFull)
+			{
+				Channel::Notifier::Emit(dataConsumer->id, "sctpsendbufferfull");
 			}
 		}
 		else if (cb)
 		{
-			(*cb)(true);
+			(*cb)(true, false);
 			delete cb;
-		}
-
-		if (errno == EWOULDBLOCK || errno == EAGAIN)
-		{
-			Channel::Notifier::Emit(dataConsumer->id, "sctpsendbufferfull");
 		}
 	}
 


### PR DESCRIPTION
DataConsumer.send(), fail with 'sctpsendbufferfull' error if that's the
error cause.