### PR TITLE
RFC: Meson build system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,7 @@
 # Rust examples.
 /rust/examples-frontend/*/node_modules
 /rust/examples-frontend/*/package-lock.json
+
+# Meson
+/worker/subprojects/*
+!/worker/subprojects/*.wrap

--- a/worker/.clang-format-include
+++ b/worker/.clang-format-include
@@ -1,0 +1,6 @@
+src/**/*.cpp
+include/**/*.hpp
+test/src/**/*.cpp
+test/include/helpers.hpp
+fuzzer/src/**/*.cpp
+fuzzer/include/**/*.hpp

--- a/worker/deps/getopt/meson.build
+++ b/worker/deps/getopt/meson.build
@@ -1,0 +1,14 @@
+getopt = library(
+  'getopt',
+  'getopt/src/getopt.c',
+  include_directories: include_directories(
+    'getopt/src',
+  ),
+)
+
+getopt_dep = declare_dependency(
+  link_with: getopt,
+  include_directories: include_directories(
+    'getopt/src',
+  ),
+)

--- a/worker/deps/libwebrtc/README.md
+++ b/worker/deps/libwebrtc/README.md
@@ -8,3 +8,5 @@ This folder contains a modified/adapted subset of the libwebrtc library, which i
 The file `libwebrtc/mediasoup_helpers.h` includes some utilities to plug mediasoup classes into libwebrtc.
 
 The file `worker/deps/libwebrtc/deps/abseil-cpp/abseil-cpp/absl/synchronization/internal/graphcycles.cc` has `#include <limits>` added to it to fix CI builds with Clang.
+
+The file `meson.build` is written for using with Meson build system.

--- a/worker/deps/libwebrtc/meson.build
+++ b/worker/deps/libwebrtc/meson.build
@@ -1,0 +1,81 @@
+libwebrtc_sources = [
+  'libwebrtc/system_wrappers/source/field_trial.cc',
+  'libwebrtc/rtc_base/rate_statistics.cc',
+  'libwebrtc/rtc_base/experiments/field_trial_parser.cc',
+  'libwebrtc/rtc_base/experiments/alr_experiment.cc',
+  'libwebrtc/rtc_base/experiments/field_trial_units.cc',
+  'libwebrtc/rtc_base/experiments/rate_control_settings.cc',
+  'libwebrtc/rtc_base/network/sent_packet.cc',
+  'libwebrtc/call/rtp_transport_controller_send.cc',
+  'libwebrtc/api/transport/bitrate_settings.cc',
+  'libwebrtc/api/transport/field_trial_based_config.cc',
+  'libwebrtc/api/transport/network_types.cc',
+  'libwebrtc/api/transport/goog_cc_factory.cc',
+  'libwebrtc/api/units/timestamp.cc',
+  'libwebrtc/api/units/time_delta.cc',
+  'libwebrtc/api/units/data_rate.cc',
+  'libwebrtc/api/units/data_size.cc',
+  'libwebrtc/api/units/frequency.cc',
+  'libwebrtc/api/network_state_predictor.cc',
+  'libwebrtc/modules/pacing/interval_budget.cc',
+  'libwebrtc/modules/pacing/bitrate_prober.cc',
+  'libwebrtc/modules/pacing/paced_sender.cc',
+  'libwebrtc/modules/remote_bitrate_estimator/overuse_detector.cc',
+  'libwebrtc/modules/remote_bitrate_estimator/overuse_estimator.cc',
+  'libwebrtc/modules/remote_bitrate_estimator/aimd_rate_control.cc',
+  'libwebrtc/modules/remote_bitrate_estimator/inter_arrival.cc',
+  'libwebrtc/modules/remote_bitrate_estimator/bwe_defines.cc',
+  'libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.cc',
+  'libwebrtc/modules/rtp_rtcp/include/rtp_rtcp_defines.cc',
+  'libwebrtc/modules/bitrate_controller/send_side_bandwidth_estimation.cc',
+  'libwebrtc/modules/bitrate_controller/loss_based_bandwidth_estimation.cc',
+  'libwebrtc/modules/congestion_controller/goog_cc/goog_cc_network_control.cc',
+  'libwebrtc/modules/congestion_controller/goog_cc/probe_bitrate_estimator.cc',
+  'libwebrtc/modules/congestion_controller/goog_cc/congestion_window_pushback_controller.cc',
+  'libwebrtc/modules/congestion_controller/goog_cc/link_capacity_estimator.cc',
+  'libwebrtc/modules/congestion_controller/goog_cc/alr_detector.cc',
+  'libwebrtc/modules/congestion_controller/goog_cc/probe_controller.cc',
+  'libwebrtc/modules/congestion_controller/goog_cc/median_slope_estimator.cc',
+  'libwebrtc/modules/congestion_controller/goog_cc/bitrate_estimator.cc',
+  'libwebrtc/modules/congestion_controller/goog_cc/trendline_estimator.cc',
+  'libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe.cc',
+  'libwebrtc/modules/congestion_controller/goog_cc/acknowledged_bitrate_estimator.cc',
+  'libwebrtc/modules/congestion_controller/rtp/send_time_history.cc',
+  'libwebrtc/modules/congestion_controller/rtp/transport_feedback_adapter.cc',
+  'libwebrtc/modules/congestion_controller/rtp/control_handler.cc',
+]
+
+abseil_cpp_proj = subproject(
+  'abseil-cpp',
+  default_options: [
+    'warning_level=0',
+  ],
+)
+
+local_include_directories = declare_dependency(
+  include_directories: include_directories('libwebrtc')
+)
+
+libwebrtc = library(
+  'libwebrtc',
+  libwebrtc_sources,
+  dependencies: [
+    local_include_directories,
+    abseil_cpp_proj.get_variable('absl_strings_dep'),
+    abseil_cpp_proj.get_variable('absl_types_dep'),
+    nlohmann_json_dep,
+    libuv_dep,
+  ],
+  include_directories: libwebrtc_include_directories,
+  cpp_args: cpp_args,
+)
+
+libwebrtc_dep = declare_dependency(
+  dependencies: [
+    local_include_directories,
+    abseil_cpp_proj.get_variable('absl_strings_dep'),
+    abseil_cpp_proj.get_variable('absl_types_dep'),
+  ],
+  include_directories: include_directories('.'),
+  link_with: libwebrtc,
+)

