### PR TITLE
Add packetLoss stats to transport

### DIFF
--- a/rust/src/router/direct_transport.rs
+++ b/rust/src/router/direct_transport.rs
@@ -105,6 +105,10 @@ pub struct DirectTransportStat {
     pub available_incoming_bitrate: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_incoming_bitrate: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtp_packet_loss_received: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtp_packet_loss_sent: Option<f64>,
 }
 
 #[derive(Default)]

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -140,6 +140,10 @@ pub struct PipeTransportStat {
     pub available_incoming_bitrate: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_incoming_bitrate: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtp_packet_loss_received: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtp_packet_loss_sent: Option<f64>,
     // PipeTransport specific.
     pub tuple: Option<TransportTuple>,
 }

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -158,6 +158,10 @@ pub struct PlainTransportStat {
     pub available_incoming_bitrate: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_incoming_bitrate: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtp_packet_loss_received: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtp_packet_loss_sent: Option<f64>,
     // PlainTransport specific.
     pub rtcp_mux: bool,
     pub comedia: bool,

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -209,6 +209,10 @@ pub struct WebRtcTransportStat {
     pub available_incoming_bitrate: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_incoming_bitrate: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtp_packet_loss_received: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rtp_packet_loss_sent: Option<f64>,
     // WebRtcTransport specific.
     pub ice_role: IceRole,
     pub ice_state: IceState,

--- a/rust/tests/integration/direct_transport.rs
+++ b/rust/tests/integration/direct_transport.rs
@@ -150,6 +150,8 @@ fn get_stats_succeeds() {
         assert_eq!(stats[0].rtx_send_bitrate, 0);
         assert_eq!(stats[0].probation_bytes_sent, 0);
         assert_eq!(stats[0].probation_send_bitrate, 0);
+        assert_eq!(stats[0].rtp_packet_loss_received, None);
+        assert_eq!(stats[0].rtp_packet_loss_sent, None);
     });
 }
 

--- a/rust/tests/integration/plain_transport.rs
+++ b/rust/tests/integration/plain_transport.rs
@@ -411,6 +411,8 @@ fn get_stats_succeeds() {
         assert_eq!(stats[0].rtx_send_bitrate, 0);
         assert_eq!(stats[0].probation_bytes_sent, 0);
         assert_eq!(stats[0].probation_send_bitrate, 0);
+        assert_eq!(stats[0].rtp_packet_loss_received, None);
+        assert_eq!(stats[0].rtp_packet_loss_sent, None);
         assert!(matches!(
             stats[0].tuple,
             Some(TransportTuple::LocalOnly { .. }),

--- a/rust/tests/integration/webrtc_transport.rs
+++ b/rust/tests/integration/webrtc_transport.rs
@@ -360,6 +360,8 @@ fn get_stats_succeeds() {
         assert_eq!(stats[0].probation_send_bitrate, 0);
         assert_eq!(stats[0].ice_selected_tuple, None);
         assert_eq!(stats[0].max_incoming_bitrate, None);
+        assert_eq!(stats[0].rtp_packet_loss_received, None);
+        assert_eq!(stats[0].rtp_packet_loss_sent, None);
     });
 }
 

--- a/worker/include/RTC/TransportCongestionControlClient.hpp
+++ b/worker/include/RTC/TransportCongestionControlClient.hpp
@@ -76,10 +76,12 @@ namespace RTC
 			return this->bitrates;
 		}
 		uint32_t GetAvailableBitrate() const;
+		double GetPacketLoss() const;
 		void RescheduleNextAvailableBitrateEvent();
 
 	private:
 		void MayEmitAvailableBitrateEvent(uint32_t previousAvailableBitrate);
+		void UpdatePacketLoss(double packetLoss);
 
 		// jmillan: missing.
 		// void OnRemoteNetworkEstimate(NetworkStateEstimate estimate) override;
@@ -113,6 +115,8 @@ namespace RTC
 		bool availableBitrateEventCalled{ false };
 		uint64_t lastAvailableBitrateEventAtMs{ 0u };
 		RTC::TrendCalculator desiredBitrateTrend;
