### PR TITLE
Make Tst header packed to fix Windows tests and unlock Windows worker CI

### DIFF
--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -32,10 +32,9 @@ jobs:
           - os: macos-11
             cc: clang
             cxx: clang++
-          # TODO: Unlock when intermittent unexplainable CI errors are resolved.
-          # - os: windows-2019
-          #   cc: cl
-          #   cxx: cl
+          - os: windows-2019
+            cc: cl
+            cxx: cl
         # A single Node.js version should be fine for C++.
         node:
           - 14

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -139,7 +139,7 @@ ifeq ($(MEDIASOUP_WORKER_BIN),)
 	$(MESON) compile -j $(CORES) -C $(BUILD_DIR) mediasoup-worker
 endif
 ifeq ($(OS),Windows_NT)
-	copy $(BUILD_DIR)/mediasoup-worker.exe $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker.exe
+	cp $(BUILD_DIR)/mediasoup-worker.exe $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker.exe
 else
 	cp $(BUILD_DIR)/mediasoup-worker $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker
 endif

--- a/worker/include/RTC/RTCP/FeedbackPsTst.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsTst.hpp
@@ -24,6 +24,12 @@ namespace RTC
 		class FeedbackPsTstItem : public FeedbackItem
 		{
 		public:
+#ifdef _WIN32
+#pragma pack(push, 1)
+#define MEDIASOUP_PACKED
+#else
+#define MEDIASOUP_PACKED __attribute__((packed))
+#endif
 			struct Header
 			{
 				uint32_t ssrc;
@@ -36,7 +42,11 @@ namespace RTC
 				uint8_t reserved2 : 3;
 				uint8_t index : 5;
 #endif
-			};
+			} MEDIASOUP_PACKED;
+#ifdef _WIN32
+#pragma pack(pop)
+#endif
+#undef SCTP_PACKED
 
 		public:
 			static const size_t HeaderSize{ 8 };

--- a/worker/include/RTC/RTCP/FeedbackPsTst.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsTst.hpp
@@ -46,7 +46,7 @@ namespace RTC
 #ifdef _WIN32
 #pragma pack(pop)
 #endif
-#undef SCTP_PACKED
+#undef MEDIASOUP_PACKED
 
 		public:
 			static const size_t HeaderSize{ 8 };


### PR DESCRIPTION
I think this is correct, see https://github.com/versatica/mediasoup/issues/702#issuecomment-1000954034 for context.

Fixes #702