### PR TITLE
Rust 0.8.1

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add convenience methods for getting information from `TransportTuple` enum, especially local IP/port
 * Add `mid` option in `ConsumerOptions` to provide way to override MID
+* Add convenience method `ConsumerStats::cosumer_stat()`
 
 ### 0.8.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### 0.8.1
+
+* Add convenience methods for getting information from `TransportTuple` enum, especially local IP/port
+* Add `mid` option in `ConsumerOptions` to provide way to override MID
+
 ### 0.8.0
 
 * `NonClosingProducer` removed (use `PipedProducer` instead, they were identical)

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup"
-version = "0.8.0"
+version = "0.8.1"
 description = "Cutting Edge WebRTC Video Conferencing in Rust"
 categories = ["api-bindings", "multimedia", "network-programming"]
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
@@ -45,7 +45,7 @@ version = "0.6.5"
 
 [dependencies.mediasoup-sys]
 path = "../worker"
-version = "0.2.0"
+version = "0.2.1"
 
 [dependencies.parking_lot]
 version = "0.11.1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -21,23 +21,23 @@ targets = []
 
 [dependencies]
 async-channel = "1.6.1"
-async-executor = "1.4.0"
+async-executor = "1.4.1"
 async-fs = "1.5.0"
-async-io = "1.3.1"
-async-lock = "2.3.0"
+async-io = "1.4.1"
+async-lock = "2.4.0"
 async-oneshot = "0.5.0"
-async-trait = "0.1.48"
+async-trait = "0.1.50"
 bytes = "1.0.1"
-event-listener-primitives = "0.2.2"
-fastrand = "1.4.0"
-futures-lite = "1.11.3"
+event-listener-primitives = "1.0.0"
+fastrand = "1.4.1"
+futures-lite = "1.12.0"
 h264-profile-level-id = "0.1.1"
 log = "0.4.14"
-libc = "0.2.90"
-once_cell = "1.7.2"
+libc = "0.2.97"
+once_cell = "1.8.0"
 serde_json = "1.0.64"
-serde_repr = "0.1.6"
-thiserror = "1.0.24"
+serde_repr = "0.1.7"
+thiserror = "1.0.25"
 
 [dependencies.lru]
 default-features = false
@@ -54,11 +54,11 @@ features = ["serde"]
 [dependencies.regex]
 default-features = false
 features = ["std", "perf"]
-version = "1.4.5"
+version = "1.5.4"
 
 [dependencies.serde]
 features = ["derive"]
-version = "1.0.124"
+version = "1.0.126"
 
 [dependencies.uuid]
 features = ["serde", "v4"]
@@ -68,4 +68,4 @@ version = "0.8.2"
 actix = "0.10.0"
 actix-web = "3.3.2"
 actix-web-actors = "3.0.0"
-env_logger = "0.8.3"
+env_logger = "0.8.4"

