### PR TITLE
Cleanup `internal` field in transport in Rust

### DIFF
--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -52,10 +52,6 @@ pub(crate) struct WebRtcServerInternal {
 pub(crate) struct TransportInternal {
     pub(crate) router_id: RouterId,
     pub(crate) transport_id: TransportId,
-    // TODO: This field should have really been in the `data`, not in `internal` data structure
-    #[serde(rename = "webRtcServerId")]
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub(crate) webrtc_server_id: Option<WebRtcServerId>,
 }
 
 #[derive(Debug, Serialize)]

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -572,7 +572,6 @@ impl Router {
                 internal: TransportInternal {
                     router_id: self.inner.id,
                     transport_id,
-                    webrtc_server_id: None,
                 },
                 data: RouterCreateDirectTransportData::from_options(&direct_transport_options),
             })
@@ -634,10 +633,6 @@ impl Router {
                 internal: TransportInternal {
                     router_id: self.inner.id,
                     transport_id,
-                    webrtc_server_id: match &webrtc_transport_options.listen {
-                        WebRtcTransportListen::Individual { .. } => None,
-                        WebRtcTransportListen::Server { webrtc_server } => Some(webrtc_server.id()),
-                    },
                 },
                 data: RouterCreateWebrtcTransportData::from_options(&webrtc_transport_options),
             })
@@ -702,7 +697,6 @@ impl Router {
                 internal: TransportInternal {
                     router_id: self.inner.id,
                     transport_id,
-                    webrtc_server_id: None,
                 },
                 data: RouterCreatePipeTransportData::from_options(&pipe_transport_options),
             })
@@ -763,7 +757,6 @@ impl Router {
                 internal: TransportInternal {
                     router_id: self.inner.id,
                     transport_id,
-                    webrtc_server_id: None,
                 },
                 data: RouterCreatePlainTransportData::from_options(&plain_transport_options),
             })

--- a/rust/src/router/direct_transport.rs
+++ b/rust/src/router/direct_transport.rs
@@ -172,7 +172,6 @@ impl Inner {
                     internal: TransportInternal {
                         router_id: self.router.id(),
                         transport_id: self.id,
-                        webrtc_server_id: None,
                     },
                 };
 
@@ -541,7 +540,6 @@ impl DirectTransport {
         TransportInternal {
             router_id: self.router().id(),
             transport_id: self.id(),
-            webrtc_server_id: None,
         }
     }
 }

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -223,7 +223,6 @@ impl Inner {
                     internal: TransportInternal {
                         router_id: self.router.id(),
                         transport_id: self.id,
-                        webrtc_server_id: None,
                     },
                 };
 
@@ -646,7 +645,6 @@ impl PipeTransport {
         TransportInternal {
             router_id: self.router().id(),
             transport_id: self.id(),
-            webrtc_server_id: None,
         }
     }
 }

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -260,7 +260,6 @@ impl Inner {
                     internal: TransportInternal {
                         router_id: self.router.id(),
                         transport_id: self.id,
-                        webrtc_server_id: None,
                     },
                 };
 
@@ -821,7 +820,6 @@ impl PlainTransport {
         TransportInternal {
             router_id: self.router().id(),
             transport_id: self.id(),
-            webrtc_server_id: None,
         }
     }
 }

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -372,7 +372,6 @@ pub(super) trait TransportImpl: TransportGeneric {
                 internal: TransportInternal {
                     router_id: self.router().id(),
                     transport_id: self.id(),
-                    webrtc_server_id: None,
                 },
             })
             .await
@@ -384,7 +383,6 @@ pub(super) trait TransportImpl: TransportGeneric {
                 internal: TransportInternal {
                     router_id: self.router().id(),
                     transport_id: self.id(),
-                    webrtc_server_id: None,
                 },
             })
             .await
@@ -396,7 +394,6 @@ pub(super) trait TransportImpl: TransportGeneric {
                 internal: TransportInternal {
                     router_id: self.router().id(),
                     transport_id: self.id(),
-                    webrtc_server_id: None,
                 },
                 data: TransportSetMaxIncomingBitrateData { bitrate },
             })
@@ -409,7 +406,6 @@ pub(super) trait TransportImpl: TransportGeneric {
                 internal: TransportInternal {
                     router_id: self.router().id(),
                     transport_id: self.id(),
-                    webrtc_server_id: None,
                 },
                 data: TransportSetMaxOutgoingBitrateData { bitrate },
             })
@@ -425,7 +421,6 @@ pub(super) trait TransportImpl: TransportGeneric {
                 internal: TransportInternal {
                     router_id: self.router().id(),
                     transport_id: self.id(),
-                    webrtc_server_id: None,
                 },
                 data: TransportEnableTraceEventData { types },
             })

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -347,7 +347,6 @@ impl Inner {
                     internal: TransportInternal {
                         router_id: self.router.id(),
                         transport_id: self.id,
-                        webrtc_server_id: None,
                     },
                 };
 
@@ -942,7 +941,6 @@ impl WebRtcTransport {
         TransportInternal {
             router_id: self.router().id(),
             transport_id: self.id(),
-            webrtc_server_id: None,
         }
     }
 }


### PR DESCRIPTION
Not sure how I missed it, but it doesn't exist in `internal` after #847, though Rust version still had it there.