### PR TITLE
Fix DepUsrSCTP::Checker::timer not being freed

### DIFF
--- a/worker/include/DepUsrSCTP.hpp
+++ b/worker/include/DepUsrSCTP.hpp
@@ -8,7 +8,7 @@
 
 class DepUsrSCTP
 {
-public:
+private:
 	class Checker : public Timer::Listener
 	{
 	public:

--- a/worker/include/DepUsrSCTP.hpp
+++ b/worker/include/DepUsrSCTP.hpp
@@ -8,7 +8,7 @@
 
 class DepUsrSCTP
 {
-private:
+public:
 	class Checker : public Timer::Listener
 	{
 	public:
@@ -31,6 +31,8 @@ private:
 public:
 	static void ClassInit();
 	static void ClassDestroy();
+	static void CreateChecker();
+	static void CloseChecker();
 	static uintptr_t GetNextSctpAssociationId();
 	static void RegisterSctpAssociation(RTC::SctpAssociation* sctpAssociation);
 	static void DeregisterSctpAssociation(RTC::SctpAssociation* sctpAssociation);

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -5,44 +5,9 @@
 #include "Logger.hpp"
 #include <cstdlib> // std::abort()
 
-#include <iostream>
-#include <fstream>
-
-using std::cout; using std::ofstream;
-using std::endl; using std::string;
-using std::cerr;
-using std::fstream;
-
 /* Static variables. */
 
 thread_local uv_loop_t* DepLibUV::loop{ nullptr };
-
-/* Static methods for UV callbacks. */
-
-inline static void onClose(uv_handle_t* handle)
-{
-	delete handle;
-}
-
-inline static void onWalk(uv_handle_t* handle, void* arg)
-{
-	MS_DUMP(
-		"---- handle [type:%d, active:%d, closing:%d, has_ref:%d]",
-		handle->type,
-		uv_is_active(handle),
-		uv_is_closing(handle),
-		uv_has_ref(handle)
-	);
-
-	string filename("/tmp/kk.txt");
-	fstream output_fstream;
-
-	output_fstream.open(filename, std::ios_base::app);
-	output_fstream << "handle type:" << handle->type << endl;
-
-	if (!uv_is_closing(handle))
-		uv_close(handle, onClose);
-}
 
 /* Static methods. */
 
@@ -62,33 +27,8 @@ void DepLibUV::ClassDestroy()
 {
 	MS_TRACE();
 
-	// This should never happen.
-	if (DepLibUV::loop != nullptr)
-	{
-		// uv_loop_close(DepLibUV::loop);
-		// delete DepLibUV::loop;
-
-
-		int err;
-
-		uv_stop(DepLibUV::loop);
-		uv_walk(DepLibUV::loop, onWalk, nullptr);
-
-		while (true)
-		{
-			err = uv_loop_close(DepLibUV::loop);
-
-			if (err != UV_EBUSY)
-				break;
-
-			uv_run(DepLibUV::loop, UV_RUN_NOWAIT);
-		}
-
-		if (err != 0)
-			MS_ABORT("failed to close libuv loop: %s", uv_err_name(err));
-
-		delete DepLibUV::loop;
-	}
+	uv_loop_close(DepLibUV::loop);
+	delete DepLibUV::loop;
 }
 
 void DepLibUV::PrintVersion()

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -18,7 +18,8 @@ inline static void onClose(uv_handle_t* handle)
 
 inline static void onWalk(uv_handle_t* handle, void* arg)
 {
-	MS_ERROR(
+	// Must use MS_ERROR_STD since at this point the Channel is already closed.
+	MS_ERROR_STD(
 	  "alive UV handle found (this shouldn't happen) [type:%d, active:%d, closing:%d, has_ref:%d]",
 	  handle->type,
 	  uv_is_active(handle),
@@ -68,7 +69,7 @@ void DepLibUV::ClassDestroy()
 	}
 
 	if (err != 0)
-		MS_ERROR("failed to close libuv loop: %s", uv_err_name(err));
+		MS_ERROR_STD("failed to close libuv loop: %s", uv_err_name(err));
 
 	delete DepLibUV::loop;
 }

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -19,7 +19,7 @@ inline static void onClose(uv_handle_t* handle)
 inline static void onWalk(uv_handle_t* handle, void* arg)
 {
 	MS_ERROR(
-	  "active UV handle found (this shouldn't happen) [type:%d, active:%d, closing:%d, has_ref:%d]",
+	  "alive UV handle found (this shouldn't happen) [type:%d, active:%d, closing:%d, has_ref:%d]",
 	  handle->type,
 	  uv_is_active(handle),
 	  uv_is_closing(handle),

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -30,7 +30,7 @@ void DepLibUV::ClassDestroy()
 	int err = uv_loop_close(DepLibUV::loop);
 
 	if (err != 0)
-		MS_ABORT("failed to close libuv loop: %s", uv_err_name(err));
+		MS_ERROR("failed to close libuv loop: %s", uv_err_name(err));
 
 	delete DepLibUV::loop;
 }

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -5,6 +5,14 @@
 #include "Logger.hpp"
 #include <cstdlib> // std::abort()
 
+#include <iostream>
+#include <fstream>
+
+using std::cout; using std::ofstream;
+using std::endl; using std::string;
+using std::cerr;
+using std::fstream;
+
 /* Static variables. */
 
 thread_local uv_loop_t* DepLibUV::loop{ nullptr };
@@ -25,6 +33,12 @@ inline static void onWalk(uv_handle_t* handle, void* arg)
 		uv_is_closing(handle),
 		uv_has_ref(handle)
 	);
+
+	string filename("/tmp/kk.txt");
+	fstream output_fstream;
+
+	output_fstream.open(filename, std::ios_base::app);
+	output_fstream << "handle type:" << handle->type << endl;
 
 	if (!uv_is_closing(handle))
 		uv_close(handle, onClose);

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -18,7 +18,7 @@ inline static void onClose(uv_handle_t* handle)
 
 inline static void onWalk(uv_handle_t* handle, void* arg)
 {
-	MS_ERROR_STD(
+	MS_DUMP(
 		"---- handle [type:%d, active:%d, closing:%d, has_ref:%d]",
 		handle->type,
 		uv_is_active(handle),

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -20,14 +20,18 @@ void DepLibUV::ClassInit()
 	int err = uv_loop_init(DepLibUV::loop);
 
 	if (err != 0)
-		MS_ABORT("libuv initialization failed");
+		MS_ABORT("libuv loop initialization failed");
 }
 
 void DepLibUV::ClassDestroy()
 {
 	MS_TRACE();
 
-	uv_loop_close(DepLibUV::loop);
+	int err = uv_loop_close(DepLibUV::loop);
+
+	if (err != 0)
+		MS_ABORT("failed to close libuv loop: %s", uv_err_name(err));
+
 	delete DepLibUV::loop;
 }
 

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -95,6 +95,13 @@ void DepUsrSCTP::ClassDestroy()
 		if (globalInstances == 0)
 		{
 			usrsctp_finish();
+
+			// TODO: This cleanup currently causes assertion errors in
+			// DepUsrSCTP::DeregisterSctpAssociation() when using mediasoup-worker
+			// in thread mode (Rust).
+			//
+			// numSctpAssociations = 0u; nextSctpAssociationId = 0u;
+			// DepUsrSCTP::mapIdSctpAssociation.clear();
 		}
 	}
 }

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -82,8 +82,6 @@ void DepUsrSCTP::ClassInit()
 
 		++globalInstances;
 	}
-
-	DepUsrSCTP::checker = new DepUsrSCTP::Checker();
 }
 
 void DepUsrSCTP::ClassDestroy()
@@ -97,13 +95,24 @@ void DepUsrSCTP::ClassDestroy()
 		if (globalInstances == 0)
 		{
 			usrsctp_finish();
-			// TODO: This cleanup currently causes assertion errors in
-			// DepUsrSCTP::DeregisterSctpAssociation()
-
-			// numSctpAssociations = 0u; nextSctpAssociationId = 0u;
-			// DepUsrSCTP::mapIdSctpAssociation.clear();
 		}
 	}
+}
+
+void DepUsrSCTP::CreateChecker()
+{
+	MS_TRACE();
+
+	MS_ASSERT(DepUsrSCTP::checker == nullptr, "Checker already created");
+
+	DepUsrSCTP::checker = new DepUsrSCTP::Checker();
+}
+
+void DepUsrSCTP::CloseChecker()
+{
+	MS_TRACE();
+
+	MS_ASSERT(DepUsrSCTP::checker != nullptr, "Checker not created");
 
 	delete DepUsrSCTP::checker;
 }
@@ -138,6 +147,8 @@ void DepUsrSCTP::RegisterSctpAssociation(RTC::SctpAssociation* sctpAssociation)
 
 	std::lock_guard<std::mutex> lock(globalSyncMutex);
 
+	MS_ASSERT(DepUsrSCTP::checker != nullptr, "Checker not created");
+
 	auto it = DepUsrSCTP::mapIdSctpAssociation.find(sctpAssociation->id);
 
 	MS_ASSERT(
@@ -155,6 +166,8 @@ void DepUsrSCTP::DeregisterSctpAssociation(RTC::SctpAssociation* sctpAssociation
 	MS_TRACE();
 
 	std::lock_guard<std::mutex> lock(globalSyncMutex);
+
+	MS_ASSERT(DepUsrSCTP::checker != nullptr, "Checker not created");
 
 	auto found = DepUsrSCTP::mapIdSctpAssociation.erase(sctpAssociation->id);
 

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -3,6 +3,7 @@
 
 #include "Worker.hpp"
 #include "DepLibUV.hpp"
+#include "DepUsrSCTP.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include "Settings.hpp"
@@ -31,6 +32,9 @@ Worker::Worker(::Channel::ChannelSocket* channel, PayloadChannel::PayloadChannel
 		this->signalsHandler->AddSignal(SIGTERM, "TERM");
 	}
 #endif
+
+	// Create the Checker instance in DepUsrSCTP.
+	DepUsrSCTP::CreateChecker();
 
 	// Tell the Node process that we are running.
 	Channel::ChannelNotifier::Emit(std::to_string(Logger::pid), "running");
@@ -74,6 +78,9 @@ void Worker::Close()
 		delete router;
 	}
 	this->mapRouters.clear();
+
+	// Close the Checker instance in DepUsrSCTP.
+	DepUsrSCTP::CloseChecker();
 
 	// Close the Channel.
 	this->channel->Close();

--- a/worker/test/src/RTC/TestKeyFrameRequestManager.cpp
+++ b/worker/test/src/RTC/TestKeyFrameRequestManager.cpp
@@ -1,16 +1,12 @@
 #include "common.hpp"
 #include "DepLibUV.hpp"
 #include "RTC/KeyFrameRequestManager.hpp"
-#include "handles/Timer.hpp"
 #include <catch.hpp>
 
 using namespace RTC;
 
 SCENARIO("KeyFrameRequestManager", "[rtp][keyframe]")
 {
-	// Start LibUV.
-	DepLibUV::ClassInit();
-
 	class TestKeyFrameRequestManagerListener : public KeyFrameRequestManager::Listener
 	{
 	public:

--- a/worker/test/src/RTC/TestKeyFrameRequestManager.cpp
+++ b/worker/test/src/RTC/TestKeyFrameRequestManager.cpp
@@ -33,6 +33,7 @@ SCENARIO("KeyFrameRequestManager", "[rtp][keyframe]")
 
 		keyFrameRequestManager.KeyFrameNeeded(1111);
 
+		// Must run the loop here to consume the timer before doing the check.
 		DepLibUV::RunLoop();
 
 		REQUIRE(listener.onKeyFrameNeededTimesCalled == 2);
@@ -48,6 +49,7 @@ SCENARIO("KeyFrameRequestManager", "[rtp][keyframe]")
 		keyFrameRequestManager.KeyFrameNeeded(1111);
 		keyFrameRequestManager.KeyFrameNeeded(1111);
 
+		// Must run the loop here to consume the timer before doing the check.
 		DepLibUV::RunLoop();
 
 		REQUIRE(listener.onKeyFrameNeededTimesCalled == 2);
@@ -61,6 +63,7 @@ SCENARIO("KeyFrameRequestManager", "[rtp][keyframe]")
 		keyFrameRequestManager.KeyFrameNeeded(1111);
 		keyFrameRequestManager.KeyFrameReceived(1111);
 
+		// Must run the loop here to consume the timer before doing the check.
 		DepLibUV::RunLoop();
 
 		REQUIRE(listener.onKeyFrameNeededTimesCalled == 1);
@@ -74,6 +77,7 @@ SCENARIO("KeyFrameRequestManager", "[rtp][keyframe]")
 		keyFrameRequestManager.KeyFrameNeeded(1111);
 		keyFrameRequestManager.ForceKeyFrameNeeded(1111);
 
+		// Must run the loop here to consume the timer before doing the check.
 		DepLibUV::RunLoop();
 
 		REQUIRE(listener.onKeyFrameNeededTimesCalled == 3);
@@ -88,8 +92,14 @@ SCENARIO("KeyFrameRequestManager", "[rtp][keyframe]")
 		keyFrameRequestManager.ForceKeyFrameNeeded(1111);
 		keyFrameRequestManager.KeyFrameReceived(1111);
 
+		// Must run the loop here to consume the timer before doing the check.
 		DepLibUV::RunLoop();
 
 		REQUIRE(listener.onKeyFrameNeededTimesCalled == 2);
 	}
+
+	// Must run the loop to wait for UV timers and close them.
+	// NOTE: Not really needed in this file since we run it in each SECTION in
+	// purpose.
+	DepLibUV::RunLoop();
 }

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -160,8 +160,6 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
-
-		DepLibUV::RunLoop();
 	}
 
 	SECTION("generate NACK for missing ordered packet")
@@ -175,8 +173,6 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
-
-		DepLibUV::RunLoop();
 	}
 
 	SECTION("sequence wrap generates no NACK")
