### PR TITLE
Stop failing MacOSX builds.

### DIFF
--- a/rust/src/worker/utils.rs
+++ b/rust/src/worker/utils.rs
@@ -38,7 +38,7 @@ fn pipe() -> [c_int; 2] {
         if libc::pipe(fds.as_mut_ptr().cast::<c_int>()) != 0 {
             panic!(
                 "libc::pipe() failed with code {}",
-                *libc::__errno_location()
+                std::io::Error::last_os_error()
             );
         }
 

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -45,11 +45,6 @@ fn main() {
         );
         println!("cargo:rustc-link-lib=static=c++");
     }
-    #[cfg(target_os = "macos")]
-    {
-        panic!("Building on macOS is not currently supported");
-        // TODO: The issue here is `libc++.a` that is not shipped with macOS's `c++` it seems
-    }
     #[cfg(target_os = "windows")]
     {
         panic!("Building on Windows is not currently supported");


### PR DESCRIPTION
It seems like the original reason for not build on MacOS X is resolved (something with `libc++.a` according to comment).
With these changes I could build media soup on my mac.