### PR TITLE
Allow setting max outgoing bitrate below the initial value

### DIFF
--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -262,9 +262,6 @@ namespace RTC
 
 	void TransportCongestionControlClient::SetMaxOutgoingBitrate(uint32_t maxBitrate)
 	{
-		if (maxBitrate < this->initialAvailableBitrate)
-			MS_THROW_ERROR("maxOutgoingBitrate must be >= initialAvailableOutgoingBitrate");
-
 		if (maxBitrate < MinBitrate)
 			MS_THROW_ERROR("maxOutgoingBitrate must be >= 30000bps");
 


### PR DESCRIPTION
We use SetMaxOutgoingBitrate API to simulate network conditions for testing the application logic in those cases.    In the tests is very common to want to simulate very low bitrate (30kbps) so that all consumers get paused but that's not possible with current implementation because the typical value of initialAvailableBitrate is 300-600kbps.

With this change it is allowed to set a maxOutgoingBitrate below initialAvailableBitrate and initialAvailableBitrate will be capped if needed.

Tested by launching mediasoup with initialAvailableBitrate set to 600kbps and then setting maxOutgoingBitrate to 30kbps and back to 1000kpbs.