@@ -191,8 +187,6 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
-
-		DepLibUV::RunLoop();
 	}
 
 	SECTION("generate NACK after sequence wrap")
@@ -207,8 +201,6 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
-
-		DepLibUV::RunLoop();
 	}
 
 	SECTION("generate NACK after sequence wrap, and yet another NACK")
@@ -226,8 +218,6 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
-
-		DepLibUV::RunLoop();
 	}
 
 	SECTION("intercalated missing packets")
@@ -244,8 +234,6 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
-
-		DepLibUV::RunLoop();
 	}
 
 	SECTION("non contiguous intercalated missing packets")
@@ -261,8 +249,6 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
-
-		DepLibUV::RunLoop();
 	}
 
 	SECTION("big jump")
@@ -279,8 +265,6 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
-
-		DepLibUV::RunLoop();
 	}
 
 	SECTION("Key Frame required. Nack list too large to be requested")
@@ -294,7 +278,8 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
-
-		DepLibUV::RunLoop();
 	}
+
+	// Must run the loop to wait for UV timers and close them.
+	DepLibUV::RunLoop();
 }

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -1,4 +1,5 @@
 #include "common.hpp"
+#include "DepLibUV.hpp"
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
 #include "RTC/NackGenerator.hpp"
 #include "RTC/RtpPacket.hpp"
