### PR TITLE
Clean everything except `mediasoup-worker` binary in postinstall step

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -94,6 +94,11 @@ Builds the `libmediasoup-worker` static library at `worker/out/Release/`.
 Cleans built objects and binaries.
 
 
+### `make clean-build`
+
+Cleans built objects and other artifacts, but keeps `mediasoup-worker` binary in place.
+
+
 ### `make clean-pip`
 
 Cleans `meson` and `ninja` installed in local prefix with pip.

--- a/npm-scripts.js
+++ b/npm-scripts.js
@@ -121,8 +121,12 @@ switch (task)
 		if (!process.env.MEDIASOUP_WORKER_BIN)
 		{
 			execute('node npm-scripts.js worker:build');
-			execute(`${MAKE} clean-pip -C worker`);
+			// Clean build artifacts except `mediasoup-worker`.
+			execute(`${MAKE} clean-build -C worker`);
+			// Clean downloaded dependencies.
 			execute(`${MAKE} clean-subprojects -C worker`);
+			// Clean PIP/Meson/Ninja.
+			execute(`${MAKE} clean-pip -C worker`);
 		}
 
 		break;

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -12,6 +12,7 @@ GULP = ./scripts/node_modules/.bin/gulp
 LCOV = ./deps/lcov/bin/lcov
 DOCKER ?= docker
 PIP_DIR = $(MEDIASOUP_OUT_DIR)/pip
+BUILD_DIR ?= $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/build
 MESON ?= $(PIP_DIR)/bin/meson
 MESON_ARGS ?= ""
 # Workaround for NixOS and Guix that don't work with pre-built binaries, see:
@@ -69,14 +70,14 @@ ifeq ($(MEDIASOUP_BUILDTYPE),Release)
 		-Db_staticpic=true \
 		--reconfigure \
 		$(MESON_ARGS) \
-		$(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE) || \
+		$(BUILD_DIR) || \
 		$(MESON) setup \
 			--buildtype release \
 			-Db_ndebug=true \
 			-Db_pie=true \
 			-Db_staticpic=true \
 			$(MESON_ARGS) \