+		std::vector<double> packetLossHistory;
+		double packetLoss{ 0 };
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/TransportCongestionControlClient.hpp
+++ b/worker/include/RTC/TransportCongestionControlClient.hpp
@@ -9,6 +9,7 @@
 #include "RTC/RtpProbationGenerator.hpp"
 #include "RTC/TrendCalculator.hpp"
 #include "handles/Timer.hpp"
+#include <deque>
 #include <libwebrtc/api/transport/goog_cc_factory.h>
 #include <libwebrtc/api/transport/network_types.h>
 #include <libwebrtc/call/rtp_transport_controller_send.h>
@@ -115,7 +116,7 @@ namespace RTC
 		bool availableBitrateEventCalled{ false };
 		uint64_t lastAvailableBitrateEventAtMs{ 0u };
 		RTC::TrendCalculator desiredBitrateTrend;
-		std::vector<double> packetLossHistory;
+		std::deque<double> packetLossHistory;
 		double packetLoss{ 0 };
 	};
 } // namespace RTC

--- a/worker/include/RTC/TransportCongestionControlClient.hpp
+++ b/worker/include/RTC/TransportCongestionControlClient.hpp
@@ -9,11 +9,11 @@
 #include "RTC/RtpProbationGenerator.hpp"
 #include "RTC/TrendCalculator.hpp"
 #include "handles/Timer.hpp"
-#include <deque>
 #include <libwebrtc/api/transport/goog_cc_factory.h>
 #include <libwebrtc/api/transport/network_types.h>
 #include <libwebrtc/call/rtp_transport_controller_send.h>
 #include <libwebrtc/modules/pacing/packet_router.h>
+#include <deque>
 
 namespace RTC
 {

--- a/worker/include/RTC/TransportCongestionControlServer.hpp
+++ b/worker/include/RTC/TransportCongestionControlServer.hpp
@@ -50,12 +50,14 @@ namespace RTC
 					return 0u;
 			}
 		}
+		double GetPacketLoss() const;
 		void IncomingPacket(uint64_t nowMs, const RTC::RtpPacket* packet);
 		void SetMaxIncomingBitrate(uint32_t bitrate);
 
 	private:
 		void SendTransportCcFeedback();
 		void MaySendLimitationRembFeedback();
+		void UpdatePacketLoss(double packetLoss);
 
 		/* Pure virtual methods inherited from webrtc::RemoteBitrateEstimator::Listener. */
 	public:
@@ -84,6 +86,8 @@ namespace RTC
 		uint32_t maxIncomingBitrate{ 0u };
 		uint64_t limitationRembSentAtMs{ 0u };
 		uint8_t unlimitedRembCounter{ 0u };
+		std::vector<double> packetLossHistory;
+		double packetLoss{ 0 };
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/TransportCongestionControlServer.hpp
+++ b/worker/include/RTC/TransportCongestionControlServer.hpp
@@ -7,8 +7,8 @@
 #include "RTC/RTCP/Packet.hpp"
 #include "RTC/RtpPacket.hpp"
 #include "handles/Timer.hpp"
-#include <deque>
 #include <libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.h>
+#include <deque>
 
 namespace RTC
 {

--- a/worker/include/RTC/TransportCongestionControlServer.hpp
+++ b/worker/include/RTC/TransportCongestionControlServer.hpp
@@ -7,6 +7,7 @@
 #include "RTC/RTCP/Packet.hpp"
 #include "RTC/RtpPacket.hpp"
 #include "handles/Timer.hpp"
+#include <deque>
 #include <libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.h>
 
 namespace RTC
@@ -86,7 +87,7 @@ namespace RTC
 		uint32_t maxIncomingBitrate{ 0u };
 		uint64_t limitationRembSentAtMs{ 0u };
 		uint8_t unlimitedRembCounter{ 0u };
-		std::vector<double> packetLossHistory;
+		std::deque<double> packetLossHistory;
 		double packetLoss{ 0 };
 	};
 } // namespace RTC

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -552,6 +552,14 @@ namespace RTC
 		// Add maxIncomingBitrate.
 		if (this->maxIncomingBitrate != 0u)
 			jsonObject["maxIncomingBitrate"] = this->maxIncomingBitrate;
