### PR TITLE
RtpStreamSend: Memory optimizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* `RtpStreamSend`: Memory optimizations. Extracted from #675.
+
+
 ### 3.10.0
 
 * `WebRtcServer`: A new class that brings to `WebRtcTransports` the ability to listen on a single UDP/TCP port (PR #834).

--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -142,7 +142,7 @@ namespace RTC
 		virtual uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) = 0;
 		virtual void ApplyLayers()                                          = 0;
 		virtual uint32_t GetDesiredBitrate() const                          = 0;
-		virtual void SendRtpPacket(RTC::RtpPacket* packet)                  = 0;
+		virtual void SendRtpPacket(std::shared_ptr<RTC::RtpPacket> packet)  = 0;
 		virtual std::vector<RTC::RtpStreamSend*> GetRtpStreams()            = 0;
 		virtual void GetRtcp(
 		  RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) = 0;

--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -30,7 +30,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet) override;
+		void SendRtpPacket(std::shared_ptr<RTC::RtpPacket> packet) override;
 		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
 		std::vector<RTC::RtpStreamSend*> GetRtpStreams() override
 		{

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -589,7 +589,7 @@ namespace RTC
 			return this->payloadDescriptorHandler->IsKeyFrame();
 		}
 
-		RtpPacket* Clone(const uint8_t* buffer) const;
+		RtpPacket* Clone() const;
 
 		void RtxEncode(uint8_t payloadType, uint32_t ssrc, uint16_t seq);
 
@@ -632,7 +632,10 @@ namespace RTC
 		uint8_t payloadPadding{ 0u };
 		size_t size{ 0u }; // Full size of the packet in bytes.
 		// Codecs
-		std::unique_ptr<Codecs::PayloadDescriptorHandler> payloadDescriptorHandler;
+		std::shared_ptr<Codecs::PayloadDescriptorHandler> payloadDescriptorHandler;
+		// Buffer where this packet is allocated, can be `nullptr` if packet was
+		// parsed from externally provided buffer.
+		uint8_t* buffer{ nullptr };
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/RtpStream.hpp
+++ b/worker/include/RTC/RtpStream.hpp
@@ -116,7 +116,7 @@ namespace RTC
 		{
 			return this->params.temporalLayers;
 		}
-		virtual bool ReceivePacket(RTC::RtpPacket* packet);
+		virtual bool ReceiveStreamPacket(RTC::RtpPacket* packet);
 		virtual void Pause()                                                                     = 0;
 		virtual void Resume()                                                                    = 0;
 		virtual uint32_t GetBitrate(uint64_t nowMs)                                              = 0;

--- a/worker/include/RTC/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RtpStreamRecv.hpp
@@ -49,7 +49,7 @@ namespace RTC
 		~RtpStreamRecv();
 
 		void FillJsonStats(json& jsonObject) override;
