### PR TITLE
Fix `MESON_ARGS` example and add corresponding options

### DIFF
--- a/worker/Makefile
+++ b/worker/Makefile
@@ -21,7 +21,7 @@ INSTALL_DIR ?= $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
 BUILD_DIR ?= $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/build
 MESON ?= $(PIP_DIR)/bin/meson
 # `MESON_ARGS` can be used to provide extra configuration parameters to Meson, such as adding defines or changing
-# optimization options. For instance, use `MESON_ARGS="-DMS_LOG_TRACE -DMS_LOG_FILE_LINE" npm i` to compile worker with
+# optimization options. For instance, use `MESON_ARGS="-Dms_log_trace=true -Dms_log_file_line=true" npm i` to compile worker with
 # tracing and enabled.
 #
 # NOTE: On Windows make sure to add `--vsenv` or have MSVS environment already active if you override this parameter.

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -26,6 +26,18 @@ if host_machine.system() == 'windows'
   ]
 endif
 
+if get_option('ms_log_trace')
+  cpp_args += [
+    '-DMS_LOG_TRACE',
+  ]
+endif
+
+if get_option('ms_log_file_line')
+  cpp_args += [
+    '-DMS_LOG_FILE_LINE',
+  ]
+endif
+
 common_sources = [
   'src/lib.cpp',
   'src/DepLibSRTP.cpp',

--- a/worker/meson_options.txt
+++ b/worker/meson_options.txt
@@ -1,0 +1,2 @@
+option('ms_log_trace', type : 'boolean', value : false, description : 'When enabled, logs the current method/function if current log level is "debug"')
+option('ms_log_file_line', type : 'boolean', value : false, description : 'When enabled, all the logging macros print more verbose information, including current file and line')


### PR DESCRIPTION
Turns out `-D` in Meson is not the same as in compilers :upside_down_face: 

Fixes #842, @HustCoderHu can you test this, please?