### PR TITLE
fix: Workaround for tsc error

### DIFF
--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -2,7 +2,7 @@
 	"compileOnSave": true,
 	"compilerOptions":
 	{
-		"lib": [ "es2021" ],
+		"lib": [ "es2021", "DOM" ],
 		"target": "esnext",
 		"module": "commonjs",
 		"moduleResolution": "node",


### PR DESCRIPTION
fix error on CI https://github.com/versatica/mediasoup/runs/4362731978?check_suite_focus=true
Jest depends to @types/jsdom since[v27.4.0](https://github.com/facebook/jest/pull/11999). I think the problem in jest not considered the environment without the DOM.

Another option: use older jest.
```
"jest": "^26.6.2",
```