@@ -278,4 +279,6 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 
 		validate(inputs);
 	}
+
+	DepLibUV::RunLoop();
 }

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -160,6 +160,8 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
+
+		DepLibUV::RunLoop();
 	}
 
 	SECTION("generate NACK for missing ordered packet")
@@ -173,6 +175,8 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
+
+		DepLibUV::RunLoop();
 	}
 
 	SECTION("sequence wrap generates no NACK")
@@ -187,6 +191,8 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
+
+		DepLibUV::RunLoop();
 	}
 
 	SECTION("generate NACK after sequence wrap")
@@ -201,6 +207,8 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
+
+		DepLibUV::RunLoop();
 	}
 
 	SECTION("generate NACK after sequence wrap, and yet another NACK")
@@ -218,6 +226,8 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
+
+		DepLibUV::RunLoop();
 	}
 
 	SECTION("intercalated missing packets")
@@ -234,6 +244,8 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
+
+		DepLibUV::RunLoop();
 	}
 
 	SECTION("non contiguous intercalated missing packets")
@@ -249,6 +261,8 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
+
+		DepLibUV::RunLoop();
 	}
 
 	SECTION("big jump")
@@ -265,6 +279,8 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
+
+		DepLibUV::RunLoop();
 	}
 
 	SECTION("Key Frame required. Nack list too large to be requested")
