### PR TITLE
Do not railse consumer score event when consumer is paused.

### DIFF
--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -557,6 +557,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		if (IsPaused())
+			return;
+
 		json data = json::object();
 
 		FillJsonScore(data);

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -1409,6 +1409,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		if (IsPaused())
+			return;
+
 		json data = json::object();
 
 		FillJsonScore(data);

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -1040,6 +1040,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		if (IsPaused())
+			return;
+
 		json data = json::object();
 
 		FillJsonScore(data);


### PR DESCRIPTION
Is it possible to consider changing behavior of consumers not to fire score event, when consumer is paused? Currently I see score updated event when create new consumer in paused state.