### PR TITLE
Erase the dominantId after removal from the map.

### DIFF
--- a/worker/src/RTC/ActiveSpeakerObserver.cpp
+++ b/worker/src/RTC/ActiveSpeakerObserver.cpp
@@ -149,6 +149,7 @@ namespace RTC
 		if (it->second.speaker != nullptr)
 		{
 			delete it->second.speaker;
+			it->second.speaker = nullptr;
 		}
 
 		this->mapProducerSpeaker.erase(producer->id);

--- a/worker/src/RTC/ActiveSpeakerObserver.cpp
+++ b/worker/src/RTC/ActiveSpeakerObserver.cpp
@@ -155,6 +155,7 @@ namespace RTC
 
 		if (producer->id == this->dominantId)
 		{
+			this->dominantId.erase();
 			Update();
 		}
 	}


### PR DESCRIPTION
This fixes a bug where by ActiveSpeakerObserver::CalculateActiveSpeaker()
may cause a crash due to a nullptr. While there is a check after getting
the dominantSpeaker from the map we have notice it will pass the check,
and then crash in EvalActivityScores.