### PR TITLE
Log error detais happen in channel socket.

### DIFF
--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -201,7 +201,7 @@ namespace Channel
 			}
 			catch (const MediaSoupError& error)
 			{
-				MS_ERROR_STD("discarding wrong Channel request");
+				MS_ERROR_STD("discarding wrong Channel request: %s", error.what());
 			}
 
 			free(message, messageLen, messageCtx);
@@ -266,7 +266,7 @@ namespace Channel
 		}
 		catch (const MediaSoupError& error)
 		{
-			MS_ERROR_STD("discarding wrong Channel request");
+			MS_ERROR_STD("discarding wrong Channel request: %s", error.what());
 		}
 	}
 

--- a/worker/src/PayloadChannel/PayloadChannelSocket.cpp
+++ b/worker/src/PayloadChannel/PayloadChannelSocket.cpp
@@ -232,7 +232,7 @@ namespace PayloadChannel
 					}
 					catch (const MediaSoupError& error)
 					{
-						MS_ERROR("discarding wrong Payload Channel notification");
+						MS_ERROR("discarding wrong Payload Channel notification: %s", error.what());
 					}
 				}
 
@@ -262,7 +262,7 @@ namespace PayloadChannel
 					}
 					catch (const MediaSoupError& error)
 					{
-						MS_ERROR("discarding wrong Payload Channel notification");
+						MS_ERROR("discarding wrong Payload Channel notification: %s", error.what());
 					}
 				}
 
@@ -277,7 +277,7 @@ namespace PayloadChannel
 			}
 			catch (const MediaSoupError& error)
 			{
-				MS_ERROR("discarding wrong Channel request");
+				MS_ERROR("discarding wrong Channel request: %s", error.what());
 			}
 
 			free(message, messageLen, messageCtx);
@@ -349,7 +349,7 @@ namespace PayloadChannel
 				}
 				catch (const MediaSoupError& error)
 				{
-					MS_ERROR("discarding wrong Payload Channel notification");
+					MS_ERROR("discarding wrong Payload Channel notification: %s", error.what());
 				}
 			}
 
@@ -365,7 +365,7 @@ namespace PayloadChannel
 				}
 				catch (const MediaSoupError& error)
 				{
-					MS_ERROR("discarding wrong Payload Channel notification");
+					MS_ERROR("discarding wrong Payload Channel notification: %s", error.what());
 				}
 			}
 


### PR DESCRIPTION
I've observed occasional error messages in the `stdout` of service which uses `mediasoup`:
```
Channel::ChannelSocket::OnConsumerSocketMessage() | discarding wrong Channel request
```
This PR extend information logged in such cases, so it should reveal more details of what happen.