### PR TITLE
Fix update bandwidth estimation configuration and available bitrate when updating max outgoing bitrate

### DIFF
--- a/worker/include/RTC/TransportCongestionControlClient.hpp
+++ b/worker/include/RTC/TransportCongestionControlClient.hpp
@@ -83,6 +83,7 @@ namespace RTC
 	private:
 		void MayEmitAvailableBitrateEvent(uint32_t previousAvailableBitrate);
 		void UpdatePacketLoss(double packetLoss);
+		void ApplyBitrateUpdates();
 
 		void InitializeController();
 		void DestroyController();

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -269,6 +269,14 @@ namespace RTC
 			MS_THROW_ERROR("maxOutgoingBitrate must be >= 30000bps");
 
 		this->maxOutgoingBitrate = maxBitrate;
+
+		ApplyBitrateUpdates();
+
+		if (this->maxOutgoingBitrate > 0u)
+		{
+			this->bitrates.availableBitrate =
+			  std::min<uint32_t>(this->maxOutgoingBitrate, this->bitrates.availableBitrate);
+		}
 	}
 
 	void TransportCongestionControlClient::SetDesiredBitrate(uint32_t desiredBitrate, bool force)
@@ -290,6 +298,11 @@ namespace RTC
 		// more stable values.
 		this->bitrates.startBitrate = std::max<uint32_t>(MinBitrate, this->bitrates.availableBitrate);
 
+		ApplyBitrateUpdates();
+	}
+
+	void TransportCongestionControlClient::ApplyBitrateUpdates()
+	{
 		auto currentMaxBitrate = this->bitrates.maxBitrate;
 		uint32_t newMaxBitrate = 0;
 


### PR DESCRIPTION
Description:

When updating the max outgoing bitrate we need to update it also in the webrtc bandwidth estimator configuration or it won't be applied until the desired bitrate changes.   Also the availableBitrate needs to be updated or the SFU will keep sending a bitrate larger than maxOutgoingBitrate for an undetermined amount of time.

Test Plan:
Ran producer and consumer locally with SVC/Simulcast enabled and configure different maxOutgoingBitrates checking that the forwarded layers change accordingly.