### PR TITLE
Fix video freezing with sync required when transport is connected

### DIFF
--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -1035,9 +1035,6 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		this->syncRequired                 = true;
-		this->keyFrameForTsOffsetRequested = false;
-
 		if (IsActive())
 			MayChangeLayers();
 	}

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -763,8 +763,6 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		this->syncRequired = true;
-
 		if (IsActive())
 			MayChangeLayers();
 	}


### PR DESCRIPTION
There are cases where the consumers video is frozen for some seconds (2-4s) after starting to consume and having had proper video for 1s already.   This happens specially when users round trip time is not low.

After some debugging it looks like the root cause is that `Consumer::UserOnTransportConnected` is being called multiple times (I think once when the DTLS connection is established and another one when the client sends the 'connect' message) and every time mediasoup resets the video stream sync (`syncRequired = true`).       

The first time that happens it is not a big deal because during the initial setup mediasoup will switch spatial layers from -1 to 1 and request a new keyFrame so video will be unfrozen soon.    The problem is the second that that happens (when the client sends the 'connect' message) because in that case nobody is requesting a keyframe so the video will be stuck until the client timeout for no video is triggered (2-3s) and it requests a new PLI.

There could be different solutions for this:
- Request a key frame in UserOnTransportConnected => More keyframes
- Avoid UserOnTransportConnected being called multiple times => Not sure if it is doable but looks something interesting to review
- Don't break the sync (don't mark syncRequired = true) when the transport is connected.  There is no need to couple transport state with stream state as far as I can tell.

This PR implements the last one of those approaches.