### PR TITLE
Fix VP9 kSVC forwarding logic to not forward lower unneded layers

### DIFF
--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -281,9 +281,19 @@ namespace RTC
 				}
 			}
 
-			// Filter spatial layers higher than current one (unless old packet).
-			if (packetSpatialLayer > tmpSpatialLayer && !isOldPacket)
-				return false;
+			// Unless old packet filter spatial layers that are either
+			// * higher than current one
+			// * different than the current one when KSVC is enabled and this is not a keyframe
+			// (interframe p bit = 1)
+			if (!isOldPacket)
+			{
+				if (
+				  packetSpatialLayer > tmpSpatialLayer ||
+				  (context->IsKSvc() && this->payloadDescriptor->p && packetSpatialLayer != tmpSpatialLayer))
+				{
+					return false;
+				}
+			}
 
 			// Check and handle temporal layer (unless old packet).
 			if (!isOldPacket)

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -285,14 +285,12 @@ namespace RTC
 			// * higher than current one
 			// * different than the current one when KSVC is enabled and this is not a keyframe
 			// (interframe p bit = 1)
-			if (!isOldPacket)
+			if (
+			  !isOldPacket &&
+			  (packetSpatialLayer > tmpSpatialLayer ||
+			   (context->IsKSvc() && this->payloadDescriptor->p && packetSpatialLayer != tmpSpatialLayer)))
 			{
-				if (
-				  packetSpatialLayer > tmpSpatialLayer ||
-				  (context->IsKSvc() && this->payloadDescriptor->p && packetSpatialLayer != tmpSpatialLayer))
-				{
-					return false;
-				}
+				return false;
 			}
 
 			// Check and handle temporal layer (unless old packet).


### PR DESCRIPTION
Description:

When using VP9 in kSVC model (current supported mode in WebRTC) the higher spatial layers are independent of the lower spatial layers and need to be filtered.  Otherwise we are consuming much more bandwidth tan needed (30%?).  

![image](https://user-images.githubusercontent.com/512252/155956656-20623870-36e5-4d3d-a4af-34e9bf20f0f7.png)
https://www.w3.org/TR/webrtc-svc/

To detect if it is a keyframe packet that needs to be forwarded even if it is a lower spatial layer this change checks the P bit in the VP9 header that distinguishes frames that are encoded independently of other frames (key frames).

Test Plan:
Ran producer and consumer locally and changed MaxOutgoingBitrate of the consumer to allocate different bitrates and check the video can always be decoded by the consumer.