### PR TITLE
Fix compilation on MinWG GCC

### DIFF
--- a/worker/fuzzer/src/FuzzerUtils.cpp
+++ b/worker/fuzzer/src/FuzzerUtils.cpp
@@ -36,11 +36,11 @@ void Fuzzer::Utils::Fuzz(const uint8_t* data, size_t len)
 	::Utils::Byte::Get3Bytes(data2, len);
 	::Utils::Byte::Get4Bytes(data2, len);
 	::Utils::Byte::Get8Bytes(data2, len);
-	::Utils::Byte::Set1Byte(data2, len, uint8_t{ 6u });
-	::Utils::Byte::Set2Bytes(data2, len, uint16_t{ 66u });
-	::Utils::Byte::Set3Bytes(data2, len, uint32_t{ 666u });
-	::Utils::Byte::Set4Bytes(data2, len, uint32_t{ 666u });
-	::Utils::Byte::Set8Bytes(data2, len, uint64_t{ 6666u });
+	::Utils::Byte::Set1Byte(data2, len, (uint8_t){ 6u });
+	::Utils::Byte::Set2Bytes(data2, len, (uint16_t){ 66u });
+	::Utils::Byte::Set3Bytes(data2, len, (uint32_t){ 666u });
+	::Utils::Byte::Set4Bytes(data2, len, (uint32_t){ 666u });
+	::Utils::Byte::Set8Bytes(data2, len, (uint64_t){ 6666u });
 	::Utils::Byte::PadTo4Bytes(static_cast<uint16_t>(len));
 	::Utils::Byte::PadTo4Bytes(static_cast<uint32_t>(len));
 

--- a/worker/include/RTC/RTCP/Feedback.hpp
+++ b/worker/include/RTC/RTCP/Feedback.hpp
@@ -35,19 +35,19 @@ namespace RTC
 			}
 			uint32_t GetSenderSsrc() const
 			{
-				return uint32_t{ ntohl(this->header->senderSsrc) };
+				return (uint32_t){ ntohl(this->header->senderSsrc) };
 			}
 			void SetSenderSsrc(uint32_t ssrc)
 			{
-				this->header->senderSsrc = uint32_t{ htonl(ssrc) };
+				this->header->senderSsrc = (uint32_t){ htonl(ssrc) };
 			}
 			uint32_t GetMediaSsrc() const
 			{
-				return uint32_t{ ntohl(this->header->mediaSsrc) };
+				return (uint32_t){ ntohl(this->header->mediaSsrc) };
 			}
 			void SetMediaSsrc(uint32_t ssrc)
 			{
-				this->header->mediaSsrc = uint32_t{ htonl(ssrc) };
+				this->header->mediaSsrc = (uint32_t){ htonl(ssrc) };
 			}
 
 			/* Pure virtual methods inherited from Packet. */