-		bool ReceivePacket(RTC::RtpPacket* packet) override;
+		bool ReceivePacket(RTC::RtpPacket* packet);
 		bool ReceiveRtxPacket(RTC::RtpPacket* packet);
 		RTC::RTCP::ReceiverReport* GetRtcpReceiverReport();
 		RTC::RTCP::ReceiverReport* GetRtxRtcpReceiverReport();

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -10,6 +10,10 @@ namespace RTC
 	class RtpStreamSend : public RTC::RtpStream
 	{
 	public:
+		// Don't retransmit packets older than this (ms).
+		static constexpr uint32_t MaxRetransmissionDelay{ 2000 };
+
+	public:
 		class Listener : public RTC::RtpStream::Listener
 		{
 		public:

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -20,6 +20,7 @@ namespace RTC
 	public:
 		struct StorageItem
 		{
+			// TODO: Remove after testing.
 			void Dump() const;
 			void Reset();
 
@@ -54,6 +55,7 @@ namespace RTC
 			void Insert(uint16_t seq, StorageItem* storageItem);
 			void RemoveFirst();
 			void Clear();
+			// TODO: Remove after testing.
 			void Dump();
 
 		private:

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -11,9 +11,9 @@ namespace RTC
 	{
 	public:
 		// Minimum retransmission buffer size (ms).
-		constexpr static uint32_t MinRetransmissionDelay{ 200 };
+		const static uint32_t MinRetransmissionDelay;
 		// Maximum retransmission buffer size (ms).
-		constexpr static uint32_t MaxRetransmissionDelay{ 2000 };
+		const static uint32_t MaxRetransmissionDelay;
 
 	public:
 		class Listener : public RTC::RtpStream::Listener

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -38,9 +38,11 @@ namespace RTC
 		};
 
 	private:
-		// Special container that can store `StorageItem*` elements addressable by their `uint16_t`
-		// sequence number, while only taking as little memory as necessary to store the range between
-		// minimum and maximum sequence number instead all 65536 potential elements.
+		// Special container that stores `StorageItem*` elements addressable by
+		// their `uint16_t` sequence number, while only taking as little memory as
+		// necessary to store the range covering a maximum of
+		// `MaxRetransmissionDelay` milliseconds.
+		// NOTE: See `MaxRetransmissionDelay` in implementation file.
 		class StorageItemBuffer
 		{
 		public:

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -26,8 +26,6 @@ namespace RTC
 	public:
 		struct StorageItem
 		{
-			// TODO: Remove after testing.
-			void Dump() const;
 			void Reset();
 
 			// Original packet.
@@ -61,8 +59,6 @@ namespace RTC
 			void Insert(uint16_t seq, StorageItem* storageItem);
 			void RemoveFirst();
 			void Clear();
-			// TODO: Remove after testing.
-			void Dump();
 
 		private:
 			uint16_t startSeq{ 0 };

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -49,7 +49,7 @@ namespace RTC
 			StorageItem* GetFirst() const;
 			StorageItem* Get(uint16_t seq) const;
 			size_t GetBufferSize() const;
-			bool Insert(uint16_t seq, StorageItem* storageItem);
+			void Insert(uint16_t seq, StorageItem* storageItem);
 			void RemoveFirst();
 			void Clear();
 			void Dump();

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -21,6 +21,7 @@ namespace RTC
 		struct StorageItem
 		{
 			void Dump() const;
+			void Reset();
 
 			// Original packet.
 			std::shared_ptr<RTC::RtpPacket> packet{ nullptr };

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -47,7 +47,6 @@ namespace RTC
 		// their `uint16_t` sequence number, while only taking as little memory as
 		// necessary to store the range covering a maximum of
 		// `MaxRetransmissionDelay` milliseconds.
-		// NOTE: See `MaxRetransmissionDelay` in implementation file.
 		class StorageItemBuffer
 		{
 		public:

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -10,7 +10,9 @@ namespace RTC
 	class RtpStreamSend : public RTC::RtpStream
 	{
 	public:
-		// Don't retransmit packets older than this (ms).
+		// Minimum retransmission buffer size (ms).
+		static constexpr uint32_t MinRetransmissionDelay{ 200 };
+		// Maximum retransmission buffer size (ms).
 		static constexpr uint32_t MaxRetransmissionDelay{ 2000 };
 
 	public:

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -11,9 +11,9 @@ namespace RTC
 	{
 	public:
 		// Minimum retransmission buffer size (ms).
-		static constexpr uint32_t MinRetransmissionDelay{ 200 };
+		constexpr static uint32_t MinRetransmissionDelay{ 200 };
 		// Maximum retransmission buffer size (ms).
-		static constexpr uint32_t MaxRetransmissionDelay{ 2000 };
+		constexpr static uint32_t MaxRetransmissionDelay{ 2000 };
 
 	public:
 		class Listener : public RTC::RtpStream::Listener

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -3,7 +3,7 @@
 
 #include "RTC/RateCalculator.hpp"
 #include "RTC/RtpStream.hpp"
-#include <vector>
+#include <deque>
 
 namespace RTC
 {
@@ -20,26 +20,52 @@ namespace RTC
 	public:
 		struct StorageItem
 		{
-			// Cloned packet.
-			RTC::RtpPacket* packet{ nullptr };
-			// Memory to hold the cloned packet (with extra space for RTX encoding).
-			uint8_t store[RTC::MtuSize + 100];
+			void Dump() const;
+
+			// Original packet.
+			std::shared_ptr<RTC::RtpPacket> packet{ nullptr };
+			// Correct SSRC since original packet may not have the same.
+			uint32_t ssrc{ 0 };
+			// Correct sequence number since original packet may not have the same.
+			uint16_t sequenceNumber{ 0 };
+			// Correct timestamp since original packet may not have the same.
+			uint32_t timestamp{ 0 };
 			// Last time this packet was resent.
 			uint64_t resentAtMs{ 0u };
 			// Number of times this packet was resent.
 			uint8_t sentTimes{ 0u };
-			// Whether the packet has been already RTX encoded.
-			bool rtxEncoded{ false };
+		};
+
+	private:
+		// Special container that can store `StorageItem*` elements addressable by their `uint16_t`
+		// sequence number, while only taking as little memory as necessary to store the range between
+		// minimum and maximum sequence number instead all 65536 potential elements.
+		class StorageItemBuffer
+		{
+		public:
+			~StorageItemBuffer();
+
+			StorageItem* GetFirst() const;
+			StorageItem* Get(uint16_t seq) const;
+			size_t GetBufferSize() const;
+			bool Insert(uint16_t seq, StorageItem* storageItem);
+			void RemoveFirst();
+			void Clear();
+			void Dump();
+
+		private:
+			uint16_t startSeq{ 0 };
+			std::deque<StorageItem*> buffer;
 		};
 
 	public:
 		RtpStreamSend(
-		  RTC::RtpStreamSend::Listener* listener, RTC::RtpStream::Params& params, size_t bufferSize);
+		  RTC::RtpStreamSend::Listener* listener, RTC::RtpStream::Params& params, std::string& mid);
 		~RtpStreamSend() override;
 
 		void FillJsonStats(json& jsonObject) override;
 		void SetRtx(uint8_t payloadType, uint32_t ssrc) override;
-		bool ReceivePacket(RTC::RtpPacket* packet) override;
+		bool ReceivePacket(std::shared_ptr<RTC::RtpPacket> packet);
 		void ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket);
 		void ReceiveKeyFrameRequest(RTC::RTCP::FeedbackPs::MessageType messageType);
 		void ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReport* report);
@@ -58,19 +84,18 @@ namespace RTC
 		uint32_t GetLayerBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer) override;
 
 	private:
-		void StorePacket(RTC::RtpPacket* packet);
+		void StorePacket(std::shared_ptr<RTC::RtpPacket> packet);
+		void ClearOldPackets(const RtpPacket* packet);
 		void ClearBuffer();
-		void UpdateBufferStartIdx();
 		void FillRetransmissionContainer(uint16_t seq, uint16_t bitmask);
 		void UpdateScore(RTC::RTCP::ReceiverReport* report);
 
 	private:
 		uint32_t lostPriorScore{ 0u }; // Packets lost at last interval for score calculation.
 		uint32_t sentPriorScore{ 0u }; // Packets sent at last interval for score calculation.
-		std::vector<StorageItem*> buffer;
-		uint16_t bufferStartIdx{ 0u };
-		size_t bufferSize{ 0u };
-		std::vector<StorageItem> storage;
+		StorageItemBuffer storageItemBuffer;
+		std::string mid;
+		uint32_t retransmissionBufferSize;
 		uint16_t rtxSeq{ 0u };
 		RTC::RtpDataCounter transmissionCounter;
 		uint32_t lastRrTimestamp{ 0u };  // The middle 32 bits out of 64 in the NTP

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -40,7 +40,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet) override;
+		void SendRtpPacket(std::shared_ptr<RTC::RtpPacket> packet) override;
 		std::vector<RTC::RtpStreamSend*> GetRtpStreams() override
 		{
 			return this->rtpStreams;

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -56,7 +56,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet) override;
+		void SendRtpPacket(std::shared_ptr<RTC::RtpPacket> packet) override;
 		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
 		std::vector<RTC::RtpStreamSend*> GetRtpStreams() override
 		{

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -51,7 +51,7 @@ namespace RTC
 		uint32_t IncreaseLayer(uint32_t bitrate, bool considerLoss) override;
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
-		void SendRtpPacket(RTC::RtpPacket* packet) override;
+		void SendRtpPacket(std::shared_ptr<RTC::RtpPacket> packet) override;
 		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
 		std::vector<RTC::RtpStreamSend*> GetRtpStreams() override
 		{

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -184,7 +184,7 @@ namespace RTC
 		return 0u;
 	}
 
-	void PipeConsumer::SendRtpPacket(RTC::RtpPacket* packet)
+	void PipeConsumer::SendRtpPacket(std::shared_ptr<RTC::RtpPacket> packet)
 	{
 		MS_TRACE();
 
@@ -256,10 +256,10 @@ namespace RTC
 		if (rtpStream->ReceivePacket(packet))
 		{
 			// Send the packet.
-			this->listener->OnConsumerSendRtpPacket(this, packet);
+			this->listener->OnConsumerSendRtpPacket(this, packet.get());
 
 			// May emit 'trace' event.
-			EmitTraceEventRtpAndKeyFrameTypes(packet);
+			EmitTraceEventRtpAndKeyFrameTypes(packet.get());
 		}
 		else
 		{
@@ -573,9 +573,7 @@ namespace RTC
 				}
 			}
 
-			// Create a RtpStreamSend for sending a single media stream.
-			size_t bufferSize = params.useNack ? 600u : 0u;
-			auto* rtpStream   = new RTC::RtpStreamSend(this, params, bufferSize);
+			auto* rtpStream = new RTC::RtpStreamSend(this, params, this->rtpParameters.mid);
 
 			// If the Consumer is paused, tell the RtpStreamSend.
 			if (IsPaused() || IsProducerPaused())

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -782,17 +782,22 @@ namespace RTC
 
 		auto& consumers = this->mapProducerConsumers.at(producer);
 
-		std::shared_ptr<RTC::RtpPacket> sharedPacket(packet);
-
-		for (auto* consumer : consumers)
+		if (!consumers.empty())
 		{
-			// Update MID RTP extension value.
-			const auto& mid = consumer->GetRtpParameters().mid;
+			// Clone the packet so it holds its own buffer, usable for future
+			// retransmissions.
+			std::shared_ptr<RTC::RtpPacket> sharedPacket(packet->Clone());
 
-			if (!mid.empty())
-				packet->UpdateMid(mid);
+			for (auto* consumer : consumers)
+			{
+				// Update MID RTP extension value.
+				const auto& mid = consumer->GetRtpParameters().mid;
 
-			consumer->SendRtpPacket(sharedPacket);
+				if (!mid.empty())
+					packet->UpdateMid(mid);
+
+				consumer->SendRtpPacket(sharedPacket);
+			}
 		}
 
 		auto it = this->mapProducerRtpObservers.find(producer);

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -782,6 +782,8 @@ namespace RTC
 
 		auto& consumers = this->mapProducerConsumers.at(producer);
 
+		std::shared_ptr<RTC::RtpPacket> shared(packet);
+
 		for (auto* consumer : consumers)
 		{
 			// Update MID RTP extension value.
@@ -790,7 +792,7 @@ namespace RTC
 			if (!mid.empty())
 				packet->UpdateMid(mid);
 
-			consumer->SendRtpPacket(packet);
+			consumer->SendRtpPacket(shared);
 		}
 
 		auto it = this->mapProducerRtpObservers.find(producer);

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -782,7 +782,7 @@ namespace RTC
 
 		auto& consumers = this->mapProducerConsumers.at(producer);
 
-		std::shared_ptr<RTC::RtpPacket> shared(packet);
+		std::shared_ptr<RTC::RtpPacket> sharedPacket(packet);
 
 		for (auto* consumer : consumers)
 		{
@@ -792,7 +792,7 @@ namespace RTC
 			if (!mid.empty())
 				packet->UpdateMid(mid);
 
-			consumer->SendRtpPacket(shared);
+			consumer->SendRtpPacket(sharedPacket);
 		}
 
 		auto it = this->mapProducerRtpObservers.find(producer);

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -147,6 +147,11 @@ namespace RTC
 	RtpPacket::~RtpPacket()
 	{
 		MS_TRACE();
+
+		if (this->buffer)
+		{
+			delete[] this->buffer;
+		}
 	}
 
 	void RtpPacket::Dump() const
@@ -631,11 +636,13 @@ namespace RTC
 		SetPayloadPaddingFlag(false);
 	}
 
-	RtpPacket* RtpPacket::Clone(const uint8_t* buffer) const
+	RtpPacket* RtpPacket::Clone() const
 	{
 		MS_TRACE();
 
-		auto* ptr = const_cast<uint8_t*>(buffer);
+		auto* buffer = new uint8_t[MtuSize + 100];
+		auto* ptr    = const_cast<uint8_t*>(buffer);
+
 		size_t numBytes{ 0 };
 
 		// Copy the minimum header.
@@ -704,6 +711,10 @@ namespace RTC
 		packet->frameMarkingExtensionId      = this->frameMarkingExtensionId;
 		packet->ssrcAudioLevelExtensionId    = this->ssrcAudioLevelExtensionId;
 		packet->videoOrientationExtensionId  = this->videoOrientationExtensionId;
+		// Clone payload descriptor handler.
+		packet->payloadDescriptorHandler = this->payloadDescriptorHandler;
+		// Store allocated buffer.
+		packet->buffer = buffer;
 
 		return packet;
 	}

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -711,7 +711,7 @@ namespace RTC
 		packet->frameMarkingExtensionId      = this->frameMarkingExtensionId;
 		packet->ssrcAudioLevelExtensionId    = this->ssrcAudioLevelExtensionId;
 		packet->videoOrientationExtensionId  = this->videoOrientationExtensionId;
-		// Clone payload descriptor handler.
+		// Assign the payload descriptor handler.
 		packet->payloadDescriptorHandler = this->payloadDescriptorHandler;
 		// Store allocated buffer.
 		packet->buffer = buffer;

--- a/worker/src/RTC/RtpStream.cpp
+++ b/worker/src/RTC/RtpStream.cpp
@@ -109,7 +109,7 @@ namespace RTC
 		this->rtxStream = new RTC::RtxStream(params);
 	}
 
-	bool RtpStream::ReceivePacket(RTC::RtpPacket* packet)
+	bool RtpStream::ReceiveStreamPacket(RTC::RtpPacket* packet)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -247,7 +247,7 @@ namespace RTC
 		MS_TRACE();
 
 		// Call the parent method.
-		if (!RTC::RtpStream::ReceivePacket(packet))
+		if (!RTC::RtpStream::ReceiveStreamPacket(packet))
 		{
 			MS_WARN_TAG(rtp, "packet discarded");
 

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -15,8 +15,6 @@ namespace RTC
 	thread_local static std::vector<RTC::RtpStreamSend::StorageItem*> RetransmissionContainer(
 	  MaxRequestedPackets + 1);
 	static constexpr uint32_t MinRetransmissionDelay{ 200 };
-	// Don't retransmit packets older than this (ms).
-	static constexpr uint32_t MaxRetransmissionDelay{ 2000 };
 	static constexpr uint32_t DefaultRtt{ 100 };
 	static constexpr uint16_t MaxSeq = std::numeric_limits<uint16_t>::max();
 

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -474,10 +474,10 @@ namespace RTC
 			return;
 		}
 
+		this->ClearOldPackets(packet.get());
+
 		auto seq          = packet->GetSequenceNumber();
 		auto* storageItem = this->storageItemBuffer.Get(seq);
-
-		this->ClearOldPackets(packet.get());
 
 		// The buffer item is already used. Check whether we should replace its
 		// storage with the new packet or just ignore it (if duplicated packet).

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -17,15 +17,6 @@ namespace RTC
 	static constexpr uint32_t DefaultRtt{ 100 };
 	static constexpr uint16_t MaxSeq = std::numeric_limits<uint16_t>::max();
 
-	void RtpStreamSend::StorageItem::Dump() const
-	{
-		MS_DUMP(
-		  "ssrc:%" PRIu32 ", seq:%" PRIu16 ", timestamp:%" PRIu32,
-		  this->ssrc,
-		  this->sequenceNumber,
-		  this->timestamp);
-	}
-
 	void RtpStreamSend::StorageItem::Reset()
 	{
 		MS_TRACE();
@@ -145,23 +136,6 @@ namespace RTC
 
 		this->buffer.clear();
 		this->startSeq = 0;
-	}
-
-	void RtpStreamSend::StorageItemBuffer::Dump()
-	{
-		for (size_t i{ 0 }; i < this->buffer.size(); i++)
-		{
-			const auto* item = this->buffer.at(i);
-
-			if (item == nullptr)
-			{
-				MS_DUMP("nullptr item at possition: %zu", i);
-
-				continue;
-			}
-
-			item->Dump();
-		}
 	}
 
 	RtpStreamSend::StorageItemBuffer::~StorageItemBuffer()

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -151,7 +151,7 @@ namespace RTC
 	RtpStreamSend::RtpStreamSend(
 	  RTC::RtpStreamSend::Listener* listener, RTC::RtpStream::Params& params, std::string& mid)
 	  : RTC::RtpStream::RtpStream(listener, params, 10), mid(mid),
-	    retransmissionBufferSize(MaxRetransmissionDelay)
+	    retransmissionBufferSize(RtpStreamSend::MaxRetransmissionDelay)
 	{
 		MS_TRACE();
 	}
@@ -307,7 +307,8 @@ namespace RTC
 		auto avgRetransmissionBufferSize =
 		  (this->retransmissionBufferSize * 7 + newRetransmissionBufferSize) / 8;
 		this->retransmissionBufferSize = std::max(
-		  std::min(avgRetransmissionBufferSize, MaxRetransmissionDelay), MinRetransmissionDelay);
+		  std::min(avgRetransmissionBufferSize, RtpStreamSend::MaxRetransmissionDelay),
+		  RtpStreamSend::MinRetransmissionDelay);
 
 		this->packetsLost  = report->GetTotalLost();
 		this->fractionLost = report->GetFractionLost();

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -14,7 +14,6 @@ namespace RTC
 	static constexpr size_t MaxRequestedPackets{ 17 };
 	thread_local static std::vector<RTC::RtpStreamSend::StorageItem*> RetransmissionContainer(
 	  MaxRequestedPackets + 1);
-	static constexpr uint32_t MinRetransmissionDelay{ 200 };
 	static constexpr uint32_t DefaultRtt{ 100 };
 	static constexpr uint16_t MaxSeq = std::numeric_limits<uint16_t>::max();
 

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -495,7 +495,7 @@ namespace RTC
 			this->storageItemBuffer.Insert(seq, storageItem);
 		}
 
-		// Store original packet and some extra info into the retrieved storage item.
+		// Store original packet and some extra info into the storage item.
 		storageItem->packet         = packet;
 		storageItem->ssrc           = packet->GetSsrc();
 		storageItem->sequenceNumber = packet->GetSequenceNumber();

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -14,9 +14,11 @@ namespace RTC
 	static constexpr size_t MaxRequestedPackets{ 17 };
 	thread_local static std::vector<RTC::RtpStreamSend::StorageItem*> RetransmissionContainer(
 	  MaxRequestedPackets + 1);
+	static constexpr uint32_t MinRetransmissionDelay{ 200 };
 	// Don't retransmit packets older than this (ms).
 	static constexpr uint32_t MaxRetransmissionDelay{ 2000 };
 	static constexpr uint32_t DefaultRtt{ 100 };
+	static constexpr uint16_t MaxSeq = std::numeric_limits<uint16_t>::max();
 
 	static void resetStorageItem(RTC::RtpStreamSend::StorageItem* storageItem)
 	{
@@ -24,20 +26,162 @@ namespace RTC
 
 		MS_ASSERT(storageItem, "storageItem cannot be nullptr");
 
-		delete storageItem->packet;
+		storageItem->packet.reset();
+		storageItem->ssrc           = 0;
+		storageItem->sequenceNumber = 0;
+		storageItem->timestamp      = 0;
+		storageItem->resentAtMs     = 0;
+		storageItem->sentTimes      = 0;
+	}
 
-		storageItem->packet     = nullptr;
-		storageItem->resentAtMs = 0;
-		storageItem->sentTimes  = 0;
-		storageItem->rtxEncoded = false;
+	void RtpStreamSend::StorageItem::Dump() const
+	{
+		MS_DUMP(
+		  "ssrc:%" PRIu32 ", seq:%" PRIu16 ", timestamp:%" PRIu32,
+		  this->ssrc,
+		  this->sequenceNumber,
+		  this->timestamp);
+	}
+
+	RtpStreamSend::StorageItem* RtpStreamSend::StorageItemBuffer::GetFirst() const
+	{
+		return this->Get(this->startSeq);
+	}
+
+	RtpStreamSend::StorageItem* RtpStreamSend::StorageItemBuffer::Get(uint16_t seq) const
+	{
+		auto idx{ static_cast<uint16_t>(seq - this->startSeq) };
+
+		if (this->buffer.empty() || idx > static_cast<uint16_t>(this->buffer.size() - 1))
+			return nullptr;
+
+		return this->buffer.at(idx);
+	}
+
+	size_t RtpStreamSend::StorageItemBuffer::GetBufferSize() const
+	{
+		return this->buffer.size();
+	}
+
+	bool RtpStreamSend::StorageItemBuffer::Insert(uint16_t seq, StorageItem* storageItem)
+	{
+		if (this->buffer.empty())
+		{
+			this->startSeq = seq;
+			this->buffer.push_back(storageItem);
+
+			return true;
+		}
+
+		if (RTC::SeqManager<uint16_t>::IsSeqHigherThan(seq, this->startSeq))
+		{
+			auto idx{ static_cast<uint16_t>(seq - this->startSeq) };
+
+			// Packet arrived out of order, so we already have a slot allocated for it.
+			if (idx <= static_cast<uint16_t>(this->buffer.size() - 1))
+			{
+				MS_ASSERT(this->buffer[idx] == nullptr, "Must insert into empty slot");
+				this->buffer[idx] = storageItem;
+
+				return true;
+			}
+
+			// Calculate how many elements would it be necessary to add when pushing new item
+			// to the back of the deque.
+			auto addToBack{ static_cast<uint16_t>(seq - (this->startSeq + this->buffer.size() - 1)) };
+
+			// Packets can arrive out of order, add blank slots.
+			for (uint16_t i{ 1 }; i < addToBack; ++i)
+				this->buffer.push_back(nullptr);
+
+			this->buffer.push_back(storageItem);
+		}
+		else
+		{
+			// Calculate how many elements would it be necessary to add when pushing new item
+			// to the front of the deque.
+			auto addToFront{ static_cast<uint16_t>(this->startSeq - seq) };
+
+			// Packets can arrive out of order, add blank slots.
+			for (uint16_t i{ 1 }; i < addToFront; ++i)
+				this->buffer.push_front(nullptr);
+
+			this->buffer.push_front(storageItem);
+			this->startSeq = seq;
+		}
+
+		MS_ASSERT(
+		  this->buffer.size() <= MaxSeq,
+		  "StorageItemBuffer contains more than %" PRIu16 " entries",
+		  MaxSeq);
+
+		return true;
+	}
+
+	void RtpStreamSend::StorageItemBuffer::RemoveFirst()
+	{
+		MS_ASSERT(!this->buffer.empty(), "buffer is empty");
+
+		auto* storageItem = this->buffer[0];
+
+		delete storageItem;
+
+		this->buffer[0] = nullptr;
+
+		// Remove all `nullptr` elements from the beginning of the buffer.
+		// NOTE: Calling front on an empty container is undefined.
+		while (!this->buffer.empty() && !this->buffer.front())
+		{
+			this->buffer.pop_front();
+			this->startSeq++;
+		}
+	}
+
+	void RtpStreamSend::StorageItemBuffer::Clear()
+	{
+		for (auto* storageItem : this->buffer)
+		{
+			if (!storageItem)
+				continue;
+
+			// Reset (free RTP packet) the storage item.
+			resetStorageItem(storageItem);
+
+			delete storageItem;
+		}
+
+		this->buffer.clear();
+		this->startSeq = 0;
+	}
+
+	void RtpStreamSend::StorageItemBuffer::Dump()
+	{
+		for (size_t i{ 0 }; i < this->buffer.size(); i++)
+		{
+			const auto* item = this->buffer.at(i);
+
+			if (item == nullptr)
+			{
+				MS_DUMP("nullptr item at possition: %zu", i);
+
+				continue;
+			}
+
+			item->Dump();
+		}
+	}
+
+	RtpStreamSend::StorageItemBuffer::~StorageItemBuffer()
+	{
+		Clear();
 	}
 
 	/* Instance methods. */
 
 	RtpStreamSend::RtpStreamSend(
-	  RTC::RtpStreamSend::Listener* listener, RTC::RtpStream::Params& params, size_t bufferSize)
-	  : RTC::RtpStream::RtpStream(listener, params, 10), buffer(bufferSize > 0 ? 65536 : 0, nullptr),
-	    storage(bufferSize)
+	  RTC::RtpStreamSend::Listener* listener, RTC::RtpStream::Params& params, std::string& mid)
+	  : RTC::RtpStream::RtpStream(listener, params, 10), mid(mid),
+	    retransmissionBufferSize(MaxRetransmissionDelay)
 	{
 		MS_TRACE();
 	}
@@ -73,20 +217,20 @@ namespace RTC
 		this->rtxSeq = Utils::Crypto::GetRandomUInt(0u, 0xFFFF);
 	}
 
