### PR TITLE
Limit max temporal layers to preferred temporal layers

### DIFF
--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -487,6 +487,16 @@ namespace RTC
 					continue;
 				}
 
+				if (
+					this->preferredTemporalLayer != -1 &&
+					temporalLayer > this->preferredTemporalLayer
+				)
+				{
+					requiredBitrate = 1u; // Don't set 0 since it would be ignored.
+					// don't use any bandwidth for this one as it will be disabled later on
+					goto done;
+				}
+
 				requiredBitrate = producerRtpStream->GetLayerBitrate(nowMs, 0, temporalLayer);
 
 				// This is simulcast so we must substract the bitrate of the current temporal
@@ -571,6 +581,11 @@ namespace RTC
 
 		auto provisionalTargetSpatialLayer  = this->provisionalTargetSpatialLayer;
 		auto provisionalTargetTemporalLayer = this->provisionalTargetTemporalLayer;
+
+		if (this->preferredTemporalLayer != -1)
+		{
+			provisionalTargetTemporalLayer = std::min(provisionalTargetTemporalLayer, this->preferredTemporalLayer);
+		}
 
 		// Reset provisional target layers.
 		this->provisionalTargetSpatialLayer  = -1;
@@ -1311,12 +1326,7 @@ namespace RTC
 
 		if (newTargetSpatialLayer != -1)
 		{
-			if (newTargetSpatialLayer == this->preferredSpatialLayer)
-				newTargetTemporalLayer = this->preferredTemporalLayer;
-			else if (newTargetSpatialLayer < this->preferredSpatialLayer)
-				newTargetTemporalLayer = this->rtpStream->GetTemporalLayers() - 1;
-			else
-				newTargetTemporalLayer = 0;
+			newTargetTemporalLayer = this->preferredTemporalLayer;
 		}
 
 		// Return true if any target layer changed.


### PR DESCRIPTION
Right now there is no way to limit the maximum number of temporal layers forwarded for a simulcast/svc consumer.

I was assuming `consumer.setPreferredLayers({spatialLayers: 2, temporalLayers: 0})` was limiting the spatial layers to [0,1] and the temporal layers to [0] but actually the implementation is allowing all the combinations up to the second spatial layer and the first temporal layer (0:0, 0:1, 0:2, 1:0, 1:1, 1:2, 2:0).

If the feature of limiting temporal layers is useful (it is useful for our use case at least) there are two options:
1/ We change the meaning of preferred temporal layers so that in the example below mediasoup never forwards the second and third temporal layers.
2/ We add a different API for that (maybe called setMaxLayers).

This PR is trying option 1/ but the authors of mediasoup should decide on which option to pursue or if this is a feature that is not interesting enough.

I'm almost sure this PR doesn't contain all the needed changes but it fixes the issues I had and can be good to help with the discussion/decission.