### PR TITLE
Fix rust test segfault

### DIFF
--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -502,20 +502,20 @@ impl Inner {
     fn close(&self) {
         let already_closed = self.closed.swap(true, Ordering::SeqCst);
 
-        let channel = self.channel.clone();
-        let payload_channel = self.payload_channel.clone();
-
-        self.executor
-            .spawn(async move {
-                let _ = channel.request(WorkerCloseRequest {}).await;
-
-                // Drop channels in here after response from worker
-                drop(channel);
-                drop(payload_channel);
-            })
-            .detach();
-
         if !already_closed {
+            let channel = self.channel.clone();
+            let payload_channel = self.payload_channel.clone();
+
+            self.executor
+                .spawn(async move {
+                    let _ = channel.request(WorkerCloseRequest {}).await;
+
+                    // Drop channels in here after response from worker
+                    drop(channel);
+                    drop(payload_channel);
+                })
+                .detach();
+
             self.handlers.close.call_simple();
         }
     }

--- a/rust/src/worker/channel.rs
+++ b/rust/src/worker/channel.rs
@@ -1,4 +1,4 @@
-use crate::messages::Request;
+use crate::messages::{Request, WorkerCloseRequest};
 use crate::worker::common::{EventHandlers, SubscriptionTarget, WeakEventHandlers};
 use crate::worker::utils;
 use crate::worker::utils::{PreparedChannelRead, PreparedChannelWrite};
@@ -11,8 +11,10 @@ use mediasoup_sys::UvAsyncT;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
+use std::any::TypeId;
 use std::collections::VecDeque;
 use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 
 #[derive(Debug, Deserialize)]
@@ -162,6 +164,8 @@ struct Inner {
     requests_container_weak: Weak<Mutex<RequestsContainer>>,
     buffered_notifications_for: Arc<Mutex<HashedMap<SubscriptionTarget, Vec<Vec<u8>>>>>,
     event_handlers_weak: WeakEventHandlers<Arc<dyn Fn(&[u8]) + Send + Sync + 'static>>,
+    worker_closed: Arc<AtomicBool>,
+    closed: AtomicBool,
 }
 
 impl Drop for Inner {
@@ -176,7 +180,9 @@ pub(crate) struct Channel {
 }
 
 impl Channel {
-    pub(super) fn new() -> (Self, PreparedChannelRead, PreparedChannelWrite) {
+    pub(super) fn new(
+        worker_closed: Arc<AtomicBool>,
+    ) -> (Self, PreparedChannelRead, PreparedChannelWrite) {
         let outgoing_message_buffer = Arc::new(Mutex::new(OutgoingMessageBuffer {
             handle: None,
             messages: VecDeque::with_capacity(10),
@@ -270,6 +276,8 @@ impl Channel {
             requests_container_weak,
             buffered_notifications_for,
             event_handlers_weak,
+            worker_closed,
+            closed: AtomicBool::new(false),
         });
 
         (
@@ -301,7 +309,7 @@ impl Channel {
 
     pub(crate) async fn request<R>(&self, request: R) -> Result<R::Response, RequestError>
     where
-        R: Request,
+        R: Request + 'static,
     {
         let method = request.as_method();
 
@@ -339,6 +347,16 @@ impl Channel {
                 .messages
                 .push_back(Arc::clone(&message));
             if let Some(handle) = outgoing_message_buffer.handle {
+                if self.inner.worker_closed.load(Ordering::Acquire) {
+                    // Forbid all requests after worker closing except one worker closing request
+                    let first_worker_closing = TypeId::of::<R>()
+                        == TypeId::of::<WorkerCloseRequest>()
+                        && !self.inner.closed.swap(true, Ordering::Relaxed);
+
+                    if !first_worker_closing {
+                        return Err(RequestError::ChannelClosed);
+                    }
+                }
                 unsafe {
                     // Notify worker that there is something to read
                     let ret = mediasoup_sys::uv_async_send(handle);

--- a/rust/src/worker/channel.rs
+++ b/rust/src/worker/channel.rs
@@ -338,10 +338,10 @@ impl Channel {
             outgoing_message_buffer
                 .messages
                 .push_back(Arc::clone(&message));
-            if let Some(handle) = &outgoing_message_buffer.handle {
+            if let Some(handle) = outgoing_message_buffer.handle {
                 unsafe {
                     // Notify worker that there is something to read
-                    let ret = mediasoup_sys::uv_async_send(*handle);
+                    let ret = mediasoup_sys::uv_async_send(handle);
                     if ret != 0 {
                         error!("uv_async_send call failed with code {}", ret);
                         return Err(RequestError::ChannelClosed);

--- a/rust/src/worker/payload_channel.rs
+++ b/rust/src/worker/payload_channel.rs
@@ -298,10 +298,10 @@ impl PayloadChannel {
             outgoing_message_buffer
                 .messages
                 .push_back(OutgoingMessage::Request(Arc::clone(&message_with_payload)));
-            if let Some(handle) = &outgoing_message_buffer.handle {
+            if let Some(handle) = outgoing_message_buffer.handle {
                 unsafe {
                     // Notify worker that there is something to read
-                    let ret = mediasoup_sys::uv_async_send(*handle);
+                    let ret = mediasoup_sys::uv_async_send(handle);
                     if ret != 0 {
                         error!("uv_async_send call failed with code {}", ret);
                         return Err(RequestError::ChannelClosed);
@@ -362,10 +362,10 @@ impl PayloadChannel {
             outgoing_message_buffer
                 .messages
                 .push_back(OutgoingMessage::Notification { message, payload });
-            if let Some(handle) = &outgoing_message_buffer.handle {
+            if let Some(handle) = outgoing_message_buffer.handle {
                 unsafe {
                     // Notify worker that there is something to read
-                    let ret = mediasoup_sys::uv_async_send(*handle);
+                    let ret = mediasoup_sys::uv_async_send(handle);
                     if ret != 0 {
                         error!("uv_async_send call failed with code {}", ret);
                         return Err(NotificationError::ChannelClosed);

--- a/rust/src/worker/payload_channel.rs
+++ b/rust/src/worker/payload_channel.rs
@@ -11,6 +11,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::VecDeque;
 use std::fmt::Debug;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Weak};
 use thiserror::Error;
 
@@ -139,6 +140,7 @@ struct Inner {
     requests_container_weak: Weak<Mutex<RequestsContainer>>,
     #[allow(clippy::type_complexity)]
     event_handlers_weak: WeakEventHandlers<Arc<dyn Fn(&[u8], &[u8]) + Send + Sync + 'static>>,
+    worker_closed: Arc<AtomicBool>,
 }
 
 impl Drop for Inner {
@@ -153,7 +155,9 @@ pub(crate) struct PayloadChannel {
 }
 
 impl PayloadChannel {
-    pub(super) fn new() -> (
+    pub(super) fn new(
+        worker_closed: Arc<AtomicBool>,
+    ) -> (
         Self,
         PreparedPayloadChannelRead,
         PreparedPayloadChannelWrite,
@@ -241,6 +245,7 @@ impl PayloadChannel {
             internal_message_receiver,
             requests_container_weak,
             event_handlers_weak,
+            worker_closed,
         });
 
         (
@@ -299,6 +304,9 @@ impl PayloadChannel {
                 .messages
                 .push_back(OutgoingMessage::Request(Arc::clone(&message_with_payload)));
             if let Some(handle) = outgoing_message_buffer.handle {
+                if self.inner.worker_closed.load(Ordering::Acquire) {
+                    return Err(RequestError::ChannelClosed);
+                }
                 unsafe {
                     // Notify worker that there is something to read
                     let ret = mediasoup_sys::uv_async_send(handle);
@@ -363,6 +371,9 @@ impl PayloadChannel {
                 .messages
                 .push_back(OutgoingMessage::Notification { message, payload });
             if let Some(handle) = outgoing_message_buffer.handle {
+                if self.inner.worker_closed.load(Ordering::Acquire) {
+                    return Err(NotificationError::ChannelClosed);
+                }
                 unsafe {
                     // Notify worker that there is something to read
                     let ret = mediasoup_sys::uv_async_send(handle);


### PR DESCRIPTION
## First commit

It only happened in two cases:
1) In `worker_close_event` test (racy behavior, if worker stops fast enough, its `loop` is de-allocated and calling into `uv_async_send` referenced de-allocated memory in the end; this is what we observed in CI)
    * not possible to hit during regular use due to test calling internal test-only API
2) In case worker exits unexpectedly with non-zero code (which is a problem in itself and basically never happens under normal circumstances)

Fixes #799

## Third commit

Fixes racy behavior when multithreaded executor is used (default executor provided by the library is single-threaded). This is caused by the fact that multiple entities are racing towards closing (worker, router, transports, etc.). And since all of them run in parallel, it sometimes happened that worker was closed first and then transport wanted to make closing request as well, but worker itself has already closed, hitting the same root issue as above issue (hence push into the same PR).

Fixes #795