-	bool RtpStreamSend::ReceivePacket(RTC::RtpPacket* packet)
+	bool RtpStreamSend::ReceivePacket(std::shared_ptr<RTC::RtpPacket> packet)
 	{
 		MS_TRACE();
 
 		// Call the parent method.
-		if (!RtpStream::ReceivePacket(packet))
+		if (!RtpStream::ReceiveStreamPacket(packet.get()))
 			return false;
 
-		// If bufferSize was given, store the packet into the buffer.
-		if (!this->storage.empty())
+		// If NACK is enabled, store the packet into the buffer.
+		if (this->params.useNack)
 			StorePacket(packet);
 
 		// Increase transmission counter.
-		this->transmissionCounter.Update(packet);
+		this->transmissionCounter.Update(packet.get());
 
 		return true;
 	}
@@ -112,18 +256,24 @@ namespace RTC
 
 				// Note that this is an already RTX encoded packet if RTX is used
 				// (FillRetransmissionContainer() did it).
-				auto* packet = storageItem->packet;
+				auto packet = storageItem->packet;
 
 				// Retransmit the packet.
 				static_cast<RTC::RtpStreamSend::Listener*>(this->listener)
-				  ->OnRtpStreamRetransmitRtpPacket(this, packet);
+				  ->OnRtpStreamRetransmitRtpPacket(this, packet.get());
 
 				// Mark the packet as retransmitted.
