### PR TITLE
Fix handling of padding only packets

### DIFF
--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -207,6 +207,14 @@ namespace RTC
 		auto& syncRequired  = this->mapRtpStreamSyncRequired.at(rtpStream);
 		auto& rtpSeqManager = this->mapRtpStreamRtpSeqManager.at(rtpStream);
 
+		// Packets with only padding are not forwarded.
+		if (packet->GetPayloadLength() == 0)
+		{
+			rtpSeqManager.Drop(packet->GetSequenceNumber());
+
+			return;
+		}
+
 		// If we need to sync, support key frames and this is not a key frame, ignore
 		// the packet.
 		if (syncRequired && this->keyFrameSupported && !packet->IsKeyFrame())

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -132,8 +132,8 @@ namespace RTC
 		uint64_t nowMs = DepLibUV::GetTimeMs();
 
 		this->packets++;
-		
-		// Ignore the bitrate of the padding only packets as they won't be forwarded
+
+		// Ignore the bitrate of the padding only packets as they won't be forwarded.
 		if (packet->GetPayloadLength() > 0)
 		{
 			this->rate.Update(packet->GetSize() - packet->GetPayloadPadding(), nowMs);

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -132,6 +132,11 @@ namespace RTC
 		uint64_t nowMs = DepLibUV::GetTimeMs();
 
 		this->packets++;
-		this->rate.Update(packet->GetSize(), nowMs);
+		
+		// Ignore the bitrate of the padding only packets as they won't be forwarded
+		if (packet->GetPayloadLength() > 0)
+		{
+			this->rate.Update(packet->GetSize() - packet->GetPayloadPadding(), nowMs);
+		}
 	}
 } // namespace RTC

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -132,11 +132,6 @@ namespace RTC
 		uint64_t nowMs = DepLibUV::GetTimeMs();
 
 		this->packets++;
-
-		// Ignore the bitrate of the padding only packets as they won't be forwarded.
-		if (packet->GetPayloadLength() > 0)
-		{
-			this->rate.Update(packet->GetSize() - packet->GetPayloadPadding(), nowMs);
-		}
+		this->rate.Update(packet->GetSize(), nowMs);
 	}
 } // namespace RTC

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -394,6 +394,9 @@ namespace RTC
 			// Increase transmission counter.
 			this->transmissionCounter.Update(packet);
 
+			if (packet->GetPayloadLength() == 0)
+				return false;
+
 			// Not inactive anymore.
 			if (this->inactive)
 			{

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -284,6 +284,10 @@ namespace RTC
 		// Increase media transmission counter.
 		this->mediaTransmissionCounter.Update(packet);
 
+		// Ignore padding-only packets and don't mark the stream as active with them.
+		if (packet->GetPayloadLength() == 0)
+			return false;
+
 		// Not inactive anymore.
 		if (this->inactive)
 		{

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -235,6 +235,14 @@ namespace RTC
 		if (!IsActive())
 			return;
 
+		// Packets with only padding are not forwarded.
+		if (packet->GetPayloadLength() == 0)
+		{
+			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
+
+			return;
+		}
+
 		auto payloadType = packet->GetPayloadType();
 
 		// NOTE: This may happen if this Consumer supports just some codecs of those

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -646,7 +646,7 @@ namespace RTC
 
 		if (!IsActive())
 			return;
-	
+
 		// Packets with only padding are not forwarded.
 		if (packet->GetPayloadLength() == 0)
 		{

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -647,7 +647,7 @@ namespace RTC
 		if (!IsActive())
 			return;
 	
-		// Packets with only padding are not forwarded
+		// Packets with only padding are not forwarded.
 		if (packet->GetPayloadLength() == 0)
 		{
 			this->rtpSeqManager.Drop(packet->GetSequenceNumber());

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -646,6 +646,14 @@ namespace RTC
 
 		if (!IsActive())
 			return;
+	
+		// Packets with only padding are not forwarded
+		if (packet->GetPayloadLength() == 0)
+		{
+			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
+
+			return;
+		}
 
 		if (this->targetTemporalLayer == -1)
 			return;

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -539,6 +539,14 @@ namespace RTC
 		if (!IsActive())
 			return;
 
+		// Packets with only padding are not forwarded
+		if (packet->GetPayloadLength() == 0)
+		{
+			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
+
+			return;
+		}
+
 		// clang-format off
 		if (
 			this->encodingContext->GetTargetSpatialLayer() == -1 ||

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -539,7 +539,7 @@ namespace RTC
 		if (!IsActive())
 			return;
 
-		// Packets with only padding are not forwarded
+		// Packets with only padding are not forwarded.
 		if (packet->GetPayloadLength() == 0)
 		{
 			this->rtpSeqManager.Drop(packet->GetSequenceNumber());


### PR DESCRIPTION
WebRTC uses padding-only packets for testing available bandwidth specially when using simulcast (to test if it is possible to enable a higher layer).

With the current handling in mediasoup those packets are:
1/ Forwarded to the consumers (wasting bandwidth)
2/ Included in the bitrate calculations of a layer. That means:
     a) The spatial layer is marked as active even if there is no media but only padding associated with it
     b) The bitrate of the spatial layer is estimated as higher than actually needed
     
Because of those issues there are cases where the SimulcastConsumer keeps sending the higher layer even if it only has padding bytes and that makes the video freeze in the receiver side because there are no new real frames received.

We have received different customer reports of video freezing for long periods that look associated to this issue.

With this PR:
1/ Padding-only packets are never forwarded
2/ Padding only packets are not included in bitrate counters and neither to mark a RtpStream as active

As far as I can tell this is only an issue if RTX is disabled but I didn't investigate that much.