### PR TITLE
Modify SimulcastConsumer to keep using layers without good scores

### DIFF
--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -13,7 +13,6 @@ namespace RTC
 {
 	/* Static. */
 
-	static constexpr uint8_t StreamGoodScore{ 5u };
 	static constexpr uint64_t StreamMinActiveMs{ 2000u };           // In ms.
 	static constexpr uint64_t BweDowngradeConservativeMs{ 10000u }; // In ms.
 	static constexpr uint64_t BweDowngradeMinActiveMs{ 8000u };     // In ms.
@@ -444,7 +443,7 @@ namespace RTC
 			auto* producerRtpStream = this->producerRtpStreams.at(spatialLayer);
 
 			// Producer stream does not exist or it's not good. Ignore.
-			if (!producerRtpStream || producerRtpStream->GetScore() < StreamGoodScore)
+			if (!producerRtpStream)
 				continue;
 
 			// If the stream has not been active time enough and we have an active one
@@ -1295,17 +1294,11 @@ namespace RTC
 			if (!CanSwitchToSpatialLayer(spatialLayer))
 				continue;
 
-			// If the stream score is worse than the best seen and not good enough, ignore
-			// this stream.
-			if (producerScore < maxProducerScore && producerScore < StreamGoodScore)
-				continue;
-
 			newTargetSpatialLayer = spatialLayer;
 			maxProducerScore      = producerScore;
 
-			// If this is the preferred or higher spatial layer and has good score,
-			// take it and exit.
-			if (spatialLayer >= this->preferredSpatialLayer && producerScore >= StreamGoodScore)
+			// If this is the preferred or higher spatial layer take it and exit.
+			if (spatialLayer >= this->preferredSpatialLayer)
 				break;
 		}
 


### PR DESCRIPTION
We have cases were some simulcast consumers get all the video layers disabled very often when the producers have a high amount of packet loss.    In those cases we see up to 5-6 transitions per minute from "no layers" <-> "first layer" and we end up with frozen video or black video depending on when it happens.

I think mediasoup doesn't need to have the logic to estimate the quality of the producer streams because of these reasons:
- In many use cases it can be better to have bad quality video that no video at all.
- The current logic is creating many transitions (5-6 constantly per minute in some of our user reports) that makes the experience not very stable.
- With this change an app listening for the 'layerschange' event from the consumer will know that if layers have changed is because of the bandwidth estimation available instead of for a combination of multiple factors (bandwidth estimation and score of the producer).   So it is easier to present that information in the UI.
- The current logic can be implemented by the app checking the producers scores if it is important.
- This way the logic is simpler.
- I haven't seen this logic in other SFUs like Janus/Signal/Jitsi.... (I could be wrong and it is not a strong reason per se, but just fyc).

If it is better to open this as an issue or forum post instead of a PR let me know.   Thx for taking a look.