+
+		// Add packetLossReceived.
+		if (this->tccServer)
+			jsonObject["rtpPacketLossReceived"] = this->tccServer->GetPacketLoss();
+
+		// Add packetLossSent.
+		if (this->tccClient)
+			jsonObject["rtpPacketLossSent"] = this->tccClient->GetPacketLoss();
 	}
 
 	void Transport::HandleRequest(Channel::ChannelRequest* request)

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -164,7 +164,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// Update packet loss history
+		// Update packet loss history.
 		size_t expected_packets = feedback->GetPacketStatusCount();
 		size_t lost_packets     = 0;
 		for (const auto& result : feedback->GetPacketResults())

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -1,5 +1,5 @@
 #define MS_CLASS "RTC::TransportCongestionControlClient"
-// #define MS_LOG_DEV_LEVEL 3
+#define MS_LOG_DEV_LEVEL 3
 
 #include "RTC/TransportCongestionControlClient.hpp"
 #include "DepLibUV.hpp"
@@ -16,6 +16,7 @@ namespace RTC
 	static constexpr float MaxBitrateIncrementFactor{ 1.35f };
 	static constexpr float MaxPaddingBitrateFactor{ 0.85f };
 	static constexpr uint64_t AvailableBitrateEventInterval{ 2000u }; // In ms.
+	static constexpr size_t PacketLossHistogramLength{ 24 };
 
 	/* Instance methods. */
 
@@ -163,7 +164,55 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		// Update packet loss history
+		size_t expected_packets = feedback->GetPacketStatusCount();
+		size_t lost_packets = 0;
+		for (const auto& result : feedback->GetPacketResults())
+		{
+			if (!result.received)
+				lost_packets += 1;
+		}
+		this->UpdatePacketLoss(static_cast<double>(lost_packets) / expected_packets);
+
 		this->rtpTransportControllerSend->OnTransportFeedback(*feedback);
+	}
+
+	void TransportCongestionControlClient::UpdatePacketLoss(double packetLoss)
+	{
+		// Add the score into the histogram.
+		if (this->packetLossHistory.size() == PacketLossHistogramLength)
+			this->packetLossHistory.erase(this->packetLossHistory.begin());
+
+		this->packetLossHistory.push_back(packetLoss);
+
+		/*
+		 * Scoring mechanism is a weighted average.
+		 *
+		 * The more recent the score is, the more weight it has.
+		 * The oldest score has a weight of 1 and subsequent scores weight is
+		 * increased by one sequentially.
+		 *
+		 * Ie:
+		 * - scores: [1,2,3,4]
+		 * - this->scores = ((1) + (2+2) + (3+3+3) + (4+4+4+4)) / 10 = 2.8 => 3
+		 */
+
+		size_t weight{ 0 };
+		size_t samples{ 0 };
+		double totalPacketLoss{ 0 };
+
+		for (auto packetLossEntry : this->packetLossHistory)
+		{
+			weight++;
+			samples += weight;
+			totalPacketLoss += weight * packetLossEntry;
+		}
+
+		[[maybe_unused]] double previousPacketLoss = this->packetLoss;
+		// clang-tidy "thinks" that this can lead to division by zero but we are
+		// smarter.
+		// NOLINTNEXTLINE(clang-analyzer-core.DivideZero)
+		this->packetLoss = totalPacketLoss / samples;
 	}
 
 	void TransportCongestionControlClient::SetMaxOutgoingBitrate(uint32_t maxBitrate)
@@ -243,6 +292,13 @@ namespace RTC
 		MS_TRACE();
 
 		return this->bitrates.availableBitrate;
+	}
+
+	double TransportCongestionControlClient::GetPacketLoss() const
+	{
+		MS_TRACE();
+
+		return this->packetLoss;
 	}
 
 	void TransportCongestionControlClient::RescheduleNextAvailableBitrateEvent()

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -166,7 +166,7 @@ namespace RTC
 
 		// Update packet loss history
 		size_t expected_packets = feedback->GetPacketStatusCount();
