### PR TITLE
Improve Windows support by not requiring MSVC configuration

### DIFF
--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -20,17 +20,6 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-      - name: Add MSVC compiler
-        uses: ilammy/msvc-dev-cmd@v1
-        if: runner.os == 'Windows'
-
-      # This is needed as a workaround for GNU linker being first in PATH and thus preventing Meson from finding MSVC
-      # linker.
-      - name: Remove GNU linker for MSVC
-        shell: bash
-        run: rm /usr/bin/link
-        if: runner.os == 'Windows'
-
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -47,7 +36,6 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
           key: ${{ matrix.os }}-cargo-${{ matrix.rust }}-${{ hashFiles('**/Cargo.toml') }}
 
       - name: cargo fmt

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -32,13 +32,6 @@ jobs:
           - os: macos-11
             cc: clang
             cxx: clang++
-          # TODO: These build, but don't run, unlock if you figure out why.
-          # - os: windows-2019
-          #   cc: gcc
-          #   cxx: g++
-          # - os: windows-2019
-          #   cc: clang
-          #   cxx: clang++
           # TODO: Unlock when intermittent unexplainable CI errors are resolved.
           # - os: windows-2019
           #   cc: cl
@@ -54,25 +47,6 @@ jobs:
       CXX: ${{ matrix.build.cxx }}
 
     steps:
-      - name: Add MSVC compiler
-        uses: ilammy/msvc-dev-cmd@v1
-        if: runner.os == 'Windows' && matrix.build.cc == 'cl'
-
-      # This is needed as a workaround for GNU linker being first in PATH and
-      # thus preventing Meson from finding MSVC linker.
-      - name: Remove GNU linker for MSVC
-        shell: bash
-        run: rm /usr/bin/link
-        if: runner.os == 'Windows' && matrix.build.cc == 'cl'
-
-      # Clang is in MSYS2's bin directory, but adding it to PATH breaks a lot of
-      # stuff, so let's just fix paths.
-      - name: Specify full path to Clang on Windows
-        run: |
-          echo "CC=C:\msys64\mingw64\bin\${env:CC}" >> $env:GITHUB_ENV
-          echo "CXX=C:\msys64\mingw64\bin\${env:CXX}" >> $env:GITHUB_ENV
-        if: runner.os == 'Windows' && matrix.build.cc == 'clang'
-
       - name: Checkout
         uses: actions/checkout@v2
 
@@ -99,7 +73,4 @@ jobs:
 
       - run: npm run worker:build
       - run: npm run test:worker
-        # All compilers on Windows can build everything, but tests fail to run
-        # on GCC/Clang with "Error -1073741511", remove condition below if you
-        # fixed it.
-        if: runner.os != 'Windows' || matrix.build.cc == 'cl'
+        if: runner.os != 'Windows'

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -37,6 +37,13 @@ else
 	export PYTHONPATH := $(PIP_DIR):${PYTHONPATH}
 endif
 
+# Activate VS environment on Windows by default.
+ifeq ($(OS),Windows_NT)
+ifeq ($(MESON_ARGS),"")
+	MESON_ARGS = $(subst $\",,"--vsenv")
+endif
+endif
+
 .PHONY:	\
 	default meson-ninja setup clean clean-pip clean-subprojects clean-all mediasoup-worker xcode lint format test tidy \
 	fuzzer fuzzer-run-all docker-build docker-run libmediasoup-worker


### PR DESCRIPTION
Since Meson `0.59.0` there is a flag `--vsenv` that will configure MSVC automatically, so users will no longer have to run cryptic commands themselves, greatly improving development process. This is why additional setup instructions are no longer needed in CI either.