### PR TITLE
Do not clone audio RTP packets

### DIFF
--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -69,9 +69,8 @@ namespace RTC
 	public:
 		enum class ReceiveRtpPacketResult
 		{
-			DISCARDED       = 0,
-			MEDIA           = 1,
-			MEDIA_FORWARDED = 2,
+			DISCARDED = 0,
+			MEDIA     = 1,
 			RETRANSMISSION
 		};
 

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -69,8 +69,9 @@ namespace RTC
 	public:
 		enum class ReceiveRtpPacketResult
 		{
-			DISCARDED = 0,
-			MEDIA     = 1,
+			DISCARDED       = 0,
+			MEDIA           = 1,
+			MEDIA_FORWARDED = 2,
 			RETRANSMISSION
 		};
 

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -625,7 +625,6 @@ namespace RTC
 			MS_WARN_TAG(rtp, "no stream found for received packet [ssrc:%" PRIu32 "]", packet->GetSsrc());
 
 			result = ReceiveRtpPacketResult::DISCARDED;
-
 			goto done;
 		}
 

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -707,7 +707,7 @@ namespace RTC
 
 		this->listener->OnProducerRtpPacketReceived(this, packet);
 
-		return result;
+		return ReceiveRtpPacketResult::MEDIA_FORWARDED;
 	}
 
 	void Producer::ReceiveRtcpSenderReport(RTC::RTCP::SenderReport* report)

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -785,13 +785,13 @@ namespace RTC
 		// The packet does not need to be accessible in the future, do not clone it.
 		if (producer->GetKind() == RTC::Media::Kind::AUDIO)
 		{
-			std::shared_ptr<RTC::RtpPacket> sharedPacket(packet);
+			sharedPacket.reset(packet);
 		}
 		else
 		{
 			// Clone the packet so it holds its own buffer, usable for future
 			// retransmissions.
-			std::shared_ptr<RTC::RtpPacket> sharedPacket(packet->Clone());
+			sharedPacket.reset(packet->Clone());
 		}
 
 		auto& consumers = this->mapProducerConsumers.at(producer);

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -784,11 +784,15 @@ namespace RTC
 
 		// The packet does not need to be accessible in the future, do not clone it.
 		if (producer->GetKind() == RTC::Media::Kind::AUDIO)
+		{
 			std::shared_ptr<RTC::RtpPacket> sharedPacket(packet);
+		}
 		else
+		{
 			// Clone the packet so it holds its own buffer, usable for future
 			// retransmissions.
 			std::shared_ptr<RTC::RtpPacket> sharedPacket(packet->Clone());
+		}
 
 		auto& consumers = this->mapProducerConsumers.at(producer);
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1714,7 +1714,6 @@ namespace RTC
 		switch (result)
 		{
 			case RTC::Producer::ReceiveRtpPacketResult::MEDIA:
-			case RTC::Producer::ReceiveRtpPacketResult::MEDIA_FORWARDED:
 				this->recvRtpTransmission.Update(packet);
 				break;
 			case RTC::Producer::ReceiveRtpPacketResult::RETRANSMISSION:
@@ -1726,10 +1725,6 @@ namespace RTC
 				break;
 			default:;
 		}
-
-		// Media forwarded, the packet lifetime is already handled.
-		if (result != RTC::Producer::ReceiveRtpPacketResult::MEDIA_FORWARDED)
-			delete packet;
 	}
 
 	void Transport::ReceiveRtcpPacket(RTC::RTCP::Packet* packet)

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1714,6 +1714,7 @@ namespace RTC
 		switch (result)
 		{
 			case RTC::Producer::ReceiveRtpPacketResult::MEDIA:
+			case RTC::Producer::ReceiveRtpPacketResult::MEDIA_FORWARDED:
 				this->recvRtpTransmission.Update(packet);
 				break;
 			case RTC::Producer::ReceiveRtpPacketResult::RETRANSMISSION:
@@ -1726,7 +1727,9 @@ namespace RTC
 			default:;
 		}
 
-		delete packet;
+		// Media forwarded, the packet lifetime is already handled.
+		if (result != RTC::Producer::ReceiveRtpPacketResult::MEDIA_FORWARDED)
+			delete packet;
 	}
 
 	void Transport::ReceiveRtcpPacket(RTC::RTCP::Packet* packet)


### PR DESCRIPTION
We are currently cloning all RTP packets and creating a shared_ptr out
of them.

* Do not clone audio RTP packets, saving the corresponding RtpPacket
  instance creation, memory allocation, memory copy, etc.