--- a/worker/deps/netstring/meson.build
+++ b/worker/deps/netstring/meson.build
@@ -1,0 +1,14 @@
+netstring = library(
+  'netstring',
+  'netstring-c/netstring.c',
+  include_directories: include_directories(
+    'netstring-c',
+  ),
+)
+
+netstring_dep = declare_dependency(
+  link_with: netstring,
+  include_directories: include_directories(
+    'netstring-c',
+  ),
+)

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -1,0 +1,285 @@
+project(
+  'mediasoup-worker',
+  ['c', 'cpp'],
+  default_options : [
+    'warning_level=1',
+    'cpp_std=c++11',
+    'default_library=static',
+  ],
+  meson_version: '>= 0.58',
+)
+
+cpp_args = [
+  host_machine.endian() == 'little' ? '-DMS_LITTLE_ENDIAN' : '-DMS_BIG_ENDIAN',
+  '-DABSL_ALLOCATOR_NOTHROW=1',
+]
+
+if host_machine.system() == 'windows'
+  cpp_args += [
+    '-DNOMINMAX', # Don't define min and max macros (windows.h)
+    # Don't bloat namespace with incompatible winsock versions.
+    '-DWIN32_LEAN_AND_MEAN',
+    # Don't warn about usage of insecure C functions.
+    '-D_CRT_SECURE_NO_WARNINGS',
+    '-D_SCL_SECURE_NO_WARNINGS',
+    # Introduced in VS 2017 15.8, allow overaligned types in aligned_storage.
+    '-D_ENABLE_EXTENDED_ALIGNED_STORAGE'
+  ]
+endif
+
+common_sources = [
+  'src/lib.cpp',
+  'src/DepLibSRTP.cpp',
+  'src/DepLibUV.cpp',
+  'src/DepLibWebRTC.cpp',
+  'src/DepOpenSSL.cpp',
+  'src/DepUsrSCTP.cpp',
+  'src/Logger.cpp',
+  'src/MediaSoupErrors.cpp',
+  'src/Settings.cpp',
+  'src/Worker.cpp',
+  'src/Utils/Crypto.cpp',
+  'src/Utils/File.cpp',
+  'src/Utils/IP.cpp',
+  'src/Utils/String.cpp',
+  'src/handles/SignalsHandler.cpp',
+  'src/handles/TcpConnectionHandler.cpp',
+  'src/handles/TcpServerHandler.cpp',
+  'src/handles/Timer.cpp',
+  'src/handles/UdpSocketHandler.cpp',
+  'src/handles/UnixStreamSocket.cpp',
+  'src/Channel/ChannelNotifier.cpp',
+  'src/Channel/ChannelRequest.cpp',
+  'src/Channel/ChannelSocket.cpp',
+  'src/PayloadChannel/Notification.cpp',
+  'src/PayloadChannel/PayloadChannelNotifier.cpp',
+  'src/PayloadChannel/PayloadChannelRequest.cpp',
+  'src/PayloadChannel/PayloadChannelSocket.cpp',
+  'src/RTC/AudioLevelObserver.cpp',
+  'src/RTC/Consumer.cpp',
+  'src/RTC/DataConsumer.cpp',
+  'src/RTC/DataProducer.cpp',
+  'src/RTC/DirectTransport.cpp',
+  'src/RTC/DtlsTransport.cpp',
+  'src/RTC/IceCandidate.cpp',
+  'src/RTC/IceServer.cpp',
+  'src/RTC/KeyFrameRequestManager.cpp',
+  'src/RTC/NackGenerator.cpp',
+  'src/RTC/PipeConsumer.cpp',
+  'src/RTC/PipeTransport.cpp',
+  'src/RTC/PlainTransport.cpp',
+  'src/RTC/PortManager.cpp',
+  'src/RTC/Producer.cpp',
+  'src/RTC/RateCalculator.cpp',
+  'src/RTC/Router.cpp',
+  'src/RTC/RtpListener.cpp',
+  'src/RTC/RtpObserver.cpp',
+  'src/RTC/RtpPacket.cpp',
+  'src/RTC/RtpProbationGenerator.cpp',
+  'src/RTC/RtpStream.cpp',
+  'src/RTC/RtpStreamRecv.cpp',
+  'src/RTC/RtpStreamSend.cpp',
+  'src/RTC/RtxStream.cpp',
+  'src/RTC/SctpAssociation.cpp',
+  'src/RTC/SctpListener.cpp',
+  'src/RTC/SenderBandwidthEstimator.cpp',
+  'src/RTC/SeqManager.cpp',
+  'src/RTC/SimpleConsumer.cpp',
+  'src/RTC/SimulcastConsumer.cpp',
+  'src/RTC/SrtpSession.cpp',
+  'src/RTC/StunPacket.cpp',
+  'src/RTC/SvcConsumer.cpp',
+  'src/RTC/TcpConnection.cpp',
+  'src/RTC/TcpServer.cpp',
+  'src/RTC/Transport.cpp',
+  'src/RTC/TransportCongestionControlClient.cpp',
+  'src/RTC/TransportCongestionControlServer.cpp',
+  'src/RTC/TransportTuple.cpp',
+  'src/RTC/TrendCalculator.cpp',
+  'src/RTC/UdpSocket.cpp',
+  'src/RTC/WebRtcTransport.cpp',
+  'src/RTC/Codecs/H264.cpp',
+  'src/RTC/Codecs/VP8.cpp',
+  'src/RTC/Codecs/VP9.cpp',
+  'src/RTC/RtpDictionaries/Media.cpp',
+  'src/RTC/RtpDictionaries/Parameters.cpp',
+  'src/RTC/RtpDictionaries/RtcpFeedback.cpp',
+  'src/RTC/RtpDictionaries/RtcpParameters.cpp',
+  'src/RTC/RtpDictionaries/RtpCodecMimeType.cpp',
+  'src/RTC/RtpDictionaries/RtpCodecParameters.cpp',
+  'src/RTC/RtpDictionaries/RtpEncodingParameters.cpp',
+  'src/RTC/RtpDictionaries/RtpHeaderExtensionParameters.cpp',
+  'src/RTC/RtpDictionaries/RtpHeaderExtensionUri.cpp',
+  'src/RTC/RtpDictionaries/RtpParameters.cpp',
+  'src/RTC/RtpDictionaries/RtpRtxParameters.cpp',
+  'src/RTC/SctpDictionaries/SctpStreamParameters.cpp',
+  'src/RTC/RTCP/Packet.cpp',
+  'src/RTC/RTCP/CompoundPacket.cpp',
+  'src/RTC/RTCP/SenderReport.cpp',
+  'src/RTC/RTCP/ReceiverReport.cpp',
+  'src/RTC/RTCP/Sdes.cpp',
+  'src/RTC/RTCP/Bye.cpp',
+  'src/RTC/RTCP/Feedback.cpp',
+  'src/RTC/RTCP/FeedbackPs.cpp',
+  'src/RTC/RTCP/FeedbackRtp.cpp',
+  'src/RTC/RTCP/FeedbackRtpNack.cpp',
+  'src/RTC/RTCP/FeedbackRtpTmmb.cpp',
+  'src/RTC/RTCP/FeedbackRtpSrReq.cpp',
+  'src/RTC/RTCP/FeedbackRtpTllei.cpp',
+  'src/RTC/RTCP/FeedbackRtpEcn.cpp',
+  'src/RTC/RTCP/FeedbackRtpTransport.cpp',
+  'src/RTC/RTCP/FeedbackPsPli.cpp',
+  'src/RTC/RTCP/FeedbackPsSli.cpp',
+  'src/RTC/RTCP/FeedbackPsRpsi.cpp',
+  'src/RTC/RTCP/FeedbackPsFir.cpp',
+  'src/RTC/RTCP/FeedbackPsTst.cpp',
+  'src/RTC/RTCP/FeedbackPsVbcm.cpp',
+  'src/RTC/RTCP/FeedbackPsLei.cpp',
+  'src/RTC/RTCP/FeedbackPsAfb.cpp',
+  'src/RTC/RTCP/FeedbackPsRemb.cpp',
+  'src/RTC/RTCP/XR.cpp',
+  'src/RTC/RTCP/XrDelaySinceLastRr.cpp',
+  'src/RTC/RTCP/XrReceiverReferenceTime.cpp',
+]
+
+cpp = meson.get_compiler('cpp')
+
+openssl_dep = dependency(
+  'openssl',
+  static: get_option('default_library') == 'static',
+  version: '>= 1.1.1'
+)
+
+nlohmann_json_dep = dependency('nlohmann_json')
+
+libuv_dep = dependency(
+  'libuv',
+  default_options: [
+    'warning_level=0',
+    'build_tests=false',
+    'build_benchmarks=false',
+  ],
+  version: '>= 1.40'
+)
+libsrtp2_dep = dependency(
+  'libsrtp2',
+  default_options: [
+    'warning_level=0',
+    'crypto-library=openssl',
+    'tests=disabled',
+  ],
+  version: '>= 2.3'
+)
+usrsctp_dep = dependency(
+  'usrsctp',
+  default_options: [
+    'warning_level=0',
+    'sctp_build_programs=false',
+  ],
+)
+abseil_cpp_proj = subproject(
+  'abseil-cpp',
+  default_options: [
+    'warning_level=0',
+  ],
+)
+subdir('deps/netstring')
+libwebrtc_include_directories = include_directories('include')
+subdir('deps/libwebrtc')
+
+dependencies = [
+  openssl_dep,
+  nlohmann_json_dep,
+  libuv_dep,
+  libsrtp2_dep,
+  usrsctp_dep,
+  netstring_dep,
+  libwebrtc_dep,
+]
+
+if host_machine.system() == 'windows'
+  subdir('dep/getopt')
+  dependencies += [
+    getopt_dep
+  ]
+endif
+
+libmediasoup_worker = library(
+  'libmediasoup-worker',
+  name_prefix: '',
+  build_by_default: false,
+  dependencies: dependencies,
+  sources: common_sources,
+  include_directories: include_directories('include'),
+  cpp_args: cpp_args,
+)
+
+executable(
+  'mediasoup-worker',
+  build_by_default: true,
+  dependencies: dependencies,
+  sources: common_sources + ['src/main.cpp'],
+  include_directories: include_directories('include'),
+  cpp_args: cpp_args + ['-DMS_EXECUTABLE'],
+)
+
+mediasoup_worker_test = executable(
+  'mediasoup-worker-test',
+  build_by_default: false,
+  dependencies: dependencies + [
+    dependency('catch2'),
+  ],
+  sources: common_sources + [
+    'test/src/tests.cpp',
+    'test/src/RTC/TestKeyFrameRequestManager.cpp',
+    'test/src/RTC/TestNackGenerator.cpp',
+    'test/src/RTC/TestRateCalculator.cpp',
+    'test/src/RTC/TestRtpPacket.cpp',
+    'test/src/RTC/TestRtpStreamSend.cpp',
+    'test/src/RTC/TestRtpStreamRecv.cpp',
+    'test/src/RTC/TestSeqManager.cpp',
+    'test/src/RTC/TestTrendCalculator.cpp',
+    'test/src/RTC/TestRtpEncodingParameters.cpp',
+    'test/src/RTC/Codecs/TestVP8.cpp',
+    'test/src/RTC/RTCP/TestFeedbackPsAfb.cpp',
+    'test/src/RTC/RTCP/TestFeedbackPsFir.cpp',
+    'test/src/RTC/RTCP/TestFeedbackPsLei.cpp',
+    'test/src/RTC/RTCP/TestFeedbackPsPli.cpp',
+    'test/src/RTC/RTCP/TestFeedbackPsRemb.cpp',
+    'test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp',
+    'test/src/RTC/RTCP/TestFeedbackPsSli.cpp',
+    'test/src/RTC/RTCP/TestFeedbackPsTst.cpp',
+    'test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp',
+    'test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp',
+    'test/src/RTC/RTCP/TestFeedbackRtpNack.cpp',
+    'test/src/RTC/RTCP/TestFeedbackRtpSrReq.cpp',
+    'test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp',
+    'test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp',
+    'test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp',
+    'test/src/RTC/RTCP/TestBye.cpp',
+    'test/src/RTC/RTCP/TestReceiverReport.cpp',
+    'test/src/RTC/RTCP/TestSdes.cpp',
+    'test/src/RTC/RTCP/TestSenderReport.cpp',
+    'test/src/RTC/RTCP/TestPacket.cpp',
+    'test/src/RTC/RTCP/TestXr.cpp',
+    'test/src/Utils/TestBits.cpp',
+    'test/src/Utils/TestIP.cpp',
+    'test/src/Utils/TestJson.cpp',
+    'test/src/Utils/TestString.cpp',
+    'test/src/Utils/TestTime.cpp',
+  ],
+  include_directories: include_directories(
+    'include',
+    'test/include',
+  ),
+  cpp_args: cpp_args + [
+    '-DMS_LOG_STD',
+    '-DMS_TEST',
+  ],
+)
+
+test(
+   'mediasoup-worker-test',
+   mediasoup_worker_test,
+   workdir: meson.source_root(),
+)

