### PR TITLE
NixOS friendly build process

### DIFF
--- a/worker/Makefile
+++ b/worker/Makefile
@@ -25,7 +25,7 @@ else
     export NINJA = $(PIP_DIR)/bin/ninja
 endif
 # Instruct Python where to look for modules it needs, such that `meson` actually runs from installed location.
-export PYTHONPATH = $(PIP_DIR)
+export PYTHONPATH := $(PIP_DIR):${PYTHONPATH}
 
 .PHONY:	\
 	default meson-ninja setup clean clean-pip clean-subprojects clean-all mediasoup-worker xcode lint format test tidy \
@@ -42,7 +42,7 @@ ifeq ($(wildcard $(PIP_DIR)),)
 		$(PYTHON) -m pip install --target=$(PIP_DIR) pip setuptools || \
 		echo "Installation failed, likely because PIP is unavailable, if you are on Debian/Ubuntu or derivative please install the python3-pip package"
 	# Install `meson` and `ninja` using `pip` into custom location, so we don't depend on system-wide installation.
-	$(PYTHON) -m pip install --upgrade --target=$(PIP_DIR) meson ninja
+	$(PYTHON) -m pip install --upgrade --target=$(PIP_DIR) --no-binary ":all:" meson ninja
 endif
 
 setup: meson-ninja

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -14,6 +14,8 @@ DOCKER ?= docker
 PIP_DIR = $(MEDIASOUP_OUT_DIR)/pip
 MESON ?= $(PIP_DIR)/bin/meson
 MESON_ARGS ?= ""
+# Workaround for NixOS and Guix that don't work with pre-built binaries, see:
+# https://github.com/NixOS/nixpkgs/issues/142383.
 PIP_BUILD_BINARIES = $(shell [ -f /etc/NIXOS -o -d /etc/guix ] && echo "--no-binary :all:")
 
 # Disable `*.pyc` files creation.

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -14,6 +14,7 @@ DOCKER ?= docker
 PIP_DIR = $(MEDIASOUP_OUT_DIR)/pip
 MESON ?= $(PIP_DIR)/bin/meson
 MESON_ARGS ?= ""
+PIP_BUILD_BINARIES = $(shell [ -f /etc/NIXOS -o -d /etc/guix ] && echo "--no-binary :all:")
 
 # Disable `*.pyc` files creation.
 export PYTHONDONTWRITEBYTECODE = 1
@@ -42,7 +43,7 @@ ifeq ($(wildcard $(PIP_DIR)),)
 		$(PYTHON) -m pip install --target=$(PIP_DIR) pip setuptools || \
 		echo "Installation failed, likely because PIP is unavailable, if you are on Debian/Ubuntu or derivative please install the python3-pip package"
 	# Install `meson` and `ninja` using `pip` into custom location, so we don't depend on system-wide installation.
-	$(PYTHON) -m pip install --upgrade --target=$(PIP_DIR) --no-binary ":all:" meson ninja
+	$(PYTHON) -m pip install --upgrade --target=$(PIP_DIR) $(PIP_BUILD_BINARIES) meson ninja
 endif
 
 setup: meson-ninja


### PR DESCRIPTION
1. keep given PYTHONPATH around (after our pip install dir)
2. build binaries rather than downloading

I'm not particularly expert in NixOS and there may be a better way of doing this, but at least these changes are minimal.  There is a performance hit for 2 but not much as a fraction of the overall build.

Tested on debian testing and NixOS 21.05