--- a/rust/src/data_structures.rs
+++ b/rust/src/data_structures.rs
@@ -199,26 +199,20 @@ pub enum TransportTuple {
 impl TransportTuple {
     /// Local IP address.
     pub fn local_ip(&self) -> IpAddr {
-        match self {
-            TransportTuple::WithRemote { local_ip, .. } => *local_ip,
-            TransportTuple::LocalOnly { local_ip, .. } => *local_ip,
-        }
+        let (Self::WithRemote { local_ip, .. } | Self::LocalOnly { local_ip, .. }) = self;
+        *local_ip
     }
 
     /// Local port.
     pub fn local_port(&self) -> u16 {
-        match self {
-            TransportTuple::WithRemote { local_port, .. } => *local_port,
-            TransportTuple::LocalOnly { local_port, .. } => *local_port,
-        }
+        let (Self::WithRemote { local_port, .. } | Self::LocalOnly { local_port, .. }) = self;
+        *local_port
     }
 
     /// Protocol.
     pub fn protocol(&self) -> TransportProtocol {
-        match self {
-            TransportTuple::WithRemote { protocol, .. } => *protocol,
-            TransportTuple::LocalOnly { protocol, .. } => *protocol,
-        }
+        let (Self::WithRemote { protocol, .. } | Self::LocalOnly { protocol, .. }) = self;
+        *protocol
     }
 
     /// Remote IP address.

--- a/rust/src/data_structures.rs
+++ b/rust/src/data_structures.rs
@@ -196,6 +196,50 @@ pub enum TransportTuple {
     },
 }
 
+impl TransportTuple {
+    /// Local IP address.
+    pub fn local_ip(&self) -> IpAddr {
+        match self {
+            TransportTuple::WithRemote { local_ip, .. } => *local_ip,
+            TransportTuple::LocalOnly { local_ip, .. } => *local_ip,
+        }
+    }
+
+    /// Local port.
+    pub fn local_port(&self) -> u16 {
+        match self {
+            TransportTuple::WithRemote { local_port, .. } => *local_port,
+            TransportTuple::LocalOnly { local_port, .. } => *local_port,
+        }
+    }
+
+    /// Protocol.
+    pub fn protocol(&self) -> TransportProtocol {
+        match self {
+            TransportTuple::WithRemote { protocol, .. } => *protocol,
+            TransportTuple::LocalOnly { protocol, .. } => *protocol,
+        }
+    }
+
+    /// Remote IP address.
+    pub fn remote_ip(&self) -> Option<IpAddr> {
+        if let TransportTuple::WithRemote { remote_ip, .. } = self {
+            Some(*remote_ip)
+        } else {
+            None
+        }
+    }
+
+    /// Remote port.
+    pub fn remote_port(&self) -> Option<u16> {
+        if let TransportTuple::WithRemote { remote_port, .. } = self {
+            Some(*remote_port)
+        } else {
+            None
+        }
+    }
+}
+
 /// DTLS state.
 #[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -253,6 +253,16 @@ pub enum ConsumerStats {
     WithProducer((ConsumerStat, ProducerStat)),
 }
 