-				RTC::RtpStream::PacketRetransmitted(packet);
+				RTC::RtpStream::PacketRetransmitted(packet.get());
 
 				// Mark the packet as repaired (only if this is the first retransmission).
 				if (storageItem->sentTimes == 1)
-					RTC::RtpStream::PacketRepaired(packet);
+					RTC::RtpStream::PacketRepaired(packet.get());
+
+				if (HasRtx())
+				{
+					// Restore the packet.
+					packet->RtxDecode(RtpStream::GetPayloadType(), storageItem->ssrc);
+				}
 			}
 		}
 	}
@@ -177,7 +327,17 @@ namespace RTC
 		this->rtt += (static_cast<float>(rtt & 0x0000FFFF) / 65536) * 1000;
 
 		if (this->rtt > 0.0f)
+		{
 			this->hasRtt = true;
+		}
+
+		// Smoothly change retransmission buffer size towards RTT + 100ms, but not more than
+		// `MaxRetransmissionDelay`.
+		auto newRetransmissionBufferSize = static_cast<uint32_t>(this->rtt + 100.0);
+		auto avgRetransmissionBufferSize =
+		  (this->retransmissionBufferSize * 7 + newRetransmissionBufferSize) / 8;
+		this->retransmissionBufferSize = std::max(
+		  std::min(avgRetransmissionBufferSize, MaxRetransmissionDelay), MinRetransmissionDelay);
 
 		this->packetsLost  = report->GetTotalLost();
 		this->fractionLost = report->GetFractionLost();
