### PR TITLE
Use more efficient collections

### DIFF
--- a/worker/include/Channel/ChannelRequest.hpp
+++ b/worker/include/Channel/ChannelRequest.hpp
@@ -2,9 +2,9 @@
 #define MS_CHANNEL_REQUEST_HPP
 
 #include "common.hpp"
+#include <absl/container/flat_hash_map.h>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <unordered_map>
 
 using json = nlohmann::json;
 
@@ -75,7 +75,7 @@ namespace Channel
 		};
 
 	private:
-		static std::unordered_map<std::string, MethodId> string2MethodId;
+		static absl::flat_hash_map<std::string, MethodId> string2MethodId;
 
 	public:
 		ChannelRequest(Channel::ChannelSocket* channel, json& jsonRequest);

--- a/worker/include/DepUsrSCTP.hpp
+++ b/worker/include/DepUsrSCTP.hpp
@@ -4,7 +4,7 @@
 #include "common.hpp"
 #include "RTC/SctpAssociation.hpp"
 #include "handles/Timer.hpp"
-#include <unordered_map>
+#include <absl/container/flat_hash_map.h>
 
 class DepUsrSCTP
 {
@@ -42,7 +42,7 @@ private:
 	thread_local static Checker* checker;
 	static uint64_t numSctpAssociations;
 	static uintptr_t nextSctpAssociationId;
-	static std::unordered_map<uintptr_t, RTC::SctpAssociation*> mapIdSctpAssociation;
+	static absl::flat_hash_map<uintptr_t, RTC::SctpAssociation*> mapIdSctpAssociation;
 };
 
 #endif

--- a/worker/include/PayloadChannel/Notification.hpp
+++ b/worker/include/PayloadChannel/Notification.hpp
@@ -2,9 +2,9 @@
 #define MS_PAYLOAD_CHANNEL_NOTIFICATION_HPP
 
 #include "common.hpp"
+#include <absl/container/flat_hash_map.h>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <unordered_map>
 
 using json = nlohmann::json;
 
@@ -24,7 +24,7 @@ namespace PayloadChannel
 		static bool IsNotification(json& jsonNotification);
 
 	private:
-		static std::unordered_map<std::string, EventId> string2EventId;
+		static absl::flat_hash_map<std::string, EventId> string2EventId;
 
 	public:
 		explicit Notification(json& jsonNotification);

--- a/worker/include/PayloadChannel/PayloadChannelRequest.hpp
+++ b/worker/include/PayloadChannel/PayloadChannelRequest.hpp
@@ -2,9 +2,9 @@
 #define MS_PAYLOAD_CHANNEL_REQUEST_HPP
 
 #include "common.hpp"
+#include <absl/container/flat_hash_map.h>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <unordered_map>
 
 using json = nlohmann::json;
 
@@ -26,7 +26,7 @@ namespace PayloadChannel
 		static bool IsRequest(json& jsonRequest);
 
 	private:
-		static std::unordered_map<std::string, MethodId> string2MethodId;
+		static absl::flat_hash_map<std::string, MethodId> string2MethodId;
 
 	public:
 		PayloadChannelRequest(PayloadChannel::PayloadChannelSocket* channel, json& jsonRequest);

--- a/worker/include/RTC/ActiveSpeakerObserver.hpp
+++ b/worker/include/RTC/ActiveSpeakerObserver.hpp
@@ -3,8 +3,8 @@
 
 #include "RTC/RtpObserver.hpp"
 #include "handles/Timer.hpp"
+#include <absl/container/flat_hash_map.h>
 #include <nlohmann/json.hpp>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -89,7 +89,7 @@ namespace RTC
 		std::string dominantId{ "" };
 		Timer* periodicTimer{ nullptr };
 		uint16_t interval{ 300u };
-		std::unordered_map<std::string, struct ProducerSpeaker> mapProducerSpeaker;
+		absl::flat_hash_map<std::string, struct ProducerSpeaker> mapProducerSpeaker;
 		uint64_t lastLevelIdleTime{ 0 };
 	};
 } // namespace RTC

--- a/worker/include/RTC/AudioLevelObserver.hpp
+++ b/worker/include/RTC/AudioLevelObserver.hpp
@@ -3,8 +3,8 @@
 
 #include "RTC/RtpObserver.hpp"
 #include "handles/Timer.hpp"
+#include <absl/container/flat_hash_map.h>
 #include <nlohmann/json.hpp>
-#include <unordered_map>
 
 using json = nlohmann::json;
 
@@ -48,7 +48,7 @@ namespace RTC
 		// Allocated by this.
 		Timer* periodicTimer{ nullptr };
 		// Others.
-		std::unordered_map<RTC::Producer*, DBovs> mapProducerDBovs;
+		absl::flat_hash_map<RTC::Producer*, DBovs> mapProducerDBovs;
 		bool silence{ true };
 	};
 } // namespace RTC

--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -14,9 +14,9 @@
 #include "RTC/RtpPacket.hpp"
 #include "RTC/RtpStream.hpp"
 #include "RTC/RtpStreamSend.hpp"
+#include <absl/container/flat_hash_set.h>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <unordered_set>
 #include <vector>
 
 using json = nlohmann::json;
@@ -182,7 +182,7 @@ namespace RTC
 		struct RTC::RtpHeaderExtensionIds rtpHeaderExtensionIds;
 		const std::vector<uint8_t>* producerRtpStreamScores{ nullptr };
 		// Others.
-		std::unordered_set<uint8_t> supportedCodecPayloadTypes;
+		absl::flat_hash_set<uint8_t> supportedCodecPayloadTypes;
 		uint64_t lastRtcpSentTime{ 0u };
 		uint16_t maxRtcpInterval{ 0u };
 		bool externallyManagedBitrate{ false };

--- a/worker/include/RTC/DtlsTransport.hpp
+++ b/worker/include/RTC/DtlsTransport.hpp
@@ -7,8 +7,8 @@
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
-#include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace RTC
@@ -144,9 +144,9 @@ namespace RTC
 		thread_local static EVP_PKEY* privateKey;
 		thread_local static SSL_CTX* sslCtx;
 		thread_local static uint8_t sslReadBuffer[];
-		static std::map<std::string, Role> string2Role;
-		static std::map<std::string, FingerprintAlgorithm> string2FingerprintAlgorithm;
-		static std::map<FingerprintAlgorithm, std::string> fingerprintAlgorithm2String;
+		static std::unordered_map<std::string, Role> string2Role;
+		static std::unordered_map<std::string, FingerprintAlgorithm> string2FingerprintAlgorithm;
+		static std::unordered_map<FingerprintAlgorithm, std::string> fingerprintAlgorithm2String;
 		thread_local static std::vector<Fingerprint> localFingerprints;
 		static std::vector<SrtpCryptoSuiteMapEntry> srtpCryptoSuites;
 

--- a/worker/include/RTC/DtlsTransport.hpp
+++ b/worker/include/RTC/DtlsTransport.hpp
@@ -7,8 +7,8 @@
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
+#include <absl/container/flat_hash_map.h>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace RTC
@@ -144,9 +144,9 @@ namespace RTC
 		thread_local static EVP_PKEY* privateKey;
 		thread_local static SSL_CTX* sslCtx;
 		thread_local static uint8_t sslReadBuffer[];
-		static std::unordered_map<std::string, Role> string2Role;
-		static std::unordered_map<std::string, FingerprintAlgorithm> string2FingerprintAlgorithm;
-		static std::unordered_map<FingerprintAlgorithm, std::string> fingerprintAlgorithm2String;
+		static absl::flat_hash_map<std::string, Role> string2Role;
+		static absl::flat_hash_map<std::string, FingerprintAlgorithm> string2FingerprintAlgorithm;
+		static absl::flat_hash_map<FingerprintAlgorithm, std::string> fingerprintAlgorithm2String;
 		thread_local static std::vector<Fingerprint> localFingerprints;
 		static std::vector<SrtpCryptoSuiteMapEntry> srtpCryptoSuites;
 

--- a/worker/include/RTC/KeyFrameRequestManager.hpp
+++ b/worker/include/RTC/KeyFrameRequestManager.hpp
@@ -2,7 +2,7 @@
 #define MS_KEY_FRAME_REQUEST_MANAGER_HPP
 
 #include "handles/Timer.hpp"
