### PR TITLE
Allow override initial consumers MID values on WebRTC transport.

### DIFF
--- a/lib/Transport.d.ts
+++ b/lib/Transport.d.ts
@@ -90,12 +90,13 @@ export declare class Transport extends EnhancedEventEmitter {
      * @emits @newdataproducer - (dataProducer: DataProducer)
      * @emits @dataproducerclose - (dataProducer: DataProducer)
      */
-    constructor({ internal, data, channel, payloadChannel, appData, getRouterRtpCapabilities, getProducerById, getDataProducerById }: {
+    constructor({ internal, data, channel, payloadChannel, appData, initialMidForConsumers, getRouterRtpCapabilities, getProducerById, getDataProducerById }: {
         internal: any;
         data: any;
         channel: Channel;
         payloadChannel: PayloadChannel;
         appData: any;
+        initialMidForConsumers: number;
         getRouterRtpCapabilities: () => RtpCapabilities;
         getProducerById: (producerId: string) => Producer;
         getDataProducerById: (dataProducerId: string) => DataProducer;

--- a/lib/Transport.js
+++ b/lib/Transport.js
@@ -21,7 +21,7 @@ class Transport extends EnhancedEventEmitter_1.EnhancedEventEmitter {
      * @emits @newdataproducer - (dataProducer: DataProducer)
      * @emits @dataproducerclose - (dataProducer: DataProducer)
      */
-    constructor({ internal, data, channel, payloadChannel, appData, getRouterRtpCapabilities, getProducerById, getDataProducerById }) {
+    constructor({ internal, data, channel, payloadChannel, appData, initialMidForConsumers, getRouterRtpCapabilities, getProducerById, getDataProducerById }) {
         super();
         // Close flag.
         this._closed = false;
@@ -33,13 +33,12 @@ class Transport extends EnhancedEventEmitter_1.EnhancedEventEmitter {
         this._dataProducers = new Map();
         // DataConsumers map.
         this._dataConsumers = new Map();
-        // Next MID for Consumers. It's converted into string when used.
-        this._nextMidForConsumers = 0;
         // Next SCTP stream id.
         this._nextSctpStreamId = 0;
         // Observer instance.
         this._observer = new EnhancedEventEmitter_1.EnhancedEventEmitter();
         logger.debug('constructor()');
+        this._nextMidForConsumers = (initialMidForConsumers >>> 0);
         this._internal = internal;
         this._data = data;
         this._channel = channel;

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -610,6 +610,7 @@ impl Router {
             data,
             webrtc_transport_options.app_data,
             self.clone(),
+            webrtc_transport_options.initial_mid_for_consumers,
         );
 
         self.inner.handlers.new_transport.call(|callback| {

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -120,7 +120,7 @@ pub struct WebRtcTransportOptions {
     /// Maximum SCTP send buffer used by DataConsumers.
     /// Default 262144.
     pub sctp_send_buffer_size: u32,
-    /// Initial MID value for consumers crated 
+    /// Initial MID value for consumers created
     /// on this transport.
     pub initial_mid_for_consumers: usize,
     /// Custom application data.

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -120,6 +120,9 @@ pub struct WebRtcTransportOptions {
     /// Maximum SCTP send buffer used by DataConsumers.
     /// Default 262144.
     pub sctp_send_buffer_size: u32,
+    /// Initial MID value for consumers crated 
+    /// on this transport.
+    pub initial_mid_for_consumers: usize,
     /// Custom application data.
     pub app_data: AppData,
 }
@@ -139,6 +142,7 @@ impl WebRtcTransportOptions {
             num_sctp_streams: NumSctpStreams::default(),
             max_sctp_message_size: 262_144,
             sctp_send_buffer_size: 262_144,
+            initial_mid_for_consumers: 0,
             app_data: AppData::default(),
         }
     }
@@ -549,6 +553,7 @@ impl WebRtcTransport {
         data: WebRtcTransportData,
         app_data: AppData,
         router: Router,
+        initial_mid_for_consumers: usize,
     ) -> Self {
         debug!("new()");
 
@@ -608,7 +613,7 @@ impl WebRtcTransport {
             })
         };
 
-        let next_mid_for_consumers = AtomicUsize::default();
+        let next_mid_for_consumers = AtomicUsize::new(initial_mid_for_consumers);
         let used_sctp_stream_ids = Mutex::new({
             let mut used_used_sctp_stream_ids = HashMap::new();
             if let Some(sctp_parameters) = &data.sctp_parameters {

--- a/src/Transport.ts
+++ b/src/Transport.ts
@@ -136,7 +136,7 @@ export class Transport extends EnhancedEventEmitter
 	private _cnameForProducers?: string;
 
 	// Next MID for Consumers. It's converted into string when used.
-	private _nextMidForConsumers = 0;
+	private _nextMidForConsumers: number;
 
 	// Buffer with available SCTP stream ids.
 	private _sctpStreamIds?: Buffer;
@@ -164,6 +164,7 @@ export class Transport extends EnhancedEventEmitter
 			channel,
 			payloadChannel,
 			appData,
+			initialMidForConsumers,
 			getRouterRtpCapabilities,
 			getProducerById,
 			getDataProducerById
@@ -174,6 +175,7 @@ export class Transport extends EnhancedEventEmitter
 			channel: Channel;
 			payloadChannel: PayloadChannel;
 			appData: any;
+			initialMidForConsumers: number;
 			getRouterRtpCapabilities: () => RtpCapabilities;
 			getProducerById: (producerId: string) => Producer;
 			getDataProducerById: (dataProducerId: string) => DataProducer;
@@ -184,6 +186,7 @@ export class Transport extends EnhancedEventEmitter
 
 		logger.debug('constructor()');
 
+		this._nextMidForConsumers = (initialMidForConsumers >>> 0);
 		this._internal = internal;
 		this._data = data;
 		this._channel = channel;


### PR DESCRIPTION
I'm working on project which uses media soup as `SFU` on server side. Media Soup clients libraries are not used and own signaling is being implemented.

Each client uses **single** peer connection in unified plan mode to send and receive media, in contrast to media soup demo app, which has distinct PC to send and receive media. The clients are supposed to have single PC with 2 `m=` sections in `sendonly` mode to send media, and `N` `m=` section in `recvonly/inactive` to receive media.

On server side for each client single `WebRTCTransport` created. `2` producers created for audio&video `m=` sections from SDP offer from client. Those producers are usually created with mid `0` and `1` (because that's how chrome and firefox generate SDP). The consumers for other producers on same router are also created starting with mid `0, 1, 2, ...` on that transport.
Later when `RTP` parameters of consumers and producers are transformed into single `SDP` with `count(producers)` `m=` sections in `sendonly` mode and `count(consumers)` `m=` sections in `recvonly` mode there is an issue: because consumers and producers has overlapping mid (in my scenario when I don't deal with sendrecv `m=` sections).

It would be nice to have a way to control initial mid value of created consumers just to make IDs non overlapping.
So this PR proposes one of the solution to my problem.