### PR TITLE
Fixed bool is serialized as string causing deserialization error in Rust.

### DIFF
--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -319,7 +319,7 @@ namespace RTC
 		jsonObject["timestamp"] = GetTimestamp();
 
 		// Add marker.
-		jsonObject["marker"] = HasMarker() ? "true" : "false";
+		jsonObject["marker"] = HasMarker();
 
 		// Add ssrc.
 		jsonObject["ssrc"] = GetSsrc();


### PR DESCRIPTION
When `probation` trace event is enabled on `WebRTC` transport there is `JSON` deserialization error happen. E.g:
```
2021-07-22T13:09:53 [ERROR] (src/router/webrtc_transport.rs:608): Failed to parse notification: invalid type: string "false", expected a boolean
```
An alternative fix would be change Rust deserializer to accept `"true"` and `"false"` as valid boolean values. But since other bools in same `JSON` object were serialized as normal bools I've decided to fix `C++` code rather than `Rust`. Could redo if requested.