### PR TITLE
Optimize RTP header extension handling

### DIFF
--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -5,6 +5,7 @@
 #include "Utils.hpp"
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
 #include <absl/container/flat_hash_map.h>
+#include <array>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
@@ -477,7 +478,7 @@ namespace RTC
 					return false;
 
 				// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
-				return this->mapOneByteExtensions[id - 1] != nullptr;
+				return this->oneByteExtensions[id - 1] != nullptr;
 			}
 			else if (HasTwoBytesExtensions())
 			{
@@ -514,7 +515,7 @@ namespace RTC
 					return nullptr;
 
 				// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
-				auto* extension = this->mapOneByteExtensions[id - 1];
+				auto* extension = this->oneByteExtensions[id - 1];
 
 				if (!extension)
 					return nullptr;
@@ -616,9 +617,8 @@ namespace RTC
 		uint8_t* csrcList{ nullptr };
 		HeaderExtension* headerExtension{ nullptr };
 		// There might be up to one-byte header extensions
-		// (https://datatracker.ietf.org/doc/html/rfc5285#section-4.2), which is why we'll just allocate
-		// a static array for them
-		OneByteExtension* mapOneByteExtensions[14];
+		// (https://datatracker.ietf.org/doc/html/rfc5285#section-4.2), use std::array.
+		std::array<OneByteExtension*, 14> oneByteExtensions;
 		absl::flat_hash_map<uint8_t, TwoBytesExtension*> mapTwoBytesExtensions;
 		uint8_t midExtensionId{ 0u };
 		uint8_t ridExtensionId{ 0u };

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -616,7 +616,7 @@ namespace RTC
 		Header* header{ nullptr };
 		uint8_t* csrcList{ nullptr };
 		HeaderExtension* headerExtension{ nullptr };
-		// There might be up to one-byte header extensions
+		// There might be up to 14 one-byte header extensions
 		// (https://datatracker.ietf.org/doc/html/rfc5285#section-4.2), use std::array.
 		std::array<OneByteExtension*, 14> oneByteExtensions;
 		absl::flat_hash_map<uint8_t, TwoBytesExtension*> mapTwoBytesExtensions;

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -4,7 +4,7 @@
 #include "common.hpp"
 #include "Utils.hpp"
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
-#include <absl/container/btree_map.h>
+#include <absl/container/flat_hash_map.h>
 #include <nlohmann/json.hpp>
 #include <string>
 #include <vector>
@@ -473,9 +473,11 @@ namespace RTC
 			}
 			else if (HasOneByteExtensions())
 			{
-				auto it = this->mapOneByteExtensions.find(id);
+				if (id > 14)
+					return false;
 
-				return it != this->mapOneByteExtensions.end();
+				// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
+				return this->mapOneByteExtensions[id - 1] != nullptr;
 			}
 			else if (HasTwoBytesExtensions())
 			{
@@ -508,12 +510,14 @@ namespace RTC
 			}
 			else if (HasOneByteExtensions())
 			{
-				auto it = this->mapOneByteExtensions.find(id);
-
-				if (it == this->mapOneByteExtensions.end())
+				if (id > 14)
 					return nullptr;
 
-				auto* extension = it->second;
+				// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
+				auto* extension = this->mapOneByteExtensions[id - 1];
+
+				if (!extension)
+					return nullptr;
 
 				// In One-Byte extensions value length 0 means 1.
 				len = extension->len + 1;
@@ -611,8 +615,11 @@ namespace RTC
 		Header* header{ nullptr };
 		uint8_t* csrcList{ nullptr };
 		HeaderExtension* headerExtension{ nullptr };
-		absl::btree_map<uint8_t, OneByteExtension*> mapOneByteExtensions;
-		absl::btree_map<uint8_t, TwoBytesExtension*> mapTwoBytesExtensions;
+		// There might be up to one-byte header extensions
+		// (https://datatracker.ietf.org/doc/html/rfc5285#section-4.2), which is why we'll just allocate
+		// a static array for them
+		OneByteExtension* mapOneByteExtensions[14];
+		absl::flat_hash_map<uint8_t, TwoBytesExtension*> mapTwoBytesExtensions;
 		uint8_t midExtensionId{ 0u };
 		uint8_t ridExtensionId{ 0u };
 		uint8_t rridExtensionId{ 0u };

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -477,7 +477,7 @@ namespace RTC
 				if (id > 14)
 					return false;
 
-				// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
+				// `-1` because we have 14 elements total 0..13 and `id` is in the range 1..14.
 				return this->oneByteExtensions[id - 1] != nullptr;
 			}
 			else if (HasTwoBytesExtensions())
