### PR TITLE
native windows build fixes

### DIFF
--- a/worker/Makefile
+++ b/worker/Makefile
@@ -16,8 +16,6 @@ MEDIASOUP_BUILDTYPE ?= Release
 GULP = ./scripts/node_modules/.bin/gulp
 LCOV = ./deps/lcov/bin/lcov
 DOCKER ?= docker
-PIP_DIR = $(MEDIASOUP_OUT_DIR)/pip
-MESON ?= $(PIP_DIR)/bin/meson
 MESON_ARGS ?= ""
 
 # Disable `*.pyc` files creation.
@@ -25,11 +23,15 @@ export PYTHONDONTWRITEBYTECODE = 1
 # Instruct `meson` where to look for ninja binary.
 ifeq ($(OS),Windows_NT)
 # Windows is, of course, special.
-	export NINJA = $(PIP_DIR)/bin/ninja.exe
+	PIP_DIR = $(MEDIASOUP_OUT_DIR)\pip
+	export NINJA = $(PIP_DIR)\bin\ninja.exe
+	MESON ?= $(PIP_DIR)\bin\meson
 	RRM = rmdir /q /s
 else
+	PIP_DIR = $(MEDIASOUP_OUT_DIR)/pip
 	export NINJA = $(PIP_DIR)/bin/ninja
 	RRM = rm -rf
+	MESON ?= $(PIP_DIR)/bin/meson
 # Workaround for NixOS and Guix that don't work with pre-built binaries, see:
 # https://github.com/NixOS/nixpkgs/issues/142383.
 	PIP_BUILD_BINARIES = $(shell [ -f /etc/NIXOS -o -d /etc/guix ] && echo "--no-binary :all:")

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -134,7 +134,7 @@ clean-all: clean-subprojects
 
 mediasoup-worker: setup
 ifeq ($(MEDIASOUP_WORKER_BIN),)
-	$(MESON) compile -j $(CORES) -C $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE) mediasoup-worker
+	$(MESON) compile -j $(CORES) $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE) mediasoup-worker
 endif
 
 xcode: setup

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -2,11 +2,16 @@
 # make tasks for mediasoup-worker.
 #
 
+ifeq ($(OS),Windows_NT)
+	MEDIASOUP_OUT_DIR ?= $(shell cd)\out
+else
+	MEDIASOUP_OUT_DIR ?= $(shell pwd)/out
+endif
+
 # We need Python 3 here.
 PYTHON ?= $(shell command -v python3 2> /dev/null || echo python)
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 CORES ?= $(shell ${ROOT_DIR}/scripts/cpu_cores.sh || echo 4)
-MEDIASOUP_OUT_DIR ?= $(shell pwd)/out
 MEDIASOUP_BUILDTYPE ?= Release
 GULP = ./scripts/node_modules/.bin/gulp
 LCOV = ./deps/lcov/bin/lcov
@@ -14,18 +19,20 @@ DOCKER ?= docker
 PIP_DIR = $(MEDIASOUP_OUT_DIR)/pip
 MESON ?= $(PIP_DIR)/bin/meson
 MESON_ARGS ?= ""
-# Workaround for NixOS and Guix that don't work with pre-built binaries, see:
-# https://github.com/NixOS/nixpkgs/issues/142383.
-PIP_BUILD_BINARIES = $(shell [ -f /etc/NIXOS -o -d /etc/guix ] && echo "--no-binary :all:")
 
 # Disable `*.pyc` files creation.
 export PYTHONDONTWRITEBYTECODE = 1
 # Instruct `meson` where to look for ninja binary.
 ifeq ($(OS),Windows_NT)
-	# Windows is, of course, special.
+# Windows is, of course, special.
 	export NINJA = $(PIP_DIR)/bin/ninja.exe
+	RRM = rmdir /q /s
 else
 	export NINJA = $(PIP_DIR)/bin/ninja