--- a/worker/subprojects/abseil-cpp.wrap
+++ b/worker/subprojects/abseil-cpp.wrap
@@ -1,0 +1,23 @@
+[wrap-file]
+directory = abseil-cpp-20210324.1
+source_url = https://github.com/abseil/abseil-cpp/archive/20210324.1.tar.gz
+source_filename = abseil-cpp-20210324.1.tar.gz
+source_hash = 441db7c09a0565376ecacf0085b2d4c2bbedde6115d7773551bc116212c2a8d6
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/abseil-cpp/20210324.1/2/get_zip
+patch_filename = abseil-cpp-20210324.1-2-wrap.zip
+patch_hash = 980cb224f1c96dbe700fd8d399911e65088fcd2958fb1352955a3f1b740e1d17
+
+[provide]
+absl_base = absl_base_dep
+absl_container = absl_container_dep
+absl_debugging = absl_debugging_dep
+absl_flags = absl_flags_dep
+absl_hash = absl_hash_dep
+absl_numeric = absl_numeric_dep
+absl_random = absl_random_dep
+absl_status = absl_status_dep
+absl_strings = absl_strings_dep
+absl_synchronization = absl_synchronization_dep
+absl_time = absl_time_dep
+absl_types = absl_types_dep
+

--- a/worker/subprojects/catch2.wrap
+++ b/worker/subprojects/catch2.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = Catch2-2.13.3
+source_url = https://github.com/catchorg/Catch2/archive/v2.13.3.zip
+source_filename = Catch2-2.13.3.zip
+source_hash = 1804feb72bc15c0856b4a43aa586c661af9c3685a75973b6a8fc0b950c7cfd13
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/catch2/2.13.3/2/get_zip
+patch_filename = catch2-2.13.3-2-wrap.zip
+patch_hash = 21b590ab8c65b593ad5ee8f8e5b822bf9877b2c2672f97fbb52459751053eadf
+
+[provide]
+catch2 = catch2_dep
+

