### PR TITLE
Rust support on macOS

### DIFF
--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -7,12 +7,16 @@ env:
 
 jobs:
   ci:
-    runs-on: ubuntu-20.04
     strategy:
       matrix:
+        os:
+          - ubuntu-20.04
+          - macos-10.15
         rust:
           - stable
           # - nightly
+
+    runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout
@@ -37,7 +41,7 @@ jobs:
             ~/.cargo/registry
             ~/.cargo/git
             target
-          key: ${{ runner.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ matrix.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: cargo fmt
         uses: actions-rs/cargo@v1

--- a/rust/src/worker/utils.rs
+++ b/rust/src/worker/utils.rs
@@ -36,23 +36,7 @@ fn pipe() -> [c_int; 2] {
         let mut fds = mem::MaybeUninit::<[c_int; 2]>::uninit();
 
         if libc::pipe(fds.as_mut_ptr().cast::<c_int>()) != 0 {
-            #[cfg(target_os = "linux")]
-            {
-                panic!(
-                    "libc::pipe() failed with code {}",
-                    *libc::__errno_location()
-                );
-            }
-            #[cfg(any(
-                target_os = "macos",
-                target_os = "freebsd",
-                target_os = "dragonfly",
-                target_os = "openbsd",
-                target_os = "netbsd"
-            ))]
-            {
-                panic!("libc::pipe() failed");
-            }
+            panic!("libc::pipe() failed: {:?}", std::io::Error::last_os_error());
         }
 
         fds.assume_init()

--- a/rust/src/worker/utils.rs
+++ b/rust/src/worker/utils.rs
@@ -36,10 +36,23 @@ fn pipe() -> [c_int; 2] {
         let mut fds = mem::MaybeUninit::<[c_int; 2]>::uninit();
 
         if libc::pipe(fds.as_mut_ptr().cast::<c_int>()) != 0 {
-            panic!(
-                "libc::pipe() failed with code {}",
-                *libc::__errno_location()
-            );
+            #[cfg(target_os = "linux")]
+            {
+                panic!(
+                    "libc::pipe() failed with code {}",
+                    *libc::__errno_location()
+                );
+            }
+            #[cfg(any(
+                target_os = "macos",
+                target_os = "freebsd",
+                target_os = "dragonfly",
+                target_os = "openbsd",
+                target_os = "netbsd"
+            ))]
+            {
+                panic!("libc::pipe() failed");
+            }
         }
 
         fds.assume_init()


### PR DESCRIPTION
This implements macOS support in Rust crates and adds macOS to CI for Rust.

What it boils down to is that on macOS there is no static version of C++ standard library available out of the box, so build.rs will download LLVM 12.0.0 tarball and will extract `libc++.a` + `libc++abi.a` and will link those into final mediasoup-sys library alongside with libmediasoup-worker itself.