### PR TITLE
Windows support in Rust library

### DIFF
--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -12,6 +12,7 @@ jobs:
         os:
           - ubuntu-20.04
           - macos-10.15
+          - windows-2019
         rust:
           - stable
           # - nightly
@@ -19,6 +20,17 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+      - name: Add MSVC compiler
+        uses: ilammy/msvc-dev-cmd@v1
+        if: runner.os == 'Windows'
+
+      # This is needed as a workaround for GNU linker being first in PATH and thus preventing Meson from finding MSVC
+      # linker.
+      - name: Remove GNU linker for MSVC
+        shell: bash
+        run: rm /usr/bin/link
+        if: runner.os == 'Windows'
+
       - name: Checkout
         uses: actions/checkout@v2
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -8,6 +8,7 @@
 * Switch from file descriptors to function calls when communicating with worker
 * Various optimizations that caused minor breaking changes to public API
 * Requests no longer have internal timeout, but they can now be cancelled, add your own timeouts on top if needed
+* Windows support
 
 # 0.8.5
 

--- a/rust/src/router/active_speaker_observer.rs
+++ b/rust/src/router/active_speaker_observer.rs
@@ -86,7 +86,7 @@ struct Inner {
     closed: AtomicBool,
     // Drop subscription to audio speaker observer-specific notifications when observer itself is
     // dropped
-    _subscription_handler: Option<SubscriptionHandler>,
+    subscription_handler: Mutex<Option<SubscriptionHandler>>,
     _on_router_close_handler: Mutex<HandlerId>,
 }
 
@@ -113,11 +113,17 @@ impl Inner {
                         rtp_observer_id: self.id,
                     },
                 };
+                let subscription_handler = self.subscription_handler.lock().take();
+
                 self.executor
                     .spawn(async move {
                         if let Err(error) = channel.request(request).await {
                             error!("active speaker observer closing failed on drop: {}", error);
                         }
+
+                        // Drop from a different thread to avoid deadlock with recursive dropping
+                        // from within another subscription drop.
+                        drop(subscription_handler);
                     })
                     .detach();
             }
@@ -348,7 +354,7 @@ impl ActiveSpeakerObserver {
             app_data,
             router,
             closed: AtomicBool::new(false),
-            _subscription_handler: subscription_handler,
+            subscription_handler: Mutex::new(subscription_handler),
             _on_router_close_handler: Mutex::new(on_router_close_handler),
         });
 

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -198,7 +198,7 @@ struct Inner {
     router: Router,
     closed: AtomicBool,
     // Drop subscription to transport-specific notifications when transport itself is dropped
-    _subscription_handler: Option<SubscriptionHandler>,
+    subscription_handler: Mutex<Option<SubscriptionHandler>>,
     _on_router_close_handler: Mutex<HandlerId>,
 }
 
@@ -225,11 +225,17 @@ impl Inner {
                         transport_id: self.id,
                     },
                 };
+                let subscription_handler = self.subscription_handler.lock().take();
+
                 self.executor
                     .spawn(async move {
                         if let Err(error) = channel.request(request).await {
                             error!("transport closing failed on drop: {}", error);
                         }
+
+                        // Drop from a different thread to avoid deadlock with recursive dropping
+                        // from within another subscription drop.
+                        drop(subscription_handler);
                     })
                     .detach();
             }
@@ -540,7 +546,7 @@ impl PipeTransport {
             app_data,
             router,
             closed: AtomicBool::new(false),
-            _subscription_handler: subscription_handler,
+            subscription_handler: Mutex::new(subscription_handler),
             _on_router_close_handler: Mutex::new(on_router_close_handler),
         });
 

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -282,7 +282,7 @@ struct Inner {
     router: Router,
     closed: AtomicBool,
     // Drop subscription to transport-specific notifications when transport itself is dropped
-    _subscription_handler: Option<SubscriptionHandler>,
+    subscription_handler: Mutex<Option<SubscriptionHandler>>,
     _on_router_close_handler: Mutex<HandlerId>,
 }
 
@@ -309,11 +309,17 @@ impl Inner {
                         transport_id: self.id,
                     },
                 };
+                let subscription_handler = self.subscription_handler.lock().take();
+
                 self.executor
                     .spawn(async move {
                         if let Err(error) = channel.request(request).await {
                             error!("transport closing failed on drop: {}", error);
                         }
+
+                        // Drop from a different thread to avoid deadlock with recursive dropping
+                        // from within another subscription drop.
+                        drop(subscription_handler);
                     })
                     .detach();
             }
@@ -651,7 +657,7 @@ impl WebRtcTransport {
             app_data,
             router,
             closed: AtomicBool::new(false),
-            _subscription_handler: subscription_handler,
+            subscription_handler: Mutex::new(subscription_handler),
             _on_router_close_handler: Mutex::new(on_router_close_handler),
         });
 


### PR DESCRIPTION
After Meson and removing file descriptor usage in Rust, Windows support is a fairly simple task.

2 notes:
* ~some of recent Rust changes cause tests to hang occasionally, I will fix those separately, this is in case they happen here~
* hopefully these Windows tests are more reliable than those with Node and we'll not have to disable them in CI, but who knows...

~After debugging tests hangs~ I will create a PR that prepares new Rust release later.