### PR TITLE
Refactor message handling

### DIFF
--- a/rust/src/data_structures.rs
+++ b/rust/src/data_structures.rs
@@ -289,7 +289,7 @@ impl Default for DtlsRole {
 /// The hash function algorithm (as defined in the "Hash function Textual Names" registry initially
 /// specified in [RFC 4572](https://tools.ietf.org/html/rfc4572#section-8) Section 8) and its
 /// corresponding certificate fingerprint value.
-#[derive(Copy, Clone, PartialOrd, PartialEq)]
+#[derive(Copy, Clone, PartialOrd, Eq, PartialEq)]
 pub enum DtlsFingerprint {
     /// sha-1
     Sha1 {
@@ -748,7 +748,7 @@ impl DtlsFingerprint {
 }
 
 /// DTLS parameters.
-#[derive(Debug, Clone, PartialOrd, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialOrd, Eq, PartialEq, Deserialize, Serialize)]
 pub struct DtlsParameters {
     /// DTLS role.
     pub role: DtlsRole,

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -356,6 +356,7 @@ impl WeakPipeTransportPair {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     new_transport: Bag<Arc<dyn Fn(NewTransport<'_>) + Send + Sync>>,
     new_rtp_observer: Bag<Arc<dyn Fn(NewRtpObserver<'_>) + Send + Sync>>,

--- a/rust/src/router/active_speaker_observer.rs
+++ b/rust/src/router/active_speaker_observer.rs
@@ -49,6 +49,7 @@ pub struct ActiveSpeakerObserverDominantSpeaker {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     dominant_speaker: Bag<
         Arc<dyn Fn(&ActiveSpeakerObserverDominantSpeaker) + Send + Sync>,

--- a/rust/src/router/audio_level_observer.rs
+++ b/rust/src/router/audio_level_observer.rs
@@ -60,6 +60,7 @@ pub struct AudioLevelObserverVolume {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     volumes: Bag<Arc<dyn Fn(&[AudioLevelObserverVolume]) + Send + Sync>>,
     silence: Bag<Arc<dyn Fn() + Send + Sync>>,

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -104,7 +104,7 @@ impl ConsumerOptions {
     }
 }
 
-#[derive(Debug, Clone, PartialOrd, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialOrd, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 pub struct RtpStreamParams {
@@ -125,7 +125,7 @@ pub struct RtpStreamParams {
     pub rtc_payload_type: Option<u8>,
 }
 
-#[derive(Debug, Clone, PartialOrd, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialOrd, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 pub struct RtpStream {
@@ -133,7 +133,7 @@ pub struct RtpStream {
     pub score: u8,
 }
 
-#[derive(Debug, Clone, PartialOrd, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialOrd, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 pub struct RtpRtxParameters {
@@ -347,6 +347,7 @@ enum PayloadNotification {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     rtp: Bag<Arc<dyn Fn(&[u8]) + Send + Sync>>,
     pause: Bag<Arc<dyn Fn() + Send + Sync>>,

--- a/rust/src/router/data_consumer.rs
+++ b/rust/src/router/data_consumer.rs
@@ -125,7 +125,7 @@ impl DataConsumerOptions {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 #[non_exhaustive]
@@ -140,7 +140,7 @@ pub struct DataConsumerDump {
 }
 
 /// RTC statistics of the data consumer.
-#[derive(Debug, Clone, PartialOrd, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialOrd, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 #[allow(missing_docs)]
@@ -182,6 +182,7 @@ enum PayloadNotification {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     message: Bag<Arc<dyn Fn(&WebRtcMessage<'_>) + Send + Sync>>,
     sctp_send_buffer_full: Bag<Arc<dyn Fn() + Send + Sync>>,

--- a/rust/src/router/data_producer.rs
+++ b/rust/src/router/data_producer.rs
@@ -95,7 +95,7 @@ pub enum DataProducerType {
     Direct,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 #[non_exhaustive]
@@ -108,7 +108,7 @@ pub struct DataProducerDump {
 }
 
 /// RTC statistics of the data producer.
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[non_exhaustive]
 #[allow(missing_docs)]
@@ -122,6 +122,7 @@ pub struct DataProducerStat {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     transport_close: BagOnce<Box<dyn FnOnce() + Send>>,
     close: BagOnce<Box<dyn FnOnce() + Send>>,

--- a/rust/src/router/direct_transport.rs
+++ b/rust/src/router/direct_transport.rs
@@ -49,7 +49,7 @@ impl Default for DirectTransportOptions {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 #[non_exhaustive]
@@ -110,6 +110,7 @@ pub struct DirectTransportStat {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     rtcp: Bag<Arc<dyn Fn(&[u8]) + Send + Sync>>,
     new_producer: Bag<Arc<dyn Fn(&Producer) + Send + Sync>, Producer>,

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -82,7 +82,7 @@ impl PipeTransportOptions {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 #[non_exhaustive]
@@ -161,6 +161,7 @@ pub struct PipeTransportRemoteParameters {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     new_producer: Bag<Arc<dyn Fn(&Producer) + Send + Sync>, Producer>,
     new_consumer: Bag<Arc<dyn Fn(&Consumer) + Send + Sync>, Consumer>,

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -98,7 +98,7 @@ impl PlainTransportOptions {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 #[non_exhaustive]
@@ -190,6 +190,7 @@ pub struct PlainTransportRemoteParameters {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     new_producer: Bag<Arc<dyn Fn(&Producer) + Send + Sync>, Producer>,
     new_consumer: Bag<Arc<dyn Fn(&Consumer) + Send + Sync>, Consumer>,

--- a/rust/src/router/plain_transport/tests.rs
+++ b/rust/src/router/plain_transport/tests.rs
@@ -24,12 +24,10 @@ async fn init() -> Router {
         .await
         .expect("Failed to create worker");
 
-    let router = worker
+    worker
         .create_router(RouterOptions::default())
         .await
-        .expect("Failed to create router");
-
-    router
+        .expect("Failed to create router")
 }
 
 #[test]

--- a/rust/src/router/producer.rs
+++ b/rust/src/router/producer.rs
@@ -89,7 +89,7 @@ impl ProducerOptions {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 pub struct RtpStreamRecv {
@@ -278,6 +278,7 @@ enum Notification {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     score: Bag<Arc<dyn Fn(&[ProducerScore]) + Send + Sync>>,
     video_orientation_change: Bag<Arc<dyn Fn(ProducerVideoOrientation) + Send + Sync>>,

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -78,7 +78,7 @@ pub enum TransportTraceEventType {
     Bwe,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 pub struct RtpListener {
@@ -101,7 +101,7 @@ pub struct RecvRtpHeaderExtensions {
     transport_wide_cc01: Option<u8>,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 pub struct SctpListener {

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -183,7 +183,7 @@ impl WebRtcTransportOptions {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 #[non_exhaustive]
@@ -258,7 +258,7 @@ pub struct WebRtcTransportStat {
 }
 
 /// Remote parameters for [`WebRtcTransport`].
-#[derive(Debug, Clone, PartialOrd, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, PartialOrd, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct WebRtcTransportRemoteParameters {
     /// Remote DTLS parameters.
@@ -266,6 +266,7 @@ pub struct WebRtcTransportRemoteParameters {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     new_producer: Bag<Arc<dyn Fn(&Producer) + Send + Sync>, Producer>,
     new_consumer: Bag<Arc<dyn Fn(&Consumer) + Send + Sync>, Consumer>,

--- a/rust/src/webrtc_server.rs
+++ b/rust/src/webrtc_server.rs
@@ -59,7 +59,7 @@ pub struct WebRtcServerTupleHash {
     pub webrtc_transport_id: TransportId,
 }
 
-#[derive(Debug, Clone, PartialEq, Deserialize, Serialize)]
+#[derive(Debug, Clone, Eq, PartialEq, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
 #[non_exhaustive]
@@ -151,6 +151,7 @@ impl WebRtcServerOptions {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     new_webrtc_transport: BagOnce<Box<dyn Fn(&WebRtcTransport) + Send>>,
     worker_close: BagOnce<Box<dyn FnOnce() + Send>>,

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -274,6 +274,7 @@ pub enum CreateRouterError {
 }
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     new_router: Bag<Arc<dyn Fn(&Router) + Send + Sync>, Router>,
     new_webrtc_server: Bag<Arc<dyn Fn(&WebRtcServer) + Send + Sync>, WebRtcServer>,

--- a/rust/src/worker/channel.rs
+++ b/rust/src/worker/channel.rs
@@ -37,6 +37,7 @@ pub(super) enum InternalMessage {
     Unexpected(Vec<u8>),
 }
 
+#[allow(clippy::type_complexity)]
 pub(crate) struct BufferMessagesGuard {
     target_id: SubscriptionTarget,
     buffered_notifications_for: Arc<Mutex<HashedMap<SubscriptionTarget, Vec<Vec<u8>>>>>,
@@ -158,6 +159,7 @@ struct OutgoingMessageBuffer {
     messages: VecDeque<Arc<AtomicTake<Vec<u8>>>>,
 }
 
+#[allow(clippy::type_complexity)]
 struct Inner {
     outgoing_message_buffer: Arc<Mutex<OutgoingMessageBuffer>>,
     internal_message_receiver: async_channel::Receiver<InternalMessage>,

--- a/rust/src/worker/utils/channel_write_fn.rs
+++ b/rust/src/worker/utils/channel_write_fn.rs
@@ -4,6 +4,7 @@ pub(super) use mediasoup_sys::{
 use std::os::raw::c_void;
 use std::slice;
 
+#[allow(clippy::type_complexity)]
 pub(super) struct ChannelReadCallback(Box<dyn FnMut(&[u8]) + Send + 'static>);
 
 pub(crate) struct PreparedChannelWrite {
@@ -59,6 +60,7 @@ where
     }
 }
 
+#[allow(clippy::type_complexity)]
 pub(super) struct PayloadChannelReadCallback(Box<dyn FnMut(&[u8], &[u8]) + Send + 'static>);
 
 pub(crate) struct PreparedPayloadChannelWrite {

--- a/rust/src/worker_manager.rs
+++ b/rust/src/worker_manager.rs
@@ -17,6 +17,7 @@ use std::sync::Arc;
 use std::{fmt, io, mem};
 
 #[derive(Default)]
+#[allow(clippy::type_complexity)]
 struct Handlers {
     new_worker: Bag<Arc<dyn Fn(&Worker) + Send + Sync>, Worker>,
 }

--- a/worker/include/RTC/ActiveSpeakerObserver.hpp
+++ b/worker/include/RTC/ActiveSpeakerObserver.hpp
@@ -62,7 +62,7 @@ namespace RTC
 		};
 
 	public:
-		ActiveSpeakerObserver(const std::string& id, json& data);
+		ActiveSpeakerObserver(const std::string& id, RTC::RtpObserver::Listener* listener, json& data);
 		~ActiveSpeakerObserver() override;
 
 	public:

--- a/worker/include/RTC/AudioLevelObserver.hpp
+++ b/worker/include/RTC/AudioLevelObserver.hpp
@@ -20,7 +20,7 @@ namespace RTC
 		};
 
 	public:
-		AudioLevelObserver(const std::string& id, json& data);
+		AudioLevelObserver(const std::string& id, RTC::RtpObserver::Listener* listener, json& data);
 		~AudioLevelObserver() override;
 
 	public:

--- a/worker/include/RTC/DataConsumer.hpp
+++ b/worker/include/RTC/DataConsumer.hpp
@@ -12,6 +12,10 @@
 
 namespace RTC
 {
+	// Define class here such that we can use it even though we don't know what it looks like yet
+	// (this is to avoid circular dependencies).
+	class SctpAssociation;
+
 	class DataConsumer : public Channel::ChannelSocket::RequestHandler,
 	                     public PayloadChannel::PayloadChannelSocket::RequestHandler
 	{
@@ -45,6 +49,7 @@ namespace RTC
 		DataConsumer(
 		  const std::string& id,
 		  const std::string& dataProducerId,
+		  RTC::SctpAssociation* sctpAssociation,
 		  RTC::DataConsumer::Listener* listener,
 		  json& data,
 		  size_t maxMessageSize);
@@ -94,6 +99,7 @@ namespace RTC
 
 	private:
 		// Passed by argument.
+		RTC::SctpAssociation* sctpAssociation{ nullptr };
 		RTC::DataConsumer::Listener* listener{ nullptr };
 		size_t maxMessageSize{ 0u };
 		// Others.

--- a/worker/include/RTC/DirectTransport.hpp
+++ b/worker/include/RTC/DirectTransport.hpp
@@ -40,10 +40,6 @@ namespace RTC
 		/* Methods inherited from PayloadChannel::PayloadChannelSocket::NotificationHandler. */
 	public:
 		void HandleNotification(PayloadChannel::Notification* notification) override;
-
-	private:
-		// Allocated by this.
-		uint8_t* buffer{ nullptr };
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -196,7 +196,8 @@ namespace RTC
 		bool videoOrientationDetected{ false };
 		struct VideoOrientation videoOrientation;
 		struct TraceEventTypes traceEventTypes;
-		uint8_t* buffer{ nullptr };
+		// Static buffer.
+		thread_local static uint8_t* buffer;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -24,6 +24,7 @@ using json = nlohmann::json;
 namespace RTC
 {
 	class Router : public RTC::Transport::Listener,
+	               public RTC::RtpObserver::Listener,
 	               public Channel::ChannelSocket::RequestHandler,
 	               public PayloadChannel::PayloadChannelSocket::RequestHandler,
 	               public PayloadChannel::PayloadChannelSocket::NotificationHandler
@@ -111,6 +112,12 @@ namespace RTC
 		void OnTransportDataConsumerDataProducerClosed(
 		  RTC::Transport* transport, RTC::DataConsumer* dataConsumer) override;
 		void OnTransportListenServerClosed(RTC::Transport* transport) override;
+
+		/* Pure virtual methods inherited from RTC::RtpObserver::Listener. */
+	public:
+		RTC::Producer* RtpObserverGetProducer(RTC::RtpObserver*, const std::string& id) override;
+		void OnRtpObserverAddProducer(RTC::RtpObserver* rtpObserver, RTC::Producer* producer) override;
+		void OnRtpObserverRemoveProducer(RTC::RtpObserver* rtpObserver, RTC::Producer* producer) override;
 
 	public:
 		// Passed by argument.

--- a/worker/include/RTC/RtpObserver.hpp
+++ b/worker/include/RTC/RtpObserver.hpp
@@ -11,7 +11,21 @@ namespace RTC
 	class RtpObserver : public Channel::ChannelSocket::RequestHandler
 	{
 	public:
-		RtpObserver(const std::string& id);
+		class Listener
+		{
+		public:
+			virtual ~Listener() = default;
+
+		public:
+			virtual RTC::Producer* RtpObserverGetProducer(
+			  RTC::RtpObserver* rtpObserver, const std::string& id) = 0;
+			virtual void OnRtpObserverAddProducer(RTC::RtpObserver* rtpObserver, RTC::Producer* producer) = 0;
+			virtual void OnRtpObserverRemoveProducer(
+			  RTC::RtpObserver* rtpObserver, RTC::Producer* producer) = 0;
+		};
+
+	public:
+		RtpObserver(const std::string& id, RTC::RtpObserver::Listener* listener);
 		virtual ~RtpObserver();
 
 	public:
@@ -35,9 +49,13 @@ namespace RTC
 		virtual void Paused()  = 0;
 		virtual void Resumed() = 0;
 
+	private:
+		std::string GetProducerIdFromData(json& data) const;
+
 	public:
 		// Passed by argument.
 		const std::string id;
+		RTC::RtpObserver::Listener* listener{ nullptr };
 
 	private:
 		// Others.

--- a/worker/include/RTC/RtpObserver.hpp
+++ b/worker/include/RTC/RtpObserver.hpp
@@ -8,7 +8,7 @@
 
 namespace RTC
 {
-	class RtpObserver
+	class RtpObserver : public Channel::ChannelSocket::RequestHandler
 	{
 	public:
 		RtpObserver(const std::string& id);
@@ -26,6 +26,10 @@ namespace RTC
 		virtual void ReceiveRtpPacket(RTC::Producer* producer, RTC::RtpPacket* packet) = 0;
 		virtual void ProducerPaused(RTC::Producer* producer)                           = 0;
 		virtual void ProducerResumed(RTC::Producer* producer)                          = 0;
+
+		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
+	public:
+		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	protected:
 		virtual void Paused()  = 0;

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -223,6 +223,10 @@ namespace RTC
 
 		/* Pure virtual methods inherited from RTC::DataProducer::Listener. */
 	public:
+		void OnDataProducerReceiveData(RTC::DataProducer* /*dataProducer*/, size_t len) override
+		{
+			this->DataReceived(len);
+		}
 		void OnDataProducerMessageReceived(
 		  RTC::DataProducer* dataProducer, uint32_t ppid, const uint8_t* msg, size_t len) override;
 

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -191,6 +191,14 @@ namespace RTC
 
 		/* Pure virtual methods inherited from RTC::Producer::Listener. */
 	public:
+		void OnProducerReceiveData(RTC::Producer* /*producer*/, size_t len) override
+		{
+			this->DataReceived(len);
+		}
+		void OnProducerReceiveRtpPacket(RTC::Producer* /*producer*/, RTC::RtpPacket* packet) override
+		{
+			this->ReceiveRtpPacket(packet);
+		}
 		void OnProducerPaused(RTC::Producer* producer) override;
 		void OnProducerResumed(RTC::Producer* producer) override;
 		void OnProducerNewRtpStream(

--- a/worker/src/RTC/ActiveSpeakerObserver.cpp
+++ b/worker/src/RTC/ActiveSpeakerObserver.cpp
@@ -92,8 +92,9 @@ namespace RTC
 		return changed;
 	}
 
-	ActiveSpeakerObserver::ActiveSpeakerObserver(const std::string& id, json& data)
-	  : RTC::RtpObserver(id)
+	ActiveSpeakerObserver::ActiveSpeakerObserver(
+	  const std::string& id, RTC::RtpObserver::Listener* listener, json& data)
+	  : RTC::RtpObserver(id, listener)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/AudioLevelObserver.cpp
+++ b/worker/src/RTC/AudioLevelObserver.cpp
@@ -14,7 +14,9 @@ namespace RTC
 {
 	/* Instance methods. */
 
-	AudioLevelObserver::AudioLevelObserver(const std::string& id, json& data) : RTC::RtpObserver(id)
+	AudioLevelObserver::AudioLevelObserver(
+	  const std::string& id, RTC::RtpObserver::Listener* listener, json& data)
+	  : RTC::RtpObserver(id, listener)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -102,32 +102,7 @@ namespace RTC
 				// This may throw.
 				RTC::DataProducer* dataProducer = GetDataProducerFromInternal(notification->internal);
 
-				auto jsonPpidIt = notification->data.find("ppid");
-
-				if (jsonPpidIt == notification->data.end() || !Utils::Json::IsPositiveInteger(*jsonPpidIt))
-				{
-					MS_THROW_TYPE_ERROR("invalid ppid");
-				}
-
-				auto ppid       = jsonPpidIt->get<uint32_t>();
-				const auto* msg = notification->payload;
-				auto len        = notification->payloadLen;
-
-				if (len > this->maxMessageSize)
-				{
-					MS_WARN_TAG(
-					  message,
-					  "given message exceeds maxMessageSize value [maxMessageSize:%zu, len:%zu]",
-					  len,
-					  this->maxMessageSize);
-
-					return;
-				}
-
-				dataProducer->ReceiveMessage(ppid, msg, len);
-
-				// Increase receive transmission.
-				RTC::Transport::DataReceived(len);
+				dataProducer->HandleNotification(notification);
 
 				break;
 			}

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -20,8 +20,6 @@ namespace RTC
 	DirectTransport::~DirectTransport()
 	{
 		MS_TRACE();
-
-		delete[] this->buffer;
 	}
 
 	void DirectTransport::FillJson(json& jsonObject) const
@@ -91,37 +89,10 @@ namespace RTC
 
 			case PayloadChannel::Notification::EventId::PRODUCER_SEND:
 			{
-				const auto* data = notification->payload;
-				auto len         = notification->payloadLen;
+				// This may throw.
+				RTC::Producer* producer = GetProducerFromInternal(notification->internal);
 
-				// Increase receive transmission.
-				RTC::Transport::DataReceived(len);
-
-				if (len > RTC::MtuSize + 100)
-				{
-					MS_WARN_TAG(rtp, "given RTP packet exceeds maximum size [len:%zu]", len);
-
-					return;
-				}
-
-				// If this is the first time to reveive a RTP packet then allocate the receiving buffer now.
-				if (!this->buffer)
-					this->buffer = new uint8_t[RTC::MtuSize + 100];
-
-				// Copy the received packet into this buffer so it can be expanded later.
-				std::memcpy(this->buffer, data, static_cast<size_t>(len));
-
-				RTC::RtpPacket* packet = RTC::RtpPacket::Parse(this->buffer, len);
-
-				if (!packet)
-				{
-					MS_WARN_TAG(rtp, "received data is not a valid RTP packet");
-
-					return;
-				}
-
-				// Pass the packet to the parent transport.
-				RTC::Transport::ReceiveRtpPacket(packet);
+				producer->HandleNotification(notification);
 
 				break;
 			}

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -332,6 +332,8 @@ namespace RTC
 
 		// Delete the KeyFrameRequestManager.
 		delete this->keyFrameRequestManager;
+
+		delete[] this->buffer;
 	}
 
 	void Producer::FillJson(json& jsonObject) const
@@ -601,6 +603,56 @@ namespace RTC
 			default:
 			{
 				MS_THROW_ERROR("unknown method '%s'", request->method.c_str());
+			}
+		}
+	}
+
+	void Producer::HandleNotification(PayloadChannel::Notification* notification)
+	{
+		MS_TRACE();
+
+		switch (notification->eventId)
+		{
+			case PayloadChannel::Notification::EventId::PRODUCER_SEND:
+			{
+				const auto* data = notification->payload;
+				auto len         = notification->payloadLen;
+
+				// Increase receive transmission.
+				this->listener->OnProducerReceiveData(this, len);
+
+				if (len > RTC::MtuSize + 100)
+				{
+					MS_WARN_TAG(rtp, "given RTP packet exceeds maximum size [len:%zu]", len);
+
+					break;
+				}
+
+				// If this is the first time to receive a RTP packet then allocate the receiving buffer now.
+				if (!this->buffer)
+					this->buffer = new uint8_t[RTC::MtuSize + 100];
+
+				// Copy the received packet into this buffer so it can be expanded later.
+				std::memcpy(this->buffer, data, static_cast<size_t>(len));
+
+				RTC::RtpPacket* packet = RTC::RtpPacket::Parse(this->buffer, len);
+
+				if (!packet)
+				{
+					MS_WARN_TAG(rtp, "received data is not a valid RTP packet");
+
+					break;
+				}
+
+				// Pass the packet to the parent transport.
+				this->listener->OnProducerReceiveRtpPacket(this, packet);
+
+				break;
+			}
+
+			default:
+			{
+				MS_ERROR("unknown event '%s'", notification->event.c_str());
 			}
 		}
 	}

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -18,6 +18,10 @@
 
 namespace RTC
 {
+	/* Static variables. */
+
+	thread_local uint8_t* Producer::buffer{ nullptr };
+
 	/* Static. */
 
 	static constexpr unsigned int SendNackDelay{ 10u }; // In ms.
@@ -332,8 +336,6 @@ namespace RTC
 
 		// Delete the KeyFrameRequestManager.
 		delete this->keyFrameRequestManager;
-
-		delete[] this->buffer;
 	}
 
 	void Producer::FillJson(json& jsonObject) const
@@ -629,13 +631,13 @@ namespace RTC
 				}
 
 				// If this is the first time to receive a RTP packet then allocate the receiving buffer now.
-				if (!this->buffer)
-					this->buffer = new uint8_t[RTC::MtuSize + 100];
+				if (!Producer::buffer)
+					Producer::buffer = new uint8_t[RTC::MtuSize + 100];
 
 				// Copy the received packet into this buffer so it can be expanded later.
-				std::memcpy(this->buffer, data, static_cast<size_t>(len));
+				std::memcpy(Producer::buffer, data, static_cast<size_t>(len));
 
-				RTC::RtpPacket* packet = RTC::RtpPacket::Parse(this->buffer, len);
+				RTC::RtpPacket* packet = RTC::RtpPacket::Parse(Producer::buffer, len);
 
 				if (!packet)
 				{

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -445,25 +445,12 @@ namespace RTC
 			}
 
 			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_PAUSE:
-			{
-				// This may throw.
-				RTC::RtpObserver* rtpObserver = GetRtpObserverFromInternal(request->internal);
-
-				rtpObserver->Pause();
-
-				request->Accept();
-
-				break;
-			}
-
 			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_RESUME:
 			{
 				// This may throw.
 				RTC::RtpObserver* rtpObserver = GetRtpObserverFromInternal(request->internal);
 
-				rtpObserver->Resume();
-
-				request->Accept();
+				rtpObserver->HandleRequest(request);
 
 				break;
 			}

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -1085,6 +1085,7 @@ namespace RTC
 		// Add to the map.
 		this->mapProducerRtpObservers[producer].insert(rtpObserver);
 	}
+
 	void Router::OnRtpObserverRemoveProducer(RTC::RtpObserver* rtpObserver, RTC::Producer* producer)
 	{
 		// Remove from the map.

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -365,7 +365,8 @@ namespace RTC
 				// This may throw.
 				SetNewRtpObserverIdFromInternal(request->internal, rtpObserverId);
 
-				auto* activeSpeakerObserver = new RTC::ActiveSpeakerObserver(rtpObserverId, request->data);
+				auto* activeSpeakerObserver =
+				  new RTC::ActiveSpeakerObserver(rtpObserverId, this, request->data);
 
 				// Insert into the map.
 				this->mapRtpObservers[rtpObserverId] = activeSpeakerObserver;
@@ -384,7 +385,7 @@ namespace RTC
 				// This may throw
 				SetNewRtpObserverIdFromInternal(request->internal, rtpObserverId);
 
-				auto* audioLevelObserver = new RTC::AudioLevelObserver(rtpObserverId, request->data);
+				auto* audioLevelObserver = new RTC::AudioLevelObserver(rtpObserverId, this, request->data);
 
 				// Insert into the map.
 				this->mapRtpObservers[rtpObserverId] = audioLevelObserver;
@@ -446,43 +447,13 @@ namespace RTC
 
 			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_PAUSE:
 			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_RESUME:
+			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_ADD_PRODUCER:
+			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_REMOVE_PRODUCER:
 			{
 				// This may throw.
 				RTC::RtpObserver* rtpObserver = GetRtpObserverFromInternal(request->internal);
 
 				rtpObserver->HandleRequest(request);
-
-				break;
-			}
-
-			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_ADD_PRODUCER:
-			{
-				// This may throw.
-				RTC::RtpObserver* rtpObserver = GetRtpObserverFromInternal(request->internal);
-				RTC::Producer* producer       = GetProducerFromData(request->data);
-
-				rtpObserver->AddProducer(producer);
-
-				// Add to the map.
-				this->mapProducerRtpObservers[producer].insert(rtpObserver);
-
-				request->Accept();
-
-				break;
-			}
-
-			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_REMOVE_PRODUCER:
-			{
-				// This may throw.
-				RTC::RtpObserver* rtpObserver = GetRtpObserverFromInternal(request->internal);
-				RTC::Producer* producer       = GetProducerFromData(request->data);
-
-				rtpObserver->RemoveProducer(producer);
-
-				// Remove from the map.
-				this->mapProducerRtpObservers[producer].erase(rtpObserver);
-
-				request->Accept();
 
 				break;
 			}
@@ -1107,5 +1078,29 @@ namespace RTC
 
 		// Delete it.
 		delete transport;
+	}
+
+	void Router::OnRtpObserverAddProducer(RTC::RtpObserver* rtpObserver, RTC::Producer* producer)
+	{
+		// Add to the map.
+		this->mapProducerRtpObservers[producer].insert(rtpObserver);
+	}
+	void Router::OnRtpObserverRemoveProducer(RTC::RtpObserver* rtpObserver, RTC::Producer* producer)
+	{
+		// Remove from the map.
+		this->mapProducerRtpObservers[producer].erase(rtpObserver);
+	}
+
+	RTC::Producer* Router::RtpObserverGetProducer(
+	  RTC::RtpObserver* /* rtpObserver */, const std::string& id)
+	{
+		auto it = this->mapProducers.find(id);
+
+		if (it == this->mapProducers.end())
+			MS_THROW_ERROR("Producer not found");
+
+		RTC::Producer* producer = it->second;
+
+		return producer;
 	}
 } // namespace RTC

--- a/worker/src/RTC/RtpObserver.cpp
+++ b/worker/src/RTC/RtpObserver.cpp
@@ -3,6 +3,7 @@
 
 #include "RTC/RtpObserver.hpp"
 #include "Logger.hpp"
+#include "MediaSoupErrors.hpp"
 
 namespace RTC
 {
@@ -16,6 +17,37 @@ namespace RTC
 	RtpObserver::~RtpObserver()
 	{
 		MS_TRACE();
+	}
+
+	void RtpObserver::HandleRequest(Channel::ChannelRequest* request)
+	{
+		MS_TRACE();
+
+		switch (request->methodId)
+		{
+			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_PAUSE:
+			{
+				this->Pause();
+
+				request->Accept();
+
+				break;
+			}
+
+			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_RESUME:
+			{
+				this->Resume();
+
+				request->Accept();
+
+				break;
+			}
+
+			default:
+			{
+				MS_THROW_ERROR("unknown method '%s'", request->method.c_str());
+			}
+		}
 	}
 
 	void RtpObserver::Pause()

--- a/worker/src/RTC/RtpObserver.cpp
+++ b/worker/src/RTC/RtpObserver.cpp
@@ -9,7 +9,8 @@ namespace RTC
 {
 	/* Instance methods. */
 
-	RtpObserver::RtpObserver(const std::string& id) : id(id)
+	RtpObserver::RtpObserver(const std::string& id, RTC::RtpObserver::Listener* listener)
+	  : id(id), listener(listener)
 	{
 		MS_TRACE();
 	}
@@ -37,6 +38,37 @@ namespace RTC
 			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_RESUME:
 			{
 				this->Resume();
+
+				request->Accept();
+
+				break;
+			}
+
+			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_ADD_PRODUCER:
+			{
+				// This may throw.
+				auto producerId         = GetProducerIdFromData(request->data);
+				RTC::Producer* producer = this->listener->RtpObserverGetProducer(this, producerId);
+
+				this->AddProducer(producer);
+
+				this->listener->OnRtpObserverAddProducer(this, producer);
+
+				request->Accept();
+
+				break;
+			}
+
+			case Channel::ChannelRequest::MethodId::RTP_OBSERVER_REMOVE_PRODUCER:
+			{
+				// This may throw.
+				auto producerId         = GetProducerIdFromData(request->data);
+				RTC::Producer* producer = this->listener->RtpObserverGetProducer(this, producerId);
+
+				this->RemoveProducer(producer);
+
+				// Remove from the map.
+				this->listener->OnRtpObserverRemoveProducer(this, producer);
 
 				request->Accept();
 
@@ -72,5 +104,17 @@ namespace RTC
 		this->paused = false;
 
 		Resumed();
+	}
+
+	std::string RtpObserver::GetProducerIdFromData(json& data) const
+	{
+		MS_TRACE();
+
+		auto jsonRouterIdIt = data.find("producerId");
+
+		if (jsonRouterIdIt == data.end() || !jsonRouterIdIt->is_string())
+			MS_THROW_ERROR("missing data.producerId");
+
+		return jsonRouterIdIt->get<std::string>();
 	}
 } // namespace RTC

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1197,7 +1197,7 @@ namespace RTC
 
 				// This may throw.
 				auto* dataConsumer = new RTC::DataConsumer(
-				  dataConsumerId, dataProducerId, this, request->data, this->maxMessageSize);
+				  dataConsumerId, dataProducerId, this->sctpAssociation, this, request->data, this->maxMessageSize);
 
 				// Verify the type of the DataConsumer.
 				switch (dataConsumer->GetType())
@@ -1486,49 +1486,11 @@ namespace RTC
 
 			case Channel::ChannelRequest::MethodId::DATA_CONSUMER_DUMP:
 			case Channel::ChannelRequest::MethodId::DATA_CONSUMER_GET_STATS:
-			{
-				// This may throw.
-				RTC::DataConsumer* dataConsumer = GetDataConsumerFromInternal(request->internal);
-
-				dataConsumer->HandleRequest(request);
-
-				break;
-			}
-
 			case Channel::ChannelRequest::MethodId::DATA_CONSUMER_GET_BUFFERED_AMOUNT:
-			{
-				// This may throw.
-				RTC::DataConsumer* dataConsumer = GetDataConsumerFromInternal(request->internal);
-
-				if (dataConsumer->GetType() != RTC::DataConsumer::Type::SCTP)
-				{
-					MS_THROW_TYPE_ERROR("invalid DataConsumer type");
-				}
-
-				if (!this->sctpAssociation)
-				{
-					MS_THROW_ERROR("no SCTP association present");
-				}
-
-				// Create status response.
-				json data = json::object();
-
-				data["bufferedAmount"] = this->sctpAssociation->GetSctpBufferedAmount();
-
-				request->Accept(data);
-
-				break;
-			}
-
 			case Channel::ChannelRequest::MethodId::DATA_CONSUMER_SET_BUFFERED_AMOUNT_LOW_THRESHOLD:
 			{
 				// This may throw.
 				RTC::DataConsumer* dataConsumer = GetDataConsumerFromInternal(request->internal);
-
-				if (dataConsumer->GetType() != RTC::DataConsumer::Type::SCTP)
-				{
-					MS_THROW_TYPE_ERROR("invalid DataConsumer type");
-				}
 
 				dataConsumer->HandleRequest(request);
 
@@ -1552,16 +1514,6 @@ namespace RTC
 			{
 				// This may throw.
 				RTC::DataConsumer* dataConsumer = GetDataConsumerFromInternal(request->internal);
-
-				if (dataConsumer->GetType() != RTC::DataConsumer::Type::SCTP)
-				{
-					MS_THROW_TYPE_ERROR("invalid DataConsumer type");
-				}
-
-				if (!this->sctpAssociation)
-				{
-					MS_THROW_ERROR("no SCTP association present");
-				}
 
 				dataConsumer->HandleRequest(request);
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1092,7 +1092,8 @@ namespace RTC
 				SetNewDataProducerIdFromInternal(request->internal, dataProducerId);
 
 				// This may throw.
-				auto* dataProducer = new RTC::DataProducer(dataProducerId, this, request->data);
+				auto* dataProducer =
+				  new RTC::DataProducer(dataProducerId, this->maxMessageSize, this, request->data);
 
 				// Verify the type of the DataProducer.
 				switch (dataProducer->GetType())


### PR DESCRIPTION
This is another refactoring that essentially changes nothing, just moves message handling logic from `Router` and `*Transport` to entities that are actually responsible for handling them.

Reviewing commit by commit should make sense.

I think is the last PR that does refactoring, next PR will actually deal with `internal`, but I had to prepare things for that PR to be managable.

Hm, this PR is based on #880, ignore the first commit here.