-		size_t lost_packets = 0;
+		size_t lost_packets     = 0;
 		for (const auto& result : feedback->GetPacketResults())
 		{
 			if (!result.received)

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -1,5 +1,5 @@
 #define MS_CLASS "RTC::TransportCongestionControlClient"
-#define MS_LOG_DEV_LEVEL 3
+// #define MS_LOG_DEV_LEVEL 3
 
 #include "RTC/TransportCongestionControlClient.hpp"
 #include "DepLibUV.hpp"
@@ -181,7 +181,7 @@ namespace RTC
 	{
 		// Add the score into the histogram.
 		if (this->packetLossHistory.size() == PacketLossHistogramLength)
-			this->packetLossHistory.erase(this->packetLossHistory.begin());
+			this->packetLossHistory.pop_front();
 
 		this->packetLossHistory.push_back(packetLoss);
 
@@ -208,7 +208,6 @@ namespace RTC
 			totalPacketLoss += weight * packetLossEntry;
 		}
 
-		[[maybe_unused]] double previousPacketLoss = this->packetLoss;
 		// clang-tidy "thinks" that this can lead to division by zero but we are
 		// smarter.
 		// NOLINTNEXTLINE(clang-analyzer-core.DivideZero)

--- a/worker/src/RTC/TransportCongestionControlServer.cpp
+++ b/worker/src/RTC/TransportCongestionControlServer.cpp
@@ -1,5 +1,5 @@
 #define MS_CLASS "RTC::TransportCongestionControlServer"
-#define MS_LOG_DEV_LEVEL 3
+// #define MS_LOG_DEV_LEVEL 3
 
 #include "RTC/TransportCongestionControlServer.hpp"
 #include "DepLibUV.hpp"
@@ -303,7 +303,7 @@ namespace RTC
 	{
 		// Add the score into the histogram.
 		if (this->packetLossHistory.size() == PacketLossHistogramLength)
-			this->packetLossHistory.erase(this->packetLossHistory.begin());
+			this->packetLossHistory.pop_front();
 
 		this->packetLossHistory.push_back(packetLoss);
 
@@ -319,7 +319,6 @@ namespace RTC
 			totalPacketLoss += weight * packetLossEntry;
 		}
 
-		[[maybe_unused]] double previousPacketLoss = this->packetLoss;
 		// clang-tidy "thinks" that this can lead to division by zero but we are
 		// smarter.
 		// NOLINTNEXTLINE(clang-analyzer-core.DivideZero)

--- a/worker/src/RTC/TransportCongestionControlServer.cpp
+++ b/worker/src/RTC/TransportCongestionControlServer.cpp
@@ -1,5 +1,5 @@
 #define MS_CLASS "RTC::TransportCongestionControlServer"
-// #define MS_LOG_DEV_LEVEL 3
+#define MS_LOG_DEV_LEVEL 3
 
 #include "RTC/TransportCongestionControlServer.hpp"
 #include "DepLibUV.hpp"
@@ -15,6 +15,7 @@ namespace RTC
 	static constexpr uint64_t TransportCcFeedbackSendInterval{ 100u }; // In ms.
 	static constexpr uint64_t LimitationRembInterval{ 1500u };         // In ms.
 	static constexpr uint8_t UnlimitedRembNumPackets{ 4u };
+	static constexpr size_t PacketLossHistogramLength{ 24 };
 
 	/* Instance methods. */
 
@@ -101,6 +102,13 @@ namespace RTC
 		}
 	}
 
+	double TransportCongestionControlServer::GetPacketLoss() const
+	{
+		MS_TRACE();
+
+		return this->packetLoss;
+	}
+
 	void TransportCongestionControlServer::IncomingPacket(uint64_t nowMs, const RTC::RtpPacket* packet)
 	{
 		MS_TRACE();
@@ -119,7 +127,7 @@ namespace RTC
 				this->transportCcFeedbackMediaSsrc  = packet->GetSsrc();
 
 				this->transportCcFeedbackPacket->SetSenderSsrc(0u);
-				this->transportCcFeedbackPacket->SetMediaSsrc(packet->GetSsrc());
+				this->transportCcFeedbackPacket->SetMediaSsrc(this->transportCcFeedbackMediaSsrc );
 
 				// Provide the feedback packet with the RTP packet info. If it fails,
 				// send current feedback and add the packet info to a new one.
@@ -223,6 +231,17 @@ namespace RTC
 		this->listener->OnTransportCongestionControlServerSendRtcpPacket(
 		  this, this->transportCcFeedbackPacket.get());
 
+		// Update packet loss history
+		size_t expected_packets = this->transportCcFeedbackPacket->GetPacketStatusCount();
+		size_t lost_packets = 0;
+		for (const auto& result : this->transportCcFeedbackPacket->GetPacketResults())
+		{
+			if (!result.received)
+				lost_packets += 1;
+		}
+
+		this->UpdatePacketLoss(static_cast<double>(lost_packets) / expected_packets);
+
 		// Create a new feedback packet.
 		this->transportCcFeedbackPacket.reset(new RTC::RTCP::FeedbackRtpTransportPacket(
 		  this->transportCcFeedbackSenderSsrc, this->transportCcFeedbackMediaSsrc));
@@ -278,6 +297,33 @@ namespace RTC
 			if (this->unlimitedRembCounter > 0u)
 				this->unlimitedRembCounter--;
 		}
