### PR TITLE
Update OSs used in CI

### DIFF
--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -11,9 +11,8 @@ jobs:
       matrix:
         os:
           - ubuntu-20.04
-          - macos-10.15
-          - macos-11
-          - windows-2019
+          - ubuntu-22.04
+          - macos-12
           - windows-2022
         rust:
           - stable

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -20,21 +20,18 @@ jobs:
           - os: ubuntu-20.04
             cc: clang
             cxx: clang++
-          - os: macos-10.15
+          - os: ubuntu-22.04
             cc: gcc
             cxx: g++
-          - os: macos-10.15
+          - os: ubuntu-22.04
             cc: clang
             cxx: clang++
-          - os: macos-11
+          - os: macos-12
             cc: gcc
             cxx: g++
-          - os: macos-11
+          - os: macos-12
             cc: clang
             cxx: clang++
-          - os: windows-2019
-            cc: cl
-            cxx: cl
           - os: windows-2022
             cc: cl
             cxx: cl


### PR DESCRIPTION
macOS and Windows are not used for production (I think), so testing just latest version is fine. Testing 3 latest Ubuntu versions is important though.

This both reduces number of jobs we'll have and makes them more relevant.