### PR TITLE
Refactor request and notification handlers to conform to the same API

### DIFF
--- a/worker/include/Channel/ChannelSocket.hpp
+++ b/worker/include/Channel/ChannelSocket.hpp
@@ -51,15 +51,22 @@ namespace Channel
 	class ChannelSocket : public ConsumerSocket::Listener
 	{
 	public:
-		class Listener
+		class RequestHandler
+		{
+		public:
+			virtual ~RequestHandler() = default;
+
+		public:
+			virtual void HandleRequest(Channel::ChannelRequest* request) = 0;
+		};
+
+		class Listener : public RequestHandler
 		{
 		public:
 			virtual ~Listener() = default;
 
 		public:
-			virtual void OnChannelRequest(
-			  Channel::ChannelSocket* channel, Channel::ChannelRequest* request) = 0;
-			virtual void OnChannelClosed(Channel::ChannelSocket* channel)        = 0;
+			virtual void OnChannelClosed(Channel::ChannelSocket* channel) = 0;
 		};
 
 	public:

--- a/worker/include/PayloadChannel/PayloadChannelSocket.hpp
+++ b/worker/include/PayloadChannel/PayloadChannelSocket.hpp
@@ -54,18 +54,30 @@ namespace PayloadChannel
 	class PayloadChannelSocket : public ConsumerSocket::Listener
 	{
 	public:
-		class Listener
+		class RequestHandler
+		{
+		public:
+			virtual ~RequestHandler() = default;
+
+		public:
+			virtual void HandleRequest(PayloadChannel::PayloadChannelRequest* request) = 0;
+		};
+
+		class NotificationHandler
+		{
+		public:
+			virtual ~NotificationHandler() = default;
+
+		public:
+			virtual void HandleNotification(PayloadChannel::Notification* notification) = 0;
+		};
+
+		class Listener : public RequestHandler, public NotificationHandler
 		{
 		public:
 			virtual ~Listener() = default;
 
 		public:
-			virtual void OnPayloadChannelNotification(
-			  PayloadChannel::PayloadChannelSocket* payloadChannel,
-			  PayloadChannel::Notification* notification) = 0;
-			virtual void OnPayloadChannelRequest(
-			  PayloadChannel::PayloadChannelSocket* payloadChannel,
-			  PayloadChannel::PayloadChannelRequest* request)                                         = 0;
 			virtual void OnPayloadChannelClosed(PayloadChannel::PayloadChannelSocket* payloadChannel) = 0;
 		};
 

--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -3,6 +3,7 @@
 
 #include "common.hpp"
 #include "Channel/ChannelRequest.hpp"
+#include "Channel/ChannelSocket.hpp"
 #include "RTC/RTCP/CompoundPacket.hpp"
 #include "RTC/RTCP/FeedbackPs.hpp"
 #include "RTC/RTCP/FeedbackPsFir.hpp"
@@ -23,7 +24,7 @@ using json = nlohmann::json;
 
 namespace RTC
 {
-	class Consumer
+	class Consumer : Channel::ChannelSocket::RequestHandler
 	{
 	public:
 		class Listener
@@ -70,7 +71,6 @@ namespace RTC
 		virtual void FillJson(json& jsonObject) const;
 		virtual void FillJsonStats(json& jsonArray) const  = 0;
 		virtual void FillJsonScore(json& jsonObject) const = 0;
-		virtual void HandleRequest(Channel::ChannelRequest* request);
 		RTC::Media::Kind GetKind() const
 		{
 			return this->kind;
@@ -154,6 +154,10 @@ namespace RTC
 		virtual void ReceiveRtcpXrReceiverReferenceTime(RTC::RTCP::ReceiverReferenceTime* report) = 0;
 		virtual uint32_t GetTransmissionRate(uint64_t nowMs)                                      = 0;
 		virtual float GetRtt() const                                                              = 0;
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	protected:
 		void EmitTraceEventRtpAndKeyFrameTypes(RTC::RtpPacket* packet, bool isRtx = false) const;

--- a/worker/include/RTC/DataConsumer.hpp
+++ b/worker/include/RTC/DataConsumer.hpp
@@ -3,14 +3,17 @@
 
 #include "common.hpp"
 #include "Channel/ChannelRequest.hpp"
+#include "Channel/ChannelSocket.hpp"
 #include "PayloadChannel/PayloadChannelRequest.hpp"
+#include "PayloadChannel/PayloadChannelSocket.hpp"
 #include "RTC/SctpDictionaries.hpp"
 #include <nlohmann/json.hpp>
 #include <string>
 
 namespace RTC
 {
-	class DataConsumer
+	class DataConsumer : Channel::ChannelSocket::RequestHandler,
+	                     PayloadChannel::PayloadChannelSocket::RequestHandler
 	{
 	protected:
 		using onQueuedCallback = const std::function<void(bool queued, bool sctpSendBufferFull)>;
@@ -50,8 +53,6 @@ namespace RTC
 	public:
 		void FillJson(json& jsonObject) const;
 		void FillJsonStats(json& jsonArray) const;
-		void HandleRequest(Channel::ChannelRequest* request);
-		void HandleRequest(PayloadChannel::PayloadChannelRequest* request);
 		Type GetType() const
 		{
 			return this->type;
@@ -77,6 +78,14 @@ namespace RTC
 		void SctpAssociationBufferedAmount(uint32_t bufferedAmount);
 		void DataProducerClosed();
 		void SendMessage(uint32_t ppid, const uint8_t* msg, size_t len, onQueuedCallback* = nullptr);
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
+
+		/* Methods inherited from PayloadChannel::PayloadChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(PayloadChannel::PayloadChannelRequest* request) override;
 
 	public:
 		// Passed by argument.

--- a/worker/include/RTC/DataProducer.hpp
+++ b/worker/include/RTC/DataProducer.hpp
@@ -3,13 +3,14 @@
 
 #include "common.hpp"
 #include "Channel/ChannelRequest.hpp"
+#include "Channel/ChannelSocket.hpp"
 #include "RTC/SctpDictionaries.hpp"
 #include <nlohmann/json.hpp>
 #include <string>
 
 namespace RTC
 {
-	class DataProducer
+	class DataProducer : Channel::ChannelSocket::RequestHandler
 	{
 	public:
 		class Listener
@@ -36,7 +37,6 @@ namespace RTC
 	public:
 		void FillJson(json& jsonObject) const;
 		void FillJsonStats(json& jsonArray) const;
-		void HandleRequest(Channel::ChannelRequest* request) const;
 		Type GetType() const
 		{
 			return this->type;
@@ -46,6 +46,10 @@ namespace RTC
 			return this->sctpStreamParameters;
 		}
 		void ReceiveMessage(uint32_t ppid, const uint8_t* msg, size_t len);
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	public:
 		// Passed by argument.

--- a/worker/include/RTC/DirectTransport.hpp
+++ b/worker/include/RTC/DirectTransport.hpp
@@ -14,7 +14,6 @@ namespace RTC
 	public:
 		void FillJson(json& jsonObject) const override;
 		void FillJsonStats(json& jsonArray) override;
-		void HandleRequest(Channel::ChannelRequest* request) override;
 		void HandleNotification(PayloadChannel::Notification* notification) override;
 
 	private:
@@ -34,6 +33,10 @@ namespace RTC
 		void SendSctpData(const uint8_t* data, size_t len) override;
 		void RecvStreamClosed(uint32_t ssrc) override;
 		void SendStreamClosed(uint32_t ssrc) override;
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	private:
 		// Allocated by this.

--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -21,7 +21,6 @@ namespace RTC
 		void FillJson(json& jsonObject) const override;
 		void FillJsonStats(json& jsonArray) const override;
 		void FillJsonScore(json& jsonObject) const override;
-		void HandleRequest(Channel::ChannelRequest* request) override;
 		void ProducerRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerNewRtpStream(RTC::RtpStream* rtpStream, uint32_t mappedSsrc) override;
 		void ProducerRtpStreamScore(RTC::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) override;
@@ -43,6 +42,10 @@ namespace RTC
 		void ReceiveRtcpXrReceiverReferenceTime(RTC::RTCP::ReceiverReferenceTime* report) override;
 		uint32_t GetTransmissionRate(uint64_t nowMs) override;
 		float GetRtt() const override;
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	private:
 		void UserOnTransportConnected() override;

--- a/worker/include/RTC/PipeTransport.hpp
+++ b/worker/include/RTC/PipeTransport.hpp
@@ -29,8 +29,11 @@ namespace RTC
 	public:
 		void FillJson(json& jsonObject) const override;
 		void FillJsonStats(json& jsonArray) override;
-		void HandleRequest(Channel::ChannelRequest* request) override;
 		void HandleNotification(PayloadChannel::Notification* notification) override;
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	private:
 		bool IsConnected() const override;

--- a/worker/include/RTC/PlainTransport.hpp
+++ b/worker/include/RTC/PlainTransport.hpp
@@ -29,8 +29,11 @@ namespace RTC
 	public:
 		void FillJson(json& jsonObject) const override;
 		void FillJsonStats(json& jsonArray) override;
-		void HandleRequest(Channel::ChannelRequest* request) override;
 		void HandleNotification(PayloadChannel::Notification* notification) override;
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	private:
 		bool IsConnected() const override;

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -3,6 +3,7 @@
 
 #include "common.hpp"
 #include "Channel/ChannelRequest.hpp"
+#include "Channel/ChannelSocket.hpp"
 #include "RTC/KeyFrameRequestManager.hpp"
 #include "RTC/RTCP/CompoundPacket.hpp"
 #include "RTC/RTCP/Packet.hpp"
@@ -20,7 +21,9 @@ using json = nlohmann::json;
 
 namespace RTC
 {
-	class Producer : public RTC::RtpStreamRecv::Listener, public RTC::KeyFrameRequestManager::Listener
+	class Producer : public RTC::RtpStreamRecv::Listener,
+	                 public RTC::KeyFrameRequestManager::Listener,
+	                 Channel::ChannelSocket::RequestHandler
 	{
 	public:
 		class Listener
@@ -91,7 +94,6 @@ namespace RTC
 	public:
 		void FillJson(json& jsonObject) const;
 		void FillJsonStats(json& jsonArray) const;
-		void HandleRequest(Channel::ChannelRequest* request);
 		RTC::Media::Kind GetKind() const
 		{
 			return this->kind;
@@ -125,6 +127,10 @@ namespace RTC
 		void ReceiveRtcpXrDelaySinceLastRr(RTC::RTCP::DelaySinceLastRr::SsrcInfo* ssrcInfo);
 		void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs);
 		void RequestKeyFrame(uint32_t mappedSsrc);
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	private:
 		RTC::RtpStreamRecv* GetRtpStream(RTC::RtpPacket* packet);

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -23,7 +23,10 @@ using json = nlohmann::json;
 
 namespace RTC
 {
-	class Router : public RTC::Transport::Listener
+	class Router : public RTC::Transport::Listener,
+	               Channel::ChannelSocket::RequestHandler,
+	               PayloadChannel::PayloadChannelSocket::RequestHandler,
+	               PayloadChannel::PayloadChannelSocket::NotificationHandler
 	{
 	public:
 		class Listener
@@ -42,9 +45,18 @@ namespace RTC
 
 	public:
 		void FillJson(json& jsonObject) const;
-		void HandleRequest(Channel::ChannelRequest* request);
-		void HandleRequest(PayloadChannel::PayloadChannelRequest* request);
-		void HandleNotification(PayloadChannel::Notification* notification);
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
+
+		/* Methods inherited from PayloadChannel::PayloadChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(PayloadChannel::PayloadChannelRequest* request) override;
+
+		/* Methods inherited from PayloadChannel::PayloadChannelSocket::NotificationHandler. */
+	public:
+		void HandleNotification(PayloadChannel::Notification* notification) override;
 
 	private:
 		void SetNewTransportIdFromInternal(json& internal, std::string& transportId) const;

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -21,7 +21,6 @@ namespace RTC
 		void FillJson(json& jsonObject) const override;
 		void FillJsonStats(json& jsonArray) const override;
 		void FillJsonScore(json& jsonObject) const override;
-		void HandleRequest(Channel::ChannelRequest* request) override;
 		bool IsActive() const override
 		{
 			// clang-format off
@@ -53,6 +52,10 @@ namespace RTC
 		void ReceiveRtcpXrReceiverReferenceTime(RTC::RTCP::ReceiverReferenceTime* report) override;
 		uint32_t GetTransmissionRate(uint64_t nowMs) override;
 		float GetRtt() const override;
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	private:
 		void UserOnTransportConnected() override;

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -22,7 +22,6 @@ namespace RTC
 		void FillJson(json& jsonObject) const override;
 		void FillJsonStats(json& jsonArray) const override;
 		void FillJsonScore(json& jsonObject) const override;
-		void HandleRequest(Channel::ChannelRequest* request) override;
 		RTC::Consumer::Layers GetPreferredLayers() const override
 		{
 			RTC::Consumer::Layers layers;
@@ -69,6 +68,10 @@ namespace RTC
 		void ReceiveRtcpXrReceiverReferenceTime(RTC::RTCP::ReceiverReferenceTime* report) override;
 		uint32_t GetTransmissionRate(uint64_t nowMs) override;
 		float GetRtt() const override;
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	private:
 		void UserOnTransportConnected() override;

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -23,7 +23,6 @@ namespace RTC
 		void FillJson(json& jsonObject) const override;
 		void FillJsonStats(json& jsonArray) const override;
 		void FillJsonScore(json& jsonObject) const override;
-		void HandleRequest(Channel::ChannelRequest* request) override;
 		RTC::Consumer::Layers GetPreferredLayers() const override
 		{
 			RTC::Consumer::Layers layers;
@@ -64,6 +63,10 @@ namespace RTC
 		void ReceiveRtcpXrReceiverReferenceTime(RTC::RTCP::ReceiverReferenceTime* report) override;
 		uint32_t GetTransmissionRate(uint64_t nowMs) override;
 		float GetRtt() const override;
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	private:
 		void UserOnTransportConnected() override;

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -5,6 +5,7 @@
 #include "common.hpp"
 #include "DepLibUV.hpp"
 #include "Channel/ChannelRequest.hpp"
+#include "Channel/ChannelSocket.hpp"
 #include "PayloadChannel/Notification.hpp"
 #include "PayloadChannel/PayloadChannelRequest.hpp"
 #include "RTC/Consumer.hpp"

--- a/worker/include/RTC/WebRtcServer.hpp
+++ b/worker/include/RTC/WebRtcServer.hpp
@@ -20,7 +20,8 @@ namespace RTC
 	class WebRtcServer : public RTC::UdpSocket::Listener,
 	                     public RTC::TcpServer::Listener,
 	                     public RTC::TcpConnection::Listener,
-	                     public RTC::WebRtcTransport::WebRtcTransportListener
+	                     public RTC::WebRtcTransport::WebRtcTransportListener,
+	                     Channel::ChannelSocket::RequestHandler
 	{
 	private:
 		struct ListenInfo
@@ -51,9 +52,12 @@ namespace RTC
 
 	public:
 		void FillJson(json& jsonObject) const;
-		void HandleRequest(Channel::ChannelRequest* request);
 		std::vector<RTC::IceCandidate> GetIceCandidates(
 		  bool enableUdp, bool enableTcp, bool preferUdp, bool preferTcp);
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	private:
 		std::string GetLocalIceUsernameFragmentFromReceivedStunPacket(RTC::StunPacket* packet) const;

--- a/worker/include/RTC/WebRtcTransport.hpp
+++ b/worker/include/RTC/WebRtcTransport.hpp
@@ -61,12 +61,15 @@ namespace RTC
 	public:
 		void FillJson(json& jsonObject) const override;
 		void FillJsonStats(json& jsonArray) override;
-		void HandleRequest(Channel::ChannelRequest* request) override;
 		void HandleNotification(PayloadChannel::Notification* notification) override;
 		void ProcessStunPacketFromWebRtcServer(RTC::TransportTuple* tuple, RTC::StunPacket* packet);
 		void ProcessNonStunPacketFromWebRtcServer(
 		  RTC::TransportTuple* tuple, const uint8_t* data, size_t len);
 		void RemoveTuple(RTC::TransportTuple* tuple);
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	private:
 		bool IsConnected() const override;

--- a/worker/include/Worker.hpp
+++ b/worker/include/Worker.hpp
@@ -34,19 +34,24 @@ private:
 	void SetNewRouterIdFromInternal(json& internal, std::string& routerId) const;
 	RTC::Router* GetRouterFromInternal(json& internal) const;
 
-	/* Methods inherited from Channel::lUnixStreamSocket::Listener. */
+	/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
 public:
-	void OnChannelRequest(Channel::ChannelSocket* channel, Channel::ChannelRequest* request) override;
+	void HandleRequest(Channel::ChannelRequest* request) override;
+
+	/* Methods inherited from Channel::ChannelSocket::Listener. */
+public:
 	void OnChannelClosed(Channel::ChannelSocket* channel) override;
 
-	/* Methods inherited from PayloadChannel::lUnixStreamSocket::Listener. */
+	/* Methods inherited from PayloadChannel::PayloadChannelSocket::RequestHandler. */
 public:
-	void OnPayloadChannelNotification(
-	  PayloadChannel::PayloadChannelSocket* payloadChannel,
-	  PayloadChannel::Notification* notification) override;
-	void OnPayloadChannelRequest(
-	  PayloadChannel::PayloadChannelSocket* payloadChannel,
-	  PayloadChannel::PayloadChannelRequest* request) override;
+	void HandleRequest(PayloadChannel::PayloadChannelRequest* request) override;
+
+	/* Methods inherited from PayloadChannel::PayloadChannelSocket::NotificationHandler. */
+public:
+	void HandleNotification(PayloadChannel::Notification* notification) override;
+
+	/* Methods inherited from PayloadChannel::PayloadChannelSocket::Listener. */
+public:
 	void OnPayloadChannelClosed(PayloadChannel::PayloadChannelSocket* payloadChannel) override;
 
 	/* Methods inherited from SignalsHandler::Listener. */

--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -181,7 +181,7 @@ namespace Channel
 				// Notify the listener.
 				try
 				{
-					this->listener->OnChannelRequest(this, request);
+					this->listener->HandleRequest(request);
 				}
 				catch (const MediaSoupTypeError& error)
 				{
@@ -246,7 +246,7 @@ namespace Channel
 			// Notify the listener.
 			try
 			{
-				this->listener->OnChannelRequest(this, request);
+				this->listener->HandleRequest(request);
 			}
 			catch (const MediaSoupTypeError& error)
 			{

--- a/worker/src/PayloadChannel/PayloadChannelSocket.cpp
+++ b/worker/src/PayloadChannel/PayloadChannelSocket.cpp
@@ -212,7 +212,7 @@ namespace PayloadChannel
 						// Notify the listener.
 						try
 						{
-							this->listener->OnPayloadChannelRequest(this, request);
+							this->listener->HandleRequest(request);
 						}
 						catch (const MediaSoupTypeError& error)
 						{
@@ -246,7 +246,7 @@ namespace PayloadChannel
 						// Notify the listener.
 						try
 						{
-							this->listener->OnPayloadChannelNotification(this, notification);
+							this->listener->HandleNotification(notification);
 						}
 						catch (const MediaSoupError& error)
 						{
@@ -381,7 +381,7 @@ namespace PayloadChannel
 			// Notify the listener.
 			try
 			{
-				this->listener->OnPayloadChannelNotification(this, this->ongoingNotification);
+				this->listener->HandleNotification(this->ongoingNotification);
 			}
 			catch (const MediaSoupError& error)
 			{
@@ -399,7 +399,7 @@ namespace PayloadChannel
 			// Notify the listener.
 			try
 			{
-				this->listener->OnPayloadChannelRequest(this, this->ongoingRequest);
+				this->listener->HandleRequest(this->ongoingRequest);
 			}
 			catch (const MediaSoupTypeError& error)
 			{

--- a/worker/src/RTC/DataProducer.cpp
+++ b/worker/src/RTC/DataProducer.cpp
@@ -110,7 +110,7 @@ namespace RTC
 		jsonObject["bytesReceived"] = this->bytesReceived;
 	}
 
-	void DataProducer::HandleRequest(Channel::ChannelRequest* request) const
+	void DataProducer::HandleRequest(Channel::ChannelRequest* request)
 	{
 		MS_TRACE();
 

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -253,7 +253,7 @@ RTC::Router* Worker::GetRouterFromInternal(json& internal) const
 	return router;
 }
 
-inline void Worker::OnChannelRequest(Channel::ChannelSocket* /*channel*/, Channel::ChannelRequest* request)
+inline void Worker::HandleRequest(Channel::ChannelRequest* request)
 {
 	MS_TRACE();
 
@@ -458,8 +458,7 @@ inline void Worker::OnChannelClosed(Channel::ChannelSocket* /*socket*/)
 	Close();
 }
 
-inline void Worker::OnPayloadChannelNotification(
-  PayloadChannel::PayloadChannelSocket* /*payloadChannel*/, PayloadChannel::Notification* notification)
+inline void Worker::HandleNotification(PayloadChannel::Notification* notification)
 {
 	MS_TRACE();
 
@@ -481,9 +480,7 @@ inline void Worker::OnPayloadChannelNotification(
 	}
 }
 
-inline void Worker::OnPayloadChannelRequest(
-  PayloadChannel::PayloadChannelSocket* /*payloadChannel*/,
-  PayloadChannel::PayloadChannelRequest* request)
+inline void Worker::HandleRequest(PayloadChannel::PayloadChannelRequest* request)
 {
 	MS_TRACE();
 


### PR DESCRIPTION
This is the first of a few PRs for `internal` refactoring to remove JSON. Here nothing really changes, except most worker entities that process requests or notifications implement the same parent class. But method names and even most of arguments are the same, most of cpp files are unchanged too.

This will allow us to put those similarly-looking entities into collections (maps), where key is ID of corresponding entity. After that we'll be able to do something like this (pseudo-code): `entities.get(id).HandleRequest(request)`. What entity it is wouldn't matter, we wouldn't need to send `internal` with a series of IDs and traverse multiple layers down, just one ID would be enough. As the result we can also avoid JSON encoding/decoding, avoid coma-separated values handling, just a simple string ID and a single map lookup is all we'll need.

I have some more refactoring in my local branch, just trying to send non-breaking simple changes separately for your convenience.