### PR TITLE
Fix wrong size_t* to int* conversion in 64bit Big-Endian hosts

### DIFF
--- a/worker/include/RTC/SrtpSession.hpp
+++ b/worker/include/RTC/SrtpSession.hpp
@@ -36,10 +36,10 @@ namespace RTC
 		~SrtpSession();
 
 	public:
-		bool EncryptRtp(const uint8_t** data, size_t* len);
-		bool DecryptSrtp(uint8_t* data, size_t* len);
-		bool EncryptRtcp(const uint8_t** data, size_t* len);
-		bool DecryptSrtcp(uint8_t* data, size_t* len);
+		bool EncryptRtp(const uint8_t** data, int* len);
+		bool DecryptSrtp(uint8_t* data, int* len);
+		bool EncryptRtcp(const uint8_t** data, int* len);
+		bool DecryptSrtcp(uint8_t* data, int* len);
 		void RemoveStream(uint32_t ssrc)
 		{
 			srtp_remove_stream(this->session, uint32_t{ htonl(ssrc) });

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -449,9 +449,9 @@ namespace RTC
 		}
 
 		const uint8_t* data = packet->GetData();
-		size_t len          = packet->GetSize();
+		auto intLen         = static_cast<int>(packet->GetSize());
 
-		if (HasSrtp() && !this->srtpSendSession->EncryptRtp(&data, &len))
+		if (HasSrtp() && !this->srtpSendSession->EncryptRtp(&data, &intLen))
 		{
 			if (cb)
 			{
@@ -461,6 +461,8 @@ namespace RTC
 
 			return;
 		}
+
+		auto len = static_cast<size_t>(intLen);
 
 		this->tuple->Send(data, len, cb);
 
@@ -476,10 +478,12 @@ namespace RTC
 			return;
 
 		const uint8_t* data = packet->GetData();
-		size_t len          = packet->GetSize();
+		auto intLen         = static_cast<int>(packet->GetSize());
 
-		if (HasSrtp() && !this->srtpSendSession->EncryptRtcp(&data, &len))
+		if (HasSrtp() && !this->srtpSendSession->EncryptRtcp(&data, &intLen))
 			return;
+
+		auto len = static_cast<size_t>(intLen);
 
 		this->tuple->Send(data, len);
 
@@ -495,10 +499,12 @@ namespace RTC
 			return;
 
 		const uint8_t* data = packet->GetData();
-		size_t len          = packet->GetSize();
+		auto intLen         = static_cast<int>(packet->GetSize());
 
-		if (HasSrtp() && !this->srtpSendSession->EncryptRtcp(&data, &len))
+		if (HasSrtp() && !this->srtpSendSession->EncryptRtcp(&data, &intLen))
 			return;
+
+		auto len = static_cast<size_t>(intLen);
 
 		this->tuple->Send(data, len);
 
@@ -583,9 +589,11 @@ namespace RTC
 			return;
 
 		// Decrypt the SRTP packet.
-		if (HasSrtp() && !this->srtpRecvSession->DecryptSrtp(const_cast<uint8_t*>(data), &len))
+		auto intLen = static_cast<int>(len);
+
+		if (HasSrtp() && !this->srtpRecvSession->DecryptSrtp(const_cast<uint8_t*>(data), &intLen))
 		{
-			RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, len);
+			RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
 
 			if (!packet)
 			{
@@ -606,7 +614,7 @@ namespace RTC
 			return;
 		}
 
-		RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, len);
+		RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
 
 		if (!packet)
 		{
@@ -641,7 +649,9 @@ namespace RTC
 			return;
 
 		// Decrypt the SRTCP packet.
-		if (HasSrtp() && !this->srtpRecvSession->DecryptSrtcp(const_cast<uint8_t*>(data), &len))
+		auto intLen = static_cast<int>(len);
+
+		if (HasSrtp() && !this->srtpRecvSession->DecryptSrtcp(const_cast<uint8_t*>(data), &intLen))
 		{
 			return;
 		}
@@ -654,7 +664,7 @@ namespace RTC
 			return;
 		}
 
-		RTC::RTCP::Packet* packet = RTC::RTCP::Packet::Parse(data, len);
+		RTC::RTCP::Packet* packet = RTC::RTCP::Packet::Parse(data, static_cast<size_t>(intLen));
 
 		if (!packet)
 		{

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -634,9 +634,9 @@ namespace RTC
 		}
 
 		const uint8_t* data = packet->GetData();
-		size_t len          = packet->GetSize();
+		auto intLen         = static_cast<int>(packet->GetSize());
 
