### PR TITLE
TransportCongestionControlClient: allow setting maxOutgoingBitrate before created

### DIFF
--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -14,8 +14,6 @@ using json = nlohmann::json;
 
 namespace RTC
 {
-	// Max RTP length.
-	constexpr size_t RtpBufferSize{ 65536u };
 	// Max MTU size.
 	constexpr size_t MtuSize{ 1500u };
 	// MID header extension max length (just used when setting/updating MID

--- a/worker/include/RTC/TransportCongestionControlClient.hpp
+++ b/worker/include/RTC/TransportCongestionControlClient.hpp
@@ -17,6 +17,8 @@
 
 namespace RTC
 {
+	constexpr uint32_t TransportCongestionControlMinOutgoingBitrate{ 30000u };
+
 	class TransportCongestionControlClient : public webrtc::PacketRouter,
 	                                         public webrtc::TargetTransferRateObserver,
 	                                         public Timer::Listener

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -630,19 +630,28 @@ namespace RTC
 					MS_THROW_TYPE_ERROR("missing bitrate");
 				}
 
+				uint32_t bitrate = jsonBitrateIt->get<uint32_t>();
+
+				if (bitrate < RTC::TransportCongestionControlMinOutgoingBitrate)
+				{
+					MS_THROW_TYPE_ERROR(
+					  "bitrate must be >= %" PRIu32 " bps", RTC::TransportCongestionControlMinOutgoingBitrate);
+				}
+
 				if (this->tccClient)
 				{
-					uint32_t bitrate = jsonBitrateIt->get<uint32_t>();
-
-					// NOTE: This may throw if given bitrate is less than current
-					// initialAvailableOutgoingBitrate, so don't update things before
-					// calling this method.
+					// NOTE: This may throw so don't update things before calling this
+					// method.
 					this->tccClient->SetMaxOutgoingBitrate(bitrate);
 					this->maxOutgoingBitrate = bitrate;
 
 					MS_DEBUG_TAG(bwe, "maximum outgoing bitrate set to %" PRIu32, this->maxOutgoingBitrate);
 
 					ComputeOutgoingDesiredBitrate();
+				}
+				else
+				{
+					this->maxOutgoingBitrate = bitrate;
 				}
 
 				request->Accept();

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -12,7 +12,8 @@ namespace RTC
 {
 	/* Static. */
 
-	static constexpr uint32_t MinBitrate{ 30000u };
+	// NOTE: TransportCongestionControlMinOutgoingBitrate is defined in
+	// TransportCongestionControlClient.hpp and exposed publicly.
 	static constexpr float MaxBitrateMarginFactor{ 0.1f };
 	static constexpr float MaxBitrateIncrementFactor{ 1.35f };
 	static constexpr float MaxPaddingBitrateFactor{ 0.85f };
@@ -27,7 +28,8 @@ namespace RTC
 	  uint32_t initialAvailableBitrate,
 	  uint32_t maxOutgoingBitrate)
 	  : listener(listener), bweType(bweType),
-	    initialAvailableBitrate(std::max<uint32_t>(initialAvailableBitrate, MinBitrate)),
+	    initialAvailableBitrate(std::max<uint32_t>(
+	      initialAvailableBitrate, RTC::TransportCongestionControlMinOutgoingBitrate)),
 	    maxOutgoingBitrate(maxOutgoingBitrate)
 	{
 		MS_TRACE();
@@ -262,9 +264,6 @@ namespace RTC
 
 	void TransportCongestionControlClient::SetMaxOutgoingBitrate(uint32_t maxBitrate)
 	{
-		if (maxBitrate < MinBitrate)
-			MS_THROW_ERROR("maxOutgoingBitrate must be >= 30000bps");
-
 		this->maxOutgoingBitrate = maxBitrate;
 
 		ApplyBitrateUpdates();
@@ -290,10 +289,11 @@ namespace RTC
 
 		this->bitrates.desiredBitrate          = desiredBitrate;
 		this->bitrates.effectiveDesiredBitrate = this->desiredBitrateTrend.GetValue();
-		this->bitrates.minBitrate              = MinBitrate;
+		this->bitrates.minBitrate              = RTC::TransportCongestionControlMinOutgoingBitrate;
 		// NOTE: Setting 'startBitrate' to 'availableBitrate' has proven to generate
 		// more stable values.
-		this->bitrates.startBitrate = std::max<uint32_t>(MinBitrate, this->bitrates.availableBitrate);
+		this->bitrates.startBitrate = std::max<uint32_t>(
+		  RTC::TransportCongestionControlMinOutgoingBitrate, this->bitrates.availableBitrate);
 
 		ApplyBitrateUpdates();
 	}


### PR DESCRIPTION
- Fixes #831
- Remove no longer used `RtpBufferSize` in `RtpPacket.hpp`.