@@ -278,7 +294,7 @@ SCENARIO("NACK generator", "[rtp][rtcp]")
 		// clang-format on
 
 		validate(inputs);
-	}
 
-	DepLibUV::RunLoop();
+		DepLibUV::RunLoop();
+	}
 }

--- a/worker/test/src/RTC/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/TestRtpStreamRecv.cpp
@@ -1,4 +1,5 @@
 #include "common.hpp"
+#include "DepLibUV.hpp"
 #include "RTC/RtpPacket.hpp"
 #include "RTC/RtpStream.hpp"
 #include "RTC/RtpStreamRecv.hpp"
@@ -163,6 +164,8 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 		rtpStream.ReceivePacket(packet);
 
 		REQUIRE(listener.nackedSeqNumbers.size() == 0);
+
+		DepLibUV::RunLoop();
 	}
 
 	SECTION("wrapping sequence numbers")
@@ -183,6 +186,8 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 		REQUIRE(listener.nackedSeqNumbers[0] == 0xffff);
 		REQUIRE(listener.nackedSeqNumbers[1] == 0);
 		listener.nackedSeqNumbers.clear();
+
+		DepLibUV::RunLoop();
 	}
 
 	SECTION("require key frame")
@@ -199,6 +204,8 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 		listener.shouldTriggerPLI = true;
 		listener.shouldTriggerFIR = false;
 		rtpStream.ReceivePacket(packet);
