### PR TITLE
Replace manual build artifacts management with Meson commands

### DIFF
--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup-sys"
-version = "0.3.1"
+version = "0.3.2"
 description = "FFI bindings to C++ libmediasoup-worker"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition = "2018"

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -12,6 +12,7 @@ GULP = ./scripts/node_modules/.bin/gulp
 LCOV = ./deps/lcov/bin/lcov
 DOCKER ?= docker
 PIP_DIR = $(MEDIASOUP_OUT_DIR)/pip
+INSTALL_DIR ?= $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
 BUILD_DIR ?= $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/build
 MESON ?= $(PIP_DIR)/bin/meson
 MESON_ARGS ?= ""
@@ -71,6 +72,9 @@ setup: meson-ninja
 # https://github.com/ninja-build/ninja/issues/1997
 ifeq ($(MEDIASOUP_BUILDTYPE),Release)
 	$(MESON) setup \
+		--prefix $(INSTALL_DIR) \
+		--bindir '' \
+		--libdir '' \
 		--buildtype release \
 		-Db_ndebug=true \
 		-Db_pie=true \
@@ -79,6 +83,9 @@ ifeq ($(MEDIASOUP_BUILDTYPE),Release)
 		$(MESON_ARGS) \
 		$(BUILD_DIR) || \
 		$(MESON) setup \
+			--prefix $(INSTALL_DIR) \
+			--bindir '' \
+			--libdir '' \
 			--buildtype release \
 			-Db_ndebug=true \
 			-Db_pie=true \
@@ -88,6 +95,9 @@ ifeq ($(MEDIASOUP_BUILDTYPE),Release)
 else
 ifeq ($(MEDIASOUP_BUILDTYPE),Debug)
 	$(MESON) setup \
+		--prefix $(INSTALL_DIR) \
+		--bindir '' \
+		--libdir '' \
 		--buildtype debug \
 		-Db_pie=true \
 		-Db_staticpic=true \
@@ -95,6 +105,9 @@ ifeq ($(MEDIASOUP_BUILDTYPE),Debug)
 		$(MESON_ARGS) \
 		$(BUILD_DIR) || \
 		$(MESON) setup \
+			--prefix $(INSTALL_DIR) \
+			--bindir '' \
+			--libdir '' \
 			--buildtype debug \
 			-Db_pie=true \
 			-Db_staticpic=true \
@@ -102,6 +115,9 @@ ifeq ($(MEDIASOUP_BUILDTYPE),Debug)
 			$(BUILD_DIR)
 else
 	$(MESON) setup \
+		--prefix $(INSTALL_DIR) \
+		--bindir '' \
+		--libdir '' \
 		--buildtype $(MEDIASOUP_BUILDTYPE) \
 		-Db_ndebug=if-release \
 		-Db_pie=true \
@@ -110,6 +126,9 @@ else
 		$(MESON_ARGS) \
 		$(BUILD_DIR) || \
 		$(MESON) setup \
+			--prefix $(INSTALL_DIR) \
+			--bindir '' \
+			--libdir '' \
 			--buildtype $(MEDIASOUP_BUILDTYPE) \
 			-Db_ndebug=if-release \
 			-Db_pie=true \
@@ -120,7 +139,7 @@ endif
 endif
 
 clean:
-	$(RM) -rf $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
+	$(RM) -rf $(INSTALL_DIR)
 
 clean-build:
 	$(RM) -rf $(BUILD_DIR)
@@ -136,12 +155,8 @@ clean-all: clean-subprojects
 
 mediasoup-worker: setup
 ifeq ($(MEDIASOUP_WORKER_BIN),)
-	$(MESON) compile -j $(CORES) -C $(BUILD_DIR) mediasoup-worker
-endif
-ifeq ($(OS),Windows_NT)
-	cp $(BUILD_DIR)/mediasoup-worker.exe $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker.exe
-else
-	cp $(BUILD_DIR)/mediasoup-worker $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/mediasoup-worker
+	$(MESON) compile -C $(BUILD_DIR) -j $(CORES) mediasoup-worker
+	$(MESON) install -C $(BUILD_DIR) --no-rebuild --tags mediasoup-worker
 endif
 
 xcode: setup
