### PR TITLE
Fix frozen video due to double call to Consumer::UserOnTransportDisconnected()

### DIFF
--- a/worker/src/RTC/Consumer.cpp
+++ b/worker/src/RTC/Consumer.cpp
@@ -373,6 +373,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		if (this->transportConnected)
+			return;
+
 		this->transportConnected = true;
 
 		MS_DEBUG_DEV("Transport connected [consumerId:%s]", this->id.c_str());
@@ -383,6 +386,9 @@ namespace RTC
 	void Consumer::TransportDisconnected()
 	{
 		MS_TRACE();
+
+		if (!this->transportConnected)
+			return;
 
 		this->transportConnected = false;
 


### PR DESCRIPTION
Rationale given here: https://github.com/versatica/mediasoup/pull/787#issuecomment-1060891193

We always check flags and return fast if the flag was already set (or unset, it depends), then we set or unset the flag and run code. Here we failed and didn't honor this pattern.