### PR TITLE
Fix Rust support after recent changes

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.11.0
+
+* Updates from mediasoup TypeScript `3.10.2..=3.10.6`.
+
 # 0.10.0
 
 * Updates from mediasoup TypeScript `3.9.10..=3.10.1`.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup"
-version = "0.10.0"
+version = "0.11.0"
 description = "Cutting Edge WebRTC Video Conferencing in Rust"
 categories = ["api-bindings", "multimedia", "network-programming"]
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
@@ -21,61 +21,61 @@ default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
 [dependencies]
-async-channel = "1.6.1"
+async-channel = "1.7.1"
 async-executor = "1.4.1"
-async-lock = "2.4.0"
+async-lock = "2.5.0"
 async-oneshot = "0.5.0"
-async-trait = "0.1.51"
+async-trait = "0.1.57"
 atomic-take = "1.0.0"
 event-listener-primitives = "2.0.1"
-fastrand = "1.5.0"
+fastrand = "1.8.0"
 futures-lite = "1.12.0"
 h264-profile-level-id = "0.1.1"
 hash_hasher = "2.0.3"
-log = "0.4.14"
+log = "0.4.17"
 nohash-hasher = "0.2.0"
-once_cell = "1.8.0"
-serde_json = "1.0.67"
-serde_repr = "0.1.7"
-thiserror = "1.0.28"
+once_cell = "1.13.1"
+serde_json = "1.0.85"
+serde_repr = "0.1.9"
+thiserror = "1.0.32"
 
 [dependencies.lru]
 default-features = false
-version = "0.7.2"
+version = "0.7.8"
 
 [dependencies.mediasoup-sys]
 path = "../worker"
-version = "0.4.0"
+version = "0.5.0"
 
 [dependencies.parking_lot]
-version = "0.11.2"
+version = "0.12.1"
 features = ["serde"]
 
 [dependencies.regex]
 default-features = false
 features = ["std", "perf"]
-version = "1.5.4"
+version = "1.6.0"
 
 [dependencies.serde]
 features = ["derive"]
-version = "1.0.130"
+version = "1.0.144"
 
 [dependencies.uuid]
 features = ["serde", "v4"]
-version = "0.8.2"
+version = "1.1.2"
 
 [dev-dependencies]
 actix = "0.13.0"
 actix-web-actors = "4.1.0"
-async-io = "1.6.0"
-criterion = "0.3.5"
+async-io = "1.8.0"
+criterion = "0.3.6"
 env_logger = "0.9.0"
 portpicker = "0.1.1"
 
 [dev-dependencies.actix-web]
 default-features = false
 features = ["macros"]