@@ -295,9 +455,12 @@ namespace RTC
 		MS_ABORT("invalid method call");
 	}
 
-	void RtpStreamSend::StorePacket(RTC::RtpPacket* packet)
+	void RtpStreamSend::StorePacket(std::shared_ptr<RTC::RtpPacket> packet)
 	{
 		MS_TRACE();
+
+		MS_ASSERT(
+		  packet->GetSsrc() == this->params.ssrc, "RTP packet SSRC does not match the encodings SSRC");
 
 		if (packet->GetSize() > RTC::MtuSize)
 		{
@@ -312,118 +475,76 @@ namespace RTC
 		}
 
 		auto seq          = packet->GetSequenceNumber();
-		auto* storageItem = this->buffer[seq];
+		auto* storageItem = this->storageItemBuffer.Get(seq);
 
-		// Buffer is empty.
-		if (this->bufferSize == 0)
-		{
-			// Take the first storage position.
-			storageItem       = std::addressof(this->storage[0]);
-			this->buffer[seq] = storageItem;
+		this->ClearOldPackets(packet.get());
 
-			// Increase buffer size and set start index.
-			this->bufferSize++;
-			this->bufferStartIdx = seq;
-		}
 		// The buffer item is already used. Check whether we should replace its
 		// storage with the new packet or just ignore it (if duplicated packet).
-		else if (storageItem)
+		if (storageItem)
 		{
-			auto* storedPacket = storageItem->packet;
-
-			if (packet->GetTimestamp() == storedPacket->GetTimestamp())
+			if (packet->GetTimestamp() == storageItem->timestamp)
 				return;
 
 			// Reset the storage item.
 			resetStorageItem(storageItem);
-
-			// If this was the item referenced by the buffer start index, move it to
-			// the next one.
-			if (this->bufferStartIdx == seq)
-				UpdateBufferStartIdx();
 		}
-		// Buffer not yet full, add an entry.
-		else if (this->bufferSize < this->storage.size())
-		{
-			// Take the next storage position.
-			storageItem       = std::addressof(this->storage[this->bufferSize]);
-			this->buffer[seq] = storageItem;
-
-			// Increase buffer size.
-			this->bufferSize++;
-		}
-		// Buffer full, remove oldest entry and add new one.
+		// Allocate new buffer item.
 		else
 		{
-			auto* firstStorageItem = this->buffer[this->bufferStartIdx];
+			// Allocate a new storage item.
+			storageItem = new StorageItem();
 
-			// Reset the first storage item.
-			resetStorageItem(firstStorageItem);
-
-			// Unfill the buffer start item.
-			this->buffer[this->bufferStartIdx] = nullptr;
-
-			// Move the buffer start index.
-			UpdateBufferStartIdx();
-
-			// Take the freed storage item.
-			storageItem       = firstStorageItem;
-			this->buffer[seq] = storageItem;
+			MS_ASSERT(this->storageItemBuffer.Insert(seq, storageItem), "sequence number must be empty");
 		}
 
-		// Clone the packet into the retrieved storage item.
-		storageItem->packet = packet->Clone(storageItem->store);
+		// Store original packet and some extra info into the retrieved storage item.
+		storageItem->packet         = packet;
+		storageItem->ssrc           = packet->GetSsrc();
+		storageItem->sequenceNumber = packet->GetSequenceNumber();
+		storageItem->timestamp      = packet->GetTimestamp();
+	}
+
+	void RtpStreamSend::ClearOldPackets(const RtpPacket* packet)
+	{
+		MS_TRACE();
+
+		auto packetTs{ packet->GetTimestamp() };
+		auto clockRate{ this->params.clockRate };
+
+		const auto bufferSize = this->storageItemBuffer.GetBufferSize();
+
+		// Go through all buffer items starting with the first and free all storage
+		// items that contain packets older than `MaxRetransmissionDelay`.
+		for (size_t i{ 0 }; i < bufferSize && this->storageItemBuffer.GetBufferSize() != 0; ++i)
+		{
+			auto* firstStorageItem = this->storageItemBuffer.GetFirst();
+
+			MS_ASSERT(firstStorageItem, "first storage item is missing");
+			MS_ASSERT(firstStorageItem->packet, "storage item does not contain original packet");
+
+			auto firstPacketTs{ firstStorageItem->timestamp };
+			uint32_t diffTs{ packetTs - firstPacketTs };
+
+			// RTP packet is older than first RTP packet.
+			if (RTC::SeqManager<uint32_t>::IsSeqLowerThan(packetTs, firstPacketTs))
+				break;
+
+			// First RTP packet is recent enough.
+			if (static_cast<uint32_t>(diffTs * 1000 / clockRate) < this->retransmissionBufferSize)
+				break;
+
+			// Unfill the buffer start item.
+			this->storageItemBuffer.RemoveFirst();
+		}
 	}
 
 	void RtpStreamSend::ClearBuffer()
 	{
 		MS_TRACE();
 
-		if (this->storage.empty())
-			return;
-
-		for (uint32_t idx{ 0 }; idx < this->buffer.size(); ++idx)
-		{
-			auto* storageItem = this->buffer[idx];
-
-			if (!storageItem)
-			{
-				MS_ASSERT(!this->buffer[idx], "key should be NULL");
-
-				continue;
-			}
-
-			// Reset (free RTP packet) the storage item.
-			resetStorageItem(storageItem);
-
-			// Unfill the buffer item.
-			this->buffer[idx] = nullptr;
-		}
-
 		// Reset buffer.
-		this->bufferStartIdx = 0;
-		this->bufferSize     = 0;
-	}
-
-	/**
-	 * Iterates the buffer starting from the current start idx + 1 until next
-	 * used one. It takes into account that the buffer is circular.
-	 */
-	inline void RtpStreamSend::UpdateBufferStartIdx()
-	{
-		uint16_t seq = this->bufferStartIdx + 1;
-
-		for (uint32_t idx{ 0 }; idx < this->buffer.size(); ++idx, ++seq)
-		{
-			auto* storageItem = this->buffer[seq];
-
-			if (storageItem)
-			{
-				this->bufferStartIdx = seq;
-
-				break;
-			}
-		}
+		this->storageItemBuffer.Clear();
 	}
 
 	// This method looks for the requested RTP packets and inserts them into the