-		if (HasSrtp() && !this->srtpSendSession->EncryptRtp(&data, &len))
+		if (HasSrtp() && !this->srtpSendSession->EncryptRtp(&data, &intLen))
 		{
 			if (cb)
 			{
@@ -646,6 +646,8 @@ namespace RTC
 
 			return;
 		}
+
+		auto len = static_cast<size_t>(intLen);
 
 		this->tuple->Send(data, len, cb);
 
@@ -661,10 +663,12 @@ namespace RTC
 			return;
 
 		const uint8_t* data = packet->GetData();
-		size_t len          = packet->GetSize();
+		auto intLen         = static_cast<int>(packet->GetSize());
 
-		if (HasSrtp() && !this->srtpSendSession->EncryptRtcp(&data, &len))
+		if (HasSrtp() && !this->srtpSendSession->EncryptRtcp(&data, &intLen))
 			return;
+
+		auto len = static_cast<size_t>(intLen);
 
 		if (this->rtcpMux)
 			this->tuple->Send(data, len);
@@ -683,10 +687,12 @@ namespace RTC
 			return;
 
 		const uint8_t* data = packet->GetData();
-		size_t len          = packet->GetSize();
+		auto intLen         = static_cast<int>(packet->GetSize());
 
-		if (HasSrtp() && !this->srtpSendSession->EncryptRtcp(&data, &len))
+		if (HasSrtp() && !this->srtpSendSession->EncryptRtcp(&data, &intLen))
 			return;
+
+		auto len = static_cast<size_t>(intLen);
 
 		if (this->rtcpMux)
 			this->tuple->Send(data, len);
@@ -775,9 +781,11 @@ namespace RTC
 			return;
 
 		// Decrypt the SRTP packet.
-		if (HasSrtp() && !this->srtpRecvSession->DecryptSrtp(const_cast<uint8_t*>(data), &len))
+		auto intLen = static_cast<int>(len);
+
+		if (HasSrtp() && !this->srtpRecvSession->DecryptSrtp(const_cast<uint8_t*>(data), &intLen))
 		{
-			RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, len);
+			RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
 
 			if (!packet)
 			{
@@ -798,7 +806,7 @@ namespace RTC
 			return;
 		}
 
-		RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, len);
+		RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
 
 		if (!packet)
 		{
@@ -871,7 +879,9 @@ namespace RTC
 			return;
 
 		// Decrypt the SRTCP packet.
-		if (HasSrtp() && !this->srtpRecvSession->DecryptSrtcp(const_cast<uint8_t*>(data), &len))
+		auto intLen = static_cast<int>(len);
+
+		if (HasSrtp() && !this->srtpRecvSession->DecryptSrtcp(const_cast<uint8_t*>(data), &intLen))
 		{
 			return;
 		}
@@ -949,7 +959,7 @@ namespace RTC
 			return;
 		}
 
-		RTC::RTCP::Packet* packet = RTC::RTCP::Packet::Parse(data, len);
+		RTC::RTCP::Packet* packet = RTC::RTCP::Packet::Parse(data, static_cast<size_t>(intLen));
 
 		if (!packet)
 		{

--- a/worker/src/RTC/SrtpSession.cpp
+++ b/worker/src/RTC/SrtpSession.cpp
@@ -146,22 +146,21 @@ namespace RTC
 		}
 	}
 
