### PR TITLE
feat: Add Send trait to future for transport trait

### DIFF
--- a/rust/src/router/direct_transport.rs
+++ b/rust/src/router/direct_transport.rs
@@ -228,7 +228,7 @@ impl fmt::Debug for DirectTransport {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Transport for DirectTransport {
     /// Transport id.
     fn id(&self) -> TransportId {
@@ -385,7 +385,7 @@ impl Transport for DirectTransport {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl TransportGeneric for DirectTransport {
     type Dump = DirectTransportDump;
     type Stat = DirectTransportStat;

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -271,7 +271,7 @@ impl fmt::Debug for PipeTransport {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Transport for PipeTransport {
     fn id(&self) -> TransportId {
         self.inner.id
@@ -414,7 +414,7 @@ impl Transport for PipeTransport {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl TransportGeneric for PipeTransport {
     type Dump = PipeTransportDump;
     type Stat = PipeTransportStat;

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -301,7 +301,7 @@ impl fmt::Debug for PlainTransport {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Transport for PlainTransport {
     fn id(&self) -> TransportId {
         self.inner.id
@@ -444,7 +444,7 @@ impl Transport for PlainTransport {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl TransportGeneric for PlainTransport {
     type Dump = PlainTransportDump;
     type Stat = PlainTransportStat;

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -149,7 +149,7 @@ pub(super) enum TransportType {
 /// * [`DirectTransport`](crate::direct_transport::DirectTransport)
 ///
 /// For additional methods see [`TransportGeneric`].
-#[async_trait(?Send)]
+#[async_trait]
 pub trait Transport: Debug + Send + Sync + private::CloneTransport {
     /// Transport id.
     #[must_use]
@@ -282,7 +282,7 @@ impl Clone for Box<dyn Transport> {
 }
 
 /// Generic transport trait with methods available on all transports in addition to [`Transport`].
-#[async_trait(?Send)]
+#[async_trait]
 pub trait TransportGeneric: Transport + Clone + 'static {
     /// Dump data structure specific to each transport.
     #[doc(hidden)]
@@ -360,7 +360,7 @@ pub enum ConsumeDataError {
     Request(RequestError),
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 pub(super) trait TransportImpl: TransportGeneric {
     fn router(&self) -> &Router;
 

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -356,7 +356,7 @@ impl fmt::Debug for WebRtcTransport {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl Transport for WebRtcTransport {
     fn id(&self) -> TransportId {
         self.inner.id
@@ -499,7 +499,7 @@ impl Transport for WebRtcTransport {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl TransportGeneric for WebRtcTransport {
     type Dump = WebRtcTransportDump;
     type Stat = WebRtcTransportStat;


### PR DESCRIPTION
It is inconvenient that only Transport cannot use the multi-threaded executor.