### PR TITLE
New mediasoup-sys release

### DIFF
--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup-sys"
-version = "0.2.2"
+version = "0.2.3"
 description = "FFI bindings to C++ libmediasoup-worker"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition = "2018"

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -119,6 +119,7 @@ fn main() {
         // Build
         if !Command::new("make")
             .arg("libmediasoup-worker")
+            .env("PYTHONDONTWRITEBYTECODE", "1")
             .spawn()
             .expect("Failed to start")
             .wait()


### PR DESCRIPTION
Python 3.9 after OS upgrade was very persistent in creation of `*.pyc` files, had to disable it with environment variable, otherwise cargo complains that source directory was modified when crate is built.