### PR TITLE
Fix memory leaks on error exit, minor tweaks

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -32,8 +32,6 @@ jobs:
         with:
           path: |
             ~/.npm
-            worker/deps
-            worker/out
           key: ${{ matrix.os }}-node-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ matrix.os }}-node-

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -61,8 +61,6 @@ jobs:
         with:
           path: |
             ~/.npm
-            worker/deps
-            worker/out
           key: ${{ matrix.build.os }}-node-${{matrix.build.cc}}-${{ hashFiles('**/package.json') }}
           restore-keys: |
             ${{ matrix.build.os }}-node-${{matrix.build.cc}}-

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -20,8 +20,8 @@ inline static void onWalk(uv_handle_t* handle, void* arg)
 {
 	// Must use MS_ERROR_STD since at this point the Channel is already closed.
 	MS_ERROR_STD(
-	  "alive UV handle found (this shouldn't happen) [type:%d, active:%d, closing:%d, has_ref:%d]",
-	  handle->type,
+	  "alive UV handle found (this shouldn't happen) [type:%s, active:%d, closing:%d, has_ref:%d]",
+	  uv_handle_type_name(handle->type),
 	  uv_is_active(handle),
 	  uv_is_closing(handle),
 	  uv_has_ref(handle));

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -96,12 +96,10 @@ void DepUsrSCTP::ClassDestroy()
 		{
 			usrsctp_finish();
 
-			// TODO: This cleanup currently causes assertion errors in
-			// DepUsrSCTP::DeregisterSctpAssociation() when using mediasoup-worker
-			// in thread mode (Rust).
-			//
-			// numSctpAssociations = 0u; nextSctpAssociationId = 0u;
-			// DepUsrSCTP::mapIdSctpAssociation.clear();
+			numSctpAssociations   = 0u;
+			nextSctpAssociationId = 0u;
+
+			DepUsrSCTP::mapIdSctpAssociation.clear();
 		}
 	}
 }

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -48,12 +48,6 @@ Worker::~Worker()
 {
 	MS_TRACE();
 
-	// Delete the Channel.
-	delete this->channel;
-
-	// Delete the PayloadChannel.
-	delete this->payloadChannel;
-
 	if (!this->closed)
 		Close();
 }

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -142,10 +142,8 @@ extern "C" int run_worker(
 		PayloadChannel::PayloadChannelNotifier::ClassInit(payloadChannel.get());
 
 #ifdef MS_EXECUTABLE
-		{
-			// Ignore some signals.
-			IgnoreSignals();
-		}
+		// Ignore some signals.
+		IgnoreSignals();
 #endif
 
 		// Run the Worker.
@@ -159,9 +157,11 @@ extern "C" int run_worker(
 		DepUsrSCTP::ClassDestroy();
 		DepLibUV::ClassDestroy();
 
+#ifdef MS_EXECUTABLE
 		// Wait a bit so pending messages to stdout/Channel arrive to the Node
 		// process.
 		uv_sleep(200);
+#endif
 
 		return 0;
 	}

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -40,37 +40,44 @@ extern "C" int run_worker(
 	// Initialize libuv stuff (we need it for the Channel).
 	DepLibUV::ClassInit();
 
-	// Channel socket (it will be handled and deleted by the Worker).
-	Channel::ChannelSocket* channel{ nullptr };
+	// Channel socket.
+	std::unique_ptr<Channel::ChannelSocket> channel{ nullptr };
 
-	// PayloadChannel socket (it will be handled and deleted by the Worker).
-	PayloadChannel::PayloadChannelSocket* payloadChannel{ nullptr };
+	// PayloadChannel socket.
+	std::unique_ptr<PayloadChannel::PayloadChannelSocket> payloadChannel{ nullptr };
 
 	try
 	{
-		channel = new Channel::ChannelSocket(consumerChannelFd, producerChannelFd);
+		channel.reset(new Channel::ChannelSocket(consumerChannelFd, producerChannelFd));
 	}
 	catch (const MediaSoupError& error)
 	{
 		MS_ERROR_STD("error creating the Channel: %s", error.what());
 
+		DepLibUV::RunLoop();
+		DepLibUV::ClassDestroy();
+
 		return 1;
 	}
 
 	try
 	{
-		payloadChannel =
-		  new PayloadChannel::PayloadChannelSocket(payloadConsumeChannelFd, payloadProduceChannelFd);
+		payloadChannel.reset(
+		  new PayloadChannel::PayloadChannelSocket(payloadConsumeChannelFd, payloadProduceChannelFd));
 	}
 	catch (const MediaSoupError& error)
 	{
 		MS_ERROR_STD("error creating the RTC Channel: %s", error.what());
 
+		channel->Close();
+		DepLibUV::RunLoop();
+		DepLibUV::ClassDestroy();
+
 		return 1;
 	}
 
 	// Initialize the Logger.
-	Logger::ClassInit(channel);
+	Logger::ClassInit(channel.get());
 
 	try
 	{
@@ -80,12 +87,22 @@ extern "C" int run_worker(
 	{
 		MS_ERROR_STD("settings error: %s", error.what());
 
+		channel->Close();
+		payloadChannel->Close();
+		DepLibUV::RunLoop();
+		DepLibUV::ClassDestroy();
+
 		// 42 is a custom exit code to notify "settings error" to the Node library.
 		return 42;
 	}
 	catch (const MediaSoupError& error)
 	{
 		MS_ERROR_STD("unexpected settings error: %s", error.what());
+
+		channel->Close();
+		payloadChannel->Close();
+		DepLibUV::RunLoop();
+		DepLibUV::ClassDestroy();
 
 		return 1;
 	}
@@ -121,8 +138,8 @@ extern "C" int run_worker(
 		Utils::Crypto::ClassInit();
 		RTC::DtlsTransport::ClassInit();
 		RTC::SrtpSession::ClassInit();
-		Channel::ChannelNotifier::ClassInit(channel);
-		PayloadChannel::PayloadChannelNotifier::ClassInit(payloadChannel);
+		Channel::ChannelNotifier::ClassInit(channel.get());
+		PayloadChannel::PayloadChannelNotifier::ClassInit(payloadChannel.get());
 
 #ifdef MS_EXECUTABLE
 		{
@@ -132,7 +149,7 @@ extern "C" int run_worker(
 #endif
 
 		// Run the Worker.
-		Worker worker(channel, payloadChannel);
+		Worker worker(channel.get(), payloadChannel.get());
 
 		// Free static stuff.
 		DepLibSRTP::ClassDestroy();


### PR DESCRIPTION
The primary goal here is to fix memory leaks that happen when library user provides incorrect worker settings. Since that is essentially a user input, it needs to be handled gracefully.

Previously worker would just exit without de-allocating channels and event loop, which was a problem in Rust case since it leaked memory forever.

Valgrind summary before after running all integration tests:
```
==652620== LEAK SUMMARY:
==652620==    definitely lost: 2,472 bytes in 87 blocks
==652620==    indirectly lost: 17,168 bytes in 271 blocks
==652620==      possibly lost: 25,167,822 bytes in 23 blocks
==652620==    still reachable: 33,705,987 bytes in 106 blocks
==652620==         suppressed: 0 bytes in 0 blocks
```

And after:
```
==688087== LEAK SUMMARY:
==688087==    definitely lost: 2,088 bytes in 87 blocks
==688087==    indirectly lost: 12,528 bytes in 261 blocks
==688087==      possibly lost: 456 bytes in 5 blocks
==688087==    still reachable: 142,774 bytes in 31 blocks
==688087==         suppressed: 0 bytes in 0 blocks
```

There are some one-time globally initialized stuff on Rust side in dependencies, so I think that non-zero result is expected.

Then I checked if SCTP-related cleanup was problematic and turns out it no longer is, I guess it was accidentally caused by other (now resolved) multi-threaded memory issues.

And lastly CI was failing because Ubuntu 20.04 on GitHub Actions got Clang update and cached object files were slightly incompatible, so I just removed them from cache. Errored build for reference: https://github.com/nazar-pc/mediasoup/runs/2754266004