+	RRM = rm -rf
+# Workaround for NixOS and Guix that don't work with pre-built binaries, see:
+# https://github.com/NixOS/nixpkgs/issues/142383.
+	PIP_BUILD_BINARIES = $(shell [ -f /etc/NIXOS -o -d /etc/guix ] && echo "--no-binary :all:")
 endif
 
 # Instruct Python where to look for modules it needs, such that `meson` actually
@@ -45,16 +52,16 @@ default: mediasoup-worker
 
 meson-ninja:
 ifeq ($(wildcard $(PIP_DIR)),)
-	# Updated pip and setuptools are needed for meson
-	# `--system` is not present everywhere and is only needed as workaround for
-	# Debian-specific issue (copied from
-	# https://github.com/gluster/gstatus/pull/33), fallback to command without
-	# `--system` if the first one fails.
+# Updated pip and setuptools are needed for meson
+# `--system` is not present everywhere and is only needed as workaround for
+# Debian-specific issue (copied from
+# https://github.com/gluster/gstatus/pull/33), fallback to command without
+# `--system` if the first one fails.
 	$(PYTHON) -m pip install --system --target=$(PIP_DIR) pip setuptools || \
 		$(PYTHON) -m pip install --target=$(PIP_DIR) pip setuptools || \
 		echo "Installation failed, likely because PIP is unavailable, if you are on Debian/Ubuntu or derivative please install the python3-pip package"
-	# Install `meson` and `ninja` using `pip` into custom location, so we don't
-	# depend on system-wide installation.
+# Install `meson` and `ninja` using `pip` into custom location, so we don't
+# depend on system-wide installation.
 	$(PYTHON) -m pip install --upgrade --target=$(PIP_DIR) $(PIP_BUILD_BINARIES) meson ninja
 endif
 
@@ -112,16 +119,16 @@ endif
 endif
 
 clean:
-	$(RM) -rf $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
+	$(RRM) $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
 
 clean-pip:
-	$(RM) -rf $(PIP_DIR)
+	$(RRM) $(PIP_DIR)
 
 clean-subprojects: meson-ninja
 	$(MESON) subprojects purge --include-cache --confirm
 
 clean-all: clean-subprojects
-	$(RM) -rf $(MEDIASOUP_OUT_DIR)
+	$(RRM) $(MEDIASOUP_OUT_DIR)
 
 mediasoup-worker: setup
 ifeq ($(MEDIASOUP_WORKER_BIN),)

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -82,8 +82,7 @@ fn main() {
         // Build
         if !Command::new("make")
             .arg("libmediasoup-worker")
-            // Force forward slashes on Windows too so that is plays well with our dumb `Makefile`
-            .env("MEDIASOUP_OUT_DIR", &out_dir.replace('\\', "/"))
+            .env("MEDIASOUP_OUT_DIR", &out_dir)
             .env("MEDIASOUP_BUILDTYPE", &build_type)
             .spawn()
             .expect("Failed to start")

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -92,20 +92,6 @@ fn main() {
         {
             panic!("Failed to build libmediasoup-worker")
         }
-
-        if env::var("KEEP_BUILD_ARTIFACTS") != Ok("1".to_string()) {
-            // Clean
-            if !Command::new("make")
-                .arg("clean-all")
-                .spawn()
-                .expect("Failed to start")
-                .wait()
-                .expect("Wasn't running")
-                .success()
-            {
-                panic!("Failed to clean libmediasoup-worker")
-            }
-        }
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
Hi there! I am using the mediasoup crate on native windows and ran into some issues with the Makefile / build.rs script.

I made the following changes

1. use windows `rmdir` instead of `rm`
2. use backslashes in file paths since `rmdir` can't handle forward slashes
3. move comments to start-of-line so they are not interpreted as part of shell command
4. remove clean-all step from build.rs (note, `MEDIASOUP_OUT_DIR` was not being set in this `Command`, so it _appears_ to be a no-op currently)

Let me know if these are changes you would consider merging upstream. For now they can just live on my personal fork :)