### PR TITLE
Fix 357

### DIFF
--- a/worker/deps/libwebrtc/libwebrtc/mediasoup_helpers.h
+++ b/worker/deps/libwebrtc/libwebrtc/mediasoup_helpers.h
@@ -15,6 +15,8 @@ namespace mediasoup_helpers
 	 */
 	namespace FeedbackRtpTransport
 	{
+		constexpr int64_t kTimeWrapPeriodUs = (1ll << 24) * 64 * 1000;
+		
 		const std::vector<webrtc::rtcp::ReceivedPacket> GetReceivedPackets(
 			const RTC::RTCP::FeedbackRtpTransportPacket* packet)
 		{
@@ -35,11 +37,22 @@ namespace mediasoup_helpers
 			return packet->GetReferenceTimestamp() * 1000;
 		}
 
-		// Get the unwrapped delta between current base time and |prev_timestamp_us|.
+		// Get the wrapped delta between current base time and |prev_timestamp_us|.
 		int64_t GetBaseDeltaUs(
 		  const RTC::RTCP::FeedbackRtpTransportPacket* packet, int64_t prev_timestamp_us)
 		{
-			return GetBaseTimeUs(packet) - prev_timestamp_us;
+			int64_t delta = GetBaseTimeUs(packet) - prev_timestamp_us;
+			
+			if (std::abs(delta - kTimeWrapPeriodUs) < std::abs(delta))
+			{
+				delta -= kTimeWrapPeriodUs;
+			}
+			else if (std::abs(delta + kTimeWrapPeriodUs) < std::abs(delta))
+			{
+				delta += kTimeWrapPeriodUs;
+			}
+
+			return delta;
 		}
 	} // namespace FeedbackRtpTransport
 } // namespace mediasoup_helpers

--- a/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.cc
@@ -48,7 +48,7 @@ bool InterArrival::ComputeDeltas(uint32_t timestamp,
     current_timestamp_group_.timestamp = timestamp;
     current_timestamp_group_.first_timestamp = timestamp;
     current_timestamp_group_.first_arrival_ms = arrival_time_ms;
-  } else if (!PacketInOrder(timestamp, arrival_time_ms)) {
+  } else if (!PacketInOrder(timestamp)) {
     return false;
   } else if (NewTimestampGroup(arrival_time_ms, timestamp)) {
     // First packet of a later frame, the previous frame sample is ready.
@@ -115,17 +115,9 @@ bool InterArrival::ComputeDeltas(uint32_t timestamp,
   return calculated_deltas;
 }
 
-bool InterArrival::PacketInOrder(uint32_t timestamp, int64_t arrival_time_ms) {
+bool InterArrival::PacketInOrder(uint32_t timestamp) {
   if (current_timestamp_group_.IsFirstPacket()) {
     return true;
-  } else if (arrival_time_ms < 0) {
-    // NOTE: Change related to https://github.com/versatica/mediasoup/issues/357
-    //
-    // Sometimes we do get negative arrival time, which causes BelongsToBurst()
-    // to fail, which may cause anything that uses InterArrival to crash.
-    //
-    // Credits to @sspanak and @Ivaka.
-    return false;
   } else {
     // Assume that a diff which is bigger than half the timestamp interval
     // (32 bits) must be due to reordering. This code is almost identical to

--- a/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.h
+++ b/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.h
@@ -70,12 +70,7 @@ class InterArrival {
     int64_t last_system_time_ms;
   };
 
-  // Returns true if the packet with timestamp |timestamp| arrived in order.
-  //
-  // NOTE: Change related to https://github.com/versatica/mediasoup/issues/357
-  //
-  // bool PacketInOrder(uint32_t timestamp);
-  bool PacketInOrder(uint32_t timestamp, int64_t arrival_time_ms);
+  bool PacketInOrder(uint32_t timestamp);
 
   // Returns true if the last packet was the end of the current batch and the
   // packet with |timestamp| is the first of a new batch.

--- a/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.h
+++ b/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.h
@@ -70,6 +70,7 @@ class InterArrival {
     int64_t last_system_time_ms;
   };
 
+  // Returns true if the packet with timestamp |timestamp| arrived in order.
   bool PacketInOrder(uint32_t timestamp);
 
   // Returns true if the last packet was the end of the current batch and the


### PR DESCRIPTION
This PR tried to fix #357 

We should deal with reference timestamp wrapping.

Refer to:
https://chromium.googlesource.com/external/webrtc/+/refs/heads/main/modules/rtp_rtcp/source/rtcp_packet/transport_feedback.cc#383