--- a/worker/include/RTC/RTCP/FeedbackPsFir.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsFir.hpp
@@ -49,7 +49,7 @@ namespace RTC
 
 			uint32_t GetSsrc() const
 			{
-				return uint32_t{ ntohl(this->header->ssrc) };
+				return (uint32_t){ ntohl(this->header->ssrc) };
 			}
 			uint8_t GetSequenceNumber() const
 			{

--- a/worker/include/RTC/RTCP/FeedbackPsLei.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsLei.hpp
@@ -40,7 +40,7 @@ namespace RTC
 
 			uint32_t GetSsrc() const
 			{
-				return uint32_t{ ntohl(this->header->ssrc) };
+				return (uint32_t){ ntohl(this->header->ssrc) };
 			}
 
 			/* Virtual methods inherited from FeedbackItem. */

--- a/worker/include/RTC/RTCP/FeedbackPsTst.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsTst.hpp
@@ -48,7 +48,7 @@ namespace RTC
 
 			uint32_t GetSsrc() const
 			{
-				return uint32_t{ ntohl(this->header->ssrc) };
+				return (uint32_t){ ntohl(this->header->ssrc) };
 			}
 			uint8_t GetSequenceNumber() const
 			{

--- a/worker/include/RTC/RTCP/FeedbackPsVbcm.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsVbcm.hpp
@@ -52,19 +52,19 @@ namespace RTC
 
 			uint32_t GetSsrc() const
 			{
-				return uint32_t{ ntohl(this->header->ssrc) };
+				return (uint32_t){ ntohl(this->header->ssrc) };
 			}
 			uint8_t GetSequenceNumber() const
 			{
-				return uint8_t{ this->header->sequenceNumber };
+				return (uint8_t){ this->header->sequenceNumber };
 			}
 			uint8_t GetPayloadType() const
 			{
-				return uint8_t{ this->header->payloadType };
+				return (uint8_t){ this->header->payloadType };
 			}
 			uint16_t GetLength() const
 			{
-				return uint16_t{ ntohs(this->header->length) };
+				return (uint16_t){ ntohs(this->header->length) };
 			}
 			uint8_t* GetValue() const
 			{

--- a/worker/include/RTC/RTCP/FeedbackRtpEcn.hpp
+++ b/worker/include/RTC/RTCP/FeedbackRtpEcn.hpp
@@ -55,31 +55,31 @@ namespace RTC
 
 			uint32_t GetSequenceNumber() const
 			{
-				return uint32_t{ ntohl(this->header->sequenceNumber) };
+				return (uint32_t){ ntohl(this->header->sequenceNumber) };
 			}
 			uint32_t GetEct0Counter() const
 			{
-				return uint32_t{ ntohl(this->header->ect0Counter) };
+				return (uint32_t){ ntohl(this->header->ect0Counter) };
 			}
 			uint32_t GetEct1Counter() const
 			{
-				return uint32_t{ ntohl(this->header->ect1Counter) };
+				return (uint32_t){ ntohl(this->header->ect1Counter) };
 			}
 			uint16_t GetEcnCeCounter() const
 			{
-				return uint16_t{ ntohs(this->header->ecnCeCounter) };
+				return (uint16_t){ ntohs(this->header->ecnCeCounter) };
 			}
 			uint16_t GetNotEctCounter() const
 			{
-				return uint16_t{ ntohs(this->header->notEctCounter) };
+				return (uint16_t){ ntohs(this->header->notEctCounter) };
 			}
 			uint16_t GetLostPackets() const
 			{
-				return uint16_t{ ntohs(this->header->lostPackets) };
+				return (uint16_t){ ntohs(this->header->lostPackets) };
 			}
 			uint16_t GetDuplicatedPackets() const
 			{
-				return uint16_t{ ntohs(this->header->duplicatedPackets) };
+				return (uint16_t){ ntohs(this->header->duplicatedPackets) };
 			}
 
 			/* Virtual methods inherited from FeedbackItem. */

--- a/worker/include/RTC/RTCP/FeedbackRtpNack.hpp
+++ b/worker/include/RTC/RTCP/FeedbackRtpNack.hpp
@@ -42,11 +42,11 @@ namespace RTC
 
 			uint16_t GetPacketId() const
 			{
-				return uint16_t{ ntohs(this->header->packetId) };
+				return (uint16_t){ ntohs(this->header->packetId) };
 			}
 			uint16_t GetLostPacketBitmask() const
 			{
-				return uint16_t{ ntohs(this->header->lostPacketBitmask) };
+				return (uint16_t){ ntohs(this->header->lostPacketBitmask) };
 			}
 			size_t CountRequestedPackets() const
 			{

--- a/worker/include/RTC/RTCP/FeedbackRtpTllei.hpp
+++ b/worker/include/RTC/RTCP/FeedbackRtpTllei.hpp
@@ -41,11 +41,11 @@ namespace RTC
 
 			uint16_t GetPacketId() const
 			{
-				return uint16_t{ ntohs(this->header->packetId) };
+				return (uint16_t){ ntohs(this->header->packetId) };
 			}
 			uint16_t GetLostPacketBitmask() const
 			{
-				return uint16_t{ ntohs(this->header->lostPacketBitmask) };
+				return (uint16_t){ ntohs(this->header->lostPacketBitmask) };
 			}
 
 			/* Virtual methods inherited from FeedbackItem. */

--- a/worker/include/RTC/RTCP/ReceiverReport.hpp
+++ b/worker/include/RTC/RTCP/ReceiverReport.hpp
@@ -50,15 +50,15 @@ namespace RTC
 			}
 			uint32_t GetSsrc() const
 			{
-				return uint32_t{ ntohl(this->header->ssrc) };
+				return (uint32_t){ ntohl(this->header->ssrc) };
 			}
 			void SetSsrc(uint32_t ssrc)
 			{
-				this->header->ssrc = uint32_t{ htonl(ssrc) };
+				this->header->ssrc = (uint32_t){ htonl(ssrc) };
 			}
 			uint8_t GetFractionLost() const
 			{
-				return uint8_t{ Utils::Byte::Get1Byte((uint8_t*)this->header, 4) };
+				return (uint8_t){ Utils::Byte::Get1Byte((uint8_t*)this->header, 4) };
 			}
 			void SetFractionLost(uint8_t fractionLost)
 			{
@@ -66,7 +66,7 @@ namespace RTC
 			}
 			int32_t GetTotalLost() const
 			{
-				auto value = uint32_t{ Utils::Byte::Get3Bytes((uint8_t*)this->header, 5) };
+				auto value = (uint32_t){ Utils::Byte::Get3Bytes((uint8_t*)this->header, 5) };
 
 				// Possitive value.
 				if (((value >> 23) & 1) == 0)
@@ -90,35 +90,35 @@ namespace RTC
 			}
 			uint32_t GetLastSeq() const
 			{
-				return uint32_t{ ntohl(this->header->lastSeq) };
+				return (uint32_t){ ntohl(this->header->lastSeq) };
 			}
 			void SetLastSeq(uint32_t lastSeq)
 			{
-				this->header->lastSeq = uint32_t{ htonl(lastSeq) };
+				this->header->lastSeq = (uint32_t){ htonl(lastSeq) };
 			}
 			uint32_t GetJitter() const
 			{
-				return uint32_t{ ntohl(this->header->jitter) };
+				return (uint32_t){ ntohl(this->header->jitter) };
 			}
 			void SetJitter(uint32_t jitter)
 			{
-				this->header->jitter = uint32_t{ htonl(jitter) };
+				this->header->jitter = (uint32_t){ htonl(jitter) };
 			}
 			uint32_t GetLastSenderReport() const
 			{
-				return uint32_t{ ntohl(this->header->lsr) };
+				return (uint32_t){ ntohl(this->header->lsr) };
 			}
 			void SetLastSenderReport(uint32_t lsr)
 			{
-				this->header->lsr = uint32_t{ htonl(lsr) };
+				this->header->lsr = (uint32_t){ htonl(lsr) };
 			}
 			uint32_t GetDelaySinceLastSenderReport() const
 			{
-				return uint32_t{ ntohl(this->header->dlsr) };
+				return (uint32_t){ ntohl(this->header->dlsr) };
 			}
 			void SetDelaySinceLastSenderReport(uint32_t dlsr)
 			{
-				this->header->dlsr = uint32_t{ htonl(dlsr) };
+				this->header->dlsr = (uint32_t){ htonl(dlsr) };
 			}
 
 		private:

--- a/worker/include/RTC/RTCP/SenderReport.hpp
+++ b/worker/include/RTC/RTCP/SenderReport.hpp
@@ -48,51 +48,51 @@ namespace RTC
 			}
 			uint32_t GetSsrc() const
 			{
-				return uint32_t{ ntohl(this->header->ssrc) };
+				return (uint32_t){ ntohl(this->header->ssrc) };
 			}
 			void SetSsrc(uint32_t ssrc)
 			{
-				this->header->ssrc = uint32_t{ htonl(ssrc) };
+				this->header->ssrc = (uint32_t){ htonl(ssrc) };
 			}
 			uint32_t GetNtpSec() const
 			{
-				return uint32_t{ ntohl(this->header->ntpSec) };
+				return (uint32_t){ ntohl(this->header->ntpSec) };
 			}
 			void SetNtpSec(uint32_t ntpSec)
 			{
-				this->header->ntpSec = uint32_t{ htonl(ntpSec) };
+				this->header->ntpSec = (uint32_t){ htonl(ntpSec) };
 			}
 			uint32_t GetNtpFrac() const
 			{
-				return uint32_t{ ntohl(this->header->ntpFrac) };
+				return (uint32_t){ ntohl(this->header->ntpFrac) };
 			}
 			void SetNtpFrac(uint32_t ntpFrac)
 			{
-				this->header->ntpFrac = uint32_t{ htonl(ntpFrac) };
+				this->header->ntpFrac = (uint32_t){ htonl(ntpFrac) };
 			}
 			uint32_t GetRtpTs() const
 			{
-				return uint32_t{ ntohl(this->header->rtpTs) };
+				return (uint32_t){ ntohl(this->header->rtpTs) };
 			}
 			void SetRtpTs(uint32_t rtpTs)
 			{
-				this->header->rtpTs = uint32_t{ htonl(rtpTs) };
+				this->header->rtpTs = (uint32_t){ htonl(rtpTs) };
 			}
 			uint32_t GetPacketCount() const
 			{
-				return uint32_t{ ntohl(this->header->packetCount) };
+				return (uint32_t){ ntohl(this->header->packetCount) };
 			}
 			void SetPacketCount(uint32_t packetCount)
 			{
-				this->header->packetCount = uint32_t{ htonl(packetCount) };
+				this->header->packetCount = (uint32_t){ htonl(packetCount) };
 			}
 			uint32_t GetOctetCount() const
 			{
-				return uint32_t{ ntohl(this->header->octetCount) };
+				return (uint32_t){ ntohl(this->header->octetCount) };
 			}
 			void SetOctetCount(uint32_t octetCount)
 			{
-				this->header->octetCount = uint32_t{ htonl(octetCount) };
+				this->header->octetCount = (uint32_t){ htonl(octetCount) };
 			}
 
 		private:

--- a/worker/include/RTC/RTCP/XrDelaySinceLastRr.hpp
+++ b/worker/include/RTC/RTCP/XrDelaySinceLastRr.hpp
@@ -65,27 +65,27 @@ namespace RTC
 				}
 				uint32_t GetSsrc() const
 				{
-					return uint32_t{ ntohl(this->body->ssrc) };
+					return (uint32_t){ ntohl(this->body->ssrc) };
 				}
 				void SetSsrc(uint32_t ssrc)
 				{
-					this->body->ssrc = uint32_t{ htonl(ssrc) };
+					this->body->ssrc = (uint32_t){ htonl(ssrc) };
 				}
 				uint32_t GetLastReceiverReport() const
 				{
-					return uint32_t{ ntohl(this->body->lrr) };
+					return (uint32_t){ ntohl(this->body->lrr) };
 				}
 				void SetLastReceiverReport(uint32_t lrr)
 				{
-					this->body->lrr = uint32_t{ htonl(lrr) };
+					this->body->lrr = (uint32_t){ htonl(lrr) };
 				}
 				uint32_t GetDelaySinceLastReceiverReport() const
 				{
-					return uint32_t{ ntohl(this->body->dlrr) };
+					return (uint32_t){ ntohl(this->body->dlrr) };
 				}
 				void SetDelaySinceLastReceiverReport(uint32_t dlrr)
 				{
-					this->body->dlrr = uint32_t{ htonl(dlrr) };
+					this->body->dlrr = (uint32_t){ htonl(dlrr) };
 				}
 
 			private:

--- a/worker/include/RTC/RTCP/XrReceiverReferenceTime.hpp
+++ b/worker/include/RTC/RTCP/XrReceiverReferenceTime.hpp
@@ -50,19 +50,19 @@ namespace RTC
 		public:
 			uint32_t GetNtpSec() const
 			{
-				return uint32_t{ ntohl(this->body->ntpSec) };
+				return (uint32_t){ ntohl(this->body->ntpSec) };
 			}
 			void SetNtpSec(uint32_t ntpSec)
 			{
-				this->body->ntpSec = uint32_t{ htonl(ntpSec) };
+				this->body->ntpSec = (uint32_t){ htonl(ntpSec) };
 			}
 			uint32_t GetNtpFrac() const
 			{
-				return uint32_t{ ntohl(this->body->ntpFrac) };
+				return (uint32_t){ ntohl(this->body->ntpFrac) };
 			}
 			void SetNtpFrac(uint32_t ntpFrac)
 			{
-				this->body->ntpFrac = uint32_t{ htonl(ntpFrac) };
+				this->body->ntpFrac = (uint32_t){ htonl(ntpFrac) };
 			}
 
 			/* Pure virtual methods inherited from ExtendedReportBlock. */

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -186,32 +186,32 @@ namespace RTC
 
 		uint16_t GetSequenceNumber() const
 		{
-			return uint16_t{ ntohs(this->header->sequenceNumber) };
+			return (uint16_t){ ntohs(this->header->sequenceNumber) };
 		}
 
 		void SetSequenceNumber(uint16_t seq)
 		{
-			this->header->sequenceNumber = uint16_t{ htons(seq) };
+			this->header->sequenceNumber = (uint16_t){ htons(seq) };
 		}
 
 		uint32_t GetTimestamp() const
 		{
-			return uint32_t{ ntohl(this->header->timestamp) };
+			return (uint32_t){ ntohl(this->header->timestamp) };
 		}
 
 		void SetTimestamp(uint32_t timestamp)
 		{
-			this->header->timestamp = uint32_t{ htonl(timestamp) };
+			this->header->timestamp = (uint32_t){ htonl(timestamp) };
 		}
 
 		uint32_t GetSsrc() const
 		{
-			return uint32_t{ ntohl(this->header->ssrc) };
+			return (uint32_t){ ntohl(this->header->ssrc) };
 		}
 
 		void SetSsrc(uint32_t ssrc)
 		{
-			this->header->ssrc = uint32_t{ htonl(ssrc) };
+			this->header->ssrc = (uint32_t){ htonl(ssrc) };
 		}
 
 		bool HasHeaderExtension() const
@@ -227,7 +227,7 @@ namespace RTC
 			if (!this->headerExtension)
 				return 0u;
 
-			return uint16_t{ ntohs(this->headerExtension->id) };
+			return (uint16_t){ ntohs(this->headerExtension->id) };
 		}
 
 		size_t GetHeaderExtensionLength() const

