### PR TITLE
Forward abs-capture-time RTP extension also in audio packets

### DIFF
--- a/node/src/supportedRtpCapabilities.ts
+++ b/node/src/supportedRtpCapabilities.ts
@@ -369,14 +369,14 @@ const supportedRtpCapabilities: RtpCapabilities =
 			direction        : 'sendrecv'
 		},
 		{
-			kind             : 'video',
+			kind             : 'audio',
 			uri              : 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
 			preferredId      : 13,
 			preferredEncrypt : false,
 			direction        : 'sendrecv'
 		},
 		{
-			kind             : 'audio',
+			kind             : 'video',
 			uri              : 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
 			preferredId      : 13,
 			preferredEncrypt : false,

--- a/rust/src/supported_rtp_capabilities.rs
+++ b/rust/src/supported_rtp_capabilities.rs
@@ -373,14 +373,14 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                 direction: RtpHeaderExtensionDirection::SendRecv,
             },
             RtpHeaderExtension {
-                kind: MediaKind::Video,
+                kind: MediaKind::Audio,
                 uri: RtpHeaderExtensionUri::AbsCaptureTime,
                 preferred_id: 13,
                 preferred_encrypt: false,
                 direction: RtpHeaderExtensionDirection::SendRecv,
             },
             RtpHeaderExtension {
-                kind: MediaKind::Audio,
+                kind: MediaKind::Video,
                 uri: RtpHeaderExtensionUri::AbsCaptureTime,
                 preferred_id: 13,
                 preferred_encrypt: false,

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1303,21 +1303,6 @@ namespace RTC
 				bufferPtr += extenLen;
 			}
 
-			// Add http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time.
-			{
-				extenLen = 3u;
-
-				// NOTE: Add value 0. The sending Transport will update it.
-				uint32_t absSendTime{ 0u };
-
-				Utils::Byte::Set3Bytes(bufferPtr, 0, absSendTime);
-
-				extensions.emplace_back(
-				  static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::ABS_SEND_TIME), extenLen, bufferPtr);
-
-				bufferPtr += extenLen;
-			}
-
 			// Proxy http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time.
 			extenValue = packet->GetExtension(this->rtpHeaderExtensionIds.absCaptureTime, extenLen);
 
@@ -1353,6 +1338,22 @@ namespace RTC
 			}
 			else if (this->kind == RTC::Media::Kind::VIDEO)
 			{
+				// Add http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time.
+				// NOTE: This is for REMB.
+				{
+					extenLen = 3u;
+
+					// NOTE: Add value 0. The sending Transport will update it.
+					uint32_t absSendTime{ 0u };
+
+					Utils::Byte::Set3Bytes(bufferPtr, 0, absSendTime);
+
+					extensions.emplace_back(
+					  static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::ABS_SEND_TIME), extenLen, bufferPtr);
+
+					bufferPtr += extenLen;
+				}
+
 				// Add http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01.
 				// NOTE: We don't include it in outbound audio packets for now.
 				{

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1330,8 +1330,7 @@ namespace RTC
 				  extenLen,
 				  bufferPtr);
 
-				// Not needed since this is the latest added extension.
-				// bufferPtr += extenLen;
+				bufferPtr += extenLen;
 			}
 
 			if (this->kind == RTC::Media::Kind::AUDIO)


### PR DESCRIPTION
For some unknown reason (bug) we were not doing it...