@@ -467,15 +588,23 @@ namespace RTC
 
 			if (requested)
 			{
-				auto* storageItem = this->buffer[currentSeq];
-				RTC::RtpPacket* packet{ nullptr };
+				auto* storageItem = this->storageItemBuffer.Get(currentSeq);
+				std::shared_ptr<RTC::RtpPacket> packet{ nullptr };
 				uint32_t diffMs;
 
-				// Calculate the elapsed time between the max timestampt seen and the
-				// requested packet's timestampt (in ms).
+				// Calculate the elapsed time between the max timestamp seen and the
+				// requested packet's timestamp (in ms).
 				if (storageItem)
 				{
 					packet = storageItem->packet;
+					// Put correct SSRC and sequence number into the packet.
+					packet->SetSsrc(storageItem->ssrc);
+					packet->SetSequenceNumber(storageItem->sequenceNumber);
+					packet->SetTimestamp(storageItem->timestamp);
+
+					// Update MID RTP extension value.
+					if (!this->mid.empty())
+						packet->UpdateMid(mid);
 
 					uint32_t diffTs = this->maxPacketTs - packet->GetTimestamp();
 
@@ -527,16 +656,7 @@ namespace RTC
 						// Increment RTX seq.
 						++this->rtxSeq;
 
-						if (!storageItem->rtxEncoded)
-						{
-							packet->RtxEncode(this->params.rtxPayloadType, this->params.rtxSsrc, this->rtxSeq);
-
-							storageItem->rtxEncoded = true;
-						}
-						else
-						{
-							packet->SetSequenceNumber(this->rtxSeq);
-						}
+						packet->RtxEncode(this->params.rtxPayloadType, this->params.rtxSsrc, this->rtxSeq);
 					}
 
 					// Save when this packet was resent.

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -85,7 +85,7 @@ namespace RTC
 			{
 				// Calculate how many elements would it be necessary to add when pushing new item
 				// to the back of the deque.
-				auto addToBack{ static_cast<uint16_t>(seq - (this->startSeq + this->buffer.size() - 1)) };
+				auto addToBack = static_cast<uint16_t>(seq - (this->startSeq + this->buffer.size() - 1));
 
 				// Packets can arrive out of order, add blank slots.
 				for (uint16_t i{ 1 }; i < addToBack; ++i)
@@ -99,7 +99,7 @@ namespace RTC
 		{
 			// Calculate how many elements would it be necessary to add when pushing new item
 			// to the front of the deque.
-			auto addToFront{ static_cast<uint16_t>(this->startSeq - seq) };
+			auto addToFront = static_cast<uint16_t>(this->startSeq - seq);
 
 			// Packets can arrive out of order, add blank slots.
 			for (uint16_t i{ 1 }; i < addToFront; ++i)

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -20,7 +20,6 @@ namespace RTC
 	static constexpr uint32_t DefaultRtt{ 100 };
 	static constexpr uint16_t MaxSeq = std::numeric_limits<uint16_t>::max();
 
-
 	void RtpStreamSend::StorageItem::Dump() const
 	{
 		MS_DUMP(

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -36,6 +36,9 @@ namespace RTC
 
 	RtpStreamSend::StorageItem* RtpStreamSend::StorageItemBuffer::Get(uint16_t seq) const
 	{
+		if (RTC::SeqManager<uint16_t>::IsSeqLowerThan(seq, this->startSeq))
+			return nullptr;
+
 		auto idx{ static_cast<uint16_t>(seq - this->startSeq) };
 
 		if (this->buffer.empty() || idx > static_cast<uint16_t>(this->buffer.size() - 1))

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -130,7 +130,7 @@ namespace RTC
 
 		// Remove all `nullptr` elements from the beginning of the buffer.
 		// NOTE: Calling front on an empty container is undefined.
-		while (!this->buffer.empty() && !this->buffer.front())
+		while (!this->buffer.empty() && this->buffer.front() == nullptr)
 		{
 			this->buffer.pop_front();
 			this->startSeq++;

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -564,7 +564,7 @@ namespace RTC
 				if (storageItem)
 				{
 					packet = storageItem->packet;
-					// Put correct SSRC and sequence number into the packet.
+					// Put correct info into the packet.
 					packet->SetSsrc(storageItem->ssrc);
 					packet->SetSequenceNumber(storageItem->sequenceNumber);
 					packet->SetTimestamp(storageItem->timestamp);

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -11,11 +11,18 @@ namespace RTC
 	/* Static. */
 
 	// 17: 16 bit mask + the initial sequence number.
-	static constexpr size_t MaxRequestedPackets{ 17 };
+	static constexpr size_t MaxRequestedPackets{ 17u };
 	thread_local static std::vector<RTC::RtpStreamSend::StorageItem*> RetransmissionContainer(
 	  MaxRequestedPackets + 1);
-	static constexpr uint32_t DefaultRtt{ 100 };
+	static constexpr uint32_t DefaultRtt{ 100u };
 	static constexpr uint16_t MaxSeq = std::numeric_limits<uint16_t>::max();
+
+	/* Class Static. */
+
+	// Minimum retransmission buffer size (ms).
+	const uint32_t RtpStreamSend::MinRetransmissionDelay{ 200u };
+	// Maximum retransmission buffer size (ms).
+	const uint32_t RtpStreamSend::MaxRetransmissionDelay{ 2000u };
 
 	void RtpStreamSend::StorageItem::Reset()
 	{

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -20,19 +20,6 @@ namespace RTC
 	static constexpr uint32_t DefaultRtt{ 100 };
 	static constexpr uint16_t MaxSeq = std::numeric_limits<uint16_t>::max();
 
-	static void resetStorageItem(RTC::RtpStreamSend::StorageItem* storageItem)
-	{
-		MS_TRACE();
-
-		MS_ASSERT(storageItem, "storageItem cannot be nullptr");
-
-		storageItem->packet.reset();
-		storageItem->ssrc           = 0;
-		storageItem->sequenceNumber = 0;
-		storageItem->timestamp      = 0;
-		storageItem->resentAtMs     = 0;
-		storageItem->sentTimes      = 0;
-	}
 
 	void RtpStreamSend::StorageItem::Dump() const
 	{
@@ -41,6 +28,18 @@ namespace RTC
 		  this->ssrc,
 		  this->sequenceNumber,
 		  this->timestamp);
+	}
+
+	void RtpStreamSend::StorageItem::Reset()
+	{
+		MS_TRACE();
+
+		this->packet.reset();
+		this->ssrc           = 0;
+		this->sequenceNumber = 0;
+		this->timestamp      = 0;
+		this->resentAtMs     = 0;
+		this->sentTimes      = 0;
 	}
 
 	RtpStreamSend::StorageItem* RtpStreamSend::StorageItemBuffer::GetFirst() const
@@ -144,8 +143,8 @@ namespace RTC
 			if (!storageItem)
 				continue;
 
-			// Reset (free RTP packet) the storage item.
-			resetStorageItem(storageItem);
+			// Reset the storage item (decrease RTP packet shared pointer counter).
+			storageItem->Reset();
 
 			delete storageItem;
 		}
@@ -487,7 +486,7 @@ namespace RTC
 				return;
 
 			// Reset the storage item.
-			resetStorageItem(storageItem);
+			storageItem->Reset();
 		}
 		// Allocate new buffer item.
 		else

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -228,7 +228,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	void SimpleConsumer::SendRtpPacket(RTC::RtpPacket* packet)
+	void SimpleConsumer::SendRtpPacket(std::shared_ptr<RTC::RtpPacket> packet)
 	{
 		MS_TRACE();
 
@@ -294,10 +294,10 @@ namespace RTC
 		if (this->rtpStream->ReceivePacket(packet))
 		{
 			// Send the packet.
-			this->listener->OnConsumerSendRtpPacket(this, packet);
+			this->listener->OnConsumerSendRtpPacket(this, packet.get());
 
 			// May emit 'trace' event.
-			EmitTraceEventRtpAndKeyFrameTypes(packet);
+			EmitTraceEventRtpAndKeyFrameTypes(packet.get());
 		}
 		else
 		{
@@ -542,10 +542,7 @@ namespace RTC
 			}
 		}
 
-		// Create a RtpStreamSend for sending a single media stream.
-		size_t bufferSize = params.useNack ? 600u : 0u;
-
-		this->rtpStream = new RTC::RtpStreamSend(this, params, bufferSize);
+		this->rtpStream = new RTC::RtpStreamSend(this, params, this->rtpParameters.mid);
 		this->rtpStreams.push_back(this->rtpStream);
 
 		// If the Consumer is paused, tell the RtpStreamSend.

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -640,7 +640,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	void SimulcastConsumer::SendRtpPacket(RTC::RtpPacket* packet)
+	void SimulcastConsumer::SendRtpPacket(std::shared_ptr<RTC::RtpPacket> packet)
 	{
 		MS_TRACE();
 
@@ -918,10 +918,10 @@ namespace RTC
 				this->lastSentPacketHasMarker = packet->HasMarker();
 
 			// Send the packet.
-			this->listener->OnConsumerSendRtpPacket(this, packet);
+			this->listener->OnConsumerSendRtpPacket(this, packet.get());
 
 			// May emit 'trace' event.
-			EmitTraceEventRtpAndKeyFrameTypes(packet);
+			EmitTraceEventRtpAndKeyFrameTypes(packet.get());
 		}
 		else
 		{
@@ -1187,10 +1187,7 @@ namespace RTC
 			}
 		}
 
-		// Create a RtpStreamSend for sending a single media stream.
-		size_t bufferSize = params.useNack ? 600u : 0u;
-
-		this->rtpStream = new RTC::RtpStreamSend(this, params, bufferSize);
+		this->rtpStream = new RTC::RtpStreamSend(this, params, this->rtpParameters.mid);
 		this->rtpStreams.push_back(this->rtpStream);
 
 		// If the Consumer is paused, tell the RtpStreamSend.

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -532,7 +532,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	void SvcConsumer::SendRtpPacket(RTC::RtpPacket* packet)
+	void SvcConsumer::SendRtpPacket(std::shared_ptr<RTC::RtpPacket> packet)
 	{
 		MS_TRACE();
 
@@ -636,10 +636,10 @@ namespace RTC
 		if (this->rtpStream->ReceivePacket(packet))
 		{
 			// Send the packet.
-			this->listener->OnConsumerSendRtpPacket(this, packet);
+			this->listener->OnConsumerSendRtpPacket(this, packet.get());
 
 			// May emit 'trace' event.
-			EmitTraceEventRtpAndKeyFrameTypes(packet);
+			EmitTraceEventRtpAndKeyFrameTypes(packet.get());
 		}
 		else
 		{
@@ -897,10 +897,7 @@ namespace RTC
 			}
 		}
 
-		// Create a RtpStreamSend for sending a single media stream.
-		size_t bufferSize = params.useNack ? 600u : 0u;
-
-		this->rtpStream = new RTC::RtpStreamSend(this, params, bufferSize);
+		this->rtpStream = new RTC::RtpStreamSend(this, params, this->rtpParameters.mid);
 		this->rtpStreams.push_back(this->rtpStream);
 
 		// If the Consumer is paused, tell the RtpStreamSend.

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1725,8 +1725,6 @@ namespace RTC
 				break;
 			default:;
 		}
-
-		delete packet;
 	}
 
 	void Transport::ReceiveRtcpPacket(RTC::RTCP::Packet* packet)

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1725,6 +1725,8 @@ namespace RTC
 				break;
 			default:;
 		}
+
+		delete packet;
 	}
 
 	void Transport::ReceiveRtcpPacket(RTC::RTCP::Packet* packet)

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -9,7 +9,6 @@
 using namespace RTC;
 
 static uint8_t buffer[65536];
-static uint8_t buffer2[65536];
 
 SCENARIO("parse RTP packets", "[parser][rtp]")
 {
@@ -128,7 +127,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->ReadAbsSendTime(absSendTime) == true);
 		REQUIRE(absSendTime == 0x65341e);
 
-		auto* clonedPacket = packet->Clone(buffer2);
+		auto* clonedPacket = packet->Clone();
 
 		std::memset(buffer, '0', sizeof(buffer));
 
@@ -339,9 +338,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions());
 