@@ -154,8 +169,8 @@ format:
 	$(GULP) --gulpfile ./scripts/gulpfile.js format:worker
 
 test: setup
-ifeq ($(MEDIASOUP_WORKER_BIN),)
-	$(MESON) compile -j $(CORES) -C $(BUILD_DIR) mediasoup-worker-test
+	$(MESON) compile -C $(BUILD_DIR) -j $(CORES) mediasoup-worker-test
+	$(MESON) install -C $(BUILD_DIR) --no-rebuild --tags mediasoup-worker-test
 	# On Windows lcov doesn't work (at least not yet) and we need to add `.exe` to
 	# the binary path.
 ifeq ($(OS),Windows_NT)
@@ -163,7 +178,6 @@ ifeq ($(OS),Windows_NT)
 else
 	$(LCOV) --directory ./ --zerocounters
 	$(BUILD_DIR)/mediasoup-worker-test --invisibles --use-colour=yes $(MEDIASOUP_TEST_TAGS)
-endif
 endif
 
 tidy:
@@ -177,9 +191,8 @@ tidy:
 		-quiet
 
 fuzzer: setup
-ifeq ($(MEDIASOUP_WORKER_BIN),)
-	$(MESON) compile -j $(CORES) -C $(BUILD_DIR) mediasoup-worker-fuzzer
-endif
+	$(MESON) compile -C $(BUILD_DIR) -j $(CORES) mediasoup-worker-fuzzer
+	$(MESON) install -C $(BUILD_DIR) --no-rebuild --tags mediasoup-worker-fuzzer
 
 fuzzer-run-all:
 	LSAN_OPTIONS=verbosity=1:log_threads=1 ./$(BUILD_DIR)/mediasoup-worker-fuzzer -artifact_prefix=fuzzer/reports/ -max_len=1400 fuzzer/new-corpus deps/webrtc-fuzzer-corpora/corpora/stun-corpus deps/webrtc-fuzzer-corpora/corpora/rtp-corpus deps/webrtc-fuzzer-corpora/corpora/rtcp-corpus
@@ -200,4 +213,5 @@ docker-run:
 		mediasoup/docker:latest
 
 libmediasoup-worker: setup
-	$(MESON) compile -j $(CORES) -C $(BUILD_DIR) libmediasoup-worker
+	$(MESON) compile -C $(BUILD_DIR) -j $(CORES) libmediasoup-worker
+	$(MESON) install -C $(BUILD_DIR) --no-rebuild --tags libmediasoup-worker

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -233,6 +233,8 @@ libmediasoup_worker = library(
   'libmediasoup-worker',
   name_prefix: '',
   build_by_default: false,
+  install: true,
+  install_tag: 'libmediasoup-worker',
   dependencies: dependencies,
   sources: common_sources,
   include_directories: include_directories('include'),
@@ -243,6 +245,8 @@ libmediasoup_worker = library(
 executable(
   'mediasoup-worker',
   build_by_default: true,
+  install: true,
+  install_tag: 'mediasoup-worker',
   dependencies: dependencies,
   sources: common_sources + ['src/main.cpp'],
   include_directories: include_directories('include'),
@@ -252,6 +256,8 @@ executable(
 mediasoup_worker_test = executable(
   'mediasoup-worker-test',
   build_by_default: false,
+  install: true,
+  install_tag: 'mediasoup-worker-test',
   dependencies: dependencies + [
     catch2_proj.get_variable('catch2_dep'),
   ],
@@ -314,6 +320,8 @@ if host_machine.system() == 'linux'
   executable(
     'mediasoup-worker-fuzzer',
     build_by_default: false,
+    install: true,
+    install_tag: 'mediasoup-worker-fuzzer',
     dependencies: dependencies,
     sources: common_sources + [
       'fuzzer/src/fuzzer.cpp',


### PR DESCRIPTION
This replaces manual file copying with more purpose-built Meson commands.

In addition to making code a bit cleaner and easier to read it also fixes #754, which only affected Rust version and caused by new feature added in latest Meson release while we were relying on older (inferior) behavior and the best solution is to just use installation commands that by default build the kind of static library we need.