### PR TITLE
Fix minor memory leak caused by non-virtual destructor in libwebrtc

### DIFF
--- a/worker/deps/libwebrtc/libwebrtc/modules/pacing/paced_sender.h
+++ b/worker/deps/libwebrtc/libwebrtc/modules/pacing/paced_sender.h
@@ -44,7 +44,7 @@ class PacedSender {
   PacedSender(PacketRouter* packet_router,
               const WebRtcKeyValueConfig* field_trials = nullptr);
 
-  ~PacedSender() = default;
+  virtual ~PacedSender() = default;
 
   virtual void CreateProbeCluster(int bitrate_bps, int cluster_id);
 

--- a/worker/deps/libwebrtc/libwebrtc/modules/pacing/packet_router.h
+++ b/worker/deps/libwebrtc/libwebrtc/modules/pacing/packet_router.h
@@ -29,7 +29,7 @@ namespace webrtc {
 class PacketRouter {
  public:
   PacketRouter() = default;
-  ~PacketRouter() = default;
+  virtual ~PacketRouter() = default;
 
   virtual void SendPacket(RTC::RtpPacket* packet,
                           const PacedPacketInfo& cluster_info) = 0;


### PR DESCRIPTION
With minor warning level following warnings were reported by GCC:
```
[80/181] Compiling C++ object mediasoup-worker.p/src_Worker.cpp.o
In file included from ../../deps/libwebrtc/libwebrtc/call/rtp_transport_controller_send.h:22,
                 from ../../include/RTC/TransportCongestionControlClient.hpp:14,
                 from ../../include/RTC/Transport.hpp:26,
                 from ../../include/RTC/Router.hpp:15,
                 from ../../include/Worker.hpp:10,
                 from ../../src/Worker.cpp:4:
../../deps/libwebrtc/libwebrtc/modules/pacing/packet_router.h:29:7: warning: ‘class webrtc::PacketRouter’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
   29 | class PacketRouter {
      |       ^~~~~~~~~~~~
In file included from ../../deps/libwebrtc/libwebrtc/call/rtp_transport_controller_send.h:23,
                 from ../../include/RTC/TransportCongestionControlClient.hpp:14,
                 from ../../include/RTC/Transport.hpp:26,
                 from ../../include/RTC/Router.hpp:15,
                 from ../../include/Worker.hpp:10,
                 from ../../src/Worker.cpp:4:
../../deps/libwebrtc/libwebrtc/modules/pacing/paced_sender.h:33:7: warning: ‘class webrtc::PacedSender’ has virtual functions and accessible non-virtual destructor [-Wnon-virtual-dtor]
   33 | class PacedSender {
      |       ^~~~~~~~~~~
In file included from ../../include/RTC/Transport.hpp:26,
                 from ../../include/RTC/Router.hpp:15,
                 from ../../include/Worker.hpp:10,
                 from ../../src/Worker.cpp:4:
../../include/RTC/TransportCongestionControlClient.hpp:19:8: warning: base class ‘class webrtc::PacketRouter’ has accessible non-virtual destructor [-Wnon-virtual-dtor]
   19 |  class TransportCongestionControlClient : public webrtc::PacketRouter,
      |        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Considering that libwebrtc is unlikely to be updated before it gets removed, we can patch those destructors to get rid of warnings.

As a sanity check I ran Rust tests under valgrind and  found that it deterministically decreased observed reachable memory by a little bit:
<details>

Before:
```
==1384689== LEAK SUMMARY:
==1384689==    definitely lost: 2,184 bytes in 91 blocks
==1384689==    indirectly lost: 13,104 bytes in 273 blocks
==1384689==      possibly lost: 456 bytes in 5 blocks
==1384689==    still reachable: 155,399 bytes in 75 blocks
==1384689==         suppressed: 0 bytes in 0 blocks
==1384689== Reachable blocks (those to which a pointer was found) are not shown.
```

After:
```
==1395585== LEAK SUMMARY:
==1395585==    definitely lost: 2,184 bytes in 91 blocks
==1395585==    indirectly lost: 13,104 bytes in 273 blocks
==1395585==      possibly lost: 456 bytes in 5 blocks
==1395585==    still reachable: 154,343 bytes in 73 blocks
==1395585==         suppressed: 0 bytes in 0 blocks
```

</details>