-		static uint8_t RtxBuffer[MtuSize];
-
-		auto rtxPacket = packet->Clone(RtxBuffer);
+		auto rtxPacket = packet->Clone();
 
 		delete packet;
 

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -211,9 +211,9 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 	SECTION("packets get retransmitted as long as they don't exceed MaxRetransmissionDelay")
 	{
 		uint32_t clockRate = 90000;
-		uint32_t firstTs = 1533790901;
-		uint32_t diffTs = RtpStreamSend::MaxRetransmissionDelay * clockRate / 1000;
-		uint32_t secondTs = firstTs + diffTs;
+		uint32_t firstTs   = 1533790901;
+		uint32_t diffTs    = RtpStreamSend::MaxRetransmissionDelay * clockRate / 1000;
+		uint32_t secondTs  = firstTs + diffTs;
 
 		auto packet1 = CreateRtpPacket(rtpBuffer1, 21006, firstTs);
 		auto packet2 = CreateRtpPacket(rtpBuffer2, 21007, secondTs - 1);
@@ -262,9 +262,9 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 	SECTION("packets don't get retransmitted if MaxRetransmissionDelay is exceeded")
 	{
 		uint32_t clockRate = 90000;
-		uint32_t firstTs = 1533790901;
-		uint32_t diffTs = RtpStreamSend::MaxRetransmissionDelay * clockRate / 1000;
-		uint32_t secondTs = firstTs + diffTs;
+		uint32_t firstTs   = 1533790901;
+		uint32_t diffTs    = RtpStreamSend::MaxRetransmissionDelay * clockRate / 1000;
+		uint32_t secondTs  = firstTs + diffTs;
 
 		auto packet1 = CreateRtpPacket(rtpBuffer1, 21006, firstTs);
 		auto packet2 = CreateRtpPacket(rtpBuffer2, 21007, secondTs);

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -50,9 +50,8 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp]")
 		packet = RtpPacket::Parse(rtpBuffer1, sizeof(rtpBuffer1));
 		std::shared_ptr<RtpPacket> packet1(packet);
 
-		REQUIRE(packet1);
-		REQUIRE(packet1->GetSequenceNumber() == 21006);
-		REQUIRE(packet1->GetTimestamp() == 1533790901);
+		packet1->SetSequenceNumber(21006);
+		packet1->SetTimestamp(1533790901);
 
 		// packet2 [pt:123, seq:21007, timestamp:1533790901]
 		packet = packet1->Clone(rtpBuffer2);
@@ -61,18 +60,12 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp]")
 		packet2->SetSequenceNumber(21007);
 		packet2->SetTimestamp(1533790901);
 
