### PR TITLE
Allow to reconctruct IDs from UUIDs.

### DIFF
--- a/rust/src/macros.rs
+++ b/rust/src/macros.rs
@@ -32,6 +32,12 @@ macro_rules! uuid_based_wrapper_type {
             }
         }
 
+        impl From<uuid::Uuid> for $struct_name {
+            fn from(id: uuid::Uuid) -> Self {
+                $struct_name(id)
+            }
+        }
+
         impl $struct_name {
             pub(super) fn new() -> Self {
                 $struct_name(uuid::Uuid::new_v4())


### PR DESCRIPTION
It is possible to convert various `MediaSoup` IDs to `uuid::UUID` via `from/into`, but I can't find a way to reconstruct `ID` from `uuid::UUID`. This PR should resolve this problem (if it was not intentional restriction).