--- a/worker/include/RTC/SrtpSession.hpp
+++ b/worker/include/RTC/SrtpSession.hpp
@@ -42,7 +42,7 @@ namespace RTC
 		bool DecryptSrtcp(uint8_t* data, size_t* len);
 		void RemoveStream(uint32_t ssrc)
 		{
-			srtp_remove_stream(this->session, uint32_t{ htonl(ssrc) });
+			srtp_remove_stream(this->session, (uint32_t){ htonl(ssrc) });
 		}
 
 	private:

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -110,23 +110,23 @@ namespace Utils
 
 		static uint16_t Get2Bytes(const uint8_t* data, size_t i)
 		{
-			return uint16_t{ data[i + 1] } | uint16_t{ data[i] } << 8;
+			return (uint16_t){ data[i + 1] } | (uint16_t){ data[i] } << 8;
 		}
 
 		static uint32_t Get3Bytes(const uint8_t* data, size_t i)
 		{
-			return uint32_t{ data[i + 2] } | uint32_t{ data[i + 1] } << 8 | uint32_t{ data[i] } << 16;
+			return (uint32_t){ data[i + 2] } | (uint32_t){ data[i + 1] } << 8 | (uint32_t){ data[i] } << 16;
 		}
 
 		static uint32_t Get4Bytes(const uint8_t* data, size_t i)
 		{
-			return uint32_t{ data[i + 3] } | uint32_t{ data[i + 2] } << 8 |
-			       uint32_t{ data[i + 1] } << 16 | uint32_t{ data[i] } << 24;
+			return (uint32_t){ data[i + 3] } | (uint32_t){ data[i + 2] } << 8 |
+			       (uint32_t){ data[i + 1] } << 16 | (uint32_t){ data[i] } << 24;
 		}
 
 		static uint64_t Get8Bytes(const uint8_t* data, size_t i)
 		{
-			return uint64_t{ Byte::Get4Bytes(data, i) } << 32 | Byte::Get4Bytes(data, i + 4);
+			return (uint64_t){ Byte::Get4Bytes(data, i) } << 32 | Byte::Get4Bytes(data, i + 4);
 		}
 
 		static void Set1Byte(uint8_t* data, size_t i, uint8_t value)
