### PR TITLE
Single H264/H264 codec configuration in supportedRtpCapabilities

### DIFF
--- a/node/lib/ortc.js
+++ b/node/lib/ortc.js
@@ -829,12 +829,11 @@ function matchCodecs(aCodec, bCodec, { strict = false, modify = false } = {}) {
             }
         case 'video/h264':
             {
-                const aPacketizationMode = aCodec.parameters['packetization-mode'] || 0;
-                const bPacketizationMode = bCodec.parameters['packetization-mode'] || 0;
-                if (aPacketizationMode !== bPacketizationMode)
-                    return false;
-                // If strict matching check profile-level-id.
                 if (strict) {
+                    const aPacketizationMode = aCodec.parameters['packetization-mode'] || 0;
+                    const bPacketizationMode = bCodec.parameters['packetization-mode'] || 0;
+                    if (aPacketizationMode !== bPacketizationMode)
+                        return false;
                     if (!h264.isSameProfile(aCodec.parameters, bCodec.parameters))
                         return false;
                     let selectedProfileLevelId;
@@ -856,7 +855,6 @@ function matchCodecs(aCodec, bCodec, { strict = false, modify = false } = {}) {
             }
         case 'video/vp9':
             {
-                // If strict matching check profile-id.
                 if (strict) {
                     const aProfileId = aCodec.parameters['profile-id'] || 0;
                     const bProfileId = bCodec.parameters['profile-id'] || 0;

--- a/node/lib/supportedRtpCapabilities.d.ts.map
+++ b/node/lib/supportedRtpCapabilities.d.ts.map
@@ -1,1 +1,1 @@
-{"version":3,"file":"supportedRtpCapabilities.d.ts","sourceRoot":"","sources":["../src/supportedRtpCapabilities.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,eAAe,EAAE,MAAM,iBAAiB,CAAC;AAElD,QAAA,MAAM,wBAAwB,EAAE,eAwY/B,CAAC;AAEF,OAAO,EAAE,wBAAwB,EAAE,CAAC"}
+{"version":3,"file":"supportedRtpCapabilities.d.ts","sourceRoot":"","sources":["../src/supportedRtpCapabilities.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,eAAe,EAAE,MAAM,iBAAiB,CAAC;AAElD,QAAA,MAAM,wBAAwB,EAAE,eAkW/B,CAAC;AAEF,OAAO,EAAE,wBAAwB,EAAE,CAAC"}

--- a/node/lib/supportedRtpCapabilities.js
+++ b/node/lib/supportedRtpCapabilities.js
@@ -207,23 +207,6 @@ const supportedRtpCapabilities = {
             mimeType: 'video/H264',
             clockRate: 90000,
             parameters: {
-                'packetization-mode': 1,
-                'level-asymmetry-allowed': 1
-            },
-            rtcpFeedback: [
-                { type: 'nack' },
-                { type: 'nack', parameter: 'pli' },
-                { type: 'ccm', parameter: 'fir' },
-                { type: 'goog-remb' },
-                { type: 'transport-cc' }
-            ]
-        },
-        {
-            kind: 'video',
-            mimeType: 'video/H264',
-            clockRate: 90000,
-            parameters: {
-                'packetization-mode': 0,
                 'level-asymmetry-allowed': 1
             },
             rtcpFeedback: [
@@ -239,23 +222,6 @@ const supportedRtpCapabilities = {
             mimeType: 'video/H265',
             clockRate: 90000,
             parameters: {
-                'packetization-mode': 1,
-                'level-asymmetry-allowed': 1
-            },
-            rtcpFeedback: [
-                { type: 'nack' },
-                { type: 'nack', parameter: 'pli' },
-                { type: 'ccm', parameter: 'fir' },
-                { type: 'goog-remb' },
-                { type: 'transport-cc' }
-            ]
-        },
-        {
-            kind: 'video',
-            mimeType: 'video/H265',
-            clockRate: 90000,
-            parameters: {
-                'packetization-mode': 0,
                 'level-asymmetry-allowed': 1
             },
             rtcpFeedback: [

--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -1224,15 +1224,14 @@ function matchCodecs(
 
 		case 'video/h264':
 		{
-			const aPacketizationMode = aCodec.parameters['packetization-mode'] || 0;
-			const bPacketizationMode = bCodec.parameters['packetization-mode'] || 0;
-
-			if (aPacketizationMode !== bPacketizationMode)
-				return false;
-
-			// If strict matching check profile-level-id.
 			if (strict)
 			{
+				const aPacketizationMode = aCodec.parameters['packetization-mode'] || 0;
+				const bPacketizationMode = bCodec.parameters['packetization-mode'] || 0;
+
+				if (aPacketizationMode !== bPacketizationMode)
+					return false;
+
 				if (!h264.isSameProfile(aCodec.parameters, bCodec.parameters))
 					return false;
 
@@ -1262,7 +1261,6 @@ function matchCodecs(
 
 		case 'video/vp9':
 		{
-			// If strict matching check profile-id.
 			if (strict)
 			{
 				const aProfileId = aCodec.parameters['profile-id'] || 0;

--- a/node/src/supportedRtpCapabilities.ts
+++ b/node/src/supportedRtpCapabilities.ts
@@ -229,25 +229,6 @@ const supportedRtpCapabilities: RtpCapabilities =
 			clockRate  : 90000,
 			parameters :
 			{
-				'packetization-mode'      : 1,
-				'level-asymmetry-allowed' : 1
-			},
-			rtcpFeedback :
-			[
-				{ type: 'nack' },
-				{ type: 'nack', parameter: 'pli' },
-				{ type: 'ccm', parameter: 'fir' },
-				{ type: 'goog-remb' },
-				{ type: 'transport-cc' }
-			]
-		},
-		{
-			kind       : 'video',
-			mimeType   : 'video/H264',
-			clockRate  : 90000,
-			parameters :
-			{
-				'packetization-mode'      : 0,
 				'level-asymmetry-allowed' : 1
 			},
 			rtcpFeedback :
@@ -265,25 +246,6 @@ const supportedRtpCapabilities: RtpCapabilities =
 			clockRate  : 90000,
 			parameters :
 			{
-				'packetization-mode'      : 1,
-				'level-asymmetry-allowed' : 1
-			},
-			rtcpFeedback :
-			[
-				{ type: 'nack' },
-				{ type: 'nack', parameter: 'pli' },
-				{ type: 'ccm', parameter: 'fir' },
-				{ type: 'goog-remb' },
-				{ type: 'transport-cc' }
-			]
-		},
-		{
-			kind       : 'video',
-			mimeType   : 'video/H265',
-			clockRate  : 90000,
-			parameters :
-			{
-				'packetization-mode'      : 0,
 				'level-asymmetry-allowed' : 1
 			},
 			rtcpFeedback :

--- a/node/tests/test-ortc.js
+++ b/node/tests/test-ortc.js
@@ -103,8 +103,9 @@ test('generateRouterRtpCapabilities() succeeds', () =>
 			clockRate            : 90000,
 			parameters           :
 			{
-
-				'packetization-mode'      : 0,
+				// Since packetization-mode param was not included in the H264 codec
+				// and it's default value is 0, it's not added by ortc file.
+				// 'packetization-mode'      : 0,
 				'level-asymmetry-allowed' : 1,
 				'profile-level-id'        : '42e01f',
 				foo                       : 'bar'
@@ -158,22 +159,6 @@ test('generateRouterRtpCapabilities() with unsupported codecs throws Unsupported
 			mimeType  : 'audio/opus',
 			clockRate : 48000,
 			channels  : 1
-		}
-	];
-
-	expect(() => ortc.generateRouterRtpCapabilities(mediaCodecs))
-		.toThrow(UnsupportedError);
-
-	mediaCodecs =
-	[
-		{
-			kind       : 'video',
-			mimeType   : 'video/H264',
-			clockRate  : 90000,
-			parameters :
-			{
-				'packetization-mode' : 5
-			}
 		}
 	];
 

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -1000,21 +1000,20 @@ fn match_codecs(
             }
         }
         MimeType::Video(MimeTypeVideo::H264) => {
-            let packetization_mode_a = codec_a
-                .parameters
-                .get("packetization-mode")
-                .unwrap_or(&RtpCodecParametersParametersValue::Number(0));
-            let packetization_mode_b = codec_b
-                .parameters
-                .get("packetization-mode")
-                .unwrap_or(&RtpCodecParametersParametersValue::Number(0));
-
-            if packetization_mode_a != packetization_mode_b {
-                return Err(());
-            }
-
-            // If strict matching check profile-level-id.
             if strict {
+                let packetization_mode_a = codec_a
+                    .parameters
+                    .get("packetization-mode")
+                    .unwrap_or(&RtpCodecParametersParametersValue::Number(0));
+                let packetization_mode_b = codec_b
+                    .parameters
+                    .get("packetization-mode")
+                    .unwrap_or(&RtpCodecParametersParametersValue::Number(0));
+
+                if packetization_mode_a != packetization_mode_b {
+                    return Err(());
+                }
+
                 let profile_level_id_a =
                     codec_a
                         .parameters

--- a/rust/src/ortc/tests.rs
+++ b/rust/src/ortc/tests.rs
@@ -78,7 +78,10 @@ fn generate_router_rtp_capabilities_succeeds() {
                 preferred_payload_type: 102, // 102 is the third available dynamic PT.
                 clock_rate: NonZeroU32::new(90000).unwrap(),
                 parameters: RtpCodecParametersParameters::from([
-                    ("packetization-mode", 0_u32.into()),
+                    // Since packetization-mode param was not included in the
+                    // H264 codec and it's default value is 0, it's not added
+                    // by ortc file.
+                    // ("packetization-mode", 0_u32.into()),
                     ("level-asymmetry-allowed", 1_u32.into()),
                     ("profile-level-id", "42e01f".into()),
                     ("foo", "bar".into()),

--- a/rust/src/ortc/tests.rs
+++ b/rust/src/ortc/tests.rs
@@ -115,17 +115,6 @@ fn generate_router_rtp_capabilities_unsupported() {
         }]),
         Err(RtpCapabilitiesError::UnsupportedCodec { .. })
     ));
-
-    assert!(matches!(
-        generate_router_rtp_capabilities(vec![RtpCodecCapability::Video {
-            mime_type: MimeTypeVideo::H264,
-            preferred_payload_type: None,
-            clock_rate: NonZeroU32::new(90000).unwrap(),
-            parameters: RtpCodecParametersParameters::from([("packetization-mode", 5u32.into())]),
-            rtcp_feedback: vec![],
-        }]),
-        Err(RtpCapabilitiesError::UnsupportedCodec { .. })
-    ));
 }
 
 #[test]

--- a/rust/src/supported_rtp_capabilities.rs
+++ b/rust/src/supported_rtp_capabilities.rs
@@ -234,23 +234,6 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                 preferred_payload_type: None,
                 clock_rate: NonZeroU32::new(90000).unwrap(),
                 parameters: RtpCodecParametersParameters::from([
-                    ("packetization-mode", 1_u32.into()),
-                    ("level-asymmetry-allowed", 1_u32.into()),
-                ]),
-                rtcp_feedback: vec![
-                    RtcpFeedback::Nack,
-                    RtcpFeedback::NackPli,
-                    RtcpFeedback::CcmFir,
-                    RtcpFeedback::GoogRemb,
-                    RtcpFeedback::TransportCc,
-                ],
-            },
-            RtpCodecCapability::Video {
-                mime_type: MimeTypeVideo::H264,
-                preferred_payload_type: None,
-                clock_rate: NonZeroU32::new(90000).unwrap(),
-                parameters: RtpCodecParametersParameters::from([
-                    ("packetization-mode", 0_u32.into()),
                     ("level-asymmetry-allowed", 1_u32.into()),
                 ]),
                 rtcp_feedback: vec![
@@ -266,23 +249,6 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                 preferred_payload_type: None,
                 clock_rate: NonZeroU32::new(90000).unwrap(),
                 parameters: RtpCodecParametersParameters::from([
-                    ("packetization-mode", 1_u32.into()),
-                    ("level-asymmetry-allowed", 1_u32.into()),
-                ]),
-                rtcp_feedback: vec![
-                    RtcpFeedback::Nack,
-                    RtcpFeedback::NackPli,
-                    RtcpFeedback::CcmFir,
-                    RtcpFeedback::GoogRemb,
-                    RtcpFeedback::TransportCc,
-                ],
-            },
-            RtpCodecCapability::Video {
-                mime_type: MimeTypeVideo::H265,
-                preferred_payload_type: None,
-                clock_rate: NonZeroU32::new(90000).unwrap(),
-                parameters: RtpCodecParametersParameters::from([
-                    ("packetization-mode", 0_u32.into()),
                     ("level-asymmetry-allowed", 1_u32.into()),
                 ]),
                 rtcp_feedback: vec![

--- a/rust/src/supported_rtp_capabilities.rs
+++ b/rust/src/supported_rtp_capabilities.rs
@@ -233,9 +233,10 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                 mime_type: MimeTypeVideo::H264,
                 preferred_payload_type: None,
                 clock_rate: NonZeroU32::new(90000).unwrap(),
-                parameters: RtpCodecParametersParameters::from([
-                    ("level-asymmetry-allowed", 1_u32.into()),
-                ]),
+                parameters: RtpCodecParametersParameters::from([(
+                    "level-asymmetry-allowed",
+                    1_u32.into(),
+                )]),
                 rtcp_feedback: vec![
                     RtcpFeedback::Nack,
                     RtcpFeedback::NackPli,
@@ -248,9 +249,10 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                 mime_type: MimeTypeVideo::H265,
                 preferred_payload_type: None,
                 clock_rate: NonZeroU32::new(90000).unwrap(),
-                parameters: RtpCodecParametersParameters::from([
-                    ("level-asymmetry-allowed", 1_u32.into()),
-                ]),
+                parameters: RtpCodecParametersParameters::from([(
+                    "level-asymmetry-allowed",
+                    1_u32.into(),
+                )]),
                 rtcp_feedback: vec![
                     RtcpFeedback::Nack,
                     RtcpFeedback::NackPli,


### PR DESCRIPTION
- Based on discussion in #714.
- We don't need to have 2 H264 and 2 H265 codec configurations in `supportedRtpCapabilities` each with a different `packetization-mode` param.
- `ortc.ts`: Just check `packetization-mode` param when matching codecs in strict mode.

@nazar-pc may you check the Rust changes please?