### PR TITLE
Do not create a std::vector in Consumer::GetRtpStreams()

### DIFF
--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -143,7 +143,7 @@ namespace RTC
 		virtual void ApplyLayers()                                          = 0;
 		virtual uint32_t GetDesiredBitrate() const                          = 0;
 		virtual void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) = 0;
-		virtual std::vector<RTC::RtpStreamSend*> GetRtpStreams() = 0;
+		virtual const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const = 0;
 		virtual void GetRtcp(
 		  RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) = 0;
 		virtual void NeedWorstRemoteFractionLost(uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost) = 0;

--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -31,7 +31,7 @@ namespace RTC
 		uint32_t GetDesiredBitrate() const override;
 		void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) override;
 		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
-		std::vector<RTC::RtpStreamSend*> GetRtpStreams() override
+		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;
 		}

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -40,7 +40,7 @@ namespace RTC
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
 		void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) override;
-		std::vector<RTC::RtpStreamSend*> GetRtpStreams() override
+		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;
 		}

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -57,7 +57,7 @@ namespace RTC
 		uint32_t GetDesiredBitrate() const override;
 		void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) override;
 		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
-		std::vector<RTC::RtpStreamSend*> GetRtpStreams() override
+		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;
 		}

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -52,7 +52,7 @@ namespace RTC
 		uint32_t GetDesiredBitrate() const override;
 		void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) override;
 		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
-		std::vector<RTC::RtpStreamSend*> GetRtpStreams() override
+		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;
 		}


### PR DESCRIPTION
No need to allocate that memory every time the method is called, which is done every time a RTCP Compound packet is sent out. Return a reference to the original vector instead.

It was seen certain CPU usage on the allocation of this vector.