+
+		DepLibUV::RunLoop();
 	}
 
 	delete packet;

--- a/worker/test/src/RTC/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/TestRtpStreamRecv.cpp
@@ -164,8 +164,6 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 		rtpStream.ReceivePacket(packet);
 
 		REQUIRE(listener.nackedSeqNumbers.size() == 0);
-
-		DepLibUV::RunLoop();
 	}
 
 	SECTION("wrapping sequence numbers")
@@ -186,8 +184,6 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 		REQUIRE(listener.nackedSeqNumbers[0] == 0xffff);
 		REQUIRE(listener.nackedSeqNumbers[1] == 0);
 		listener.nackedSeqNumbers.clear();
-
-		DepLibUV::RunLoop();
 	}
 
 	SECTION("require key frame")
@@ -204,9 +200,10 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 		listener.shouldTriggerPLI = true;
 		listener.shouldTriggerFIR = false;
 		rtpStream.ReceivePacket(packet);
-
-		DepLibUV::RunLoop();
 	}
+
+	// Must run the loop to wait for UV timers and close them.
+	DepLibUV::RunLoop();
 
 	delete packet;
 }

--- a/worker/test/src/tests.cpp
+++ b/worker/test/src/tests.cpp
@@ -39,11 +39,11 @@ int main(int argc, char* argv[])
 	int status = Catch::Session().run(argc, argv);
 
 	// Free static stuff.
