### PR TITLE
fix: panic message on cargo test

### DIFF
--- a/rust/src/worker_manager.rs
+++ b/rust/src/worker_manager.rs
@@ -138,8 +138,9 @@ impl WorkerManager {
 
                 move || {
                     let _ = exit_sender.send(());
-                    let id = id.lock().take().unwrap();
-                    workers.lock().remove(&id);
+                    if let Some(id) = id.lock().take() {
+                        workers.lock().remove(&id);
+                    }
                 }
             },
         )


### PR DESCRIPTION
`cargo test -- --nocapture` outputs a panic message
[In this test](https://github.com/versatica/mediasoup/blob/d01e6676fa0484140bf68f0bdd5da292814f6de0/rust/tests/integration/worker.rs#L86), `create_worker` returns an error, but on_close is called. It may be better to fix this behavior.
```rust
RUST_BACKTRACE=1 cargo test worker::create_worker_wrong_settings -- --nocapture
    Finished test [unoptimized + debuginfo] target(s) in 0.10s
     Running unittests (target/debug/deps/mediasoup-7d9d78ae00cb7faf)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 24 filtered out; finished in 0.00s

     Running tests/integration/main.rs (target/debug/deps/integration-4d64bb0427330110)

running 1 test
mediasoup-worker::mediasoup_worker_run() | settings error: dtlsCertificateFile: cannot read file '/notfound/cert.pem': No such file or directory
thread 'mediasoup-worker-dbf8272f-9729-4469-b5aa-b850581ce05f' panicked at 'called `Option::unwrap()` on a `None` value', /Users/masataka/projects/mediasoup/rust/src/worker_manager.rs:141:47
stack backtrace:
test worker::create_worker_wrong_settings ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 94 filtered out; finished in 0.00s

     Running unittests (target/debug/deps/mediasoup_sys-d7d9d06a50b8136d)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```