### PR TITLE
Fix old buffer items cleanup in `RTC::RateCalculator`

### DIFF
--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -29,22 +29,9 @@ namespace RTC
 			if (this->newestItemIndex >= this->windowItems)
 				this->newestItemIndex = 0;
 
-			// Newest index overlaps with the oldest one, remove it.
-			if (this->newestItemIndex == this->oldestItemIndex && this->oldestItemIndex != -1)
-			{
-				MS_WARN_TAG(
-				  info,
-				  "calculation buffer full, windowSizeMs:%zu ms windowItems:%" PRIu16,
-				  this->windowSizeMs,
-				  this->windowItems);
-
-				BufferItem& oldestItem = this->buffer[this->oldestItemIndex];
-				this->totalCount -= oldestItem.count;
-				oldestItem.count = 0u;
-				oldestItem.time  = 0u;
-				if (++this->oldestItemIndex >= this->windowItems)
-					this->oldestItemIndex = 0;
-			}
+			MS_ASSERT(
+			  this->newestItemIndex != this->oldestItemIndex || this->oldestItemIndex == -1,
+			  "newest index overlaps with the oldest one");
 
 			// Set the newest item.
 			BufferItem& item = this->buffer[this->newestItemIndex];

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -88,7 +88,7 @@ namespace RTC
 		uint64_t newOldestTime = nowMs - this->windowSizeMs;
 
 		// Oldest item already removed.
-		if (newOldestTime <= this->oldestItemStartTime)
+		if (newOldestTime < this->oldestItemStartTime)
 			return;
 
 		// A whole window size time has elapsed since last entry. Reset the buffer.
@@ -99,7 +99,7 @@ namespace RTC
 			return;
 		}
 
-		while (this->oldestItemStartTime < newOldestTime)
+		while (newOldestTime >= this->oldestItemStartTime)
 		{
 			BufferItem& oldestItem = this->buffer[this->oldestItemIndex];
 			this->totalCount -= oldestItem.count;

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -92,7 +92,7 @@ namespace RTC
 			return;
 
 		// A whole window size time has elapsed since last entry. Reset the buffer.
-		if (newOldestTime > this->newestItemStartTime)
+		if (newOldestTime >= this->newestItemStartTime)
 		{
 			Reset();
 

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -98,21 +98,21 @@ namespace RTC
 		if (this->newestItemIndex < 0 || this->oldestItemIndex < 0)
 			return;
 
-		uint64_t newoldestTime = nowMs - this->windowSizeMs;
+		uint64_t newOldestTime = nowMs - this->windowSizeMs;
 
 		// Oldest item already removed.
-		if (newoldestTime <= this->oldestItemStartTime)
+		if (newOldestTime <= this->oldestItemStartTime)
 			return;
 
 		// A whole window size time has elapsed since last entry. Reset the buffer.
-		if (newoldestTime > this->newestItemStartTime)
+		if (newOldestTime > this->newestItemStartTime)
 		{
 			Reset();
 
 			return;
 		}
 
-		while (this->oldestItemStartTime < newoldestTime)
+		while (this->oldestItemStartTime < newOldestTime)
 		{
 			BufferItem& oldestItem = this->buffer[this->oldestItemIndex];
 			this->totalCount -= oldestItem.count;

--- a/worker/test/src/RTC/TestRateCalculator.cpp
+++ b/worker/test/src/RTC/TestRateCalculator.cpp
@@ -59,6 +59,22 @@ SCENARIO("Bitrate calculator", "[rtp][bitrate]")
 		validate(rate, nowMs, input);
 	}
 
+	SECTION("receive item every 1000 ms")
+	{
+		RateCalculator rate(1000, 8000, 100);
+
+		// clang-format off
+		std::vector<data> input =
+		{
+			{ 0,    5, 40 },
+			{ 1000, 5, 40 },
+			{ 2000, 5, 40 }
+		};
+		// clang-format on
+
+		validate(rate, nowMs, input);
+	}
+
 	SECTION("slide")
 	{
 		RateCalculator rate(1000, 8000, 1000);


### PR DESCRIPTION
This is the fix for the issue described in #818 and the infinite loop found in #819 (the first attempt to fix #818)