@@ -514,7 +514,7 @@ namespace RTC
 				if (id > 14)
 					return nullptr;
 
-				// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
+				// `-1` because we have 14 elements total 0..13 and `id` is in the range 1..14.
 				auto* extension = this->oneByteExtensions[id - 1];
 
 				if (!extension)

--- a/worker/include/RTC/SenderBandwidthEstimator.hpp
+++ b/worker/include/RTC/SenderBandwidthEstimator.hpp
@@ -6,6 +6,7 @@
 #include "RTC/RateCalculator.hpp"
 #include "RTC/SeqManager.hpp"
 #include "RTC/TrendCalculator.hpp"
+#include <absl/container/btree_map.h>
 #include <map>
 
 namespace RTC

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -177,7 +177,7 @@ namespace RTC
 
 			if (HasOneByteExtensions())
 			{
-				for (const auto& extension : this->mapOneByteExtensions)
+				for (const auto& extension : this->oneByteExtensions)
 				{
 					extIds.push_back(std::to_string(extension->id));
 				}
@@ -378,7 +378,7 @@ namespace RTC
 		this->videoOrientationExtensionId  = 0u;
 
 		// Clear the One-Byte and Two-Bytes extension elements maps.
-		std::fill(std::begin(this->mapOneByteExtensions), std::end(this->mapOneByteExtensions), nullptr);
+		std::fill(std::begin(this->oneByteExtensions), std::end(this->oneByteExtensions), nullptr);
 		this->mapTwoBytesExtensions.clear();
 
 		// If One-Byte is requested and the packet already has One-Byte extensions,
@@ -491,7 +491,7 @@ namespace RTC
 
 				// Store the One-Byte extension element in an array.
 				// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
-				this->mapOneByteExtensions[extension.id - 1] = reinterpret_cast<OneByteExtension*>(ptr);
+				this->oneByteExtensions[extension.id - 1] = reinterpret_cast<OneByteExtension*>(ptr);
 
 				*ptr = (extension.id << 4) | ((extension.len - 1) & 0x0F);
 				++ptr;
@@ -575,7 +575,7 @@ namespace RTC
 		else if (HasOneByteExtensions())
 		{
 			// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
-			auto* extension = this->mapOneByteExtensions[id - 1];
+			auto* extension = this->oneByteExtensions[id - 1];
 
 			if (!extension)
 				return false;
@@ -857,7 +857,7 @@ namespace RTC
 		if (HasOneByteExtensions())
 		{
 			// Clear the One-Byte extension elements map.
-			std::fill(std::begin(this->mapOneByteExtensions), std::end(this->mapOneByteExtensions), nullptr);
+			std::fill(std::begin(this->oneByteExtensions), std::end(this->oneByteExtensions), nullptr);
 
 			uint8_t* extensionStart = reinterpret_cast<uint8_t*>(this->headerExtension) + 4;
 			uint8_t* extensionEnd   = extensionStart + GetHeaderExtensionLength();
@@ -886,7 +886,7 @@ namespace RTC
 
 					// Store the One-Byte extension element in an array.
 					// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
-					this->mapOneByteExtensions[id - 1] = reinterpret_cast<OneByteExtension*>(ptr);
+					this->oneByteExtensions[id - 1] = reinterpret_cast<OneByteExtension*>(ptr);
 
 					ptr += (1 + len);
 				}

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -177,11 +177,9 @@ namespace RTC
 
 			if (HasOneByteExtensions())
 			{
-				extIds.reserve(this->mapOneByteExtensions.size());
-
-				for (const auto& kv : this->mapOneByteExtensions)
+				for (const auto& extension : this->mapOneByteExtensions)
 				{
-					extIds.push_back(std::to_string(kv.first));
+					extIds.push_back(std::to_string(extension->id));
 				}
 			}
 			else
@@ -380,7 +378,7 @@ namespace RTC
 		this->videoOrientationExtensionId  = 0u;
 
 		// Clear the One-Byte and Two-Bytes extension elements maps.
-		this->mapOneByteExtensions.clear();
+		std::fill(std::begin(this->mapOneByteExtensions), std::end(this->mapOneByteExtensions), nullptr);
 		this->mapTwoBytesExtensions.clear();
 
 		// If One-Byte is requested and the packet already has One-Byte extensions,
@@ -491,8 +489,9 @@ namespace RTC
 				if (extension.id == 0 || extension.id > 14 || extension.len == 0 || extension.len > 16)
 					continue;
 
-				// Store the One-Byte extension element in the map.
-				this->mapOneByteExtensions[extension.id] = reinterpret_cast<OneByteExtension*>(ptr);
+				// Store the One-Byte extension element in an array.
+				// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
+				this->mapOneByteExtensions[extension.id - 1] = reinterpret_cast<OneByteExtension*>(ptr);
 
 				*ptr = (extension.id << 4) | ((extension.len - 1) & 0x0F);
 				++ptr;
@@ -575,12 +574,12 @@ namespace RTC
 		}
 		else if (HasOneByteExtensions())
 		{
-			auto it = this->mapOneByteExtensions.find(id);
+			// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
+			auto* extension = this->mapOneByteExtensions[id - 1];
 
-			if (it == this->mapOneByteExtensions.end())
+			if (!extension)
 				return false;
 
-			auto* extension = it->second;
 			auto currentLen = extension->len + 1;
 
 			// Fill with 0's if new length is minor.
@@ -858,7 +857,7 @@ namespace RTC
 		if (HasOneByteExtensions())
 		{
 			// Clear the One-Byte extension elements map.
-			this->mapOneByteExtensions.clear();
+			std::fill(std::begin(this->mapOneByteExtensions), std::end(this->mapOneByteExtensions), nullptr);
 
 			uint8_t* extensionStart = reinterpret_cast<uint8_t*>(this->headerExtension) + 4;
 			uint8_t* extensionEnd   = extensionStart + GetHeaderExtensionLength();
@@ -885,8 +884,9 @@ namespace RTC
 						break;
 					}
 
-					// Store the One-Byte extension element in the map.
-					this->mapOneByteExtensions[id] = reinterpret_cast<OneByteExtension*>(ptr);
+					// Store the One-Byte extension element in an array.
+					// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
+					this->mapOneByteExtensions[id - 1] = reinterpret_cast<OneByteExtension*>(ptr);
 
 					ptr += (1 + len);
 				}

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -490,7 +490,7 @@ namespace RTC
 					continue;
 
 				// Store the One-Byte extension element in an array.
-				// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
+				// `-1` because we have 14 elements total 0..13 and `id` is in the range 1..14.
 				this->oneByteExtensions[extension.id - 1] = reinterpret_cast<OneByteExtension*>(ptr);
 
 				*ptr = (extension.id << 4) | ((extension.len - 1) & 0x0F);
@@ -574,7 +574,7 @@ namespace RTC
 		}
 		else if (HasOneByteExtensions())
 		{
-			// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
+			// `-1` because we have 14 elements total 0..13 and `id` is in the range 1..14.
 			auto* extension = this->oneByteExtensions[id - 1];
 
 			if (!extension)
@@ -885,7 +885,7 @@ namespace RTC
 					}
 
 					// Store the One-Byte extension element in an array.
-					// `-1` because we have 14 elements total 0..=13 and `id` is in the range 1..=14
+					// `-1` because we have 14 elements total 0..13 and `id` is in the range 1..14.
 					this->oneByteExtensions[id - 1] = reinterpret_cast<OneByteExtension*>(ptr);
 
 					ptr += (1 + len);


### PR DESCRIPTION
Yet another extract from `memory-optimizations` branch.

Use `std::array` instead of a  map for one byte extensions.