### PR TITLE
Export worker workflow artifacts

### DIFF
--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -76,3 +76,9 @@ jobs:
       - run: npm run worker:build
       - run: npm run test:worker
         if: runner.os != 'Windows'
+
+      - name: Release artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: mediasoup-worker-${{ matrix.build.os }}-${{ matrix.build.cc }}
+          path: worker/out/Release


### PR DESCRIPTION
Having worker binaries it is much easier to start using mediasoup as one does not need to prepare the whole environment for building it. 

One caveat is that these artifacts expire in 30 days.
