### PR TITLE
Fix drop ordering

### DIFF
--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -398,14 +398,11 @@ impl Inner {
                 let request = RouterCloseRequest {
                     internal: RouterInternal { router_id: self.id },
                 };
-                let worker = self.worker.clone();
                 self.executor
                     .spawn(async move {
                         if let Err(error) = channel.request(request).await {
                             error!("router closing failed on drop: {}", error);
                         }
-
-                        drop(worker);
                     })
                     .detach();
             }

--- a/rust/src/router/active_speaker_observer.rs
+++ b/rust/src/router/active_speaker_observer.rs
@@ -110,14 +110,11 @@ impl Inner {
                         rtp_observer_id: self.id,
                     },
                 };
-                let router = self.router.clone();
                 self.executor
                     .spawn(async move {
                         if let Err(error) = channel.request(request).await {
                             error!("active speaker observer closing failed on drop: {}", error);
                         }
-
-                        drop(router);
                     })
                     .detach();
             }

--- a/rust/src/router/audio_level_observer.rs
+++ b/rust/src/router/audio_level_observer.rs
@@ -124,14 +124,11 @@ impl Inner {
                         rtp_observer_id: self.id,
                     },
                 };
-                let router = self.router.clone();
                 self.executor
                     .spawn(async move {
                         if let Err(error) = channel.request(request).await {
                             error!("audio level observer closing failed on drop: {}", error);
                         }
-
-                        drop(router);
                     })
                     .detach();
             }

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -409,19 +409,15 @@ impl Inner {
                         producer_id: self.producer_id,
                     },
                 };
-                let producer = self.weak_producer.upgrade();
-                let transport = self.transport.clone();
+                let weak_producer = self.weak_producer.clone();
 
                 self.executor
                     .spawn(async move {
-                        if producer.is_some() {
+                        if weak_producer.upgrade().is_some() {
                             if let Err(error) = channel.request(request).await {
                                 error!("consumer closing failed on drop: {}", error);
                             }
                         }
-
-                        drop(producer);
-                        drop(transport);
                     })
                     .detach();
             }

--- a/rust/src/router/data_consumer.rs
+++ b/rust/src/router/data_consumer.rs
@@ -238,19 +238,15 @@ impl Inner {
                         data_producer_id: self.data_producer_id,
                     },
                 };
-                let data_producer = self.weak_data_producer.upgrade();
-                let transport = self.transport.clone();
+                let weak_data_producer = self.weak_data_producer.clone();
 
                 self.executor
                     .spawn(async move {
-                        if data_producer.is_some() {
+                        if weak_data_producer.upgrade().is_some() {
                             if let Err(error) = channel.request(request).await {
                                 error!("consumer closing failed on drop: {}", error);
                             }
                         }
-
-                        drop(data_producer);
-                        drop(transport);
                     })
                     .detach();
             }

--- a/rust/src/router/data_producer.rs
+++ b/rust/src/router/data_producer.rs
@@ -168,14 +168,11 @@ impl Inner {
                         data_producer_id: self.id,
                     },
                 };
-                let transport = self.transport.clone();
                 self.executor
                     .spawn(async move {
                         if let Err(error) = channel.request(request).await {
                             error!("data producer closing failed on drop: {}", error);
                         }
-
-                        drop(transport);
                     })
                     .detach();
             }

--- a/rust/src/router/direct_transport.rs
+++ b/rust/src/router/direct_transport.rs
@@ -176,14 +176,11 @@ impl Inner {
                         transport_id: self.id,
                     },
                 };
-                let router = self.router.clone();
                 self.executor
                     .spawn(async move {
                         if let Err(error) = channel.request(request).await {
                             error!("transport closing failed on drop: {}", error);
                         }
-
-                        drop(router);
                     })
                     .detach();
             }

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -225,14 +225,11 @@ impl Inner {
                         transport_id: self.id,
                     },
                 };
-                let router = self.router.clone();
                 self.executor
                     .spawn(async move {
                         if let Err(error) = channel.request(request).await {
                             error!("transport closing failed on drop: {}", error);
                         }
-
-                        drop(router);
                     })
                     .detach();
             }

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -257,14 +257,11 @@ impl Inner {
                         transport_id: self.id,
                     },
                 };
-                let router = self.router.clone();
                 self.executor
                     .spawn(async move {
                         if let Err(error) = channel.request(request).await {
                             error!("transport closing failed on drop: {}", error);
                         }
-
-                        drop(router);
                     })
                     .detach();
             }

--- a/rust/src/router/producer.rs
+++ b/rust/src/router/producer.rs
@@ -334,14 +334,11 @@ impl Inner {
                         producer_id: self.id,
                     },
                 };
-                let transport = self.transport.clone();
                 self.executor
                     .spawn(async move {
                         if let Err(error) = channel.request(request).await {
                             error!("producer closing failed on drop: {}", error);
                         }
-
-                        drop(transport);
                     })
                     .detach();
             }

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -309,14 +309,11 @@ impl Inner {
                         transport_id: self.id,
                     },
                 };
-                let router = self.router.clone();
                 self.executor
                     .spawn(async move {
                         if let Err(error) = channel.request(request).await {
                             error!("transport closing failed on drop: {}", error);
                         }
-
-                        drop(router);
                     })
                     .detach();
             }


### PR DESCRIPTION
This was a tricky racy error that resulted in this among other crashes:
```
(ABORT) DepUsrSCTP::DeregisterSctpAssociation() | failed assertion `found > 0': SctpAssociation not found
```

This primarily happened with very fast tests, sometimes under special circumstances.

The root issue is that process was exiting without waiting for worker to finish properly, thus global C++ destructors were racing with worker shutdown, resulting in weird things that do not make sense like above or sometimes in various interesting segfaults.

With these changes when the very last thing holding `WorkerManager` on Rust side is dropped (worker manager is the first thing user of the library needs to create), it will synchronously wait for all workers to finish whatever they are doing before moving any further, making sure everything is de-initialized on C++ side gracefully.