### PR TITLE
Fix FailedToParse errors during get_stats() for Consumer and Producer in rust API

### DIFF
--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -239,7 +239,7 @@ pub struct ConsumerStat {
     pub packet_count: usize,
     pub byte_count: usize,
     pub bitrate: u32,
-    pub round_trip_time: Option<f64>,
+    pub round_trip_time: Option<f32>,
 }
 
 /// RTC statistics of the consumer, may or may not include producer statistics.

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -239,7 +239,7 @@ pub struct ConsumerStat {
     pub packet_count: usize,
     pub byte_count: usize,
     pub bitrate: u32,
-    pub round_trip_time: Option<u32>,
+    pub round_trip_time: Option<f64>,
 }
 
 /// RTC statistics of the consumer, may or may not include producer statistics.

--- a/rust/src/router/producer.rs
+++ b/rust/src/router/producer.rs
@@ -198,7 +198,7 @@ pub struct ProducerStat {
     pub packet_count: usize,
     pub byte_count: usize,
     pub bitrate: u32,
-    pub round_trip_time: Option<f64>,
+    pub round_trip_time: Option<f32>,
     pub rtx_packets_discarded: Option<u32>,
     // RtpStreamRecv specific.
     pub jitter: u32,

--- a/rust/src/router/producer.rs
+++ b/rust/src/router/producer.rs
@@ -202,7 +202,7 @@ pub struct ProducerStat {
     pub rtx_packets_discarded: Option<u32>,
     // RtpStreamRecv specific.
     pub jitter: u32,
-    pub bitrate_by_layer: HashMap<String, u32>,
+    pub bitrate_by_layer: Option<HashMap<String, u32>>,
 }
 
 /// 'trace' event data.

--- a/rust/src/router/producer.rs
+++ b/rust/src/router/producer.rs
@@ -198,7 +198,7 @@ pub struct ProducerStat {
     pub packet_count: usize,
     pub byte_count: usize,
     pub bitrate: u32,
-    pub round_trip_time: Option<u32>,
+    pub round_trip_time: Option<f64>,
     pub rtx_packets_discarded: Option<u32>,
     // RtpStreamRecv specific.
     pub jitter: u32,


### PR DESCRIPTION
Update ```ProducerStat``` and ```ConsumerStat``` according to ```FillJsonStats``` methods in mediasoup C++ library.

1. https://github.com/versatica/mediasoup/blob/v3/worker/include/RTC/RtpStream.hpp#L202  - rtt is ```float```
2. https://github.com/versatica/mediasoup/blob/v3/worker/src/RTC/RtpStreamRecv.cpp#L230  - bitrateByLayer is optinal field