--- a/worker/subprojects/libsrtp2.wrap
+++ b/worker/subprojects/libsrtp2.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+url = https://github.com/cisco/libsrtp
+# Snapshot of `master` that already has Meson support upstream
+revision = bd0f27ec0e299ad101a396dde3f7c90d48efc8fc
+depth = 1
+
+[provide]
+libsrtp2 = libsrtp2_dep

--- a/worker/subprojects/libuv.wrap
+++ b/worker/subprojects/libuv.wrap
@@ -1,0 +1,12 @@
+[wrap-file]
+directory = libuv-v1.41.0
+source_url = https://dist.libuv.org/dist/v1.41.0/libuv-v1.41.0.tar.gz
+source_filename = libuv-v1.41.0.tar.gz
+source_hash = 1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/libuv/1.41.0/1/get_zip
+patch_filename = libuv-1.41.0-1-wrap.zip
+patch_hash = 66cab50ca1f002d823a2015611c08401b69d6f7c1ecd0059cb6afd34e1138b40
+
+[provide]
+libuv = libuv_dep
+

--- a/worker/subprojects/nlohmann_json.wrap
+++ b/worker/subprojects/nlohmann_json.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = nlohmann_json-3.9.1
+lead_directory_missing = true
+source_url = https://github.com/nlohmann/json/releases/download/v3.9.1/include.zip
+source_filename = nlohmann_json-3.9.1.zip
+source_hash = 6bea5877b1541d353bd77bdfbdb2696333ae5ed8f9e8cc22df657192218cad91
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/nlohmann_json/3.9.1/1/get_zip
+patch_filename = nlohmann_json-3.9.1-1-wrap.zip
+patch_hash = 1774e5506fbe3897d652f67e41973194b948d2ab851cf464a742f35f160a1435
+
+[provide]
+nlohmann_json = nlohmann_json_dep
+