@@ -208,7 +208,7 @@ namespace Utils
 			// return (((Crypto::seed>>16)&0x7FFF) % (max - min + 1)) + min;
 
 			// This seems to produce better results.
-			Crypto::seed = uint32_t{ ((214013 * Crypto::seed) + 2531011) };
+			Crypto::seed = (uint32_t){ ((214013 * Crypto::seed) + 2531011) };
 
 			// Special case.
 			if (max == 4294967295)

--- a/worker/src/RTC/RTCP/CompoundPacket.cpp
+++ b/worker/src/RTC/RTCP/CompoundPacket.cpp
@@ -60,7 +60,7 @@ namespace RTC
 					    (sizeof(ReceiverReport::Header) * this->receiverReportPacket.GetCount())) /
 					   4);
 
-					header->length = uint16_t{ htons(length) };
+					header->length = (uint16_t){ htons(length) };
 
 					// Fix header count field.
 					header->count = this->receiverReportPacket.GetCount();

--- a/worker/src/RTC/RTCP/Feedback.cpp
+++ b/worker/src/RTC/RTCP/Feedback.cpp
@@ -56,8 +56,8 @@ namespace RTC
 		{
 			this->raw                = new uint8_t[sizeof(Header)];
 			this->header             = reinterpret_cast<Header*>(this->raw);
-			this->header->senderSsrc = uint32_t{ htonl(senderSsrc) };
-			this->header->mediaSsrc  = uint32_t{ htonl(mediaSsrc) };
+			this->header->senderSsrc = (uint32_t){ htonl(senderSsrc) };
+			this->header->mediaSsrc  = (uint32_t){ htonl(mediaSsrc) };
 		}
 
 		template<typename T>

