### PR TITLE
Cleanup for non-existing header files and potentially uninitialized local variable

### DIFF
--- a/worker/mediasoup-worker.gyp
+++ b/worker/mediasoup-worker.gyp
@@ -438,8 +438,8 @@
         'fuzzer/src/RTC/RTCP/FuzzerXr.cpp',
         # C++ include files.
         'fuzzer/include/FuzzerUtils.hpp',
-        'fuzzer/include/RTC/FuzzerStunMessage.hpp',
         'fuzzer/include/RTC/FuzzerRtpPacket.hpp',
+        'fuzzer/include/RTC/FuzzerStunPacket.hpp',
         'fuzzer/include/RTC/FuzzerTrendCalculator.hpp',
         'fuzzer/include/RTC/RTCP/FuzzerBye.hpp',
         'fuzzer/include/RTC/RTCP/FuzzerFeedbackPs.hpp',
@@ -461,7 +461,7 @@
         'fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTransport.hpp',
         'fuzzer/include/RTC/RTCP/FuzzerPacket.hpp',
         'fuzzer/include/RTC/RTCP/FuzzerReceiverReport.hpp',
-        'fuzzer/include/RTC/RTCP/FuzzerSdesReport.hpp',
+        'fuzzer/include/RTC/RTCP/FuzzerSdes.hpp',
         'fuzzer/include/RTC/RTCP/FuzzerSenderReport.hpp',
         'fuzzer/include/RTC/RTCP/FuzzerXr.hpp',
       ],

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2371,7 +2371,7 @@ namespace RTC
 				// provide it with more available bitrate to choose its preferred layers.
 				for (uint8_t i{ 1u }; i <= priority; ++i)
 				{
-					uint32_t usedBitrate;
+					uint32_t usedBitrate{ 0u };
 
 					switch (bweType)
 					{


### PR DESCRIPTION
Those 2 header files do not actually exist (found while playing with GYP's CMake generator :wink: ).

Local variable is, obviously, defined for all practical purposes, but compiler complained so decided to make it happy, I hope that's fine.