-#include <unordered_map>
+#include <absl/container/flat_hash_map.h>
 
 namespace RTC
 {
@@ -122,8 +122,8 @@ namespace RTC
 	private:
 		Listener* listener{ nullptr };
 		uint32_t keyFrameRequestDelay{ 0u }; // 0 means disabled.
-		std::unordered_map<uint32_t, PendingKeyFrameInfo*> mapSsrcPendingKeyFrameInfo;
-		std::unordered_map<uint32_t, KeyFrameRequestDelayer*> mapSsrcKeyFrameRequestDelayer;
+		absl::flat_hash_map<uint32_t, PendingKeyFrameInfo*> mapSsrcPendingKeyFrameInfo;
+		absl::flat_hash_map<uint32_t, KeyFrameRequestDelayer*> mapSsrcKeyFrameRequestDelayer;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/KeyFrameRequestManager.hpp
+++ b/worker/include/RTC/KeyFrameRequestManager.hpp
@@ -2,7 +2,7 @@
 #define MS_KEY_FRAME_REQUEST_MANAGER_HPP
 
 #include "handles/Timer.hpp"
-#include <map>
+#include <unordered_map>
 
 namespace RTC
 {
@@ -122,8 +122,8 @@ namespace RTC
 	private:
 		Listener* listener{ nullptr };
 		uint32_t keyFrameRequestDelay{ 0u }; // 0 means disabled.
-		std::map<uint32_t, PendingKeyFrameInfo*> mapSsrcPendingKeyFrameInfo;
-		std::map<uint32_t, KeyFrameRequestDelayer*> mapSsrcKeyFrameRequestDelayer;
+		std::unordered_map<uint32_t, PendingKeyFrameInfo*> mapSsrcPendingKeyFrameInfo;
+		std::unordered_map<uint32_t, KeyFrameRequestDelayer*> mapSsrcKeyFrameRequestDelayer;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/NackGenerator.hpp
+++ b/worker/include/RTC/NackGenerator.hpp
@@ -5,6 +5,8 @@
 #include "RTC/RtpPacket.hpp"
 #include "RTC/SeqManager.hpp"
 #include "handles/Timer.hpp"
+#include <absl/container/btree_map.h>
+#include <absl/container/btree_set.h>
 #include <map>
 #include <set>
 #include <vector>
@@ -75,9 +77,9 @@ namespace RTC
 		// Allocated by this.
 		Timer* timer{ nullptr };
 		// Others.
-		std::map<uint16_t, NackInfo, RTC::SeqManager<uint16_t>::SeqLowerThan> nackList;
-		std::set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> keyFrameList;
-		std::set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;
+		absl::btree_map<uint16_t, NackInfo, RTC::SeqManager<uint16_t>::SeqLowerThan> nackList;
+		absl::btree_set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> keyFrameList;
+		absl::btree_set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;
 		bool started{ false };
 		uint16_t lastSeq{ 0u }; // Seq number of last valid packet.
 		uint32_t rtt{ 0u };     // Round trip time (ms).

--- a/worker/include/RTC/Parameters.hpp
+++ b/worker/include/RTC/Parameters.hpp
@@ -2,9 +2,9 @@
 #define MS_RTC_PARAMETERS_HPP
 
 #include "common.hpp"
+#include <absl/container/flat_hash_map.h>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 using json = nlohmann::json;
@@ -78,7 +78,7 @@ namespace RTC
 		const std::vector<int32_t>& GetArrayOfIntegers(const std::string& key) const;
 
 	private:
-		std::unordered_map<std::string, Value> mapKeyValues;
+		absl::flat_hash_map<std::string, Value> mapKeyValues;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -60,11 +60,11 @@ namespace RTC
 		// Allocated by this.
 		std::vector<RTC::RtpStreamSend*> rtpStreams;
 		// Others.
-		std::unordered_map<uint32_t, uint32_t> mapMappedSsrcSsrc;
-		std::unordered_map<uint32_t, RTC::RtpStreamSend*> mapSsrcRtpStream;
+		absl::flat_hash_map<uint32_t, uint32_t> mapMappedSsrcSsrc;
+		absl::flat_hash_map<uint32_t, RTC::RtpStreamSend*> mapSsrcRtpStream;
 		bool keyFrameSupported{ false };
-		std::unordered_map<RTC::RtpStreamSend*, bool> mapRtpStreamSyncRequired;
-		std::unordered_map<RTC::RtpStreamSend*, RTC::SeqManager<uint16_t>> mapRtpStreamRtpSeqManager;
+		absl::flat_hash_map<RTC::RtpStreamSend*, bool> mapRtpStreamSyncRequired;
+		absl::flat_hash_map<RTC::RtpStreamSend*, RTC::SeqManager<uint16_t>> mapRtpStreamRtpSeqManager;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/PlainTransport.hpp
+++ b/worker/include/RTC/PlainTransport.hpp
@@ -5,7 +5,7 @@
 #include "RTC/Transport.hpp"
 #include "RTC/TransportTuple.hpp"
 #include "RTC/UdpSocket.hpp"
-#include <unordered_map>
+#include <absl/container/flat_hash_map.h>
 
 namespace RTC
 {
@@ -19,8 +19,8 @@ namespace RTC
 		};
 
 	private:
-		static std::unordered_map<std::string, RTC::SrtpSession::CryptoSuite> string2SrtpCryptoSuite;
-		static std::unordered_map<RTC::SrtpSession::CryptoSuite, std::string> srtpCryptoSuite2String;
+		static absl::flat_hash_map<std::string, RTC::SrtpSession::CryptoSuite> string2SrtpCryptoSuite;
+		static absl::flat_hash_map<RTC::SrtpSession::CryptoSuite, std::string> srtpCryptoSuite2String;
 		static size_t srtpMasterLength;
 
 	public:

--- a/worker/include/RTC/PlainTransport.hpp
+++ b/worker/include/RTC/PlainTransport.hpp
@@ -5,7 +5,7 @@
 #include "RTC/Transport.hpp"
 #include "RTC/TransportTuple.hpp"
 #include "RTC/UdpSocket.hpp"
-#include <map>
+#include <unordered_map>
 
 namespace RTC
 {
@@ -19,8 +19,8 @@ namespace RTC
 		};
 
 	private:
-		static std::map<std::string, RTC::SrtpSession::CryptoSuite> string2SrtpCryptoSuite;
-		static std::map<RTC::SrtpSession::CryptoSuite, std::string> srtpCryptoSuite2String;
+		static std::unordered_map<std::string, RTC::SrtpSession::CryptoSuite> string2SrtpCryptoSuite;
+		static std::unordered_map<RTC::SrtpSession::CryptoSuite, std::string> srtpCryptoSuite2String;
 		static size_t srtpMasterLength;
 
 	public:

--- a/worker/include/RTC/PortManager.hpp
+++ b/worker/include/RTC/PortManager.hpp
@@ -4,9 +4,9 @@
 #include "common.hpp"
 #include "Settings.hpp"
 #include <uv.h>
+#include <absl/container/flat_hash_map.h>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace RTC
@@ -54,8 +54,8 @@ namespace RTC
 		static std::vector<bool>& GetPorts(Transport transport, const std::string& ip);
 
 	private:
-		thread_local static std::unordered_map<std::string, std::vector<bool>> mapUdpIpPorts;
-		thread_local static std::unordered_map<std::string, std::vector<bool>> mapTcpIpPorts;
+		thread_local static absl::flat_hash_map<std::string, std::vector<bool>> mapUdpIpPorts;
+		thread_local static absl::flat_hash_map<std::string, std::vector<bool>> mapTcpIpPorts;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -54,7 +54,7 @@ namespace RTC
 	private:
 		struct RtpMapping
 		{
-			std::unordered_map<uint8_t, uint8_t> codecs;
+			absl::flat_hash_map<uint8_t, uint8_t> codecs;
 			std::vector<RtpEncodingMapping> encodings;
 		};
 
@@ -112,7 +112,7 @@ namespace RTC
 		{
 			return this->paused;
 		}
-		const std::unordered_map<RTC::RtpStreamRecv*, uint32_t>& GetRtpStreams()
+		const absl::flat_hash_map<RTC::RtpStreamRecv*, uint32_t>& GetRtpStreams()
 		{
 			return this->mapRtpStreamMappedSsrc;
 		}
@@ -160,7 +160,7 @@ namespace RTC
 		// Passed by argument.
 		RTC::Producer::Listener* listener{ nullptr };
 		// Allocated by this.
-		std::unordered_map<uint32_t, RTC::RtpStreamRecv*> mapSsrcRtpStream;
+		absl::flat_hash_map<uint32_t, RTC::RtpStreamRecv*> mapSsrcRtpStream;
 		RTC::KeyFrameRequestManager* keyFrameRequestManager{ nullptr };
 		// Others.
 		RTC::Media::Kind kind;
@@ -169,9 +169,9 @@ namespace RTC
 		struct RtpMapping rtpMapping;
 		std::vector<RTC::RtpStreamRecv*> rtpStreamByEncodingIdx;
 		std::vector<uint8_t> rtpStreamScores;
-		std::unordered_map<uint32_t, RTC::RtpStreamRecv*> mapRtxSsrcRtpStream;
-		std::unordered_map<RTC::RtpStreamRecv*, uint32_t> mapRtpStreamMappedSsrc;
-		std::unordered_map<uint32_t, uint32_t> mapMappedSsrcSsrc;
+		absl::flat_hash_map<uint32_t, RTC::RtpStreamRecv*> mapRtxSsrcRtpStream;
+		absl::flat_hash_map<RTC::RtpStreamRecv*, uint32_t> mapRtpStreamMappedSsrc;
+		absl::flat_hash_map<uint32_t, uint32_t> mapMappedSsrcSsrc;
 		struct RTC::RtpHeaderExtensionIds rtpHeaderExtensionIds;
 		bool paused{ false };
 		RTC::RtpPacket* currentRtpPacket{ nullptr };

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -12,7 +12,6 @@
 #include "RTC/RtpHeaderExtensionIds.hpp"
 #include "RTC/RtpPacket.hpp"
 #include "RTC/RtpStreamRecv.hpp"
-#include <map>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
@@ -55,7 +54,7 @@ namespace RTC
 	private:
 		struct RtpMapping
 		{
-			std::map<uint8_t, uint8_t> codecs;
+			std::unordered_map<uint8_t, uint8_t> codecs;
 			std::vector<RtpEncodingMapping> encodings;
 		};
 
@@ -113,7 +112,7 @@ namespace RTC
 		{
 			return this->paused;
 		}
-		const std::map<RTC::RtpStreamRecv*, uint32_t>& GetRtpStreams()
+		const std::unordered_map<RTC::RtpStreamRecv*, uint32_t>& GetRtpStreams()
 		{
 			return this->mapRtpStreamMappedSsrc;
 		}
@@ -161,7 +160,7 @@ namespace RTC
 		// Passed by argument.
 		RTC::Producer::Listener* listener{ nullptr };
 		// Allocated by this.
-		std::map<uint32_t, RTC::RtpStreamRecv*> mapSsrcRtpStream;
+		std::unordered_map<uint32_t, RTC::RtpStreamRecv*> mapSsrcRtpStream;
 		RTC::KeyFrameRequestManager* keyFrameRequestManager{ nullptr };
 		// Others.
 		RTC::Media::Kind kind;
@@ -170,9 +169,9 @@ namespace RTC
 		struct RtpMapping rtpMapping;
 		std::vector<RTC::RtpStreamRecv*> rtpStreamByEncodingIdx;
 		std::vector<uint8_t> rtpStreamScores;
-		std::map<uint32_t, RTC::RtpStreamRecv*> mapRtxSsrcRtpStream;
-		std::map<RTC::RtpStreamRecv*, uint32_t> mapRtpStreamMappedSsrc;
-		std::map<uint32_t, uint32_t> mapMappedSsrcSsrc;
+		std::unordered_map<uint32_t, RTC::RtpStreamRecv*> mapRtxSsrcRtpStream;
+		std::unordered_map<RTC::RtpStreamRecv*, uint32_t> mapRtpStreamMappedSsrc;
+		std::unordered_map<uint32_t, uint32_t> mapMappedSsrcSsrc;
 		struct RTC::RtpHeaderExtensionIds rtpHeaderExtensionIds;
 		bool paused{ false };
 		RTC::RtpPacket* currentRtpPacket{ nullptr };

--- a/worker/include/RTC/RTCP/Feedback.hpp
+++ b/worker/include/RTC/RTCP/Feedback.hpp
@@ -4,6 +4,7 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackItem.hpp"
 #include "RTC/RTCP/Packet.hpp"
+#include <unordered_map>
 
 namespace RTC
 {
@@ -27,7 +28,7 @@ namespace RTC
 			static const std::string& MessageType2String(typename T::MessageType type);
 
 		private:
-			static std::map<typename T::MessageType, std::string> type2String;
+			static std::unordered_map<typename T::MessageType, std::string> type2String;
 
 		public:
 			typename T::MessageType GetMessageType() const

--- a/worker/include/RTC/RTCP/Feedback.hpp
+++ b/worker/include/RTC/RTCP/Feedback.hpp
@@ -4,7 +4,7 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackItem.hpp"
 #include "RTC/RTCP/Packet.hpp"
-#include <unordered_map>
+#include <absl/container/flat_hash_map.h>
 
 namespace RTC
 {
@@ -28,7 +28,7 @@ namespace RTC
 			static const std::string& MessageType2String(typename T::MessageType type);
 
 		private:
-			static std::unordered_map<typename T::MessageType, std::string> type2String;
+			static absl::flat_hash_map<typename T::MessageType, std::string> type2String;
 
 		public:
 			typename T::MessageType GetMessageType() const

--- a/worker/include/RTC/RTCP/FeedbackRtpTransport.hpp
+++ b/worker/include/RTC/RTCP/FeedbackRtpTransport.hpp
@@ -197,7 +197,7 @@ namespace RTC
 			static FeedbackRtpTransportPacket* Parse(const uint8_t* data, size_t len);
 
 		private:
-			static std::map<Status, std::string> status2String;
+			static std::unordered_map<Status, std::string> status2String;
 
 		public:
 			FeedbackRtpTransportPacket(uint32_t senderSsrc, uint32_t mediaSsrc)

--- a/worker/include/RTC/RTCP/FeedbackRtpTransport.hpp
+++ b/worker/include/RTC/RTCP/FeedbackRtpTransport.hpp
@@ -197,7 +197,7 @@ namespace RTC
 			static FeedbackRtpTransportPacket* Parse(const uint8_t* data, size_t len);
 
 		private:
-			static std::unordered_map<Status, std::string> status2String;
+			static absl::flat_hash_map<Status, std::string> status2String;
 
 		public:
 			FeedbackRtpTransportPacket(uint32_t senderSsrc, uint32_t mediaSsrc)

--- a/worker/include/RTC/RTCP/Packet.hpp
+++ b/worker/include/RTC/RTCP/Packet.hpp
@@ -2,8 +2,8 @@
 #define MS_RTC_RTCP_PACKET_HPP
 
 #include "common.hpp"
-#include <map>
 #include <string>
+#include <unordered_map>
 
 namespace RTC
 {
@@ -72,7 +72,7 @@ namespace RTC
 			static const std::string& Type2String(Type type);
 
 		private:
-			static std::map<Type, std::string> type2String;
+			static std::unordered_map<Type, std::string> type2String;
 
 		public:
 			explicit Packet(Type type) : type(type)

--- a/worker/include/RTC/RTCP/Packet.hpp
+++ b/worker/include/RTC/RTCP/Packet.hpp
@@ -2,8 +2,8 @@
 #define MS_RTC_RTCP_PACKET_HPP
 
 #include "common.hpp"
+#include <absl/container/flat_hash_map.h>
 #include <string>
-#include <unordered_map>
 
 namespace RTC
 {
@@ -72,7 +72,7 @@ namespace RTC
 			static const std::string& Type2String(Type type);
 
 		private:
-			static std::unordered_map<Type, std::string> type2String;
+			static absl::flat_hash_map<Type, std::string> type2String;
 
 		public:
 			explicit Packet(Type type) : type(type)

--- a/worker/include/RTC/RTCP/Sdes.hpp
+++ b/worker/include/RTC/RTCP/Sdes.hpp
@@ -76,7 +76,7 @@ namespace RTC
 			std::unique_ptr<uint8_t[]> raw;
 
 		private:
-			static std::unordered_map<SdesItem::Type, std::string> type2String;
+			static absl::flat_hash_map<SdesItem::Type, std::string> type2String;
 		};
 
 		class SdesChunk

--- a/worker/include/RTC/RTCP/Sdes.hpp
+++ b/worker/include/RTC/RTCP/Sdes.hpp
@@ -3,7 +3,6 @@
 
 #include "common.hpp"
 #include "RTC/RTCP/Packet.hpp"
-#include <map>
 #include <string>
 #include <vector>
 
@@ -77,7 +76,7 @@ namespace RTC
 			std::unique_ptr<uint8_t[]> raw;
 
 		private:
-			static std::map<SdesItem::Type, std::string> type2String;
+			static std::unordered_map<SdesItem::Type, std::string> type2String;
 		};
 
 		class SdesChunk

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -13,9 +13,9 @@
 #include "RTC/RtpPacket.hpp"
 #include "RTC/RtpStream.hpp"
 #include "RTC/Transport.hpp"
+#include <absl/container/flat_hash_map.h>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <unordered_map>
 #include <unordered_set>
 
 using json = nlohmann::json;
@@ -93,16 +93,17 @@ namespace RTC
 
 	private:
 		// Allocated by this.
-		std::unordered_map<std::string, RTC::Transport*> mapTransports;
-		std::unordered_map<std::string, RTC::RtpObserver*> mapRtpObservers;
+		absl::flat_hash_map<std::string, RTC::Transport*> mapTransports;
+		absl::flat_hash_map<std::string, RTC::RtpObserver*> mapRtpObservers;
 		// Others.
-		std::unordered_map<RTC::Producer*, std::unordered_set<RTC::Consumer*>> mapProducerConsumers;
-		std::unordered_map<RTC::Consumer*, RTC::Producer*> mapConsumerProducer;
-		std::unordered_map<RTC::Producer*, std::unordered_set<RTC::RtpObserver*>> mapProducerRtpObservers;
-		std::unordered_map<std::string, RTC::Producer*> mapProducers;
-		std::unordered_map<RTC::DataProducer*, std::unordered_set<RTC::DataConsumer*>> mapDataProducerDataConsumers;
-		std::unordered_map<RTC::DataConsumer*, RTC::DataProducer*> mapDataConsumerDataProducer;
-		std::unordered_map<std::string, RTC::DataProducer*> mapDataProducers;
+		absl::flat_hash_map<RTC::Producer*, absl::flat_hash_set<RTC::Consumer*>> mapProducerConsumers;
+		absl::flat_hash_map<RTC::Consumer*, RTC::Producer*> mapConsumerProducer;
+		absl::flat_hash_map<RTC::Producer*, absl::flat_hash_set<RTC::RtpObserver*>> mapProducerRtpObservers;
+		absl::flat_hash_map<std::string, RTC::Producer*> mapProducers;
+		absl::flat_hash_map<RTC::DataProducer*, absl::flat_hash_set<RTC::DataConsumer*>>
+		  mapDataProducerDataConsumers;
+		absl::flat_hash_map<RTC::DataConsumer*, RTC::DataProducer*> mapDataConsumerDataProducer;
+		absl::flat_hash_map<std::string, RTC::DataProducer*> mapDataProducers;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/RtpDictionaries.hpp
+++ b/worker/include/RTC/RtpDictionaries.hpp
@@ -3,7 +3,6 @@
 
 #include "common.hpp"
 #include "RTC/Parameters.hpp"
-#include <map>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <unordered_map>
@@ -30,7 +29,7 @@ namespace RTC
 
 	private:
 		static std::unordered_map<std::string, Kind> string2Kind;
-		static std::map<Kind, std::string> kind2String;
+		static std::unordered_map<Kind, std::string> kind2String;
 	};
 
 	class RtpCodecMimeType
@@ -76,9 +75,9 @@ namespace RTC
 
 	public:
 		static std::unordered_map<std::string, Type> string2Type;
-		static std::map<Type, std::string> type2String;
+		static std::unordered_map<Type, std::string> type2String;
 		static std::unordered_map<std::string, Subtype> string2Subtype;
-		static std::map<Subtype, std::string> subtype2String;
+		static std::unordered_map<Subtype, std::string> subtype2String;
 
 	public:
 		RtpCodecMimeType() = default;
@@ -270,7 +269,7 @@ namespace RTC
 
 	private:
 		static std::unordered_map<std::string, Type> string2Type;
-		static std::map<Type, std::string> type2String;
+		static std::unordered_map<Type, std::string> type2String;
 
 	public:
 		RtpParameters() = default;

--- a/worker/include/RTC/RtpDictionaries.hpp
+++ b/worker/include/RTC/RtpDictionaries.hpp
@@ -3,9 +3,9 @@
 
 #include "common.hpp"
 #include "RTC/Parameters.hpp"
+#include <absl/container/flat_hash_map.h>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 using json = nlohmann::json;
@@ -28,8 +28,8 @@ namespace RTC
 		static const std::string& GetString(Kind kind);
 
 	private:
-		static std::unordered_map<std::string, Kind> string2Kind;
-		static std::unordered_map<Kind, std::string> kind2String;
+		static absl::flat_hash_map<std::string, Kind> string2Kind;
+		static absl::flat_hash_map<Kind, std::string> kind2String;
 	};
 
 	class RtpCodecMimeType
@@ -74,10 +74,10 @@ namespace RTC
 		};
 
 	public:
-		static std::unordered_map<std::string, Type> string2Type;
-		static std::unordered_map<Type, std::string> type2String;
-		static std::unordered_map<std::string, Subtype> string2Subtype;
-		static std::unordered_map<Subtype, std::string> subtype2String;
+		static absl::flat_hash_map<std::string, Type> string2Type;
+		static absl::flat_hash_map<Type, std::string> type2String;
+		static absl::flat_hash_map<std::string, Subtype> string2Subtype;
+		static absl::flat_hash_map<Subtype, std::string> subtype2String;
 
 	public:
 		RtpCodecMimeType() = default;
@@ -144,7 +144,7 @@ namespace RTC
 		};
 
 	private:
-		static std::unordered_map<std::string, Type> string2Type;
+		static absl::flat_hash_map<std::string, Type> string2Type;
 
 	public:
 		static Type GetType(std::string& uri);
@@ -268,8 +268,8 @@ namespace RTC
 		static std::string& GetTypeString(Type type);
 
 	private:
-		static std::unordered_map<std::string, Type> string2Type;
-		static std::unordered_map<Type, std::string> type2String;
+		static absl::flat_hash_map<std::string, Type> string2Type;
+		static absl::flat_hash_map<Type, std::string> type2String;
 
 	public:
 		RtpParameters() = default;

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -4,9 +4,9 @@
 #include "common.hpp"
 #include "Utils.hpp"
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
+#include <absl/container/btree_map.h>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 using json = nlohmann::json;
@@ -611,8 +611,8 @@ namespace RTC
 		Header* header{ nullptr };
 		uint8_t* csrcList{ nullptr };
 		HeaderExtension* headerExtension{ nullptr };
-		std::unordered_map<uint8_t, OneByteExtension*> mapOneByteExtensions;
-		std::unordered_map<uint8_t, TwoBytesExtension*> mapTwoBytesExtensions;
+		absl::btree_map<uint8_t, OneByteExtension*> mapOneByteExtensions;
+		absl::btree_map<uint8_t, TwoBytesExtension*> mapTwoBytesExtensions;
 		uint8_t midExtensionId{ 0u };
 		uint8_t ridExtensionId{ 0u };
 		uint8_t rridExtensionId{ 0u };

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -4,9 +4,9 @@
 #include "common.hpp"
 #include "Utils.hpp"
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
-#include <map>
 #include <nlohmann/json.hpp>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 using json = nlohmann::json;