--- a/worker/src/RTC/RTCP/FeedbackPsFir.cpp
+++ b/worker/src/RTC/RTCP/FeedbackPsFir.cpp
@@ -24,7 +24,7 @@ namespace RTC
 			// Set reserved bits to zero.
 			std::memset(this->header, 0, sizeof(Header));
 
-			this->header->ssrc           = uint32_t{ htonl(ssrc) };
+			this->header->ssrc           = (uint32_t){ htonl(ssrc) };
 			this->header->sequenceNumber = sequenceNumber;
 		}
 

--- a/worker/src/RTC/RTCP/FeedbackPsLei.cpp
+++ b/worker/src/RTC/RTCP/FeedbackPsLei.cpp
@@ -16,7 +16,7 @@ namespace RTC
 
 			this->raw          = new uint8_t[sizeof(Header)];
 			this->header       = reinterpret_cast<Header*>(this->raw);
-			this->header->ssrc = uint32_t{ htonl(ssrc) };
+			this->header->ssrc = (uint32_t){ htonl(ssrc) };
 		}
 
 		size_t FeedbackPsLeiItem::Serialize(uint8_t* buffer)

--- a/worker/src/RTC/RTCP/FeedbackPsSli.cpp
+++ b/worker/src/RTC/RTCP/FeedbackPsSli.cpp
@@ -17,7 +17,7 @@ namespace RTC
 
 			this->header = header;
 