-		REQUIRE(packet2->GetSequenceNumber() == 21007);
-		REQUIRE(packet2->GetTimestamp() == 1533790901);
-
 		// packet3 [pt:123, seq:21008, timestamp:1533793871]
 		packet = packet1->Clone(rtpBuffer3);
 		std::shared_ptr<RtpPacket> packet3(packet);
 
 		packet3->SetSequenceNumber(21008);
 		packet3->SetTimestamp(1533793871);
-
-		REQUIRE(packet3->GetSequenceNumber() == 21008);
-		REQUIRE(packet3->GetTimestamp() == 1533793871);
 
 		// packet4 [pt:123, seq:21009, timestamp:1533793871]
 		packet = packet1->Clone(rtpBuffer4);
@@ -81,18 +74,12 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp]")
 		packet4->SetSequenceNumber(21009);
 		packet4->SetTimestamp(1533793871);
 
-		REQUIRE(packet4->GetSequenceNumber() == 21009);
-		REQUIRE(packet4->GetTimestamp() == 1533793871);
-
 		// packet5 [pt:123, seq:21010, timestamp:1533796931]
 		packet = packet1->Clone(rtpBuffer5);
 		std::shared_ptr<RtpPacket> packet5(packet);
 
 		packet5->SetSequenceNumber(21010);
 		packet5->SetTimestamp(1533796931);
-
-		REQUIRE(packet5->GetSequenceNumber() == 21010);
-		REQUIRE(packet5->GetTimestamp() == 1533796931);
 
 		RtpStream::Params params;
 

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -218,7 +218,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		auto packet1 = CreateRtpPacket(rtpBuffer1, 21006, firstTs);
 		auto packet2 = CreateRtpPacket(rtpBuffer2, 21007, secondTs - 1);
 
-		// Create two RtpStreamSend instances.
+		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener1;
 
 		RtpStream::Params params1;
@@ -269,7 +269,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		auto packet1 = CreateRtpPacket(rtpBuffer1, 21006, firstTs);
 		auto packet2 = CreateRtpPacket(rtpBuffer2, 21007, secondTs);
 
-		// Create two RtpStreamSend instances.
+		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener1;
 
 		RtpStream::Params params1;

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -92,7 +92,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params.clockRate = 90000;
 		params.useNack   = true;
 
-		std::string mid{ "" };
+		std::string mid;
 		RtpStreamSend* stream = new RtpStreamSend(&testRtpStreamListener, params, mid);
 
 		// Receive all the packets (some of them not in order and/or duplicated).
@@ -151,7 +151,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params1.clockRate = 90000;
 		params1.useNack   = true;
 
-		std::string mid{ "" };
+		std::string mid;
 		RtpStreamSend* stream1 = new RtpStreamSend(&testRtpStreamListener1, params1, mid);
 
 		RtpStream::Params params2;
@@ -227,7 +227,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params1.clockRate = clockRate;
 		params1.useNack   = true;
 
-		std::string mid{ "" };
+		std::string mid;
 		RtpStreamSend* stream1 = new RtpStreamSend(&testRtpStreamListener1, params1, mid);
 
 		// Receive all the packets.
@@ -278,7 +278,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params1.clockRate = clockRate;
 		params1.useNack   = true;
 
-		std::string mid{ "" };
+		std::string mid;
 		RtpStreamSend* stream1 = new RtpStreamSend(&testRtpStreamListener1, params1, mid);
 
 		// Receive all the packets.

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -8,6 +8,18 @@
 
 using namespace RTC;
 
+static std::shared_ptr<RtpPacket> CreateRtpPacket(uint8_t* buffer, uint16_t seq, uint32_t timestamp)
+{
+	auto* packet = RtpPacket::Parse(buffer, 1500);
+
+	packet->SetSequenceNumber(seq);
+	packet->SetTimestamp(timestamp);
+
+	std::shared_ptr<RtpPacket> shared(packet);
+
+	return shared;
+}
+
 SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp]")
 {
 	class TestRtpStreamListener : public RtpStreamSend::Listener
@@ -39,47 +51,26 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp]")
 		};
 		// clang-format on
 
-		uint8_t rtpBuffer2[65536];
-		uint8_t rtpBuffer3[65536];
-		uint8_t rtpBuffer4[65536];
-		uint8_t rtpBuffer5[65536];
+		uint8_t rtpBuffer2[1500];
+		uint8_t rtpBuffer3[1500];
+		uint8_t rtpBuffer4[1500];
+		uint8_t rtpBuffer5[1500];
 
-		RtpPacket* packet{ nullptr };
+		std::memcpy(rtpBuffer2, rtpBuffer1, sizeof(rtpBuffer1));
+		std::memcpy(rtpBuffer3, rtpBuffer1, sizeof(rtpBuffer1));
+		std::memcpy(rtpBuffer4, rtpBuffer1, sizeof(rtpBuffer1));
+		std::memcpy(rtpBuffer5, rtpBuffer1, sizeof(rtpBuffer1));
 
 		// packet1 [pt:123, seq:21006, timestamp:1533790901]
-		packet = RtpPacket::Parse(rtpBuffer1, sizeof(rtpBuffer1));
-		std::shared_ptr<RtpPacket> packet1(packet);
-
-		packet1->SetSequenceNumber(21006);
-		packet1->SetTimestamp(1533790901);
-
+		auto packet1 = CreateRtpPacket(rtpBuffer1, 21006, 1533790901);
 		// packet2 [pt:123, seq:21007, timestamp:1533790901]
-		packet = packet1->Clone(rtpBuffer2);
-		std::shared_ptr<RtpPacket> packet2(packet);
-
-		packet2->SetSequenceNumber(21007);
-		packet2->SetTimestamp(1533790901);
-
+		auto packet2 = CreateRtpPacket(rtpBuffer2, 21007, 1533790901);
 		// packet3 [pt:123, seq:21008, timestamp:1533793871]
-		packet = packet1->Clone(rtpBuffer3);
-		std::shared_ptr<RtpPacket> packet3(packet);
-
-		packet3->SetSequenceNumber(21008);
-		packet3->SetTimestamp(1533793871);
-
+		auto packet3 = CreateRtpPacket(rtpBuffer3, 21008, 1533793871);
 		// packet4 [pt:123, seq:21009, timestamp:1533793871]
-		packet = packet1->Clone(rtpBuffer4);
-		std::shared_ptr<RtpPacket> packet4(packet);
-
-		packet4->SetSequenceNumber(21009);
-		packet4->SetTimestamp(1533793871);
-
+		auto packet4 = CreateRtpPacket(rtpBuffer4, 21009, 1533793871);
 		// packet5 [pt:123, seq:21010, timestamp:1533796931]
-		packet = packet1->Clone(rtpBuffer5);
-		std::shared_ptr<RtpPacket> packet5(packet);
-
-		packet5->SetSequenceNumber(21010);
-		packet5->SetTimestamp(1533796931);
+		auto packet5 = CreateRtpPacket(rtpBuffer5, 21010, 1533796931);
 
 		RtpStream::Params params;
 


### PR DESCRIPTION
Essentially extracted from https://github.com/versatica/mediasoup/pull/675

* RtpStreamSend does not clone each RTP packet coming from Producer.
  - A `std::shared_ptr` holding the original packet is used by all RtpStreamSend
   instances.

* RtpStreamSend does not clone each RTP packet when sending DTX.
  - The original RTP packet is DTX encoded/decoded when needed.

* RtpStreamSend does not store up to 65536 RTP packets in a `std::map`.
  - Only a limited range of RTP packets are stored in a `std::deque` (up to 2000 ms of media).

Memory usage differences using mediasoup-demo with 6 attendees in a room:

* v3: 60MB
* rtpstreamsend-optimizations: 17.5MB.