-	bool SrtpSession::EncryptRtp(const uint8_t** data, size_t* len)
+	bool SrtpSession::EncryptRtp(const uint8_t** data, int* len)
 	{
 		MS_TRACE();
 
 		// Ensure that the resulting SRTP packet fits into the encrypt buffer.
-		if (*len + SRTP_MAX_TRAILER_LEN > EncryptBufferSize)
+		if (static_cast<size_t>(*len) + SRTP_MAX_TRAILER_LEN > EncryptBufferSize)
 		{
-			MS_WARN_TAG(srtp, "cannot encrypt RTP packet, size too big (%zu bytes)", *len);
+			MS_WARN_TAG(srtp, "cannot encrypt RTP packet, size too big (%i bytes)", *len);
 
 			return false;
 		}
 
 		std::memcpy(EncryptBuffer, *data, *len);
 
-		srtp_err_status_t err =
-		  srtp_protect(this->session, static_cast<void*>(EncryptBuffer), reinterpret_cast<int*>(len));
+		srtp_err_status_t err = srtp_protect(this->session, static_cast<void*>(EncryptBuffer), len);
 
 		if (DepLibSRTP::IsError(err))
 		{
@@ -176,12 +175,11 @@ namespace RTC
 		return true;
 	}
 
-	bool SrtpSession::DecryptSrtp(uint8_t* data, size_t* len)
+	bool SrtpSession::DecryptSrtp(uint8_t* data, int* len)
 	{
 		MS_TRACE();
 
-		srtp_err_status_t err =
-		  srtp_unprotect(this->session, static_cast<void*>(data), reinterpret_cast<int*>(len));
+		srtp_err_status_t err = srtp_unprotect(this->session, static_cast<void*>(data), len);
 
 		if (DepLibSRTP::IsError(err))
 		{
@@ -193,22 +191,21 @@ namespace RTC
 		return true;
 	}
 
-	bool SrtpSession::EncryptRtcp(const uint8_t** data, size_t* len)
+	bool SrtpSession::EncryptRtcp(const uint8_t** data, int* len)
 	{
 		MS_TRACE();
 
 		// Ensure that the resulting SRTCP packet fits into the encrypt buffer.
-		if (*len + SRTP_MAX_TRAILER_LEN > EncryptBufferSize)
+		if (static_cast<size_t>(*len) + SRTP_MAX_TRAILER_LEN > EncryptBufferSize)
 		{
-			MS_WARN_TAG(srtp, "cannot encrypt RTCP packet, size too big (%zu bytes)", *len);
+			MS_WARN_TAG(srtp, "cannot encrypt RTCP packet, size too big (%i bytes)", *len);
 
 			return false;
 		}
 
 		std::memcpy(EncryptBuffer, *data, *len);
 
-		srtp_err_status_t err = srtp_protect_rtcp(
-		  this->session, static_cast<void*>(EncryptBuffer), reinterpret_cast<int*>(len));
+		srtp_err_status_t err = srtp_protect_rtcp(this->session, static_cast<void*>(EncryptBuffer), len);
 
 		if (DepLibSRTP::IsError(err))
 		{
@@ -223,12 +220,11 @@ namespace RTC
 		return true;
 	}
 
-	bool SrtpSession::DecryptSrtcp(uint8_t* data, size_t* len)
+	bool SrtpSession::DecryptSrtcp(uint8_t* data, int* len)
 	{
 		MS_TRACE();
 
-		srtp_err_status_t err =
-		  srtp_unprotect_rtcp(this->session, static_cast<void*>(data), reinterpret_cast<int*>(len));
+		srtp_err_status_t err = srtp_unprotect_rtcp(this->session, static_cast<void*>(data), len);
 
 		if (DepLibSRTP::IsError(err))
 		{

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -751,9 +751,9 @@ namespace RTC
 		}
 
 		const uint8_t* data = packet->GetData();
-		size_t len          = packet->GetSize();
+		auto intLen         = static_cast<int>(packet->GetSize());
 
-		if (!this->srtpSendSession->EncryptRtp(&data, &len))
+		if (!this->srtpSendSession->EncryptRtp(&data, &intLen))
 		{
 			if (cb)
 			{
@@ -763,6 +763,8 @@ namespace RTC
 
 			return;
 		}
+
+		auto len = static_cast<size_t>(intLen);
 
 		this->iceServer->GetSelectedTuple()->Send(data, len, cb);
 
@@ -778,7 +780,7 @@ namespace RTC
 			return;
 
 		const uint8_t* data = packet->GetData();
-		size_t len          = packet->GetSize();
+		auto intLen         = static_cast<int>(packet->GetSize());
 
 		// Ensure there is sending SRTP session.
 		if (!this->srtpSendSession)
@@ -788,8 +790,10 @@ namespace RTC
 			return;
 		}
 
-		if (!this->srtpSendSession->EncryptRtcp(&data, &len))
+		if (!this->srtpSendSession->EncryptRtcp(&data, &intLen))
 			return;
+
+		auto len = static_cast<size_t>(intLen);
 
 		this->iceServer->GetSelectedTuple()->Send(data, len);
 
@@ -805,7 +809,7 @@ namespace RTC
 			return;
 
 		const uint8_t* data = packet->GetData();
-		size_t len          = packet->GetSize();
+		auto intLen         = static_cast<int>(packet->GetSize());
 
 		// Ensure there is sending SRTP session.
 		if (!this->srtpSendSession)
@@ -815,8 +819,10 @@ namespace RTC
 			return;
 		}
 
-		if (!this->srtpSendSession->EncryptRtcp(&data, &len))
+		if (!this->srtpSendSession->EncryptRtcp(&data, &intLen))
 			return;
+
+		auto len = static_cast<size_t>(intLen);
 
 		this->iceServer->GetSelectedTuple()->Send(data, len);
 
@@ -984,9 +990,11 @@ namespace RTC
 		}
 
 		// Decrypt the SRTP packet.
-		if (!this->srtpRecvSession->DecryptSrtp(const_cast<uint8_t*>(data), &len))
+		auto intLen = static_cast<int>(len);
+
+		if (!this->srtpRecvSession->DecryptSrtp(const_cast<uint8_t*>(data), &intLen))
 		{
-			RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, len);
+			RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
 
 			if (!packet)
 			{
@@ -1007,7 +1015,7 @@ namespace RTC
 			return;
 		}
 
-		RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, len);
+		RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, static_cast<size_t>(intLen));
 
 		if (!packet)
 		{
@@ -1053,10 +1061,12 @@ namespace RTC
 		}
 
 		// Decrypt the SRTCP packet.
-		if (!this->srtpRecvSession->DecryptSrtcp(const_cast<uint8_t*>(data), &len))
+		auto intLen = static_cast<int>(len);
+
+		if (!this->srtpRecvSession->DecryptSrtcp(const_cast<uint8_t*>(data), &intLen))
 			return;
 
-		RTC::RTCP::Packet* packet = RTC::RTCP::Packet::Parse(data, len);
+		RTC::RTCP::Packet* packet = RTC::RTCP::Packet::Parse(data, static_cast<size_t>(intLen));
 
 		if (!packet)
 		{


### PR DESCRIPTION
- Fixes #636
- Ensure that we have RTP or RTCP packet length into a `int` variable since `srtp_(un)protect_xxxx()` methods expect a pointer to `int` and modify the length referenced by the given pointer.