### PR TITLE
Update libuv to 1.42

### DIFF
--- a/worker/subprojects/libuv.wrap
+++ b/worker/subprojects/libuv.wrap
@@ -1,11 +1,11 @@
 [wrap-file]
-directory = libuv-v1.41.0
-source_url = https://dist.libuv.org/dist/v1.41.0/libuv-v1.41.0.tar.gz
-source_filename = libuv-v1.41.0.tar.gz
-source_hash = 1184533907e1ddad9c0dcd30a5abb0fe25288c287ff7fee303fff7b9b2d6eb6e
-patch_url = https://wrapdb.mesonbuild.com/v2/libuv_1.41.0-1/get_patch
-patch_filename = libuv-1.41.0-1-wrap.zip
-patch_hash = 66cab50ca1f002d823a2015611c08401b69d6f7c1ecd0059cb6afd34e1138b40
+directory = libuv-v1.42.0
+source_url = https://dist.libuv.org/dist/v1.42.0/libuv-v1.42.0.tar.gz
+source_filename = libuv-v1.42.0.tar.gz
+source_hash = 43129625155a8aed796ebe90b8d4c990a73985ec717de2b2d5d3a23cfe4deb72
+patch_filename = libuv_1.42.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libuv_1.42.0-1/get_patch
+patch_hash = 891698d781bc68379b799e47bc7e100698f03985b6db5d1ddc4eaa9be42a8f35
 
 [provide]
 libuv = libuv_dep


### PR DESCRIPTION
Gets us never upstream version and resolves CLang warnings mentioned in the initial Meson integration PR