### PR TITLE
Fix multiopus frontend example compilation, update dependencies

### DIFF
--- a/rust/examples-frontend/echo/package.json
+++ b/rust/examples-frontend/echo/package.json
@@ -9,13 +9,13 @@
   },
   "author": "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
   "dependencies": {
-    "mediasoup-client": "^3.6.36"
+    "mediasoup-client": "^3.6.43"
   },
   "devDependencies": {
-    "ts-loader": "^9.2.4",
-    "typescript": "^4.3.5",
-    "webpack": "^5.46.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "ts-loader": "^9.2.6",
+    "typescript": "^4.4.4",
+    "webpack": "^5.59.1",
+    "webpack-cli": "^4.9.1",
+    "webpack-dev-server": "^4.3.1"
   }
 }

--- a/rust/examples-frontend/multiopus/package.json
+++ b/rust/examples-frontend/multiopus/package.json
@@ -9,13 +9,13 @@
   },
   "author": "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
   "dependencies": {
-    "mediasoup-client": "^3.6.36"
+    "mediasoup-client": "^3.6.43"
   },
   "devDependencies": {
-    "ts-loader": "^9.2.4",
-    "typescript": "^4.3.5",
-    "webpack": "^5.46.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "ts-loader": "^9.2.6",
+    "typescript": "^4.4.4",
+    "webpack": "^5.59.1",
+    "webpack-cli": "^4.9.1",
+    "webpack-dev-server": "^4.3.1"
   }
 }

--- a/rust/examples-frontend/multiopus/src/index.ts
+++ b/rust/examples-frontend/multiopus/src/index.ts
@@ -142,7 +142,7 @@ async function init()
 					//  this case properly
 					{
 						// @ts-ignore
-						const pc = consumerTransport._handler._pc as RTCPeerConnection;
+						const pc = consumerTransport._handler._pc;
 						const setLocalDescription = pc.setLocalDescription;
 
 						pc.setLocalDescription = (answer: {type: 'answer'; sdp: string}) =>

--- a/rust/examples-frontend/videoroom/package.json
+++ b/rust/examples-frontend/videoroom/package.json
@@ -9,13 +9,13 @@
   },
   "author": "Nazar Mokrynskyi <nazar@mokrynskyi.com>",
   "dependencies": {
-    "mediasoup-client": "^3.6.36"
+    "mediasoup-client": "^3.6.43"
   },
   "devDependencies": {
-    "ts-loader": "^9.2.4",
-    "typescript": "^4.3.5",
-    "webpack": "^5.46.0",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
+    "ts-loader": "^9.2.6",
+    "typescript": "^4.4.4",
+    "webpack": "^5.59.1",
+    "webpack-cli": "^4.9.1",
+    "webpack-dev-server": "^4.3.1"
   }
 }


### PR DESCRIPTION
There was a strange update in types that somehow was causing compilation errors in multiopus like this:
```
./src/index.ts 157:34-50
[tsl] ERROR in /web/github/mediasoup/rust/examples-frontend/multiopus/src/index.ts(157,35)
      TS2554: Expected 4 arguments, but got 2.
```

Not sure what caused legacy `setLocalDescription` function signature to be used, but we don't really need much types there anyway.