### PR TITLE
Fix marker bit not reseted after mangling in each consumer

### DIFF
--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -602,7 +602,7 @@ namespace RTC
 			this->payloadDescriptorHandler.reset(payloadDescriptorHandler);
 		}
 
-		bool ProcessPayload(RTC::Codecs::EncodingContext* context);
+		bool ProcessPayload(RTC::Codecs::EncodingContext* context, bool& marker);
 
 		void RestorePayload();
 

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -782,20 +782,15 @@ namespace RTC
 		return true;
 	}
 
-	bool RtpPacket::ProcessPayload(RTC::Codecs::EncodingContext* context)
+	bool RtpPacket::ProcessPayload(RTC::Codecs::EncodingContext* context, bool& marker)
 	{
 		MS_TRACE();
 
 		if (!this->payloadDescriptorHandler)
 			return true;
 
-		bool marker{ false };
-
 		if (this->payloadDescriptorHandler->Process(context, this->payload, marker))
 		{
-			if (marker)
-				SetMarker(true);
-
 			return true;
 		}
 		else

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -822,6 +822,8 @@ namespace RTC
 			this->keyFrameForTsOffsetRequested = false;
 		}
 
+		bool marker{ false };
+
 		if (shouldSwitchCurrentSpatialLayer)
 		{
 			// Update current spatial layer.
@@ -841,14 +843,14 @@ namespace RTC
 			EmitScore();
 
 			// Rewrite payload if needed.
-			packet->ProcessPayload(this->encodingContext.get());
+			packet->ProcessPayload(this->encodingContext.get(), marker);
 		}
 		else
 		{
 			auto previousTemporalLayer = this->encodingContext->GetCurrentTemporalLayer();
 
 			// Rewrite payload if needed. Drop packet if necessary.
-			if (!packet->ProcessPayload(this->encodingContext.get()))
+			if (!packet->ProcessPayload(this->encodingContext.get(), marker))
 			{
 				this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -581,7 +581,9 @@ namespace RTC
 		auto previousSpatialLayer  = this->encodingContext->GetCurrentSpatialLayer();
 		auto previousTemporalLayer = this->encodingContext->GetCurrentTemporalLayer();
 
-		if (!packet->ProcessPayload(this->encodingContext.get()))
+		bool marker{ false };
+		bool origMarker = packet->HasMarker();
+		if (!packet->ProcessPayload(this->encodingContext.get(), marker))
 		{
 			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
@@ -611,6 +613,10 @@ namespace RTC
 		// Rewrite packet.
 		packet->SetSsrc(this->rtpParameters.encodings[0].ssrc);
 		packet->SetSequenceNumber(seq);
+		if (marker)
+		{
+			packet->SetMarker(true);
+		}
 
 		if (isSyncPacket)
 		{
@@ -649,6 +655,7 @@ namespace RTC
 		// Restore packet fields.
 		packet->SetSsrc(origSsrc);
 		packet->SetSequenceNumber(origSeq);
+		packet->SetMarker(origMarker);
 
 		// Restore the original payload if needed.
 		packet->RestorePayload();

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -583,6 +583,7 @@ namespace RTC
 
 		bool marker{ false };
 		bool origMarker = packet->HasMarker();
+
 		if (!packet->ProcessPayload(this->encodingContext.get(), marker))
 		{
 			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
@@ -613,6 +614,7 @@ namespace RTC
 		// Rewrite packet.
 		packet->SetSsrc(this->rtpParameters.encodings[0].ssrc);
 		packet->SetSequenceNumber(seq);
+
 		if (marker)
 		{
 			packet->SetMarker(true);


### PR DESCRIPTION
The marker bit is set in some cases when processing the payload for VP9 SVC consumers and that bit is not reseted so a consumer affects to the next ones.

The effect is that some SVC consumers receive more frames with marker bit than expected and libwebrtc is not able to decode them properly.    From a user point of view the effect is having very low framerate because it is only able to decode the framerates and the browser keeps sending PLIs forever.