### PR TITLE
Create a buffer to process RTP packets.

### DIFF
--- a/worker/include/RTC/DirectTransport.hpp
+++ b/worker/include/RTC/DirectTransport.hpp
@@ -34,6 +34,10 @@ namespace RTC
 		void SendSctpData(const uint8_t* data, size_t len) override;
 		void RecvStreamClosed(uint32_t ssrc) override;
 		void SendStreamClosed(uint32_t ssrc) override;
+
+	private:
+		// Allocated by this.
+		uint8_t* buffer{ nullptr };
 	};
 } // namespace RTC
 

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -20,6 +20,8 @@ namespace RTC
 	DirectTransport::~DirectTransport()
 	{
 		MS_TRACE();
+
+		delete[] this->buffer;
 	}
 
 	void DirectTransport::FillJson(json& jsonObject) const
@@ -102,7 +104,14 @@ namespace RTC
 					return;
 				}
 
-				RTC::RtpPacket* packet = RTC::RtpPacket::Parse(data, len);
+				// If this is the first time to reveive a rtp packet then allocate the receiving buffer now.
+				if (!this->buffer)
+					this->buffer = new uint8_t[RTC::MtuSize + 100];
+				
+				// Copy the received packet into this buffer so it can be expanded later.
+				std::memcpy(this->buffer, data, static_cast<size_t>(len));
+
+				RTC::RtpPacket* packet = RTC::RtpPacket::Parse(this->buffer, len);
 
 				if (!packet)
 				{

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -104,7 +104,7 @@ namespace RTC
 					return;
 				}
 
-				// If this is the first time to reveive a rtp packet then allocate the receiving buffer now.
+				// If this is the first time to reveive a RTP packet then allocate the receiving buffer now.
 				if (!this->buffer)
 					this->buffer = new uint8_t[RTC::MtuSize + 100];
 

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -107,7 +107,7 @@ namespace RTC
 				// If this is the first time to reveive a rtp packet then allocate the receiving buffer now.
 				if (!this->buffer)
 					this->buffer = new uint8_t[RTC::MtuSize + 100];
-				
+
 				// Copy the received packet into this buffer so it can be expanded later.
 				std::memcpy(this->buffer, data, static_cast<size_t>(len));
 


### PR DESCRIPTION
Fix the problem about the method 'RtpPacket::SetExtensions' changed the content of the buffer beyond the rtp length.