### PR TITLE
Fix memory leak caused by incomplete libuv closing procedure

### DIFF
--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -9,20 +9,6 @@
 
 thread_local uv_loop_t* DepLibUV::loop{ nullptr };
 
-void on_uv_close(uv_handle_t* handle)
-{
-	if (handle != NULL)
-	{
-		delete handle;
-	}
-}
-
-void on_uv_walk(uv_handle_t* handle, void* arg)
-{
-	if (!uv_is_closing(handle))
-		uv_close(handle, on_uv_close);
-}
-
 /* Static methods. */
 
 void DepLibUV::ClassInit()
@@ -45,17 +31,12 @@ void DepLibUV::ClassDestroy()
 	{
 		int err;
 
-		uv_stop(DepLibUV::loop);
-		uv_walk(DepLibUV::loop, on_uv_walk, NULL);
-
 		while (true)
 		{
 			err = uv_loop_close(DepLibUV::loop);
 
 			if (err != UV_EBUSY)
-			{
 				break;
-			}
 
 			uv_run(DepLibUV::loop, UV_RUN_NOWAIT);
 		}

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -9,6 +9,20 @@
 
 thread_local uv_loop_t* DepLibUV::loop{ nullptr };
 
+void on_uv_close(uv_handle_t* handle)
+{
+	if (handle != NULL)
+	{
+		delete handle;
+	}
+}
+
+void on_uv_walk(uv_handle_t* handle, void* arg)
+{
+	if (!uv_is_closing(handle))
+		uv_close(handle, on_uv_close);
+}
+
 /* Static methods. */
 
 void DepLibUV::ClassInit()
@@ -30,7 +44,26 @@ void DepLibUV::ClassDestroy()
 	// This should never happen.
 	if (DepLibUV::loop != nullptr)
 	{
-		uv_loop_close(DepLibUV::loop);
+		int err;
+
+		uv_stop(DepLibUV::loop);
+		uv_walk(DepLibUV::loop, on_uv_walk, NULL);
+
+		while (true)
+		{
+			err = uv_loop_close(DepLibUV::loop);
+
+			if (err != UV_EBUSY)
+			{
+				break;
+			}
+
+			uv_run(DepLibUV::loop, UV_RUN_NOWAIT);
+		}
+
+		if (err != 0)
+			MS_ABORT("failed to close libuv loop: %s", uv_err_name(err));
+
 		delete DepLibUV::loop;
 	}
 }

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -41,7 +41,6 @@ void DepLibUV::ClassDestroy()
 {
 	MS_TRACE();
 
-	// This should never happen.
 	if (DepLibUV::loop != nullptr)
 	{
 		int err;


### PR DESCRIPTION
Turns out `uv_loop_close()` can return `UV_EBUSY`, which means there are still handles that are not closed. Correct behavior is to wait for all handles to stop or else memory will be leaked.