### PR TITLE
Fix bad printing of error messages from Worker

### DIFF
--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -259,7 +259,7 @@ inline void Worker::OnChannelRequest(Channel::ChannelSocket* /*channel*/, Channe
 			}
 			catch (const MediaSoupError& error)
 			{
-				MS_THROW_ERROR("%s [method:%s]", error.buffer, request->method.c_str());
+				MS_THROW_ERROR("%s [method:%s]", error.what(), request->method.c_str());
 			}
 
 			auto* router = new RTC::Router(routerId);
@@ -283,7 +283,7 @@ inline void Worker::OnChannelRequest(Channel::ChannelSocket* /*channel*/, Channe
 			}
 			catch (const MediaSoupError& error)
 			{
-				MS_THROW_ERROR("%s [method:%s]", error.buffer, request->method.c_str());
+				MS_THROW_ERROR("%s [method:%s]", error.what(), request->method.c_str());
 			}
 
 			// Remove it from the map and delete it.
@@ -308,11 +308,11 @@ inline void Worker::OnChannelRequest(Channel::ChannelSocket* /*channel*/, Channe
 			}
 			catch (const MediaSoupTypeError& error)
 			{
-				MS_THROW_TYPE_ERROR("%s [method:%s]", error.buffer, request->method.c_str());
+				MS_THROW_TYPE_ERROR("%s [method:%s]", error.what(), request->method.c_str());
 			}
 			catch (const MediaSoupError& error)
 			{
-				MS_THROW_ERROR("%s [method:%s]", error.buffer, request->method.c_str());
+				MS_THROW_ERROR("%s [method:%s]", error.what(), request->method.c_str());
 			}
 
 			break;
@@ -349,11 +349,11 @@ inline void Worker::OnPayloadChannelNotification(
 	}
 	catch (const MediaSoupTypeError& error)
 	{
-		MS_THROW_TYPE_ERROR("%s [event:%s]", error.buffer, notification->event.c_str());
+		MS_THROW_TYPE_ERROR("%s [event:%s]", error.what(), notification->event.c_str());
 	}
 	catch (const MediaSoupError& error)
 	{
-		MS_THROW_ERROR("%s [method:%s]", error.buffer, notification->event.c_str());
+		MS_THROW_ERROR("%s [method:%s]", error.what(), notification->event.c_str());
 	}
 }
 
@@ -376,11 +376,11 @@ inline void Worker::OnPayloadChannelRequest(
 	}
 	catch (const MediaSoupTypeError& error)
 	{
-		MS_THROW_TYPE_ERROR("%s [method:%s]", error.buffer, request->method.c_str());
+		MS_THROW_TYPE_ERROR("%s [method:%s]", error.what(), request->method.c_str());
 	}
 	catch (const MediaSoupError& error)
 	{
-		MS_THROW_ERROR("%s [method:%s]", error.buffer, request->method.c_str());
+		MS_THROW_ERROR("%s [method:%s]", error.what(), request->method.c_str());
 	}
 }
 


### PR DESCRIPTION
Directly passing the error buffer caused issues with the snprintf that MS_THROW_ERROR() does.

Possibly due to the fact that it might be overwriting the same memory buffer that is passed. This meant that incomplete messages would end up arriving to the client side.

## What was wrong

I was getting these logs from mediasoup:

```
mediasoup:Channel request() [method:transport.produce, id:5] +2ms
mediasoup:ERROR:Channel [pid:24259 RTC::Producer::Producer() | throwing MediaSoupTypeError: video/VP9 codec not supported for simulcast +0ms
mediasoup:ERROR:Channel [pid:24259 Worker::OnChannelRequest() | throwing MediaSoupTypeError: video/VP9 codec not supported for simulcastS[method:transport.produce] +0ms
mediasoup:WARN:Channel request failed [method:transport.produce, id:5]: S[method:transport.produce] +0ms
```

Note that I replaced the space with an `S` [here](https://github.com/versatica/mediasoup/blob/6df7e245b13d6cfe5f0ebd91aff2f009ec8950ff/worker/src/Worker.cpp#L311) (_only for my tests_), so it becomes more obvious that the original contents of the `buffer` were getting lost, _while exactly the new string is the only part that survives_.

And my call to `console.error("ERROR: " + error)` showed this:
```
ERROR: TypeError: S[method:transport.produce]
```

While I expected it to show the whole error string.

## How it's fixed

With this patch, the logs now look like this:

```
mediasoup:Channel request() [method:transport.produce, id:5] +1ms
mediasoup:ERROR:Channel [pid:27384 RTC::Producer::Producer() | throwing MediaSoupTypeError: video/VP9 codec not supported for simulcast +0ms
mediasoup:ERROR:Channel [pid:27384 Worker::OnChannelRequest() | throwing MediaSoupTypeError: video/VP9 codec not supported for simulcastS[method:transport.produce] +0ms
mediasoup:WARN:Channel request failed [method:transport.produce, id:5]: video/VP9 codec not supported for simulcastS[method:transport.produce] +0ms
```

And my call to `console.error("ERROR: " + error)` shows this:
```
ERROR: TypeError: video/VP9 codec not supported for simulcastS[method:transport.produce]
```


I.e. the complete error message is able to reach the Node.js client.

I've only tested the particular code path that happens in this case (a Worker error caused by attempting to use Simulcast with VP9) but it only makes sense that this memory overwriting error would happen everywhere there the `error.buffer` was passed directly instead of the class accessor method, `error.what()`.