+impl ConsumerStats {
+    /// RTC statistics of the consumer
+    pub fn consumer_stats(&self) -> &ConsumerStat {
+        match self {
+            ConsumerStats::JustConsumer((consumer_stat,)) => consumer_stat,
+            ConsumerStats::WithProducer((consumer_stat, _)) => consumer_stat,
+        }
+    }
+}
+
 /// 'trace' event data.
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(tag = "type", rename_all = "lowercase")]

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -148,21 +148,18 @@ impl RtpCodecCapabilityFinalized {
     }
 
     pub(crate) fn clock_rate(&self) -> NonZeroU32 {
-        match self {
-            Self::Audio { clock_rate, .. } | Self::Video { clock_rate, .. } => *clock_rate,
-        }
+        let (Self::Audio { clock_rate, .. } | Self::Video { clock_rate, .. }) = self;
+        *clock_rate
     }
 
     pub(crate) fn parameters(&self) -> &RtpCodecParametersParameters {
-        match self {
-            Self::Audio { parameters, .. } | Self::Video { parameters, .. } => parameters,
-        }
+        let (Self::Audio { parameters, .. } | Self::Video { parameters, .. }) = self;
+        parameters
     }
 
     pub(crate) fn parameters_mut(&mut self) -> &mut RtpCodecParametersParameters {
-        match self {
-            Self::Audio { parameters, .. } | Self::Video { parameters, .. } => parameters,
-        }
+        let (Self::Audio { parameters, .. } | Self::Video { parameters, .. }) = self;
+        parameters
     }
 
     pub(crate) fn preferred_payload_type(&self) -> u8 {
@@ -338,15 +335,13 @@ impl RtpCodecCapability {
     }
 
     pub(crate) fn parameters(&self) -> &RtpCodecParametersParameters {
-        match self {
-            Self::Audio { parameters, .. } | Self::Video { parameters, .. } => parameters,
-        }
+        let (Self::Audio { parameters, .. } | Self::Video { parameters, .. }) = self;
+        parameters
     }
 
     pub(crate) fn parameters_mut(&mut self) -> &mut RtpCodecParametersParameters {
-        match self {
-            Self::Audio { parameters, .. } | Self::Video { parameters, .. } => parameters,
-        }
+        let (Self::Audio { parameters, .. } | Self::Video { parameters, .. }) = self;
+        parameters
     }
 
     pub(crate) fn preferred_payload_type(&self) -> Option<u8> {
@@ -363,9 +358,8 @@ impl RtpCodecCapability {
     }
 
     pub(crate) fn rtcp_feedback(&self) -> &Vec<RtcpFeedback> {
-        match self {
-            Self::Audio { rtcp_feedback, .. } | Self::Video { rtcp_feedback, .. } => rtcp_feedback,
-        }
+        let (Self::Audio { rtcp_feedback, .. } | Self::Video { rtcp_feedback, .. }) = self;
+        rtcp_feedback
     }
 }
 
@@ -635,21 +629,18 @@ impl RtpCodecParameters {
     }
 
     pub(crate) fn payload_type(&self) -> u8 {
-        match self {
-            Self::Audio { payload_type, .. } | Self::Video { payload_type, .. } => *payload_type,
-        }
+        let (Self::Audio { payload_type, .. } | Self::Video { payload_type, .. }) = self;
+        *payload_type
     }
 
     pub(crate) fn parameters(&self) -> &RtpCodecParametersParameters {
-        match self {
-            Self::Audio { parameters, .. } | Self::Video { parameters, .. } => parameters,
-        }
+        let (Self::Audio { parameters, .. } | Self::Video { parameters, .. }) = self;
+        parameters
     }
 
     pub(crate) fn rtcp_feedback_mut(&mut self) -> &mut Vec<RtcpFeedback> {
-        match self {
-            Self::Audio { rtcp_feedback, .. } | Self::Video { rtcp_feedback, .. } => rtcp_feedback,
-        }
+        let (Self::Audio { rtcp_feedback, .. } | Self::Video { rtcp_feedback, .. }) = self;
+        rtcp_feedback
     }
 }
 

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -51,7 +51,7 @@ where
     K: Into<String>,
 {
     fn from(array: [(K, RtpCodecParametersParametersValue); N]) -> Self {
-        Self::from_iter(std::array::IntoIter::new(array))
+        std::array::IntoIter::new(array).collect()
     }
 }
 

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -1,8 +1,7 @@
 use async_io::Timer;
 use futures_lite::future;
 use mediasoup::consumer::{
-    ConsumableRtpEncoding, ConsumerLayers, ConsumerOptions, ConsumerScore, ConsumerStats,
-    ConsumerType,
+    ConsumableRtpEncoding, ConsumerLayers, ConsumerOptions, ConsumerScore, ConsumerType,
 };
 use mediasoup::data_structures::{AppData, TransportListenIp};
 use mediasoup::producer::ProducerOptions;
@@ -1071,10 +1070,7 @@ fn get_stats_succeeds() {
                 .await
                 .expect("Audio consumer get_stats failed");
 
-            let consumer_stat = match stats {
-                ConsumerStats::JustConsumer((consumer_stat,)) => consumer_stat,
-                ConsumerStats::WithProducer((consumer_stat, _)) => consumer_stat,
-            };
+            let consumer_stat = stats.consumer_stats();
 
             assert_eq!(consumer_stat.kind, MediaKind::Audio);
             assert_eq!(
@@ -1123,10 +1119,7 @@ fn get_stats_succeeds() {
                 .await
                 .expect("Video consumer get_stats failed");
 
-            let consumer_stat = match stats {
-                ConsumerStats::JustConsumer((consumer_stat,)) => consumer_stat,
-                ConsumerStats::WithProducer((consumer_stat, _)) => consumer_stat,
-            };
+            let consumer_stat = stats.consumer_stats();
 
             assert_eq!(consumer_stat.kind, MediaKind::Video);
             assert_eq!(

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup-sys"
-version = "0.2.0"
+version = "0.2.1"
 description = "FFI bindings to C++ libmediasoup-worker"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition = "2018"


### PR DESCRIPTION
Fix for clippy lint, some convenience methods on enums so that there is less need to use match statements externally and version bump for publishing.