-	DepLibUV::ClassDestroy();
 	DepLibSRTP::ClassDestroy();
 	Utils::Crypto::ClassDestroy();
 	DepLibWebRTC::ClassDestroy();
 	DepUsrSCTP::ClassDestroy();
+	DepLibUV::ClassDestroy();
 
 	return status;
 }

--- a/worker/test/src/tests.cpp
+++ b/worker/test/src/tests.cpp
@@ -32,7 +32,7 @@ int main(int argc, char* argv[])
 	DepLibUV::ClassInit();
 	DepOpenSSL::ClassInit();
 	DepLibSRTP::ClassInit();
-	DepUsrSCTP::ClassInit();
+	// DepUsrSCTP::ClassInit();
 	DepLibWebRTC::ClassInit();
 	Utils::Crypto::ClassInit();
 
@@ -42,7 +42,7 @@ int main(int argc, char* argv[])
 	DepLibSRTP::ClassDestroy();
 	Utils::Crypto::ClassDestroy();
 	DepLibWebRTC::ClassDestroy();
-	DepUsrSCTP::ClassDestroy();
+	// DepUsrSCTP::ClassDestroy();
 	DepLibUV::ClassDestroy();
 
 	return status;

--- a/worker/test/src/tests.cpp
+++ b/worker/test/src/tests.cpp
@@ -32,7 +32,7 @@ int main(int argc, char* argv[])
 	DepLibUV::ClassInit();
 	DepOpenSSL::ClassInit();
 	DepLibSRTP::ClassInit();
-	// DepUsrSCTP::ClassInit();
+	DepUsrSCTP::ClassInit();
 	DepLibWebRTC::ClassInit();
 	Utils::Crypto::ClassInit();
 
@@ -42,7 +42,7 @@ int main(int argc, char* argv[])
 	DepLibSRTP::ClassDestroy();
 	Utils::Crypto::ClassDestroy();
 	DepLibWebRTC::ClassDestroy();
-	// DepUsrSCTP::ClassDestroy();
+	DepUsrSCTP::ClassDestroy();
 	DepLibUV::ClassDestroy();
 
 	return status;


### PR DESCRIPTION
**UPDATE: THIS PR IS NOW READY TO BE MERGED**

Rationale and solution below in [this comment](https://github.com/versatica/mediasoup/pull/576/#issuecomment-852562403).

----


Related to PR #575.

THIS PR IS NOT INTENDED TO BE MERGED AT ALL

I've added this in `DepLibUV.cpp`:

```c++
inline static void onWalk(uv_handle_t* handle, void* arg)
{
	MS_ERROR_STD(
		"---- handle [type:%d, active:%d, closing:%d, has_ref:%d]",
		handle->type,
		uv_is_active(handle),
		uv_is_closing(handle),
		uv_has_ref(handle)
	);

	if (!uv_is_closing(handle))
		uv_close(handle, onClose);
}
```

What I see:

- In mediasoup **Node** tests, `onWalk()` is **never** called (this is good and expected/desired behavior).

- When running mediasoup in a real application (example, mediasoup-demo), if I call `worker.close()` in Node, neither I see any call to `onWalk()` (this is good and expected/desired behavior).

- However, when running the mediasoup-worker tests (this is: `make test -C worker`) I see this output:
```
Done.
./out/Release/mediasoup-worker-test --invisibles --use-colour=yes
===============================================================================
All tests passed (1606 assertions in 39 test cases)

DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
DepLibUV::onWalk() | ---- handle [type:13, active:0, closing:1, has_ref:1]
```

Note that `handle->type` 13 means `UV_TIMER`: http://docs.libuv.org/en/v1.x/handle.html?highlight=uv_handle_type#c.uv_handle_type

And this seems to be because, in worker tests, we initiate (maybe among others) some `KeyFrameRequestManager` instances (although the problem may be somewhere else) and it may happen that we are not closing some of them properly so they remain active.

So what I mean is that, AFAIS, the only issue I see in in `mediasoup/worker/tests/`.