@@ -611,8 +611,8 @@ namespace RTC
 		Header* header{ nullptr };
 		uint8_t* csrcList{ nullptr };
 		HeaderExtension* headerExtension{ nullptr };
-		std::map<uint8_t, OneByteExtension*> mapOneByteExtensions;
-		std::map<uint8_t, TwoBytesExtension*> mapTwoBytesExtensions;
+		std::unordered_map<uint8_t, OneByteExtension*> mapOneByteExtensions;
+		std::unordered_map<uint8_t, TwoBytesExtension*> mapTwoBytesExtensions;
 		uint8_t midExtensionId{ 0u };
 		uint8_t ridExtensionId{ 0u };
 		uint8_t rridExtensionId{ 0u };

--- a/worker/include/RTC/SenderBandwidthEstimator.hpp
+++ b/worker/include/RTC/SenderBandwidthEstimator.hpp
@@ -102,7 +102,7 @@ namespace RTC
 		uint32_t initialAvailableBitrate{ 0u };
 		uint32_t availableBitrate{ 0u };
 		uint64_t lastAvailableBitrateEventAtMs{ 0u };
-		std::map<uint16_t, SentInfo, RTC::SeqManager<uint16_t>::SeqLowerThan> sentInfos;
+		absl::btree_map<uint16_t, SentInfo, RTC::SeqManager<uint16_t>::SeqLowerThan> sentInfos;
 		float rtt{ 0 }; // Round trip time in ms.
 		CummulativeResult cummulativeResult;
 		CummulativeResult probationCummulativeResult;

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -97,7 +97,7 @@ namespace RTC
 		// Allocated by this.
 		RTC::RtpStreamSend* rtpStream{ nullptr };
 		// Others.
-		std::unordered_map<uint32_t, int16_t> mapMappedSsrcSpatialLayer;
+		absl::flat_hash_map<uint32_t, int16_t> mapMappedSsrcSpatialLayer;
 		std::vector<RTC::RtpStreamSend*> rtpStreams;
 		std::vector<RTC::RtpStream*> producerRtpStreams; // Indexed by spatial layer.
 		bool syncRequired{ false };

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -26,9 +26,9 @@
 #include "RTC/TransportCongestionControlClient.hpp"
 #include "RTC/TransportCongestionControlServer.hpp"
 #include "handles/Timer.hpp"
