### PR TITLE
Emit the dominant speaker event at every interval.

### DIFF
--- a/src/Router.ts
+++ b/src/Router.ts
@@ -930,7 +930,7 @@ export class Router extends EnhancedEventEmitter
 	 */
 	async createActiveSpeakerObserver(
 		{
-			interval = 300,
+			interval = 1000,
 			appData = {}
 		}: ActiveSpeakerObserverOptions = {}
 	): Promise<ActiveSpeakerObserver>

--- a/worker/include/RTC/ActiveSpeakerObserver.hpp
+++ b/worker/include/RTC/ActiveSpeakerObserver.hpp
@@ -87,7 +87,7 @@ namespace RTC
 		double relativeSpeachActivities[relativeSpeachActivitiesLen];
 		std::string dominantId{ "" };
 		Timer* periodicTimer{ nullptr };
-		uint16_t interval{ 300u };
+		uint16_t interval{ 1000u };
 		std::unordered_map<std::string, struct ProducerSpeaker> mapProducerSpeaker;
 		uint64_t lastLevelIdleTime{ 0 };
 	};

--- a/worker/src/RTC/ActiveSpeakerObserver.cpp
+++ b/worker/src/RTC/ActiveSpeakerObserver.cpp
@@ -250,7 +250,9 @@ namespace RTC
 			this->lastLevelIdleTime = now;
 		}
 
-		if (!this->mapProducerSpeaker.empty() && CalculateActiveSpeaker())
+		CalculateActiveSpeaker();
+
+		if (!this->mapProducerSpeaker.empty())
 		{
 			json data          = json::object();
 			data["producerId"] = this->dominantId;


### PR DESCRIPTION
The dominant speaker event will now be emitted on each 'interval'. The reasoning for doing this is if you have a producer that is already the dominant speaker and a consumer joins, that consumer will not know who in the "room" is the dominant speaker. This solves the issue for client side applications without having to resort to storing the current dominant speaker in the server application code.