-			$(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
+			$(BUILD_DIR)
 else
 ifeq ($(MEDIASOUP_BUILDTYPE),Debug)
 	$(MESON) setup \
@@ -85,13 +86,13 @@ ifeq ($(MEDIASOUP_BUILDTYPE),Debug)
 		-Db_staticpic=true \
 		--reconfigure \
 		$(MESON_ARGS) \
-		$(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE) || \
+		$(BUILD_DIR) || \
 		$(MESON) setup \
 			--buildtype debug \
 			-Db_pie=true \
 			-Db_staticpic=true \
 			$(MESON_ARGS) \
-			$(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
+			$(BUILD_DIR)
 else
 	$(MESON) setup \
 		--buildtype $(MEDIASOUP_BUILDTYPE) \
@@ -100,19 +101,22 @@ else
 		-Db_staticpic=true \
 		--reconfigure \
 		$(MESON_ARGS) \
-		$(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE) || \
+		$(BUILD_DIR) || \
 		$(MESON) setup \
 			--buildtype $(MEDIASOUP_BUILDTYPE) \
 			-Db_ndebug=if-release \
 			-Db_pie=true \
 			-Db_staticpic=true \
 			$(MESON_ARGS) \
-			$(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
+			$(BUILD_DIR)
 endif
 endif
 
 clean:
 	$(RM) -rf $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
+
+clean-build:
+	$(RM) -rf $(BUILD_DIR)
 
 clean-pip:
 	$(RM) -rf $(PIP_DIR)
@@ -125,7 +129,12 @@ clean-all: clean-subprojects
 
 mediasoup-worker: setup
 ifeq ($(MEDIASOUP_WORKER_BIN),)
-	$(MESON) compile -j $(CORES) -C $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE) mediasoup-worker
+	$(MESON) compile -j $(CORES) -C $(BUILD_DIR) mediasoup-worker
+endif
+ifeq ($(OS),Windows_NT)
+	copy $(BUILD_DIR)/mediasoup-worker.exe $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker.exe
+else
+	cp $(BUILD_DIR)/mediasoup-worker $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker
 endif
 
 xcode: setup
@@ -139,14 +148,14 @@ format:
 
 test: setup
 ifeq ($(MEDIASOUP_WORKER_BIN),)
-	$(MESON) compile -j $(CORES) -C $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE) mediasoup-worker-test
+	$(MESON) compile -j $(CORES) -C $(BUILD_DIR) mediasoup-worker-test
 	# On Windows lcov doesn't work (at least not yet) and we need to add `.exe` to
 	# the binary path.
 ifeq ($(OS),Windows_NT)
-	$(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker-test.exe --invisibles --use-colour=yes $(MEDIASOUP_TEST_TAGS)
+	$(BUILD_DIR)/mediasoup-worker-test.exe --invisibles --use-colour=yes $(MEDIASOUP_TEST_TAGS)
 else
 	$(LCOV) --directory ./ --zerocounters
-	$(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker-test --invisibles --use-colour=yes $(MEDIASOUP_TEST_TAGS)
+	$(BUILD_DIR)/mediasoup-worker-test --invisibles --use-colour=yes $(MEDIASOUP_TEST_TAGS)
 endif
 endif
 
@@ -155,18 +164,18 @@ tidy:
 		-clang-tidy-binary=./scripts/node_modules/.bin/clang-tidy \
 		-clang-apply-replacements-binary=./scripts/node_modules/.bin/clang-apply-replacements \
 		-header-filter='(Channel/**/*.hpp|DepLibSRTP.hpp|DepLibUV.hpp|DepLibWebRTC.hpp|DepOpenSSL.hpp|DepUsrSCTP.hpp|LogLevel.hpp|Logger.hpp|MediaSoupError.hpp|RTC/**/*.hpp|Settings.hpp|Utils.hpp|Worker.hpp|common.hpp|handles/**/*.hpp)' \
-		-p=$(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE) \
+		-p=$(BUILD_DIR) \
 		-j=$(CORES) \
 		-checks=$(MEDIASOUP_TIDY_CHECKS) \
 		-quiet
 
 fuzzer: setup
 ifeq ($(MEDIASOUP_WORKER_BIN),)
-	$(MESON) compile -j $(CORES) -C $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE) mediasoup-worker-fuzzer
+	$(MESON) compile -j $(CORES) -C $(BUILD_DIR) mediasoup-worker-fuzzer
 endif
 
 fuzzer-run-all:
-	LSAN_OPTIONS=verbosity=1:log_threads=1 ./$(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker-fuzzer -artifact_prefix=fuzzer/reports/ -max_len=1400 fuzzer/new-corpus deps/webrtc-fuzzer-corpora/corpora/stun-corpus deps/webrtc-fuzzer-corpora/corpora/rtp-corpus deps/webrtc-fuzzer-corpora/corpora/rtcp-corpus
+	LSAN_OPTIONS=verbosity=1:log_threads=1 ./$(BUILD_DIR)/mediasoup-worker-fuzzer -artifact_prefix=fuzzer/reports/ -max_len=1400 fuzzer/new-corpus deps/webrtc-fuzzer-corpora/corpora/stun-corpus deps/webrtc-fuzzer-corpora/corpora/rtp-corpus deps/webrtc-fuzzer-corpora/corpora/rtcp-corpus
 
 docker-build:
 ifeq ($(DOCKER_NO_CACHE),true)
@@ -184,4 +193,4 @@ docker-run:
 		mediasoup/docker:latest
 
 libmediasoup-worker: setup
-	$(MESON) compile -j $(CORES) -C $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE) libmediasoup-worker
+	$(MESON) compile -j $(CORES) -C $(BUILD_DIR) libmediasoup-worker

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -96,7 +96,10 @@ fn main() {
 
     #[cfg(not(target_os = "windows"))]
     {
-        let from = format!("{}/{}/libmediasoup-worker.a", mediasoup_out_dir, build_type);
+        let from = format!(
+            "{}/{}/build/libmediasoup-worker.a",
+            mediasoup_out_dir, build_type
+        );
         let to = format!("{}/libmediasoup-worker.a", out_dir);
         std::fs::copy(&from, &to).unwrap_or_else(|error| {
             panic!(
@@ -107,8 +110,14 @@ fn main() {
     }
     #[cfg(target_os = "windows")]
     {
-        let dot_a = format!("{}/{}/libmediasoup-worker.a", mediasoup_out_dir, build_type);
-        let from = format!("{}/{}/mediasoup-worker.lib", mediasoup_out_dir, build_type);
+        let dot_a = format!(
+            "{}/{}/build/libmediasoup-worker.a",
+            mediasoup_out_dir, build_type
+        );
+        let from = format!(
+            "{}/{}/build/mediasoup-worker.lib",
+            mediasoup_out_dir, build_type
+        );
         let to = format!("{}/mediasoup-worker.lib", out_dir);
 
         // Meson builds `libmediasoup-worker.a` on Windows instead of `*.lib` file under MinGW


### PR DESCRIPTION
This makes `node_modules/mediasoup` smaller than ever before.

Fixes #736, cc @jcpage