+#include <absl/container/flat_hash_map.h>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <unordered_map>
 
 using json = nlohmann::json;
 
@@ -273,12 +273,12 @@ namespace RTC
 		// Passed by argument.
 		Listener* listener{ nullptr };
 		// Allocated by this.
-		std::unordered_map<std::string, RTC::Producer*> mapProducers;
-		std::unordered_map<std::string, RTC::Consumer*> mapConsumers;
-		std::unordered_map<std::string, RTC::DataProducer*> mapDataProducers;
-		std::unordered_map<std::string, RTC::DataConsumer*> mapDataConsumers;
-		std::unordered_map<uint32_t, RTC::Consumer*> mapSsrcConsumer;
-		std::unordered_map<uint32_t, RTC::Consumer*> mapRtxSsrcConsumer;
+		absl::flat_hash_map<std::string, RTC::Producer*> mapProducers;
+		absl::flat_hash_map<std::string, RTC::Consumer*> mapConsumers;
+		absl::flat_hash_map<std::string, RTC::DataProducer*> mapDataProducers;
+		absl::flat_hash_map<std::string, RTC::DataConsumer*> mapDataConsumers;
+		absl::flat_hash_map<uint32_t, RTC::Consumer*> mapSsrcConsumer;
+		absl::flat_hash_map<uint32_t, RTC::Consumer*> mapRtxSsrcConsumer;
 		Timer* rtcpTimer{ nullptr };
 		RTC::TransportCongestionControlClient* tccClient{ nullptr };
 		RTC::TransportCongestionControlServer* tccServer{ nullptr };

--- a/worker/include/RTC/WebRtcTransport.hpp
+++ b/worker/include/RTC/WebRtcTransport.hpp
@@ -110,8 +110,8 @@ namespace RTC
 		// Allocated by this.
 		RTC::IceServer* iceServer{ nullptr };
 		// Map of UdpSocket/TcpServer and local announced IP (if any).
-		std::unordered_map<RTC::UdpSocket*, std::string> udpSockets;
-		std::unordered_map<RTC::TcpServer*, std::string> tcpServers;
+		absl::flat_hash_map<RTC::UdpSocket*, std::string> udpSockets;
+		absl::flat_hash_map<RTC::TcpServer*, std::string> tcpServers;
 		RTC::DtlsTransport* dtlsTransport{ nullptr };
 		RTC::SrtpSession* srtpRecvSession{ nullptr };
 		RTC::SrtpSession* srtpSendSession{ nullptr };

--- a/worker/include/Settings.hpp
+++ b/worker/include/Settings.hpp
@@ -4,8 +4,8 @@
 #include "common.hpp"
 #include "LogLevel.hpp"
 #include "Channel/ChannelRequest.hpp"
-#include <map>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 class Settings
@@ -54,8 +54,8 @@ public:
 	thread_local static struct Configuration configuration;
 
 private:
-	static std::map<std::string, LogLevel> string2LogLevel;
-	static std::map<LogLevel, std::string> logLevel2String;
+	static std::unordered_map<std::string, LogLevel> string2LogLevel;
+	static std::unordered_map<LogLevel, std::string> logLevel2String;
 };
 
 #endif

--- a/worker/include/Settings.hpp
+++ b/worker/include/Settings.hpp
@@ -4,8 +4,8 @@
 #include "common.hpp"
 #include "LogLevel.hpp"
 #include "Channel/ChannelRequest.hpp"
+#include <absl/container/flat_hash_map.h>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 class Settings
@@ -54,8 +54,8 @@ public:
 	thread_local static struct Configuration configuration;
 
 private:
-	static std::unordered_map<std::string, LogLevel> string2LogLevel;
-	static std::unordered_map<LogLevel, std::string> logLevel2String;
+	static absl::flat_hash_map<std::string, LogLevel> string2LogLevel;
+	static absl::flat_hash_map<LogLevel, std::string> logLevel2String;
 };
 
 #endif

--- a/worker/include/Worker.hpp
+++ b/worker/include/Worker.hpp
@@ -9,9 +9,9 @@
 #include "PayloadChannel/PayloadChannelSocket.hpp"
 #include "RTC/Router.hpp"
 #include "handles/SignalsHandler.hpp"
+#include <absl/container/flat_hash_map.h>
 #include <nlohmann/json.hpp>
 #include <string>
-#include <unordered_map>
 
 using json = nlohmann::json;
 
@@ -55,7 +55,7 @@ private:
 	PayloadChannel::PayloadChannelSocket* payloadChannel{ nullptr };
 	// Allocated by this.
 	SignalsHandler* signalsHandler{ nullptr };
-	std::unordered_map<std::string, RTC::Router*> mapRouters;
+	absl::flat_hash_map<std::string, RTC::Router*> mapRouters;
 	// Others.
 	bool closed{ false };
 };

--- a/worker/include/handles/TcpServerHandler.hpp
+++ b/worker/include/handles/TcpServerHandler.hpp
@@ -4,8 +4,8 @@
 #include "common.hpp"
 #include "handles/TcpConnectionHandler.hpp"
 #include <uv.h>
+#include <absl/container/flat_hash_set.h>
 #include <string>