-			auto compact = uint32_t{ ntohl(header->compact) };
+			auto compact = (uint32_t){ ntohl(header->compact) };
 
 			this->first     = compact >> 19;           /* first 13 bits */
 			this->number    = (compact >> 6) & 0x1fff; /* next  13 bits */
@@ -29,7 +29,7 @@ namespace RTC
 			uint32_t compact = (this->first << 19) | (this->number << 6) | this->pictureId;
 			auto* header     = reinterpret_cast<Header*>(buffer);
 
-			header->compact = uint32_t{ htonl(compact) };
+			header->compact = (uint32_t){ htonl(compact) };
 			std::memcpy(buffer, header, sizeof(Header));
 
 			return sizeof(Header);

--- a/worker/src/RTC/RTCP/FeedbackPsTst.cpp
+++ b/worker/src/RTC/RTCP/FeedbackPsTst.cpp
@@ -20,7 +20,7 @@ namespace RTC
 			// Set reserved bits to zero.
 			std::memset(this->header, 0, sizeof(Header));
 
-			this->header->ssrc           = uint32_t{ htonl(ssrc) };
+			this->header->ssrc           = (uint32_t){ htonl(ssrc) };
 			this->header->sequenceNumber = sequenceNumber;
 			this->header->index          = index;
 		}