+	}
+
+	void TransportCongestionControlServer::UpdatePacketLoss(double packetLoss)
+	{
+		// Add the score into the histogram.
+		if (this->packetLossHistory.size() == PacketLossHistogramLength)
+			this->packetLossHistory.erase(this->packetLossHistory.begin());
+
+		this->packetLossHistory.push_back(packetLoss);
+
+		// Calculate a weighted average
+		size_t weight{ 0 };
+		size_t samples{ 0 };
+		double totalPacketLoss{ 0 };
+
+		for (auto packetLossEntry : this->packetLossHistory)
+		{
+			weight++;
+			samples += weight;
+			totalPacketLoss += weight * packetLossEntry;
+		}
+
+		[[maybe_unused]] double previousPacketLoss = this->packetLoss;
+		// clang-tidy "thinks" that this can lead to division by zero but we are
+		// smarter.
+		// NOLINTNEXTLINE(clang-analyzer-core.DivideZero)
+		this->packetLoss = totalPacketLoss / samples;
 	}
 
 	inline void TransportCongestionControlServer::OnRembServerAvailableBitrate(

--- a/worker/src/RTC/TransportCongestionControlServer.cpp
+++ b/worker/src/RTC/TransportCongestionControlServer.cpp
@@ -231,7 +231,7 @@ namespace RTC
 		this->listener->OnTransportCongestionControlServerSendRtcpPacket(
 		  this, this->transportCcFeedbackPacket.get());
 
-		// Update packet loss history
+		// Update packet loss history.
 		size_t expected_packets = this->transportCcFeedbackPacket->GetPacketStatusCount();
 		size_t lost_packets     = 0;
 		for (const auto& result : this->transportCcFeedbackPacket->GetPacketResults())

--- a/worker/src/RTC/TransportCongestionControlServer.cpp
+++ b/worker/src/RTC/TransportCongestionControlServer.cpp
@@ -127,7 +127,7 @@ namespace RTC
 				this->transportCcFeedbackMediaSsrc  = packet->GetSsrc();
 
 				this->transportCcFeedbackPacket->SetSenderSsrc(0u);
-				this->transportCcFeedbackPacket->SetMediaSsrc(this->transportCcFeedbackMediaSsrc );
+				this->transportCcFeedbackPacket->SetMediaSsrc(this->transportCcFeedbackMediaSsrc);
 
 				// Provide the feedback packet with the RTP packet info. If it fails,
 				// send current feedback and add the packet info to a new one.
@@ -233,7 +233,7 @@ namespace RTC
 
 		// Update packet loss history
 		size_t expected_packets = this->transportCcFeedbackPacket->GetPacketStatusCount();
-		size_t lost_packets = 0;
+		size_t lost_packets     = 0;
 		for (const auto& result : this->transportCcFeedbackPacket->GetPacketResults())
 		{
 			if (!result.received)


### PR DESCRIPTION
One common requirement is to monitor the quality of the user's connections to notify the user and the rest of participants when their connections are not good enough so that they can understand any audio/video issue they can experience during conversations.

This is typically based on packetLoss and/or roundTripTime.

With existing APIs those stats are available per consumer and producer so the application could request all/some of them and aggregate the stats but that can be more efficient and simpler if some of those stats are exposed at transport level.

This PR adds packetLoss as a stat at transport level.  The application can retrieve this metric every X seconds and notify the user when its uplink or downlink is bad and also notify rest of participants about it.

The implementation is based on transportCc feedback messages (comparing expected and received values and averaging last 24 of those measurements) so these new stats are only available when transportCC is enabled.

