### PR TITLE
Thread and memory safety fixes

### DIFF
--- a/worker/include/Channel/ChannelSocket.hpp
+++ b/worker/include/Channel/ChannelSocket.hpp
@@ -63,6 +63,7 @@ namespace Channel
 		virtual ~ChannelSocket();
 
 	public:
+		void Close();
 		void SetListener(Listener* listener);
 		void Send(json& jsonMessage);
 		void SendLog(char* message, size_t messageLen);

--- a/worker/include/Logger.hpp
+++ b/worker/include/Logger.hpp
@@ -135,7 +135,7 @@ public:
 	static const int64_t pid;
 	thread_local static Channel::ChannelSocket* channel;
 	static const size_t bufferSize {50000};
-	static char buffer[];
+	thread_local static char buffer[];
 };
 
 /* Logging macros. */

--- a/worker/include/MediaSoupErrors.hpp
+++ b/worker/include/MediaSoupErrors.hpp
@@ -11,6 +11,9 @@ public:
 	explicit MediaSoupError(const char* description) : std::runtime_error(description)
 	{
 	}
+public:
+	static const size_t bufferSize {2000};
+	thread_local static char buffer[];
 };
 
 class MediaSoupTypeError : public MediaSoupError
@@ -26,44 +29,32 @@ public:
 	do \
 	{ \
 		MS_ERROR("throwing MediaSoupError: " desc, ##__VA_ARGS__); \
-		\
-		static char buffer[2000]; \
-		\
-		std::snprintf(buffer, 2000, desc, ##__VA_ARGS__); \
-		throw MediaSoupError(buffer); \
+		std::snprintf(MediaSoupError::buffer, MediaSoupError::bufferSize, desc, ##__VA_ARGS__); \
+		throw MediaSoupError(MediaSoupError::buffer); \
 	} while (false)
 
 #define MS_THROW_ERROR_STD(desc, ...) \
 	do \
 	{ \
 		MS_ERROR_STD("throwing MediaSoupError: " desc, ##__VA_ARGS__); \
-		\
-		static char buffer[2000]; \
-		\
-		std::snprintf(buffer, 2000, desc, ##__VA_ARGS__); \
-		throw MediaSoupError(buffer); \
+		std::snprintf(MediaSoupError::buffer, MediaSoupError::bufferSize, desc, ##__VA_ARGS__); \
+		throw MediaSoupError(MediaSoupError::buffer); \
 	} while (false)
 
 #define MS_THROW_TYPE_ERROR(desc, ...) \
 	do \
 	{ \
 		MS_ERROR("throwing MediaSoupTypeError: " desc, ##__VA_ARGS__); \
-		\
-		static char buffer[2000]; \
-		\
-		std::snprintf(buffer, 2000, desc, ##__VA_ARGS__); \
-		throw MediaSoupTypeError(buffer); \
+		std::snprintf(MediaSoupError::buffer, MediaSoupError::bufferSize, desc, ##__VA_ARGS__); \
+		throw MediaSoupTypeError(MediaSoupError::buffer); \
 	} while (false)
 
 #define MS_THROW_TYPE_ERROR_STD(desc, ...) \
 	do \
 	{ \
 		MS_ERROR_STD("throwing MediaSoupTypeError: " desc, ##__VA_ARGS__); \
-		\
-		static char buffer[2000]; \
-		\
-		std::snprintf(buffer, 2000, desc, ##__VA_ARGS__); \
-		throw MediaSoupTypeError(buffer); \
+		std::snprintf(MediaSoupError::buffer, MediaSoupError::bufferSize, desc, ##__VA_ARGS__); \
+		throw MediaSoupTypeError(MediaSoupError::buffer); \
 	} while (false)
 // clang-format on
 

--- a/worker/include/MediaSoupErrors.hpp
+++ b/worker/include/MediaSoupErrors.hpp
@@ -11,8 +11,9 @@ public:
 	explicit MediaSoupError(const char* description) : std::runtime_error(description)
 	{
 	}
+
 public:
-	static const size_t bufferSize {2000};
+	static const size_t bufferSize{ 2000 };
 	thread_local static char buffer[];
 };
 

--- a/worker/include/PayloadChannel/PayloadChannelSocket.hpp
+++ b/worker/include/PayloadChannel/PayloadChannelSocket.hpp
@@ -69,6 +69,7 @@ namespace PayloadChannel
 		virtual ~PayloadChannelSocket();
 
 	public:
+		void Close();
 		void SetListener(Listener* listener);
 		void Send(json& jsonMessage, const uint8_t* payload, size_t payloadLen);
 		void Send(json& jsonMessage);

--- a/worker/include/RTC/PortManager.hpp
+++ b/worker/include/RTC/PortManager.hpp
@@ -45,8 +45,8 @@ namespace RTC
 		static std::vector<bool>& GetPorts(Transport transport, const std::string& ip);
 
 	private:
-		static std::unordered_map<std::string, std::vector<bool>> mapUdpIpPorts;
-		static std::unordered_map<std::string, std::vector<bool>> mapTcpIpPorts;
+		thread_local static std::unordered_map<std::string, std::vector<bool>> mapUdpIpPorts;
+		thread_local static std::unordered_map<std::string, std::vector<bool>> mapTcpIpPorts;
 	};
 } // namespace RTC
 

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -222,7 +222,7 @@ namespace Utils
 
 		static const std::string GetRandomString(size_t len)
 		{
-			static char buffer[64];
+			char buffer[64];
 			static const char chars[] = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b',
 				                            'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
 				                            'o', 'p', 'q', 'r', 's', 't', 'u', 'v', 'w', 'x', 'y', 'z' };

--- a/worker/mediasoup-worker.gyp
+++ b/worker/mediasoup-worker.gyp
@@ -23,6 +23,7 @@
       'src/DepOpenSSL.cpp',
       'src/DepUsrSCTP.cpp',
       'src/Logger.cpp',
+      'src/MediaSoupErrors.cpp',
       'src/Settings.cpp',
       'src/Worker.cpp',
       'src/Utils/Crypto.cpp',

--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -36,6 +36,14 @@ namespace Channel
 		std::free(this->WriteBuffer);
 	}
 
+	void ChannelSocket::Close()
+	{
+		MS_TRACE_STD();
+
+		this->consumerSocket.Close();
+		this->producerSocket.Close();
+	}
+
 	void ChannelSocket::SetListener(Listener* listener)
 	{
 		MS_TRACE_STD();

--- a/worker/src/Logger.cpp
+++ b/worker/src/Logger.cpp
@@ -8,7 +8,7 @@
 
 const int64_t Logger::pid{ static_cast<int64_t>(uv_os_getpid()) };
 thread_local Channel::ChannelSocket* Logger::channel{ nullptr };
-char Logger::buffer[Logger::bufferSize];
+thread_local char Logger::buffer[Logger::bufferSize];
 
 /* Class methods. */
 

--- a/worker/src/MediaSoupErrors.cpp
+++ b/worker/src/MediaSoupErrors.cpp
@@ -1,0 +1,5 @@
+#define MS_CLASS "MediaSoupError"
+
+#include "MediaSoupErrors.hpp"
+
+thread_local char MediaSoupError::buffer[MediaSoupError::bufferSize];

--- a/worker/src/PayloadChannel/PayloadChannelSocket.cpp
+++ b/worker/src/PayloadChannel/PayloadChannelSocket.cpp
@@ -38,6 +38,14 @@ namespace PayloadChannel
 		delete this->ongoingNotification;
 	}
 
+	void PayloadChannelSocket::Close()
+	{
+		MS_TRACE_STD();
+
+		this->consumerSocket.Close();
+		this->producerSocket.Close();
+	}
+
 	void PayloadChannelSocket::SetListener(Listener* listener)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -26,8 +26,8 @@ namespace RTC
 {
 	/* Class variables. */
 
-	std::unordered_map<std::string, std::vector<bool>> PortManager::mapUdpIpPorts;
-	std::unordered_map<std::string, std::vector<bool>> PortManager::mapTcpIpPorts;
+	thread_local std::unordered_map<std::string, std::vector<bool>> PortManager::mapUdpIpPorts;
+	thread_local std::unordered_map<std::string, std::vector<bool>> PortManager::mapTcpIpPorts;
 
 	/* Class methods. */
 

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1206,8 +1206,8 @@ namespace RTC
 
 		// Mangle RTP header extensions.
 		{
-			static uint8_t buffer[4096];
-			static std::vector<RTC::RtpPacket::GenericExtension> extensions;
+			thread_local static uint8_t buffer[4096];
+			thread_local static std::vector<RTC::RtpPacket::GenericExtension> extensions;
 
 			// This happens just once.
 			if (extensions.capacity() != 24)

--- a/worker/src/RTC/RtpProbationGenerator.cpp
+++ b/worker/src/RTC/RtpProbationGenerator.cpp
@@ -62,7 +62,7 @@ namespace RTC
 		this->probationPacket->SetTimestamp(Utils::Crypto::GetRandomUInt(0, 4294967295));
 
 		// Add BWE related RTP header extensions.
-		static uint8_t buffer[4096];
+		thread_local static uint8_t buffer[4096];
 
 		std::vector<RTC::RtpPacket::GenericExtension> extensions;
 		uint8_t extenLen;

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -770,7 +770,7 @@ namespace RTC
 						if (notification->sn_header.sn_length > 0)
 						{
 							static const size_t BufferSize{ 1024 };
-							static char buffer[BufferSize];
+							thread_local static char buffer[BufferSize];
 
 							uint32_t len = notification->sn_header.sn_length;
 
@@ -838,7 +838,7 @@ namespace RTC
 						if (notification->sn_header.sn_length > 0)
 						{
 							static const size_t BufferSize{ 1024 };
-							static char buffer[BufferSize];
+							thread_local static char buffer[BufferSize];
 
 							uint32_t len = notification->sn_header.sn_length;
 
@@ -879,7 +879,7 @@ namespace RTC
 			case SCTP_REMOTE_ERROR:
 			{
 				static const size_t BufferSize{ 1024 };
-				static char buffer[BufferSize];
+				thread_local static char buffer[BufferSize];
 
 				uint32_t len = notification->sn_remote_error.sre_length - sizeof(struct sctp_remote_error);
 
@@ -915,7 +915,7 @@ namespace RTC
 			case SCTP_SEND_FAILED_EVENT:
 			{
 				static const size_t BufferSize{ 1024 };
-				static char buffer[BufferSize];
+				thread_local static char buffer[BufferSize];
 
 				uint32_t len =
 				  notification->sn_send_failed_event.ssfe_length - sizeof(struct sctp_send_failed_event);

--- a/worker/src/RTC/StunPacket.cpp
+++ b/worker/src/RTC/StunPacket.cpp
@@ -353,7 +353,7 @@ namespace RTC
 		}
 		MS_DUMP("  size: %zu bytes", this->size);
 
-		static char transactionId[25];
+		char transactionId[25];
 
 		for (int i{ 0 }; i < 12; ++i)
 		{
@@ -385,7 +385,7 @@ namespace RTC
 		}
 		if (this->messageIntegrity != nullptr)
 		{
-			static char messageIntegrity[41];
+			char messageIntegrity[41];
 
 			for (int i{ 0 }; i < 20; ++i)
 			{

--- a/worker/src/Utils/IP.cpp
+++ b/worker/src/Utils/IP.cpp
@@ -83,7 +83,7 @@ namespace Utils
 	{
 		MS_TRACE();
 
-		static sockaddr_storage addrStorage;
+		sockaddr_storage addrStorage;
 		char ipBuffer[INET6_ADDRSTRLEN] = { 0 };
 		int err;
 

--- a/worker/src/Utils/String.cpp
+++ b/worker/src/Utils/String.cpp
@@ -19,7 +19,7 @@
 /* Static. */
 
 static constexpr size_t BufferOutSize{ 65536 };
-static uint8_t BufferOut[BufferOutSize];
+thread_local static uint8_t BufferOut[BufferOutSize];
 static const uint8_t Base64Table[65] =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -44,6 +44,12 @@ Worker::~Worker()
 {
 	MS_TRACE();
 
+	// Delete the Channel.
+	delete this->channel;
+
+	// Delete the PayloadChannel.
+	delete this->payloadChannel;
+
 	if (!this->closed)
 		Close();
 }

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -70,10 +70,10 @@ void Worker::Close()
 	this->mapRouters.clear();
 
 	// Close the Channel.
-	delete this->channel;
+	this->channel->Close();
 
 	// Close the PayloadChannel.
-	delete this->payloadChannel;
+	this->payloadChannel->Close();
 }
 
 void Worker::FillJson(json& jsonObject) const

--- a/worker/src/handles/UnixStreamSocket.cpp
+++ b/worker/src/handles/UnixStreamSocket.cpp
@@ -113,10 +113,10 @@ UnixStreamSocket::~UnixStreamSocket()
 {
 	MS_TRACE_STD();
 
+	delete[] this->buffer;
+
 	if (!this->closed)
 		Close();
-
-	delete[] this->buffer;
 }
 
 void UnixStreamSocket::Close()

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -135,14 +135,14 @@ extern "C" int run_worker(
 		Worker worker(channel, payloadChannel);
 
 		// Free static stuff.
-		DepLibUV::ClassDestroy();
 		DepLibSRTP::ClassDestroy();
 		Utils::Crypto::ClassDestroy();
 		DepLibWebRTC::ClassDestroy();
 		RTC::DtlsTransport::ClassDestroy();
 		DepUsrSCTP::ClassDestroy();
+		DepLibUV::ClassDestroy();
 
-		// Wait a bit so peding messages to stdout/Channel arrive to the Node
+		// Wait a bit so pending messages to stdout/Channel arrive to the Node
 		// process.
 		uv_sleep(200);
 


### PR DESCRIPTION
First commit adds some more `thread_local` and other minor tweaks to make sure things don't go wrong when multiple workers are running in different threads concurrently, I believe all cases should now be covered.

Next 2 commits fix some interesting use-after-free memory issues that were reported by `valgrind`. They weren't causing crashes under Linux, at least most of the time, but were crashing on macOS most of the time. Now things should work well, but please look carefully because I don't know what I'm doing when it comes to C++ :sweat_smile: 

This is the last prerequisite to introduction of macOS support in Rust version, which will be a separate PR.