### PR TITLE
Update CI setup with Node.js 16 and remove EOL'd versions

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -12,10 +12,9 @@ jobs:
           # - macos-11.0
           # - windows-2019
         node:
-          - 10
           - 12
           - 14
-          - 15
+          - 16
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -8,12 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - os: ubuntu-16.04
-            cc: gcc
-            cxx: g++
-          - os: ubuntu-16.04
-            cc: clang
-            cxx: clang++
           - os: ubuntu-18.04
             cc: gcc
             cxx: g++


### PR DESCRIPTION
Changes:
* add Node.js 16 (will become LTS)
* remove Node.js 10 and 15 (they are EOL, so no point to test any longer)
* remove Ubuntu 16.04 (again, it is EOL unless you pay Canonical a lot of money, so no point to test there either)