### PR TITLE
Add `Send` to async trait of `RtpObserver`

### DIFF
--- a/rust/src/router/active_speaker_observer.rs
+++ b/rust/src/router/active_speaker_observer.rs
@@ -164,7 +164,7 @@ impl fmt::Debug for ActiveSpeakerObserver {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl RtpObserver for ActiveSpeakerObserver {
     fn id(&self) -> RtpObserverId {
         self.inner.id

--- a/rust/src/router/audio_level_observer.rs
+++ b/rust/src/router/audio_level_observer.rs
@@ -175,7 +175,7 @@ impl fmt::Debug for AudioLevelObserver {
     }
 }
 
-#[async_trait(?Send)]
+#[async_trait]
 impl RtpObserver for AudioLevelObserver {
     fn id(&self) -> RtpObserverId {
         self.inner.id

--- a/rust/src/router/rtp_observer.rs
+++ b/rust/src/router/rtp_observer.rs
@@ -31,7 +31,7 @@ impl RtpObserverAddProducerOptions {
 /// mediasoup implements the following RTP observers:
 /// * [`AudioLevelObserver`](crate::audio_level_observer::AudioLevelObserver)
 /// * [`ActiveSpeakerObserver`](crate::active_speaker_observer::ActiveSpeakerObserver)
-#[async_trait(?Send)]
+#[async_trait]
 pub trait RtpObserver {
     /// RtpObserver id.
     #[must_use]


### PR DESCRIPTION
Remove the `(?Send)` constraint on `async_trait` so It can be sent between threads.
Related to https://mediasoup.discourse.group/t/rust-future-created-by-async-block-is-not-send/3977/3