### PR TITLE
Make TCP and UDP properties available for all `WebRtcTransportOptions`

### DIFF
--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -289,10 +289,6 @@ enum RouterCreateWebrtcTransportListen {
         listen_ips: TransportListenIps,
         #[serde(skip_serializing_if = "Option::is_none")]
         port: Option<u16>,
-        enable_udp: bool,
-        enable_tcp: bool,
-        prefer_udp: bool,
-        prefer_tcp: bool,
     },
     Server {
         #[serde(rename = "webRtcServerId")]
@@ -305,6 +301,10 @@ enum RouterCreateWebrtcTransportListen {
 pub(crate) struct RouterCreateWebrtcTransportData {
     #[serde(flatten)]
     listen: RouterCreateWebrtcTransportListen,
+    enable_udp: bool,
+    enable_tcp: bool,
+    prefer_udp: bool,
+    prefer_tcp: bool,
     initial_available_outgoing_bitrate: u32,
     enable_sctp: bool,
     num_sctp_streams: NumSctpStreams,
@@ -317,27 +317,22 @@ impl RouterCreateWebrtcTransportData {
     pub(crate) fn from_options(webrtc_transport_options: &WebRtcTransportOptions) -> Self {
         Self {
             listen: match &webrtc_transport_options.listen {
-                WebRtcTransportListen::Individual {
-                    listen_ips,
-                    port,
-                    enable_udp,
-                    enable_tcp,
-                    prefer_udp,
-                    prefer_tcp,
-                } => RouterCreateWebrtcTransportListen::Individual {
-                    listen_ips: listen_ips.clone(),
-                    port: *port,
-                    enable_udp: *enable_udp,
-                    enable_tcp: *enable_tcp,
-                    prefer_udp: *prefer_udp,
-                    prefer_tcp: *prefer_tcp,
-                },
+                WebRtcTransportListen::Individual { listen_ips, port } => {
+                    RouterCreateWebrtcTransportListen::Individual {
+                        listen_ips: listen_ips.clone(),
+                        port: *port,
+                    }
+                }
                 WebRtcTransportListen::Server { webrtc_server } => {
                     RouterCreateWebrtcTransportListen::Server {
                         webrtc_server_id: webrtc_server.id(),
                     }
                 }
             },
+            enable_udp: webrtc_transport_options.enable_udp,
+            enable_tcp: webrtc_transport_options.enable_tcp,
+            prefer_udp: webrtc_transport_options.prefer_udp,
+            prefer_tcp: webrtc_transport_options.prefer_tcp,
             initial_available_outgoing_bitrate: webrtc_transport_options
                 .initial_available_outgoing_bitrate,
             enable_sctp: webrtc_transport_options.enable_sctp,

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -96,17 +96,6 @@ pub enum WebRtcTransportListen {
         listen_ips: TransportListenIps,
         /// Fixed port to listen on instead of selecting automatically from Worker's port range.
         port: Option<u16>,
-        /// Listen in UDP. Default true.
-        enable_udp: bool,
-        /// Listen in TCP.
-        /// Default false.
-        enable_tcp: bool,
-        /// Prefer UDP.
-        /// Default false.
-        prefer_udp: bool,
-        /// Prefer TCP.
-        /// Default false.
-        prefer_tcp: bool,
     },
     /// Share [`WebRtcServer`] with other transports withing the same worker.
     Server {
@@ -125,6 +114,17 @@ pub enum WebRtcTransportListen {
 pub struct WebRtcTransportOptions {
     /// How [`WebRtcTransport`] should listen on interfaces.
     pub listen: WebRtcTransportListen,
+    /// Listen in UDP. Default true.
+    pub enable_udp: bool,
+    /// Listen in TCP.
+    /// Default false.
+    pub enable_tcp: bool,
+    /// Prefer UDP.
+    /// Default false.
+    pub prefer_udp: bool,
+    /// Prefer TCP.
+    /// Default false.
+    pub prefer_tcp: bool,
     /// Initial available outgoing bitrate (in bps).
     /// Default 600000.
     pub initial_available_outgoing_bitrate: u32,
@@ -151,11 +151,11 @@ impl WebRtcTransportOptions {
             listen: WebRtcTransportListen::Individual {
                 listen_ips,
                 port: None,
-                enable_udp: true,
-                enable_tcp: false,
-                prefer_udp: false,
-                prefer_tcp: false,
             },
+            enable_udp: true,
+            enable_tcp: false,
+            prefer_udp: false,
+            prefer_tcp: false,
             initial_available_outgoing_bitrate: 600_000,
             enable_sctp: false,
             num_sctp_streams: NumSctpStreams::default(),
@@ -169,6 +169,10 @@ impl WebRtcTransportOptions {
     pub fn new_with_server(webrtc_server: WebRtcServer) -> Self {
         Self {
             listen: WebRtcTransportListen::Server { webrtc_server },
+            enable_udp: true,
+            enable_tcp: false,
+            prefer_udp: false,
+            prefer_tcp: false,
             initial_available_outgoing_bitrate: 600_000,
             enable_sctp: false,
             num_sctp_streams: NumSctpStreams::default(),

--- a/rust/tests/integration/webrtc_transport.rs
+++ b/rust/tests/integration/webrtc_transport.rs
@@ -145,19 +145,8 @@ fn create_succeeds() {
                         .try_into()
                         .unwrap(),
                     );
-                    match &mut webrtc_transport_options.listen {
-                        WebRtcTransportListen::Individual {
-                            enable_tcp,
-                            prefer_udp,
-                            ..
-                        } => {
-                            *enable_tcp = true;
-                            *prefer_udp = true;
-                        }
-                        WebRtcTransportListen::Server { .. } => {
-                            unreachable!();
-                        }
-                    }
+                    webrtc_transport_options.enable_tcp = true;
+                    webrtc_transport_options.prefer_udp = true;
                     webrtc_transport_options.enable_sctp = true;
                     webrtc_transport_options.num_sctp_streams = NumSctpStreams {
                         os: 2048,


### PR DESCRIPTION
As discussed in original PR. those fields must be available for WebRTC server too