### PR TITLE
Pin the version of meson

### DIFF
--- a/worker/Makefile
+++ b/worker/Makefile
@@ -20,7 +20,7 @@ PIP_DIR = $(MEDIASOUP_OUT_DIR)/pip
 INSTALL_DIR ?= $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
 BUILD_DIR ?= $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/build
 MESON ?= $(PIP_DIR)/bin/meson
-MESON_VERSION ?= 0.63.0
+MESON_VERSION ?= 0.61.5
 # `MESON_ARGS` can be used to provide extra configuration parameters to Meson, such as adding defines or changing
 # optimization options. For instance, use `MESON_ARGS="-Dms_log_trace=true -Dms_log_file_line=true" npm i` to compile worker with
 # tracing and enabled.

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -20,6 +20,7 @@ PIP_DIR = $(MEDIASOUP_OUT_DIR)/pip
 INSTALL_DIR ?= $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
 BUILD_DIR ?= $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)/build
 MESON ?= $(PIP_DIR)/bin/meson
+MESON_VERSION ?= 0.63.0
 # `MESON_ARGS` can be used to provide extra configuration parameters to Meson, such as adding defines or changing
 # optimization options. For instance, use `MESON_ARGS="-Dms_log_trace=true -Dms_log_file_line=true" npm i` to compile worker with
 # tracing and enabled.
@@ -74,7 +75,7 @@ ifeq ($(wildcard $(PIP_DIR)),)
 		echo "Installation failed, likely because PIP is unavailable, if you are on Debian/Ubuntu or derivative please install the python3-pip package"
 	# Install `meson` and `ninja` using `pip` into custom location, so we don't
 	# depend on system-wide installation.
-	$(PYTHON) -m pip install --upgrade --target=$(PIP_DIR) $(PIP_BUILD_BINARIES) meson ninja
+	$(PYTHON) -m pip install --upgrade --target=$(PIP_DIR) $(PIP_BUILD_BINARIES) meson==$(MESON_VERSION) ninja
 endif
 
 setup: meson-ninja


### PR DESCRIPTION
The PR fixates the version of Meson to prevent unexpected built failures like [this one](https://github.com/versatica/mediasoup/pull/857) in future.