-#include <unordered_set>
 
 class TcpServerHandler : public TcpConnectionHandler::Listener
 {
@@ -68,7 +68,7 @@ private:
 	// Allocated by this (may be passed by argument).
 	uv_tcp_t* uvHandle{ nullptr };
 	// Others.
-	std::unordered_set<TcpConnectionHandler*> connections;
+	absl::flat_hash_set<TcpConnectionHandler*> connections;
 	bool closed{ false };
 };
 

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -196,6 +196,7 @@ libwebrtc_include_directories = include_directories('include')
 subdir('deps/libwebrtc')
 
 dependencies = [
+  abseil_cpp_proj.get_variable('absl_container_dep'),
   openssl_proj.get_variable('openssl_dep'),
   nlohmann_json_proj.get_variable('nlohmann_json_dep'),
   libuv_proj.get_variable('libuv_dep'),
@@ -205,6 +206,7 @@ dependencies = [
 ]
 
 link_whole = [
+  abseil_cpp_proj.get_variable('absl_container_lib'),
   openssl_proj.get_variable('libcrypto_lib'),
   openssl_proj.get_variable('libssl_lib'),
   libuv_proj.get_variable('libuv'),

--- a/worker/src/Channel/ChannelRequest.cpp
+++ b/worker/src/Channel/ChannelRequest.cpp
@@ -11,7 +11,7 @@ namespace Channel
 	/* Class variables. */
 
 	// clang-format off
-	std::unordered_map<std::string, ChannelRequest::MethodId> ChannelRequest::string2MethodId =
+	absl::flat_hash_map<std::string, ChannelRequest::MethodId> ChannelRequest::string2MethodId =
 	{
 		{ "worker.close",                                ChannelRequest::MethodId::WORKER_CLOSE                                     },
 		{ "worker.dump",                                 ChannelRequest::MethodId::WORKER_DUMP                                      },

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -55,7 +55,7 @@ inline static void sctpDebug(const char* format, ...)
 thread_local DepUsrSCTP::Checker* DepUsrSCTP::checker{ nullptr };
 uint64_t DepUsrSCTP::numSctpAssociations{ 0u };
 uintptr_t DepUsrSCTP::nextSctpAssociationId{ 0u };
-std::unordered_map<uintptr_t, RTC::SctpAssociation*> DepUsrSCTP::mapIdSctpAssociation;
+absl::flat_hash_map<uintptr_t, RTC::SctpAssociation*> DepUsrSCTP::mapIdSctpAssociation;
 
 /* Static methods. */
 

--- a/worker/src/PayloadChannel/Notification.cpp
+++ b/worker/src/PayloadChannel/Notification.cpp
@@ -11,7 +11,7 @@ namespace PayloadChannel
 	/* Class variables. */
 
 	// clang-format off
-	std::unordered_map<std::string, Notification::EventId> Notification::string2EventId =
+	absl::flat_hash_map<std::string, Notification::EventId> Notification::string2EventId =
 	{
 		{ "transport.sendRtcp", Notification::EventId::TRANSPORT_SEND_RTCP },
 		{ "producer.send",      Notification::EventId::PRODUCER_SEND       },

--- a/worker/src/PayloadChannel/PayloadChannelRequest.cpp
+++ b/worker/src/PayloadChannel/PayloadChannelRequest.cpp
@@ -12,7 +12,7 @@ namespace PayloadChannel
 	/* Class variables. */
 
 	// clang-format off
-	std::unordered_map<std::string, PayloadChannelRequest::MethodId> PayloadChannelRequest::string2MethodId =
+	absl::flat_hash_map<std::string, PayloadChannelRequest::MethodId> PayloadChannelRequest::string2MethodId =
 	{
 		{ "dataConsumer.send", PayloadChannelRequest::MethodId::DATA_CONSUMER_SEND },
 	};

--- a/worker/src/RTC/AudioLevelObserver.cpp
+++ b/worker/src/RTC/AudioLevelObserver.cpp
@@ -146,7 +146,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		std::map<int8_t, RTC::Producer*> mapDBovsProducer;
+		absl::btree_map<int8_t, RTC::Producer*> mapDBovsProducer;
 
 		for (auto& kv : this->mapProducerDBovs)
 		{

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -83,7 +83,7 @@ namespace RTC
 	thread_local SSL_CTX* DtlsTransport::sslCtx{ nullptr };
 	thread_local uint8_t DtlsTransport::sslReadBuffer[SslReadBufferSize];
 	// clang-format off
-	std::unordered_map<std::string, DtlsTransport::FingerprintAlgorithm> DtlsTransport::string2FingerprintAlgorithm =
+	absl::flat_hash_map<std::string, DtlsTransport::FingerprintAlgorithm> DtlsTransport::string2FingerprintAlgorithm =
 	{
 		{ "sha-1",   DtlsTransport::FingerprintAlgorithm::SHA1   },
 		{ "sha-224", DtlsTransport::FingerprintAlgorithm::SHA224 },
@@ -91,7 +91,7 @@ namespace RTC
 		{ "sha-384", DtlsTransport::FingerprintAlgorithm::SHA384 },
 		{ "sha-512", DtlsTransport::FingerprintAlgorithm::SHA512 }
 	};
-	std::unordered_map<DtlsTransport::FingerprintAlgorithm, std::string> DtlsTransport::fingerprintAlgorithm2String =
+	absl::flat_hash_map<DtlsTransport::FingerprintAlgorithm, std::string> DtlsTransport::fingerprintAlgorithm2String =
 	{
 		{ DtlsTransport::FingerprintAlgorithm::SHA1,   "sha-1"   },
 		{ DtlsTransport::FingerprintAlgorithm::SHA224, "sha-224" },
@@ -99,7 +99,7 @@ namespace RTC
 		{ DtlsTransport::FingerprintAlgorithm::SHA384, "sha-384" },
 		{ DtlsTransport::FingerprintAlgorithm::SHA512, "sha-512" }
 	};
-	std::unordered_map<std::string, DtlsTransport::Role> DtlsTransport::string2Role =
+	absl::flat_hash_map<std::string, DtlsTransport::Role> DtlsTransport::string2Role =
 	{
 		{ "auto",   DtlsTransport::Role::AUTO   },
 		{ "client", DtlsTransport::Role::CLIENT },

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -83,7 +83,7 @@ namespace RTC
 	thread_local SSL_CTX* DtlsTransport::sslCtx{ nullptr };
 	thread_local uint8_t DtlsTransport::sslReadBuffer[SslReadBufferSize];
 	// clang-format off
-	std::map<std::string, DtlsTransport::FingerprintAlgorithm> DtlsTransport::string2FingerprintAlgorithm =
+	std::unordered_map<std::string, DtlsTransport::FingerprintAlgorithm> DtlsTransport::string2FingerprintAlgorithm =
 	{
 		{ "sha-1",   DtlsTransport::FingerprintAlgorithm::SHA1   },
 		{ "sha-224", DtlsTransport::FingerprintAlgorithm::SHA224 },
@@ -91,7 +91,7 @@ namespace RTC
 		{ "sha-384", DtlsTransport::FingerprintAlgorithm::SHA384 },
 		{ "sha-512", DtlsTransport::FingerprintAlgorithm::SHA512 }
 	};
-	std::map<DtlsTransport::FingerprintAlgorithm, std::string> DtlsTransport::fingerprintAlgorithm2String =
+	std::unordered_map<DtlsTransport::FingerprintAlgorithm, std::string> DtlsTransport::fingerprintAlgorithm2String =
 	{
 		{ DtlsTransport::FingerprintAlgorithm::SHA1,   "sha-1"   },
 		{ DtlsTransport::FingerprintAlgorithm::SHA224, "sha-224" },
@@ -99,7 +99,7 @@ namespace RTC
 		{ DtlsTransport::FingerprintAlgorithm::SHA384, "sha-384" },
 		{ DtlsTransport::FingerprintAlgorithm::SHA512, "sha-512" }
 	};
-	std::map<std::string, DtlsTransport::Role> DtlsTransport::string2Role =
+	std::unordered_map<std::string, DtlsTransport::Role> DtlsTransport::string2Role =
 	{
 		{ "auto",   DtlsTransport::Role::AUTO   },
 		{ "client", DtlsTransport::Role::CLIENT },

--- a/worker/src/RTC/NackGenerator.cpp
+++ b/worker/src/RTC/NackGenerator.cpp
@@ -152,18 +152,18 @@ namespace RTC
 		// clear it and request a keyframe.
 		uint16_t numNewNacks = seqEnd - seqStart;
 
-		if (this->nackList.size() + numNewNacks > MaxNackPackets)
+		if (static_cast<uint16_t>(this->nackList.size()) + numNewNacks > MaxNackPackets)
 		{
 			// clang-format off
 			while (
 				RemoveNackItemsUntilKeyFrame() &&
-				this->nackList.size() + numNewNacks > MaxNackPackets
+				static_cast<uint16_t>(this->nackList.size()) + numNewNacks > MaxNackPackets
 			)
 			// clang-format on
 			{
 			}
 
-			if (this->nackList.size() + numNewNacks > MaxNackPackets)
+			if (static_cast<uint16_t>(this->nackList.size()) + numNewNacks > MaxNackPackets)
 			{
 				MS_WARN_TAG(
 				  rtx, "NACK list full, clearing it and requesting a key frame [seqEnd:%" PRIu16 "]", seqEnd);

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -14,12 +14,12 @@ namespace RTC
 	// NOTE: PlainTransport allows AES_CM_128_HMAC_SHA1_80 and
 	// AES_CM_128_HMAC_SHA1_32 SRTP crypto suites.
 	// clang-format off
-	std::map<std::string, RTC::SrtpSession::CryptoSuite> PlainTransport::string2SrtpCryptoSuite =
+	std::unordered_map<std::string, RTC::SrtpSession::CryptoSuite> PlainTransport::string2SrtpCryptoSuite =
 	{
 		{ "AES_CM_128_HMAC_SHA1_80", RTC::SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_80 },
 		{ "AES_CM_128_HMAC_SHA1_32", RTC::SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_32 }
 	};
-	std::map<RTC::SrtpSession::CryptoSuite, std::string> PlainTransport::srtpCryptoSuite2String =
+	std::unordered_map<RTC::SrtpSession::CryptoSuite, std::string> PlainTransport::srtpCryptoSuite2String =
 	{
 		{ RTC::SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_80, "AES_CM_128_HMAC_SHA1_80" },
 		{ RTC::SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_32, "AES_CM_128_HMAC_SHA1_32" }

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -14,12 +14,12 @@ namespace RTC
 	// NOTE: PlainTransport allows AES_CM_128_HMAC_SHA1_80 and
 	// AES_CM_128_HMAC_SHA1_32 SRTP crypto suites.
 	// clang-format off
-	std::unordered_map<std::string, RTC::SrtpSession::CryptoSuite> PlainTransport::string2SrtpCryptoSuite =
+	absl::flat_hash_map<std::string, RTC::SrtpSession::CryptoSuite> PlainTransport::string2SrtpCryptoSuite =
 	{
 		{ "AES_CM_128_HMAC_SHA1_80", RTC::SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_80 },
 		{ "AES_CM_128_HMAC_SHA1_32", RTC::SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_32 }
 	};
-	std::unordered_map<RTC::SrtpSession::CryptoSuite, std::string> PlainTransport::srtpCryptoSuite2String =
+	absl::flat_hash_map<RTC::SrtpSession::CryptoSuite, std::string> PlainTransport::srtpCryptoSuite2String =
 	{
 		{ RTC::SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_80, "AES_CM_128_HMAC_SHA1_80" },
 		{ RTC::SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_32, "AES_CM_128_HMAC_SHA1_32" }

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -26,8 +26,8 @@ namespace RTC
 {
 	/* Class variables. */
 
-	thread_local std::unordered_map<std::string, std::vector<bool>> PortManager::mapUdpIpPorts;
-	thread_local std::unordered_map<std::string, std::vector<bool>> PortManager::mapTcpIpPorts;
+	thread_local absl::flat_hash_map<std::string, std::vector<bool>> PortManager::mapUdpIpPorts;
+	thread_local absl::flat_hash_map<std::string, std::vector<bool>> PortManager::mapTcpIpPorts;
 
 	/* Class methods. */
 

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -11,6 +11,7 @@
 #include "RTC/RTCP/FeedbackPs.hpp"
 #include "RTC/RTCP/FeedbackRtp.hpp"
 #include "RTC/RTCP/XrReceiverReferenceTime.hpp"
+#include <absl/container/inlined_vector.h>
 #include <cstring>  // std::memcpy()
 #include <iterator> // std::ostream_iterator
 #include <sstream>  // std::ostringstream

--- a/worker/src/RTC/RTCP/Feedback.cpp
+++ b/worker/src/RTC/RTCP/Feedback.cpp
@@ -98,7 +98,7 @@ namespace RTC
 
 		// clang-format off
 		template<>
-		std::unordered_map<FeedbackPs::MessageType, std::string> FeedbackPacket<FeedbackPs>::type2String =
+		absl::flat_hash_map<FeedbackPs::MessageType, std::string> FeedbackPacket<FeedbackPs>::type2String =
 		{
 			{ FeedbackPs::MessageType::PLI,   "PLI"   },
 			{ FeedbackPs::MessageType::SLI,   "SLI"   },
@@ -188,7 +188,7 @@ namespace RTC
 
 		// clang-format off
 		template<>
-		std::unordered_map<FeedbackRtp::MessageType, std::string> FeedbackPacket<FeedbackRtp>::type2String =
+		absl::flat_hash_map<FeedbackRtp::MessageType, std::string> FeedbackPacket<FeedbackRtp>::type2String =
 		{
 			{ FeedbackRtp::MessageType::NACK,   "NACK"   },
 			{ FeedbackRtp::MessageType::TMMBR,  "TMMBR"  },

--- a/worker/src/RTC/RTCP/Feedback.cpp
+++ b/worker/src/RTC/RTCP/Feedback.cpp
@@ -98,7 +98,7 @@ namespace RTC
 
 		// clang-format off
 		template<>
-		std::map<FeedbackPs::MessageType, std::string> FeedbackPacket<FeedbackPs>::type2String =
+		std::unordered_map<FeedbackPs::MessageType, std::string> FeedbackPacket<FeedbackPs>::type2String =
 		{
 			{ FeedbackPs::MessageType::PLI,   "PLI"   },
 			{ FeedbackPs::MessageType::SLI,   "SLI"   },
@@ -188,7 +188,7 @@ namespace RTC
 
 		// clang-format off
 		template<>
-		std::map<FeedbackRtp::MessageType, std::string> FeedbackPacket<FeedbackRtp>::type2String =
+		std::unordered_map<FeedbackRtp::MessageType, std::string> FeedbackPacket<FeedbackRtp>::type2String =
 		{
 			{ FeedbackRtp::MessageType::NACK,   "NACK"   },
 			{ FeedbackRtp::MessageType::TMMBR,  "TMMBR"  },

--- a/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
+++ b/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
@@ -60,7 +60,7 @@ namespace RTC
 		int16_t FeedbackRtpTransportPacket::maxPacketDelta{ 0x7FFF };
 
 		// clang-format off
-		std::map<FeedbackRtpTransportPacket::Status, std::string> FeedbackRtpTransportPacket::status2String =
+		std::unordered_map<FeedbackRtpTransportPacket::Status, std::string> FeedbackRtpTransportPacket::status2String =
 		{
 			{ FeedbackRtpTransportPacket::Status::NotReceived, "NR" },
 			{ FeedbackRtpTransportPacket::Status::SmallDelta,  "SD" },

--- a/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
+++ b/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
@@ -60,7 +60,7 @@ namespace RTC
 		int16_t FeedbackRtpTransportPacket::maxPacketDelta{ 0x7FFF };
 
 		// clang-format off
-		std::unordered_map<FeedbackRtpTransportPacket::Status, std::string> FeedbackRtpTransportPacket::status2String =
+		absl::flat_hash_map<FeedbackRtpTransportPacket::Status, std::string> FeedbackRtpTransportPacket::status2String =
 		{
 			{ FeedbackRtpTransportPacket::Status::NotReceived, "NR" },
 			{ FeedbackRtpTransportPacket::Status::SmallDelta,  "SD" },

--- a/worker/src/RTC/RTCP/Packet.cpp
+++ b/worker/src/RTC/RTCP/Packet.cpp
@@ -21,7 +21,7 @@ namespace RTC
 		/* Class variables. */
 
 		// clang-format off
-		std::unordered_map<Type, std::string> Packet::type2String =
+		absl::flat_hash_map<Type, std::string> Packet::type2String =
 		{
 			{ Type::SR,    "SR"    },
 			{ Type::RR,    "RR"    },

--- a/worker/src/RTC/RTCP/Packet.cpp
+++ b/worker/src/RTC/RTCP/Packet.cpp
@@ -21,7 +21,7 @@ namespace RTC
 		/* Class variables. */
 
 		// clang-format off
-		std::map<Type, std::string> Packet::type2String =
+		std::unordered_map<Type, std::string> Packet::type2String =
 		{
 			{ Type::SR,    "SR"    },
 			{ Type::RR,    "RR"    },

--- a/worker/src/RTC/RTCP/Sdes.cpp
+++ b/worker/src/RTC/RTCP/Sdes.cpp
@@ -13,7 +13,7 @@ namespace RTC
 		/* Item Class variables. */
 
 		// clang-format off
-		std::map<SdesItem::Type, std::string> SdesItem::type2String =
+		std::unordered_map<SdesItem::Type, std::string> SdesItem::type2String =
 		{
 			{ SdesItem::Type::END,   "END"   },
 			{ SdesItem::Type::CNAME, "CNAME" },

--- a/worker/src/RTC/RTCP/Sdes.cpp
+++ b/worker/src/RTC/RTCP/Sdes.cpp
@@ -13,7 +13,7 @@ namespace RTC
 		/* Item Class variables. */
 
 		// clang-format off
-		std::unordered_map<SdesItem::Type, std::string> SdesItem::type2String =
+		absl::flat_hash_map<SdesItem::Type, std::string> SdesItem::type2String =
 		{
 			{ SdesItem::Type::END,   "END"   },
 			{ SdesItem::Type::CNAME, "CNAME" },

--- a/worker/src/RTC/RtpDictionaries/Media.cpp
+++ b/worker/src/RTC/RtpDictionaries/Media.cpp
@@ -17,7 +17,7 @@ namespace RTC
 		{ "audio", Media::Kind::AUDIO },
 		{ "video", Media::Kind::VIDEO }
 	};
-	std::map<Media::Kind, std::string> Media::kind2String =
+	std::unordered_map<Media::Kind, std::string> Media::kind2String =
 	{
 		{ Media::Kind::ALL,   ""      },
 		{ Media::Kind::AUDIO, "audio" },

--- a/worker/src/RTC/RtpDictionaries/Media.cpp
+++ b/worker/src/RTC/RtpDictionaries/Media.cpp
@@ -11,13 +11,13 @@ namespace RTC
 	/* Class variables. */
 
 	// clang-format off
-	std::unordered_map<std::string, Media::Kind> Media::string2Kind =
+	absl::flat_hash_map<std::string, Media::Kind> Media::string2Kind =
 	{
 		{ "",      Media::Kind::ALL   },
 		{ "audio", Media::Kind::AUDIO },
 		{ "video", Media::Kind::VIDEO }
 	};
-	std::unordered_map<Media::Kind, std::string> Media::kind2String =
+	absl::flat_hash_map<Media::Kind, std::string> Media::kind2String =
 	{
 		{ Media::Kind::ALL,   ""      },
 		{ Media::Kind::AUDIO, "audio" },

--- a/worker/src/RTC/RtpDictionaries/RtpCodecMimeType.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpCodecMimeType.cpp
@@ -16,7 +16,7 @@ namespace RTC
 		{ "audio", RtpCodecMimeType::Type::AUDIO },
 		{ "video", RtpCodecMimeType::Type::VIDEO }
 	};
-	std::map<RtpCodecMimeType::Type, std::string> RtpCodecMimeType::type2String =
+	std::unordered_map<RtpCodecMimeType::Type, std::string> RtpCodecMimeType::type2String =
 	{
 		{ RtpCodecMimeType::Type::AUDIO, "audio" },
 		{ RtpCodecMimeType::Type::VIDEO, "video" }
@@ -48,7 +48,7 @@ namespace RTC
 		{ "x-ulpfecuc",      RtpCodecMimeType::Subtype::X_ULPFECUC      },
 		{ "red",             RtpCodecMimeType::Subtype::RED             }
 	};
-	std::map<RtpCodecMimeType::Subtype, std::string> RtpCodecMimeType::subtype2String =
+	std::unordered_map<RtpCodecMimeType::Subtype, std::string> RtpCodecMimeType::subtype2String =
 	{
 		// Audio codecs:
 		{ RtpCodecMimeType::Subtype::OPUS,            "opus"            },

--- a/worker/src/RTC/RtpDictionaries/RtpCodecMimeType.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpCodecMimeType.cpp
@@ -11,17 +11,17 @@ namespace RTC
 	/* Class variables. */
 
 	// clang-format off
-	std::unordered_map<std::string, RtpCodecMimeType::Type> RtpCodecMimeType::string2Type =
+	absl::flat_hash_map<std::string, RtpCodecMimeType::Type> RtpCodecMimeType::string2Type =
 	{
 		{ "audio", RtpCodecMimeType::Type::AUDIO },
 		{ "video", RtpCodecMimeType::Type::VIDEO }
 	};
-	std::unordered_map<RtpCodecMimeType::Type, std::string> RtpCodecMimeType::type2String =
+	absl::flat_hash_map<RtpCodecMimeType::Type, std::string> RtpCodecMimeType::type2String =
 	{
 		{ RtpCodecMimeType::Type::AUDIO, "audio" },
 		{ RtpCodecMimeType::Type::VIDEO, "video" }
 	};
-	std::unordered_map<std::string, RtpCodecMimeType::Subtype> RtpCodecMimeType::string2Subtype =
+	absl::flat_hash_map<std::string, RtpCodecMimeType::Subtype> RtpCodecMimeType::string2Subtype =
 	{
 		// Audio codecs:
 		{ "opus",            RtpCodecMimeType::Subtype::OPUS            },
@@ -48,7 +48,7 @@ namespace RTC
 		{ "x-ulpfecuc",      RtpCodecMimeType::Subtype::X_ULPFECUC      },
 		{ "red",             RtpCodecMimeType::Subtype::RED             }
 	};
-	std::unordered_map<RtpCodecMimeType::Subtype, std::string> RtpCodecMimeType::subtype2String =
+	absl::flat_hash_map<RtpCodecMimeType::Subtype, std::string> RtpCodecMimeType::subtype2String =
 	{
 		// Audio codecs:
 		{ RtpCodecMimeType::Subtype::OPUS,            "opus"            },

--- a/worker/src/RTC/RtpDictionaries/RtpHeaderExtensionUri.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpHeaderExtensionUri.cpp
@@ -10,7 +10,7 @@ namespace RTC
 	/* Class variables. */
 
 	// clang-format off
-	std::unordered_map<std::string, RtpHeaderExtensionUri::Type> RtpHeaderExtensionUri::string2Type =
+	absl::flat_hash_map<std::string, RtpHeaderExtensionUri::Type> RtpHeaderExtensionUri::string2Type =
 	{
 		{ "urn:ietf:params:rtp-hdrext:sdes:mid",                                       RtpHeaderExtensionUri::Type::MID                    },
 		{ "urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id",                             RtpHeaderExtensionUri::Type::RTP_STREAM_ID          },

--- a/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
@@ -4,14 +4,14 @@
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include "RTC/RtpDictionaries.hpp"
-#include <unordered_set>
+#include <absl/container/flat_hash_set.h>
 
 namespace RTC
 {
 	/* Class variables. */
 
 	// clang-format off
-	std::unordered_map<std::string, RtpParameters::Type> RtpParameters::string2Type =
+	absl::flat_hash_map<std::string, RtpParameters::Type> RtpParameters::string2Type =
 	{
 		{ "none",      RtpParameters::Type::NONE      },
 		{ "simple",    RtpParameters::Type::SIMPLE    },
@@ -19,7 +19,7 @@ namespace RTC
 		{ "svc",       RtpParameters::Type::SVC       },
 		{ "pipe",      RtpParameters::Type::PIPE      }
 	};
-	std::unordered_map<RtpParameters::Type, std::string> RtpParameters::type2String =
+	absl::flat_hash_map<RtpParameters::Type, std::string> RtpParameters::type2String =
 	{
 		{ RtpParameters::Type::NONE,      "none"      },
 		{ RtpParameters::Type::SIMPLE,    "simple"    },
@@ -266,7 +266,7 @@ namespace RTC
 
 		static const std::string AptString{ "apt" };
 
-		std::unordered_set<uint8_t> payloadTypes;
+		absl::flat_hash_set<uint8_t> payloadTypes;
 
 		for (auto& codec : this->codecs)
 		{

--- a/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
@@ -19,7 +19,7 @@ namespace RTC
 		{ "svc",       RtpParameters::Type::SVC       },
 		{ "pipe",      RtpParameters::Type::PIPE      }
 	};
-	std::map<RtpParameters::Type, std::string> RtpParameters::type2String =
+	std::unordered_map<RtpParameters::Type, std::string> RtpParameters::type2String =
 	{
 		{ RtpParameters::Type::NONE,      "none"      },
 		{ RtpParameters::Type::SIMPLE,    "simple"    },

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -5,8 +5,7 @@
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include "Utils.hpp"
-#include <cctype> // isprint()
-#include <cerrno>
+#include <cctype>   // isprint()
 #include <iterator> // std::ostream_iterator
 #include <mutex>
 #include <nlohmann/json.hpp>
@@ -24,14 +23,14 @@ static std::mutex globalSyncMutex;
 
 thread_local struct Settings::Configuration Settings::configuration;
 // clang-format off
-std::map<std::string, LogLevel> Settings::string2LogLevel =
+std::unordered_map<std::string, LogLevel> Settings::string2LogLevel =
 {
 	{ "debug", LogLevel::LOG_DEBUG },
 	{ "warn",  LogLevel::LOG_WARN  },
 	{ "error", LogLevel::LOG_ERROR },
 	{ "none",  LogLevel::LOG_NONE  }
 };
-std::map<LogLevel, std::string> Settings::logLevel2String =
+std::unordered_map<LogLevel, std::string> Settings::logLevel2String =
 {
 	{ LogLevel::LOG_DEBUG, "debug" },
 	{ LogLevel::LOG_WARN,  "warn"  },

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -23,14 +23,14 @@ static std::mutex globalSyncMutex;
 
 thread_local struct Settings::Configuration Settings::configuration;
 // clang-format off
-std::unordered_map<std::string, LogLevel> Settings::string2LogLevel =
+absl::flat_hash_map<std::string, LogLevel> Settings::string2LogLevel =
 {
 	{ "debug", LogLevel::LOG_DEBUG },
 	{ "warn",  LogLevel::LOG_WARN  },
 	{ "error", LogLevel::LOG_ERROR },
 	{ "none",  LogLevel::LOG_NONE  }
 };
-std::unordered_map<LogLevel, std::string> Settings::logLevel2String =
+absl::flat_hash_map<LogLevel, std::string> Settings::logLevel2String =
 {
 	{ LogLevel::LOG_DEBUG, "debug" },
 	{ LogLevel::LOG_WARN,  "warn"  },

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -19,12 +19,12 @@
 #include "RTC/DtlsTransport.hpp"
 #include "RTC/SrtpSession.hpp"
 #include <uv.h>
+#include <absl/container/flat_hash_map.h>
 #include <cerrno>
 #include <csignal>  // sigaction()
 #include <cstdlib>  // std::_Exit(), std::genenv()
 #include <iostream> // std::cerr, std::endl
 #include <string>
-#include <unordered_map>
 
 void IgnoreSignals();
 
@@ -210,7 +210,7 @@ void IgnoreSignals()
 	struct sigaction act; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 	// clang-format off
-	std::unordered_map<std::string, int> ignoredSignals =
+	absl::flat_hash_map<std::string, int> ignoredSignals =
 	{
 		{ "PIPE", SIGPIPE },
 		{ "HUP",  SIGHUP  },

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -23,8 +23,8 @@
 #include <csignal>  // sigaction()
 #include <cstdlib>  // std::_Exit(), std::genenv()
 #include <iostream> // std::cerr, std::endl
-#include <map>
 #include <string>
+#include <unordered_map>
 
 void IgnoreSignals();
 
@@ -210,7 +210,7 @@ void IgnoreSignals()
 	struct sigaction act; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 	// clang-format off
-	std::map<std::string, int> ignoredSignals =
+	std::unordered_map<std::string, int> ignoredSignals =
 	{
 		{ "PIPE", SIGPIPE },
 		{ "HUP",  SIGHUP  },


### PR DESCRIPTION
Extracted from `memory-optimizations` branch to make it more readable and concise.