### PR TITLE
Support VP9 profile-id 0 and 2

### DIFF
--- a/node/src/supportedRtpCapabilities.ts
+++ b/node/src/supportedRtpCapabilities.ts
@@ -211,9 +211,30 @@ const supportedRtpCapabilities: RtpCapabilities =
 			]
 		},
 		{
-			kind         : 'video',
-			mimeType     : 'video/VP9',
-			clockRate    : 90000,
+			kind       : 'video',
+			mimeType   : 'video/VP9',
+			clockRate  : 90000,
+			parameters :
+			{
+				'profile-id' : 0
+			},
+			rtcpFeedback :
+			[
+				{ type: 'nack' },
+				{ type: 'nack', parameter: 'pli' },
+				{ type: 'ccm', parameter: 'fir' },
+				{ type: 'goog-remb' },
+				{ type: 'transport-cc' }
+			]
+		},
+		{
+			kind       : 'video',
+			mimeType   : 'video/VP9',
+			clockRate  : 90000,
+			parameters :
+			{
+				'profile-id' : 2
+			},
 			rtcpFeedback :
 			[
 				{ type: 'nack' },


### PR DESCRIPTION
Different values of VP9 `profile-id` must be provided by endpoints with different Payload Types. Seems that this parameter would work like `packetization-mode` does in H.264, and should be declared multiple times inside mediasoup caps arrays.

Browsers such as Chrome and Safari already generate SDP Offers where VP9 is offered twice, with lines such as:

```
m=video 9 UDP/TLS/RTP/SAVPF 98 100
a=rtpmap:98 VP9/90000
a=fmtp:98 profile-id=0
a=rtpmap:100 VP9/90000
a=fmtp:100 profile-id=2
```

However, `ortc.getExtendedRtpCapabilities()` in mediasoup-client does codec matching [^1] based on the single VP9 entry that exists in the Router [^2], which doesn't contain `packetization-mode`, and thus is assumed to always be `0` [^3]. What this means is that `packetization-mode=2` is always dropped as a valid codec alternative. The Extended capabilities array ends up with a single VP9 entry, with `packetization-mode=0`.

[^1]: https://github.com/versatica/mediasoup-client/blob/3.6.45/src/ortc.ts#L573
[^2]: https://github.com/versatica/mediasoup/blob/3.9.2/node/src/supportedRtpCapabilities.ts#L213-L225
[^3]: https://github.com/versatica/mediasoup-client/blob/3.6.45/src/ortc.ts#L1123-L1124

Firefox doesn't include `profile-id` in its Offers as of writing this PR; however, RFC says that lack of it must be assumed equivalent to `profile-id=0` anyway.

So if it makes sense, I'd like to propose this addition to mediasoup.

Relevant doc:
* RTP Payload Format for VP9, 6.1. SDP Parameters
  https://datatracker.ietf.org/doc/html/draft-ietf-payload-vp9-16#section-6.1