--- a/worker/subprojects/usrsctp.wrap
+++ b/worker/subprojects/usrsctp.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://github.com/sctplab/usrsctp
+revision = 0f8d58300b1fdcd943b4a9dd3fbd830825390d4d
+depth = 1
+
+[provide]
+usrsctp = usrsctp_dep


### PR DESCRIPTION
### This PR is a request for comments for Meson build system.

I spent a lot of time trying to add CMake and it was so painful that I decided to look at Meson that many projects are moving towards and found it surprisingly expressive and easy to use. This is basically as an alternative solution for #359.

This PR implements Meson support for building `mediasoup-worker`, `libmediasoup-worker` and tests.

If this makes sense to everyone I can things currently missing, switch from GYP and remove things which are GYP-specific. The only concern there is fuzzing-related code that I have never used myself, but it should be doable too.

### Important notes:
* OpenSSL is no longer built from source, it is expected to be installed on the system (it would be possible to add OpenSSL Meson build, but it would take significant amount of time that I don't have at the moment, see https://github.com/mesonbuild/wrapdb/issues/109)
* following dependencies no longer need to be bundled and can be installed on the fly if not already present on the system:
  * abseil-cpp
  * libsrtp2
  * libuv
  * usrsctp
  * catch2
* It is possible to easily make build that relies on system shared libraries instead of building them from scratch or building them statically (if needed), in fact system-wide static OpenSSL library is already used since no version that can be built from source is provided

### How to try it out:
Assuming you have `meson` and `ninja` installed:
```bash
cd worker
# Prepare `build` directory where builds will happen
meson setup build
# Build mediasoup-worker
meson compile -C build mediasoup-worker
# Build static C++ library
meson compile -C build libmediasoup-worker
# Build and run worker tests
meson test -C build
```