### PR TITLE
Update actix dependencies

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -66,14 +66,15 @@ version = "0.8.2"
 
 [dev-dependencies]
 actix = "0.12.0"
-actix-web-actors = "4.0.0-beta.6"
+actix-web-actors = "4.0.0-beta.11"
 async-io = "1.6.0"
 criterion = "0.3.5"
 env_logger = "0.9.0"
 
 [dev-dependencies.actix-web]
 default-features = false
-version = "4.0.0-beta.8"
+features = ["macros"]
+version = "4.0.0-rc.3"
 
 [[bench]]
 name = "direct_data"


### PR DESCRIPTION
This fixes newer CI errors in latest pre-release version of actix-web (used in examples)