### PR TITLE
Upgrade Node.js

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -8,7 +8,7 @@ jobs:
       matrix:
         # Just 1 OS should be fine for TypeScript.
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           # - macos-11.0
           # - windows-2019
         node:

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -12,9 +12,9 @@ jobs:
           # - macos-11.0
           # - windows-2019
         node:
-          - 12
           - 14
           - 16
+          - 18
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -40,7 +40,7 @@ jobs:
             cxx: cl
         # A single Node.js version should be fine for C++.
         node:
-          - 14
+          - 18
 
     runs-on: ${{ matrix.build.os }}
 

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -40,7 +40,7 @@ jobs:
             cxx: cl
         # A single Node.js version should be fine for C++.
         node:
-          - 18
+          - 16
 
     runs-on: ${{ matrix.build.os }}
 


### PR DESCRIPTION
Node.js 12 is EOL for some time now and Node.js 18 is both current and will become LTS in a few months.

No code changes to intentionally break older versions yet, but doesn't make sense to test on older versions in CI either.