--- a/worker/src/RTC/RTCP/FeedbackPsVbcm.cpp
+++ b/worker/src/RTC/RTCP/FeedbackPsVbcm.cpp
@@ -16,11 +16,11 @@ namespace RTC
 			this->raw    = new uint8_t[8 + length];
 			this->header = reinterpret_cast<Header*>(this->raw);
 
-			this->header->ssrc           = uint32_t{ htonl(ssrc) };
+			this->header->ssrc           = (uint32_t){ htonl(ssrc) };
 			this->header->sequenceNumber = sequenceNumber;
 			this->header->zero           = 0;
 			this->header->payloadType    = payloadType;
-			this->header->length         = uint16_t{ htons(length) };
+			this->header->length         = (uint16_t){ htons(length) };
 			std::memcpy(this->header->value, value, sizeof(length));
 		}
 

--- a/worker/src/RTC/RTCP/FeedbackRtpNack.cpp
+++ b/worker/src/RTC/RTCP/FeedbackRtpNack.cpp
@@ -16,8 +16,8 @@ namespace RTC
 			this->raw    = new uint8_t[sizeof(Header)];
 			this->header = reinterpret_cast<Header*>(this->raw);
 
-			this->header->packetId          = uint16_t{ htons(packetId) };
-			this->header->lostPacketBitmask = uint16_t{ htons(lostPacketBitmask) };
+			this->header->packetId          = (uint16_t){ htons(packetId) };
+			this->header->lostPacketBitmask = (uint16_t){ htons(lostPacketBitmask) };
 		}
 
 		size_t FeedbackRtpNackItem::Serialize(uint8_t* buffer)

--- a/worker/src/RTC/RTCP/FeedbackRtpTllei.cpp
+++ b/worker/src/RTC/RTCP/FeedbackRtpTllei.cpp
@@ -15,8 +15,8 @@ namespace RTC
 			this->raw    = new uint8_t[sizeof(Header)];
 			this->header = reinterpret_cast<Header*>(this->raw);
 
-			this->header->packetId          = uint16_t{ htons(packetId) };
-			this->header->lostPacketBitmask = uint16_t{ htons(lostPacketBitmask) };
+			this->header->packetId          = (uint16_t){ htons(packetId) };
+			this->header->lostPacketBitmask = (uint16_t){ htons(lostPacketBitmask) };
 		}
 
 		size_t FeedbackRtpTlleiItem::Serialize(uint8_t* buffer)

--- a/worker/src/RTC/RTCP/Packet.cpp
+++ b/worker/src/RTC/RTCP/Packet.cpp
@@ -211,7 +211,7 @@ namespace RTC
 			this->header->padding    = 0;
 			this->header->count      = static_cast<uint8_t>(GetCount());
 			this->header->packetType = static_cast<uint8_t>(GetType());
-			this->header->length     = uint16_t{ htons(length) };
+			this->header->length     = (uint16_t){ htons(length) };
 
 			return sizeof(CommonHeader);
 		}

--- a/worker/src/RTC/RTCP/XrDelaySinceLastRr.cpp
+++ b/worker/src/RTC/RTCP/XrDelaySinceLastRr.cpp
@@ -99,7 +99,7 @@ namespace RTC
 			// Fill the common header.
 			this->header->blockType = static_cast<uint8_t>(this->type);
 			this->header->reserved  = 0;
