### PR TITLE
Fix old buffer items cleanup in `RTC::RateCalculator`

### DIFF
--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -87,7 +87,7 @@ namespace RTC
 		uint64_t newOldestTime = nowMs - this->windowSizeMs;
 
 		// Oldest item already removed.
-		if (newOldestTime <= this->oldestItemStartTime)
+		if (newOldestTime < this->oldestItemStartTime)
 			return;
 
 		// A whole window size time has elapsed since last entry. Reset the buffer.
@@ -98,7 +98,7 @@ namespace RTC
 			return;
 		}
 
-		while (this->oldestItemStartTime < newOldestTime)
+		while (this->oldestItemStartTime <= newOldestTime)
 		{
 			BufferItem& oldestItem = this->buffer[this->oldestItemIndex];
 			this->totalCount -= oldestItem.count;

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -31,7 +31,7 @@ namespace RTC
 
 			MS_ASSERT(
 			  this->newestItemIndex != this->oldestItemIndex || this->oldestItemIndex == -1,
-			  "Newest index overlaps with the oldest one");
+			  "newest index overlaps with the oldest one");
 
 			// Set the newest item.
 			BufferItem& item = this->buffer[this->newestItemIndex];

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -29,22 +29,8 @@ namespace RTC
 			if (this->newestItemIndex >= this->windowItems)
 				this->newestItemIndex = 0;
 
-			// Newest index overlaps with the oldest one, remove it.
-			if (this->newestItemIndex == this->oldestItemIndex && this->oldestItemIndex != -1)
-			{
-				MS_WARN_TAG(
-				  info,
-				  "calculation buffer full, windowSizeMs:%zu ms windowItems:%" PRIu16,
-				  this->windowSizeMs,
-				  this->windowItems);
-
-				BufferItem& oldestItem = this->buffer[this->oldestItemIndex];
-				this->totalCount -= oldestItem.count;
-				oldestItem.count = 0u;
-				oldestItem.time  = 0u;
-				if (++this->oldestItemIndex >= this->windowItems)
-					this->oldestItemIndex = 0;
-			}
+			MS_ASSERT(this->newestItemIndex != this->oldestItemIndex || this->oldestItemIndex == -1,
+					  "Newest index overlaps with the oldest one");
 
 			// Set the newest item.
 			BufferItem& item = this->buffer[this->newestItemIndex];

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -98,21 +98,21 @@ namespace RTC
 		if (this->newestItemIndex < 0 || this->oldestItemIndex < 0)
 			return;
 
-		uint64_t newoldestTime = nowMs - this->windowSizeMs;
+		uint64_t newOldestTime = nowMs - this->windowSizeMs;
 
 		// Oldest item already removed.
-		if (newoldestTime <= this->oldestItemStartTime)
+		if (newOldestTime <= this->oldestItemStartTime)
 			return;
 
 		// A whole window size time has elapsed since last entry. Reset the buffer.
-		if (newoldestTime > this->newestItemStartTime)
+		if (newOldestTime > this->newestItemStartTime)
 		{
 			Reset();
 
 			return;
 		}
 
-		while (this->oldestItemStartTime < newoldestTime)
+		while (this->oldestItemStartTime < newOldestTime)
 		{
 			BufferItem& oldestItem = this->buffer[this->oldestItemIndex];
 			this->totalCount -= oldestItem.count;

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -29,8 +29,9 @@ namespace RTC
 			if (this->newestItemIndex >= this->windowItems)
 				this->newestItemIndex = 0;
 
-			MS_ASSERT(this->newestItemIndex != this->oldestItemIndex || this->oldestItemIndex == -1,
-					  "Newest index overlaps with the oldest one");
+			MS_ASSERT(
+			  this->newestItemIndex != this->oldestItemIndex || this->oldestItemIndex == -1,
+			  "Newest index overlaps with the oldest one");
 
 			// Set the newest item.
 			BufferItem& item = this->buffer[this->newestItemIndex];


### PR DESCRIPTION
In the PR, besides fixing the bug described in #818, I also replaced the `if condition` with an assert as the code under it is [not supposed to be executed anyway](https://github.com/versatica/mediasoup/pull/547#discussion_r621078697). Moreover, the assertion allows to catch the bug by running the unit test for `RTC::RateCalculator`