### PR TITLE
Emit Worker `died` event before closing Routers

### DIFF
--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -594,14 +594,14 @@ export class Worker extends EnhancedEventEmitter
 		// Close the PayloadChannel instance.
 		this.#payloadChannel.close();
 
+		this.safeEmit('died', error);
+
 		// Close every Router.
 		for (const router of this.#routers)
 		{
 			router.workerClosed();
 		}
 		this.#routers.clear();
-
-		this.safeEmit('died', error);
 
 		// Emit observer event.
 		this.#observer.safeEmit('close');


### PR DESCRIPTION
This fixes #698. It's done quickly on the web interface, but can improve it on my editor, and also add support for `workerdied` event if you like it.