-			this->header->length    = uint16_t{ htons(length) };
+			this->header->length    = (uint16_t){ htons(length) };
 
 			std::memcpy(buffer, this->header, sizeof(ExtendedReportBlock::CommonHeader));
 

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -399,9 +399,9 @@ namespace RTC
 		else if (this->headerExtension)
 		{
 			if (type == 1u)
-				this->headerExtension->id = uint16_t{ htons(0xBEDE) };
+				this->headerExtension->id = (uint16_t){ htons(0xBEDE) };
 			else if (type == 2u)
-				this->headerExtension->id = uint16_t{ htons(0b0001000000000000) };
+				this->headerExtension->id = (uint16_t){ htons(0b0001000000000000) };
 		}
 
 		// Calculate total size required for all extensions (with padding if needed).
@@ -473,9 +473,9 @@ namespace RTC
 
 			// Set the header extension id.
 			if (type == 1u)
-				this->headerExtension->id = uint16_t{ htons(0xBEDE) };
+				this->headerExtension->id = (uint16_t){ htons(0xBEDE) };
 			else if (type == 2u)
-				this->headerExtension->id = uint16_t{ htons(0b0001000000000000) };
+				this->headerExtension->id = (uint16_t){ htons(0b0001000000000000) };
 
 			// Set the header extension length.
 			this->headerExtension->length = htons(extensionsTotalSize / 4);

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -484,7 +484,7 @@ namespace RTC
 			// Express delay in units of 1/65536 seconds.
 			uint32_t dlsr = (delayMs / 1000) << 16;
 
-			dlsr |= uint32_t{ (delayMs % 1000) * 65536 / 1000 };
+			dlsr |= (uint32_t){ (delayMs % 1000) * 65536 / 1000 };
 
 			report->SetDelaySinceLastSenderReport(dlsr);
 			report->SetLastSenderReport(this->lastSrTimestamp);

--- a/worker/src/RTC/RtxStream.cpp
+++ b/worker/src/RTC/RtxStream.cpp
@@ -130,7 +130,7 @@ namespace RTC
 			// Express delay in units of 1/65536 seconds.
 			uint32_t dlsr = (delayMs / 1000) << 16;
 
-			dlsr |= uint32_t{ (delayMs % 1000) * 65536 / 1000 };
+			dlsr |= (uint32_t){ (delayMs % 1000) * 65536 / 1000 };
 
 			report->SetDelaySinceLastSenderReport(dlsr);
 			report->SetLastSenderReport(this->lastSrTimestamp);

--- a/worker/src/Utils/String.cpp
+++ b/worker/src/Utils/String.cpp
@@ -108,7 +108,7 @@ namespace Utils
 		{
 			dtable[Base64Table[i]] = static_cast<uint8_t>(i);
 		}
-		dtable[uint8_t{ '=' }] = 0;
+		dtable[(uint8_t){ '=' }] = 0;
 
 		count = 0;
 		for (i = 0; i < len; ++i)


### PR DESCRIPTION
I'm working on Meson build system for Mediasoup, including Windows CI (otherwise I'll have no idea if it works).

Windows CI on MinWG with GCC was failing like this: https://github.com/nazar-pc/mediasoup/runs/3148235269?check_suite_focus=true
```
In file included from ..\..\include/RTC/SctpAssociation.hpp:8,
                 from ..\..\include/DepUsrSCTP.hpp:5,
                 from ../../src/lib.cpp:9:
..\..\include/RTC/RTCP/ReceiverReport.hpp: In member function 'unsigned int RTC::RTCP::ReceiverReport::GetSsrc() const':
..\..\subprojects\usrsctp-1ade45cbadfd19298d2c47dc538962d4425ad2dd\usrsctplib/usrsctp.h:69:19: error: expected primary-expression before 'unsigned'
 #define uint32_t  unsigned __int32
                   ^~~~~~~~
..\..\subprojects\usrsctp-1ade45cbadfd19298d2c47dc538962d4425ad2dd\usrsctplib/usrsctp.h:69:19: note: in definition of macro 'uint32_t'
 #define uint32_t  unsigned __int32
                   ^~~~~~~~
```

Turns out GCC wasn't happy with the way macro was expanded in some cases, adding `()` around macro helped to fix those compiler errors.

UPD: It might be fixed in usrsctp if https://github.com/sctplab/usrsctp/pull/601 is accepted, converted to draft for now.
UPD2: It breaks MSVC :disappointed: 