### PR TITLE
Fix release contents by including `meson_options.txt`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "worker/test/src",
     "worker/Makefile",
     "worker/meson.build",
+    "worker/meson_options.txt",
     "npm-scripts.js"
   ],
   "keywords": [

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -22,6 +22,7 @@ include = [
     "/Cargo.toml",
     "/Makefile",
     "/meson.build",
+    "/meson_options.txt",
 ]
 
 [package.metadata.docs.rs]


### PR DESCRIPTION
I think this might affect both Rust and TypeScript.

Cargo actually creates a package and then tries to build it, so it fails to publish if required files are not included.

Without this I'm getting following error:
```
  meson.build:29:3: ERROR: Tried to access unknown option 'ms_log_trace'.
```