-version = "4.0.1"
+version = "4.1.0"
 
 [[bench]]
 name = "direct_data"

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -31,13 +31,12 @@ use crate::data_producer::{
 use crate::data_structures::{AppData, ListenIp};
 use crate::direct_transport::{DirectTransport, DirectTransportOptions};
 use crate::messages::{
-    RouterCloseRequest, RouterCloseRequestData, RouterCreateActiveSpeakerObserverData,
+    RouterCloseRequest, RouterCreateActiveSpeakerObserverData,
     RouterCreateActiveSpeakerObserverRequest, RouterCreateAudioLevelObserverData,
     RouterCreateAudioLevelObserverRequest, RouterCreateDirectTransportData,
     RouterCreateDirectTransportRequest, RouterCreatePipeTransportData,
     RouterCreatePipeTransportRequest, RouterCreatePlainTransportData,
-    RouterCreatePlainTransportRequest, RouterCreateWebrtcTransportData,
-    RouterCreateWebrtcTransportRequest, RouterDumpRequest,
+    RouterCreatePlainTransportRequest, RouterCreateWebrtcTransportRequest, RouterDumpRequest,
 };
 use crate::pipe_transport::{
     PipeTransport, PipeTransportOptions, PipeTransportRemoteParameters, WeakPipeTransport,
@@ -397,12 +396,10 @@ impl Inner {
 
             {
                 let channel = self.channel.clone();
-                let request = RouterCloseRequest {
-                    data: RouterCloseRequestData { router_id: self.id },
-                };
+                let request = RouterCloseRequest { router_id: self.id };
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(request).await {
+                        if let Err(error) = channel.request("", request).await {
                             error!("router closing failed on drop: {}", error);
                         }
                     })
@@ -535,9 +532,7 @@ impl Router {
 
         self.inner
             .channel
-            .request(RouterDumpRequest {
-                handler_id: self.inner.id,
-            })
+            .request(self.inner.id, RouterDumpRequest {})
             .await
     }
 
@@ -566,13 +561,15 @@ impl Router {
 
         self.inner
             .channel
-            .request(RouterCreateDirectTransportRequest {
-                handler_id: self.inner.id,
-                data: RouterCreateDirectTransportData::from_options(
-                    transport_id,
-                    &direct_transport_options,
-                ),
-            })
+            .request(
+                self.inner.id,
+                RouterCreateDirectTransportRequest {
+                    data: RouterCreateDirectTransportData::from_options(
+                        transport_id,
+                        &direct_transport_options,
+                    ),
+                },
+            )
             .await?;
 
         let transport = DirectTransport::new(
@@ -627,13 +624,13 @@ impl Router {
         let data = self
             .inner
             .channel
-            .request(RouterCreateWebrtcTransportRequest {
-                handler_id: self.inner.id,
-                data: RouterCreateWebrtcTransportData::from_options(
+            .request(
+                self.inner.id,
+                RouterCreateWebrtcTransportRequest::from_options(
                     transport_id,
                     &webrtc_transport_options,
                 ),
-            })
+            )
             .await?;
 
         let transport = WebRtcTransport::new(
@@ -691,13 +688,15 @@ impl Router {
         let data = self
             .inner
             .channel
-            .request(RouterCreatePipeTransportRequest {
-                handler_id: self.inner.id,
-                data: RouterCreatePipeTransportData::from_options(
-                    transport_id,
-                    &pipe_transport_options,
-                ),
-            })
+            .request(
+                self.inner.id,
+                RouterCreatePipeTransportRequest {
+                    data: RouterCreatePipeTransportData::from_options(
+                        transport_id,
+                        &pipe_transport_options,
+                    ),
+                },
+            )
             .await?;
 
         let transport = PipeTransport::new(
@@ -751,13 +750,15 @@ impl Router {
         let data = self
             .inner
             .channel
-            .request(RouterCreatePlainTransportRequest {
-                handler_id: self.inner.id,
-                data: RouterCreatePlainTransportData::from_options(
-                    transport_id,
-                    &plain_transport_options,
-                ),
-            })
+            .request(
+                self.inner.id,
+                RouterCreatePlainTransportRequest {
+                    data: RouterCreatePlainTransportData::from_options(
+                        transport_id,
+                        &plain_transport_options,
+                    ),
+                },
+            )
             .await?;
 
         let transport = PlainTransport::new(
@@ -816,13 +817,15 @@ impl Router {
 
         self.inner
             .channel
-            .request(RouterCreateAudioLevelObserverRequest {
-                handler_id: self.inner.id,
-                data: RouterCreateAudioLevelObserverData::from_options(
-                    rtp_observer_id,
-                    &audio_level_observer_options,
-                ),
-            })
+            .request(
+                self.inner.id,
+                RouterCreateAudioLevelObserverRequest {
+                    data: RouterCreateAudioLevelObserverData::from_options(
+                        rtp_observer_id,
+                        &audio_level_observer_options,
+                    ),
+                },
+            )
             .await?;
 
         let audio_level_observer = AudioLevelObserver::new(
@@ -874,13 +877,15 @@ impl Router {
 
         self.inner
             .channel
-            .request(RouterCreateActiveSpeakerObserverRequest {
-                handler_id: self.inner.id,
-                data: RouterCreateActiveSpeakerObserverData::from_options(
-                    rtp_observer_id,
-                    &active_speaker_observer_options,
-                ),
-            })
+            .request(
+                self.inner.id,
+                RouterCreateActiveSpeakerObserverRequest {
+                    data: RouterCreateActiveSpeakerObserverData::from_options(
+                        rtp_observer_id,
+                        &active_speaker_observer_options,
+                    ),
+                },
+            )
             .await?;
 
         let active_speaker_observer = ActiveSpeakerObserver::new(

--- a/rust/src/router/audio_level_observer.rs
+++ b/rust/src/router/audio_level_observer.rs
@@ -3,8 +3,7 @@ mod tests;
 
 use crate::data_structures::AppData;
 use crate::messages::{
-    RtpObserverAddProducerRequest, RtpObserverAddRemoveProducerRequestData,
-    RtpObserverCloseRequest, RtpObserverCloseRequestData, RtpObserverPauseRequest,
+    RtpObserverAddProducerRequest, RtpObserverCloseRequest, RtpObserverPauseRequest,
     RtpObserverRemoveProducerRequest, RtpObserverResumeRequest,
 };
 use crate::producer::{Producer, ProducerId};
@@ -119,16 +118,14 @@ impl Inner {
 
             if close_request {
                 let channel = self.channel.clone();
+                let router_id = self.router.id();
                 let request = RtpObserverCloseRequest {
-                    handler_id: self.router.id(),
-                    data: RtpObserverCloseRequestData {
-                        rtp_observer_id: self.id,
-                    },
+                    rtp_observer_id: self.id,
                 };
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(request).await {
+                        if let Err(error) = channel.request(router_id, request).await {
                             error!("audio level observer closing failed on drop: {}", error);
                         }
                     })
@@ -189,9 +186,7 @@ impl RtpObserver for AudioLevelObserver {
 
         self.inner
             .channel
-            .request(RtpObserverPauseRequest {
-                handler_id: self.id(),
-            })
+            .request(self.id(), RtpObserverPauseRequest {})
             .await?;
 
         let was_paused = self.inner.paused.swap(true, Ordering::SeqCst);
@@ -208,9 +203,7 @@ impl RtpObserver for AudioLevelObserver {
 
         self.inner
             .channel
-            .request(RtpObserverResumeRequest {
-                handler_id: self.id(),
-            })
+            .request(self.id(), RtpObserverResumeRequest {})
             .await?;
 
         let was_paused = self.inner.paused.swap(false, Ordering::SeqCst);
@@ -234,10 +227,7 @@ impl RtpObserver for AudioLevelObserver {
         };
         self.inner
             .channel
-            .request(RtpObserverAddProducerRequest {
-                handler_id: self.id(),
-                data: RtpObserverAddRemoveProducerRequestData { producer_id },
-            })
+            .request(self.id(), RtpObserverAddProducerRequest { producer_id })
             .await?;
 
         self.inner.handlers.add_producer.call_simple(&producer);
@@ -254,10 +244,7 @@ impl RtpObserver for AudioLevelObserver {
         };
         self.inner
             .channel
-            .request(RtpObserverRemoveProducerRequest {
-                handler_id: self.id(),
-                data: RtpObserverAddRemoveProducerRequestData { producer_id },
-            })
+            .request(self.id(), RtpObserverRemoveProducerRequest { producer_id })
             .await?;
 
         self.inner.handlers.remove_producer.call_simple(&producer);

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -3,10 +3,9 @@ mod tests;
 
 use crate::data_structures::{AppData, RtpPacketTraceInfo, SsrcTraceInfo, TraceEventDirection};
 use crate::messages::{
-    ConsumerCloseRequest, ConsumerCloseRequestData, ConsumerDumpRequest,
-    ConsumerEnableTraceEventData, ConsumerEnableTraceEventRequest, ConsumerGetStatsRequest,
-    ConsumerPauseRequest, ConsumerRequestKeyFrameRequest, ConsumerResumeRequest,
-    ConsumerSetPreferredLayersRequest, ConsumerSetPriorityData, ConsumerSetPriorityRequest,
+    ConsumerCloseRequest, ConsumerDumpRequest, ConsumerEnableTraceEventRequest,
+    ConsumerGetStatsRequest, ConsumerPauseRequest, ConsumerRequestKeyFrameRequest,
+    ConsumerResumeRequest, ConsumerSetPreferredLayersRequest, ConsumerSetPriorityRequest,
 };
 use crate::producer::{Producer, ProducerId, ProducerStat, ProducerType, WeakProducer};
 use crate::rtp_parameters::{MediaKind, MimeType, RtpCapabilities, RtpParameters};
@@ -404,18 +403,16 @@ impl Inner {
 
             if close_request {
                 let channel = self.channel.clone();
+                let transport_id = self.transport.id();
                 let request = ConsumerCloseRequest {
-                    handler_id: self.transport.id(),
-                    data: ConsumerCloseRequestData {
-                        consumer_id: self.id,
-                    },
+                    consumer_id: self.id,
                 };
                 let weak_producer = self.weak_producer.clone();
 
                 self.executor
                     .spawn(async move {
                         if weak_producer.upgrade().is_some() {
-                            if let Err(error) = channel.request(request).await {
+                            if let Err(error) = channel.request(transport_id, request).await {
                                 error!("consumer closing failed on drop: {}", error);
                             }
                         }
@@ -715,9 +712,7 @@ impl Consumer {
 
         self.inner
             .channel
-            .request(ConsumerDumpRequest {
-                handler_id: self.id(),
-            })
+            .request(self.id(), ConsumerDumpRequest {})
             .await
     }
 
@@ -730,9 +725,7 @@ impl Consumer {
 
         self.inner
             .channel
-            .request(ConsumerGetStatsRequest {
-                handler_id: self.id(),
-            })
+            .request(self.id(), ConsumerGetStatsRequest {})
             .await
     }
 
@@ -742,9 +735,7 @@ impl Consumer {
 
         self.inner
             .channel
-            .request(ConsumerPauseRequest {
-                handler_id: self.id(),
-            })
+            .request(self.id(), ConsumerPauseRequest {})
             .await?;
 
         let mut paused = self.inner.paused.lock();
@@ -764,9 +755,7 @@ impl Consumer {
 
         self.inner
             .channel
-            .request(ConsumerResumeRequest {
-                handler_id: self.id(),
-            })
+            .request(self.id(), ConsumerResumeRequest {})
             .await?;
 
         let mut paused = self.inner.paused.lock();
@@ -791,10 +780,12 @@ impl Consumer {
         let consumer_layers = self
             .inner
             .channel
-            .request(ConsumerSetPreferredLayersRequest {
-                handler_id: self.id(),
-                data: consumer_layers,
-            })
+            .request(
+                self.id(),
+                ConsumerSetPreferredLayersRequest {
+                    data: consumer_layers,
+                },
+            )
             .await?;
 
         *self.inner.preferred_layers.lock() = consumer_layers;
@@ -811,10 +802,7 @@ impl Consumer {
         let result = self
             .inner
             .channel
-            .request(ConsumerSetPriorityRequest {
-                handler_id: self.id(),
-                data: ConsumerSetPriorityData { priority },
-            })
+            .request(self.id(), ConsumerSetPriorityRequest { priority })
             .await?;
 
         *self.inner.priority.lock() = result.priority;
@@ -831,10 +819,7 @@ impl Consumer {
         let result = self
             .inner
             .channel
-            .request(ConsumerSetPriorityRequest {
-                handler_id: self.id(),
-                data: ConsumerSetPriorityData { priority },
-            })
+            .request(self.id(), ConsumerSetPriorityRequest { priority })
             .await?;
 
         *self.inner.priority.lock() = result.priority;
@@ -848,9 +833,7 @@ impl Consumer {
 
         self.inner
             .channel
-            .request(ConsumerRequestKeyFrameRequest {
-                handler_id: self.id(),
-            })
+            .request(self.id(), ConsumerRequestKeyFrameRequest {})
             .await
     }
 
@@ -863,10 +846,7 @@ impl Consumer {
 
         self.inner
             .channel
-            .request(ConsumerEnableTraceEventRequest {
-                handler_id: self.id(),
-                data: ConsumerEnableTraceEventData { types },
-            })
+            .request(self.id(), ConsumerEnableTraceEventRequest { types })
             .await
     }
 

--- a/rust/src/router/direct_transport.rs
+++ b/rust/src/router/direct_transport.rs
@@ -5,9 +5,7 @@ use crate::consumer::{Consumer, ConsumerId, ConsumerOptions};
 use crate::data_consumer::{DataConsumer, DataConsumerId, DataConsumerOptions, DataConsumerType};
 use crate::data_producer::{DataProducer, DataProducerId, DataProducerOptions, DataProducerType};
 use crate::data_structures::{AppData, SctpState};
-use crate::messages::{
-    TransportCloseRequest, TransportCloseRequestData, TransportSendRtcpNotification,
-};
+use crate::messages::{TransportCloseRequest, TransportSendRtcpNotification};
 use crate::producer::{Producer, ProducerId, ProducerOptions};
 use crate::router::transport::{TransportImpl, TransportType};
 use crate::router::Router;
@@ -171,16 +169,14 @@ impl Inner {
 
             if close_request {
                 let channel = self.channel.clone();
+                let router_id = self.router.id();
                 let request = TransportCloseRequest {
-                    handler_id: self.router.id(),
-                    data: TransportCloseRequestData {
-                        transport_id: self.id,
-                    },
+                    transport_id: self.id,
                 };
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(request).await {
+                        if let Err(error) = channel.request(router_id, request).await {
                             error!("transport closing failed on drop: {}", error);
                         }
                     })
@@ -518,12 +514,9 @@ impl DirectTransport {
     ///
     /// * `rtcp_packet` - Bytes containing a valid RTCP packet (can be a compound packet).
     pub fn send_rtcp(&self, rtcp_packet: Vec<u8>) -> Result<(), NotificationError> {
-        self.inner.payload_channel.notify(
-            TransportSendRtcpNotification {
-                handler_id: self.id(),
-            },
-            rtcp_packet,
-        )
+        self.inner
+            .payload_channel
+            .notify(self.id(), TransportSendRtcpNotification {}, rtcp_packet)
     }
 
     /// Callback is called when the direct transport receives a RTCP packet from its router.

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -3,12 +3,10 @@ use crate::data_consumer::{DataConsumer, DataConsumerId, DataConsumerOptions, Da
 use crate::data_producer::{DataProducer, DataProducerId, DataProducerOptions, DataProducerType};
 use crate::data_structures::{AppData, BweTraceInfo, RtpPacketTraceInfo, TraceEventDirection};
 use crate::messages::{
-    TransportConsumeData, TransportConsumeDataData, TransportConsumeDataRequest,
-    TransportConsumeRequest, TransportDumpRequest, TransportEnableTraceEventData,
-    TransportEnableTraceEventRequest, TransportGetStatsRequest, TransportProduceData,
-    TransportProduceDataData, TransportProduceDataRequest, TransportProduceRequest,
-    TransportSetMaxIncomingBitrateData, TransportSetMaxIncomingBitrateRequest,
-    TransportSetMaxOutgoingBitrateData, TransportSetMaxOutgoingBitrateRequest,
+    TransportConsumeDataRequest, TransportConsumeRequest, TransportDumpRequest,
+    TransportEnableTraceEventRequest, TransportGetStatsRequest, TransportProduceDataRequest,
+    TransportProduceRequest, TransportSetMaxIncomingBitrateRequest,
+    TransportSetMaxOutgoingBitrateRequest,
 };
 pub use crate::ortc::{
     ConsumerRtpParametersError, RtpCapabilitiesError, RtpParametersError, RtpParametersMappingError,
@@ -366,35 +364,25 @@ pub(super) trait TransportImpl: TransportGeneric {
 
     async fn dump_impl(&self) -> Result<Value, RequestError> {
         self.channel()
-            .request(TransportDumpRequest {
-                handler_id: self.id(),
-            })
+            .request(self.id(), TransportDumpRequest {})
             .await
     }
 
     async fn get_stats_impl(&self) -> Result<Value, RequestError> {
         self.channel()
-            .request(TransportGetStatsRequest {
-                handler_id: self.id(),
-            })
+            .request(self.id(), TransportGetStatsRequest {})
             .await
     }
 
     async fn set_max_incoming_bitrate_impl(&self, bitrate: u32) -> Result<(), RequestError> {
         self.channel()
-            .request(TransportSetMaxIncomingBitrateRequest {
-                handler_id: self.id(),
-                data: TransportSetMaxIncomingBitrateData { bitrate },
-            })
+            .request(self.id(), TransportSetMaxIncomingBitrateRequest { bitrate })
             .await
     }
 
     async fn set_max_outgoing_bitrate_impl(&self, bitrate: u32) -> Result<(), RequestError> {
         self.channel()
-            .request(TransportSetMaxOutgoingBitrateRequest {
-                handler_id: self.id(),
-                data: TransportSetMaxOutgoingBitrateData { bitrate },
-            })
+            .request(self.id(), TransportSetMaxOutgoingBitrateRequest { bitrate })
             .await
     }
 
@@ -403,10 +391,7 @@ pub(super) trait TransportImpl: TransportGeneric {
         types: Vec<TransportTraceEventType>,
     ) -> Result<(), RequestError> {
         self.channel()
-            .request(TransportEnableTraceEventRequest {
-                handler_id: self.id(),
-                data: TransportEnableTraceEventData { types },
-            })
+            .request(self.id(), TransportEnableTraceEventRequest { types })
             .await
     }
 
@@ -478,9 +463,9 @@ pub(super) trait TransportImpl: TransportGeneric {
 
         let response = self
             .channel()
-            .request(TransportProduceRequest {
-                handler_id: self.id(),
-                data: TransportProduceData {
+            .request(
+                self.id(),
+                TransportProduceRequest {
                     producer_id,
                     kind,
                     rtp_parameters: rtp_parameters.clone(),
@@ -488,7 +473,7 @@ pub(super) trait TransportImpl: TransportGeneric {
                     key_frame_request_delay,
                     paused,
                 },
-            })
+            )
             .await
             .map_err(ProduceError::Request)?;
 
@@ -573,9 +558,9 @@ pub(super) trait TransportImpl: TransportGeneric {
 
         let response = self
             .channel()
-            .request(TransportConsumeRequest {
-                handler_id: self.id(),
-                data: TransportConsumeData {
+            .request(
+                self.id(),
+                TransportConsumeRequest {
                     consumer_id,
                     producer_id: producer.id(),
                     kind: producer.kind(),
@@ -589,7 +574,7 @@ pub(super) trait TransportImpl: TransportGeneric {
                     preferred_layers,
                     ignore_dtx,
                 },
-            })
+            )
             .await
             .map_err(ConsumeError::Request)?;
 
@@ -651,16 +636,16 @@ pub(super) trait TransportImpl: TransportGeneric {
 
         let response = self
             .channel()
-            .request(TransportProduceDataRequest {
-                handler_id: self.id(),
-                data: TransportProduceDataData {
+            .request(
+                self.id(),
+                TransportProduceDataRequest {
                     data_producer_id,
                     r#type,
                     sctp_stream_parameters,
                     label,
                     protocol,
                 },
-            })
+            )
             .await
             .map_err(ProduceDataError::Request)?;
 
@@ -736,9 +721,9 @@ pub(super) trait TransportImpl: TransportGeneric {
 
         let response = self
             .channel()
-            .request(TransportConsumeDataRequest {
-                handler_id: self.id(),
-                data: TransportConsumeDataData {
+            .request(
+                self.id(),
+                TransportConsumeDataRequest {
                     data_consumer_id,
                     data_producer_id: data_producer.id(),
                     r#type,
@@ -746,7 +731,7 @@ pub(super) trait TransportImpl: TransportGeneric {
                     label: data_producer.label().clone(),
                     protocol: data_producer.protocol().clone(),
                 },
-            })
+            )
             .await
             .map_err(ConsumeDataError::Request)?;
 

--- a/rust/src/webrtc_server.rs
+++ b/rust/src/webrtc_server.rs
@@ -11,9 +11,7 @@
 mod tests;
 
 use crate::data_structures::{AppData, ListenIp, Protocol};
-use crate::messages::{
-    WebRtcServerCloseRequest, WebRtcServerCloseRequestData, WebRtcServerDumpRequest,
-};
+use crate::messages::{WebRtcServerCloseRequest, WebRtcServerDumpRequest};
 use crate::transport::TransportId;
 use crate::uuid_based_wrapper_type;
 use crate::webrtc_transport::WebRtcTransport;
@@ -187,13 +185,11 @@ impl Inner {
             {
                 let channel = self.channel.clone();
                 let request = WebRtcServerCloseRequest {
-                    data: WebRtcServerCloseRequestData {
-                        webrtc_server_id: self.id,
-                    },
+                    webrtc_server_id: self.id,
                 };
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(request).await {
+                        if let Err(error) = channel.request("", request).await {
                             error!("WebRTC server closing failed on drop: {}", error);
                         }
                     })
@@ -295,9 +291,7 @@ impl WebRtcServer {
 
         self.inner
             .channel
-            .request(WebRtcServerDumpRequest {
-                handler_id: self.id(),
-            })
+            .request(self.id(), WebRtcServerDumpRequest {})
             .await
     }
 

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -34,6 +34,7 @@ use std::sync::Arc;
 use std::{fmt, io};
 use thiserror::Error;
 use utils::WorkerRunResult;
+use uuid::Uuid;
 
 uuid_based_wrapper_type!(
     /// Worker identifier.
@@ -256,6 +257,15 @@ pub struct WorkerUpdateSettings {
     pub log_tags: Option<Vec<WorkerLogTag>>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize, Eq, PartialEq)]
+#[serde(rename_all = "camelCase")]
+#[doc(hidden)]
+pub struct ChannelMessageHandlers {
+    pub channel_request_handlers: Vec<Uuid>,
+    pub payload_channel_request_handlers: Vec<Uuid>,
+    pub payload_channel_notification_handlers: Vec<Uuid>,
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
@@ -265,6 +275,7 @@ pub struct WorkerDump {
     pub router_ids: Vec<RouterId>,
     #[serde(rename = "webRtcServerIds")]
     pub webrtc_server_ids: Vec<WebRtcServerId>,
+    pub channel_message_handlers: ChannelMessageHandlers,
 }
 
 /// Error that caused [`Worker::create_webrtc_server`] to fail.

--- a/rust/tests/integration/router.rs
+++ b/rust/tests/integration/router.rs
@@ -5,7 +5,7 @@ use mediasoup::router::RouterOptions;
 use mediasoup::rtp_parameters::{
     MimeTypeAudio, MimeTypeVideo, RtpCodecCapability, RtpCodecParametersParameters,
 };
-use mediasoup::worker::{Worker, WorkerSettings};
+use mediasoup::worker::{ChannelMessageHandlers, Worker, WorkerSettings};
 use mediasoup::worker_manager::WorkerManager;
 use std::env;
 use std::num::{NonZeroU32, NonZeroU8};
@@ -107,6 +107,14 @@ fn create_router_succeeds() {
 
         assert_eq!(worker_dump.router_ids, vec![router.id()]);
         assert_eq!(worker_dump.webrtc_server_ids, vec![]);
+        assert_eq!(
+            worker_dump.channel_message_handlers,
+            ChannelMessageHandlers {
+                channel_request_handlers: vec![router.id().into()],
+                payload_channel_request_handlers: vec![],
+                payload_channel_notification_handlers: vec![]
+            }
+        );
 
         let dump = router.dump().await.expect("Failed to dump router");
 

--- a/rust/tests/integration/webrtc_server.rs
+++ b/rust/tests/integration/webrtc_server.rs
@@ -4,7 +4,7 @@ use mediasoup::data_structures::{AppData, ListenIp, Protocol};
 use mediasoup::webrtc_server::{
     WebRtcServerIpPort, WebRtcServerListenInfo, WebRtcServerListenInfos, WebRtcServerOptions,
 };
-use mediasoup::worker::{CreateWebRtcServerError, Worker, WorkerSettings};
+use mediasoup::worker::{ChannelMessageHandlers, CreateWebRtcServerError, Worker, WorkerSettings};
 use mediasoup::worker_manager::WorkerManager;
 use portpicker::pick_unused_port;
 use std::env;
@@ -97,6 +97,14 @@ fn create_webrtc_server_succeeds() {
 
         assert_eq!(worker_dump.router_ids, vec![]);
         assert_eq!(worker_dump.webrtc_server_ids, vec![webrtc_server.id()]);
+        assert_eq!(
+            worker_dump.channel_message_handlers,
+            ChannelMessageHandlers {
+                channel_request_handlers: vec![webrtc_server.id().into()],
+                payload_channel_request_handlers: vec![],
+                payload_channel_notification_handlers: vec![]
+            }
+        );
 
         let dump = webrtc_server
             .dump()

--- a/rust/tests/integration/worker.rs
+++ b/rust/tests/integration/worker.rs
@@ -1,7 +1,8 @@
 use futures_lite::future;
 use mediasoup::data_structures::AppData;
 use mediasoup::worker::{
-    WorkerDtlsFiles, WorkerLogLevel, WorkerLogTag, WorkerSettings, WorkerUpdateSettings,
+    ChannelMessageHandlers, WorkerDtlsFiles, WorkerLogLevel, WorkerLogTag, WorkerSettings,
+    WorkerUpdateSettings,
 };
 use mediasoup::worker_manager::WorkerManager;
 use std::{env, io};
@@ -143,6 +144,14 @@ fn dump_succeeds() {
 
         assert_eq!(dump.router_ids, vec![]);
         assert_eq!(dump.webrtc_server_ids, vec![]);
+        assert_eq!(
+            dump.channel_message_handlers,
+            ChannelMessageHandlers {
+                channel_request_handlers: vec![],
+                payload_channel_request_handlers: vec![],
+                payload_channel_notification_handlers: vec![]
+            }
+        );
     });
 }
 

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup-sys"
-version = "0.4.3"
+version = "0.5.0"
 description = "FFI bindings to C++ libmediasoup-worker"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition = "2021"

--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -188,9 +188,13 @@ namespace Channel
 		uint32_t messageLen;
 		size_t messageCtx;
 
+		// Try to read next message using `channelReadFn`, message, its length and context will be
+		// stored in provided arguments.
 		auto free = this->channelReadFn(
 		  &message, &messageLen, &messageCtx, this->uvReadHandle, this->channelReadCtx);
 
+		// Non-null free function pointer means message was successfully read above and will need to be
+		// freed later.
 		if (free)
 		{
 			try
@@ -225,9 +229,11 @@ namespace Channel
 				MS_ERROR_STD("discarding wrong Channel request: %s", error.what());
 			}
 
+			// Message needs to be freed using stored function pointer.
 			free(message, messageLen, messageCtx);
 		}
 
+		// Return `true` if something was processed.
 		return free != nullptr;
 	}
 

--- a/worker/src/PayloadChannel/PayloadChannelSocket.cpp
+++ b/worker/src/PayloadChannel/PayloadChannelSocket.cpp
@@ -226,6 +226,96 @@ namespace PayloadChannel
 		  this->uvReadHandle,
 		  this->payloadChannelReadCtx);
 
+		if (free)
+		{
+			try
+			{
+				char* charMessage{ reinterpret_cast<char*>(message) };
+
+				if (PayloadChannelRequest::IsRequest(charMessage, messageLen))
+				{
+					try
+					{
+						auto* request =
+						  new PayloadChannel::PayloadChannelRequest(this, charMessage + 2, messageLen - 2);
+						request->SetPayload(payload, payloadLen);
+
+						// Notify the listener.
+						try
+						{
+							this->listener->HandleRequest(request);
+						}
+						catch (const MediaSoupTypeError& error)
+						{
+							request->TypeError(error.what());
+						}
+						catch (const MediaSoupError& error)
+						{
+							request->Error(error.what());
+						}
+
+						// Delete the Request.
+						delete request;
+					}
+					catch (const json::parse_error& error)
+					{
+						MS_ERROR_STD("message parsing error: %s", error.what());
+					}
+					catch (const MediaSoupError& error)
+					{
+						MS_ERROR("discarding wrong PayloadChannel request: %s", error.what());
+					}
+				}
+
+				else if (PayloadChannelNotification::IsNotification(charMessage, messageLen))
+				{
+					try
+					{
+						auto* notification =
+						  new PayloadChannel::PayloadChannelNotification(charMessage + 2, messageLen - 2);
+						notification->SetPayload(payload, payloadLen);
+
+						// Notify the listener.
+						try
+						{
+							this->listener->HandleNotification(notification);
+						}
+						catch (const MediaSoupError& error)
+						{
+							MS_ERROR("notification failed: %s", error.what());
+						}
+
+						// Delete the Notification.
+						delete notification;
+					}
+					catch (const json::parse_error& error)
+					{
+						MS_ERROR_STD("message parsing error: %s", error.what());
+					}
+					catch (const MediaSoupError& error)
+					{
+						MS_ERROR("discarding wrong PayloadChannel notification: %s", error.what());
+					}
+				}
+
+				else
+				{
+					MS_ERROR("discarding wrong PayloadChannel data");
+				}
+			}
+			catch (const json::parse_error& error)
+			{
+				MS_ERROR("JSON parsing error: %s", error.what());
+			}
+			catch (const MediaSoupError& error)
+			{
+				MS_ERROR("discarding wrong Channel request: %s", error.what());
+			}
+
+			free(message, messageLen, messageCtx);
+			free(payload, payloadLen, payloadCapacity);
+		}
+
 		return free != nullptr;
 	}
 

--- a/worker/src/PayloadChannel/PayloadChannelSocket.cpp
+++ b/worker/src/PayloadChannel/PayloadChannelSocket.cpp
@@ -216,6 +216,8 @@ namespace PayloadChannel
 		uint32_t payloadLen;
 		size_t payloadCapacity;
 
+		// Try to read next message and payload using `payloadChannelReadFn`, message and payload,
+		// alongside their lengths and contexts will be stored in provided arguments.
 		auto free = this->payloadChannelReadFn(
 		  &message,
 		  &messageLen,
@@ -226,6 +228,8 @@ namespace PayloadChannel
 		  this->uvReadHandle,
 		  this->payloadChannelReadCtx);
 
+		// Non-null free function pointer means message was successfully read above and will need to be
+		// freed later.
 		if (free)
 		{
 			try
@@ -312,10 +316,12 @@ namespace PayloadChannel
 				MS_ERROR("discarding wrong Channel request: %s", error.what());
 			}
 
+			// Message and payload need to be freed using stored function pointer.
 			free(message, messageLen, messageCtx);
 			free(payload, payloadLen, payloadCapacity);
 		}
 
+		// Return `true` if something was processed.
 		return free != nullptr;
 	}
 


### PR DESCRIPTION
First commit restores code unnecessarily removed in #893 without which Rust can't send anything to worker.

Second commit fixes Rust support after #893, there I had to change how requests and notifications look like a bit, as the result we have less code and it is a bit cleaner.

Third commit updates dump data structure and tests according to changes in #894.

Last commit bumps versions, dependencies and updates changelog so we can publish it.