### PR TITLE
worker: backport m1 compilation to v2

### DIFF
--- a/worker/common.gypi
+++ b/worker/common.gypi
@@ -63,6 +63,9 @@
       [ 'target_arch == "x64"', {
         'xcode_settings': { 'ARCHS': [ 'x86_64' ] }
       }],
+      [ 'target_arch == "arm64"', {
+        'xcode_settings': { 'ARCHS': [ 'arm64' ] }
+      }],
       [ 'OS in "linux freebsd openbsd solaris"', {
         'target_conditions':
         [

--- a/worker/scripts/configure.py
+++ b/worker/scripts/configure.py
@@ -30,6 +30,7 @@ def host_arch():
   if machine == 'i386': return 'ia32'
   if machine == 'x86_64': return 'x64'
   if machine == 'aarch64': return 'arm64'
+  if machine == 'arm64': return 'arm64'
   if machine.startswith('arm'): return 'arm'
   if machine.startswith('mips'): return 'mips'
   return machine  # Return as-is and hope for the best.


### PR DESCRIPTION
This is a backport of #548 to v2, which we still use in production. Compilation from docker in arm64 works fine but not natively (M1 Pro).