### PR TITLE
Rtcp enhancements

### DIFF
--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -143,9 +143,8 @@ namespace RTC
 		virtual void ApplyLayers()                                          = 0;
 		virtual uint32_t GetDesiredBitrate() const                          = 0;
 		virtual void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) = 0;
+		virtual void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) = 0;
 		virtual const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const = 0;
-		virtual void GetRtcp(
-		  RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) = 0;
 		virtual void NeedWorstRemoteFractionLost(uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost) = 0;
 		virtual void ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket) = 0;
 		virtual void ReceiveKeyFrameRequest(

--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -143,8 +143,8 @@ namespace RTC
 		virtual void ApplyLayers()                                          = 0;
 		virtual uint32_t GetDesiredBitrate() const                          = 0;
 		virtual void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) = 0;
-		virtual void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) = 0;
-		virtual const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const = 0;
+		virtual bool GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) = 0;
+		virtual const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const   = 0;
 		virtual void NeedWorstRemoteFractionLost(uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost) = 0;
 		virtual void ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket) = 0;
 		virtual void ReceiveKeyFrameRequest(

--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -30,7 +30,7 @@ namespace RTC
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
 		void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) override;
-		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
+		void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;

--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -30,7 +30,7 @@ namespace RTC
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
 		void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) override;
-		void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) override;
+		bool GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -129,7 +129,7 @@ namespace RTC
 		ReceiveRtpPacketResult ReceiveRtpPacket(RTC::RtpPacket* packet);
 		void ReceiveRtcpSenderReport(RTC::RTCP::SenderReport* report);
 		void ReceiveRtcpXrDelaySinceLastRr(RTC::RTCP::DelaySinceLastRr::SsrcInfo* ssrcInfo);
-		void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs);
+		bool GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs);
 		void RequestKeyFrame(uint32_t mappedSsrc);
 
 		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */

--- a/worker/include/RTC/RTCP/CompoundPacket.hpp
+++ b/worker/include/RTC/RTCP/CompoundPacket.hpp
@@ -2,12 +2,12 @@
 #define MS_RTC_RTCP_COMPOUND_PACKET_HPP
 
 #include "common.hpp"
-#include "RTC/RtpPacket.hpp" // MtuSize.
 #include "RTC/RTCP/ReceiverReport.hpp"
 #include "RTC/RTCP/Sdes.hpp"
 #include "RTC/RTCP/SenderReport.hpp"
 #include "RTC/RTCP/XrDelaySinceLastRr.hpp"
 #include "RTC/RTCP/XrReceiverReferenceTime.hpp"
+#include "RTC/RtpPacket.hpp" // MtuSize.
 #include <vector>
 
 namespace RTC

--- a/worker/include/RTC/RTCP/CompoundPacket.hpp
+++ b/worker/include/RTC/RTCP/CompoundPacket.hpp
@@ -2,6 +2,7 @@
 #define MS_RTC_RTCP_COMPOUND_PACKET_HPP
 
 #include "common.hpp"
+#include "RTC/RtpPacket.hpp" // MtuSize.
 #include "RTC/RTCP/ReceiverReport.hpp"
 #include "RTC/RTCP/Sdes.hpp"
 #include "RTC/RTCP/SenderReport.hpp"
@@ -16,6 +17,13 @@ namespace RTC
 		class CompoundPacket
 		{
 		public:
+			// Maximum size for a CompundPacket, leaving free space for encryption.
+			// 144 is the maximum number of octects that will be added to an RTP packet
+			// by srtp_protect().
+			// srtp.h: SRTP_MAX_TRAILER_LEN (SRTP_MAX_TAG_LEN + SRTP_MAX_MKI_LEN)
+			constexpr static size_t MaxSize{ RTC::MtuSize - 144u };
+
+		public:
 			CompoundPacket() = default;
 
 		public:
@@ -23,10 +31,7 @@ namespace RTC
 			{
 				return this->header;
 			}
-			size_t GetSize() const
-			{
-				return this->size;
-			}
+			size_t GetSize();
 			size_t GetSenderReportCount() const
 			{
 				return this->senderReportPacket.GetCount();
@@ -36,6 +41,17 @@ namespace RTC
 				return this->receiverReportPacket.GetCount();
 			}
 			void Dump();
+			// RTCP additions per Consumer.
+			// Adds the given data and returns true if there is enough space to hold it,
+			// false otherwise.
+			bool Add(
+			  std::vector<SenderReport*>& senderReports,
+			  std::vector<SdesChunk*>& sdesChunks,
+			  std::vector<DelaySinceLastRr*>& delaySinceLastRrReports);
+			// RTCP additions per Producer.
+			// Adds the given data and returns true if there is enough space to hold it,
+			// false otherwise.
+			bool Add(std::vector<ReceiverReport*>&, ReceiverReferenceTime*);
 			void AddSenderReport(SenderReport* report);
 			void AddReceiverReport(ReceiverReport* report);
 			void AddSdesChunk(SdesChunk* chunk);
@@ -57,7 +73,6 @@ namespace RTC
 
 		private:
 			uint8_t* header{ nullptr };
-			size_t size{ 0 };
 			SenderReportPacket senderReportPacket;
 			ReceiverReportPacket receiverReportPacket;
 			SdesPacket sdesPacket;

--- a/worker/include/RTC/RTCP/CompoundPacket.hpp
+++ b/worker/include/RTC/RTCP/CompoundPacket.hpp
@@ -41,7 +41,12 @@ namespace RTC
 				return this->receiverReportPacket.GetCount();
 			}
 			void Dump();
-			// RTCP additions per Consumer.
+			// RTCP additions per Consumer (non pipe).
+			// Adds the given data and returns true if there is enough space to hold it,
+			// false otherwise.
+			bool Add(
+			  SenderReport* senderReport, SdesChunk* sdesChunk, DelaySinceLastRr* delaySinceLastRrReport);
+			// RTCP additions per Consumer (pipe).
 			// Adds the given data and returns true if there is enough space to hold it,
 			// false otherwise.
 			bool Add(

--- a/worker/include/RTC/RTCP/ReceiverReport.hpp
+++ b/worker/include/RTC/RTCP/ReceiverReport.hpp
@@ -165,6 +165,13 @@ namespace RTC
 			{
 				this->reports.push_back(report);
 			}
+			void RemoveReport(ReceiverReport* report)
+			{
+				auto it = std::find(this->reports.begin(), this->reports.end(), report);
+
+				if (it != this->reports.end())
+					this->reports.erase(it);
+			}
 			Iterator Begin()
 			{
 				return this->reports.begin();

--- a/worker/include/RTC/RTCP/Sdes.hpp
+++ b/worker/include/RTC/RTCP/Sdes.hpp
@@ -180,6 +180,13 @@ namespace RTC
 			{
 				this->chunks.push_back(chunk);
 			}
+			void RemoveChunk(SdesChunk* chunk)
+			{
+				auto it = std::find(this->chunks.begin(), this->chunks.end(), chunk);
+
+				if (it != this->chunks.end())
+					this->chunks.erase(it);
+			}
 			Iterator Begin()
 			{
 				return this->chunks.begin();

--- a/worker/include/RTC/RTCP/Sdes.hpp
+++ b/worker/include/RTC/RTCP/Sdes.hpp
@@ -154,6 +154,8 @@ namespace RTC
 		class SdesPacket : public Packet
 		{
 		public:
+			static size_t MaxChunksPerPacket;
+
 			using Iterator = std::vector<SdesChunk*>::iterator;
 
 		public:
@@ -197,7 +199,10 @@ namespace RTC
 			}
 			size_t GetSize() const override
 			{
-				size_t size = Packet::CommonHeaderSize;
+				// A serialized packet can contain a maximum of 31 chunks.
+				// If number of chunks exceeds 31 then the required number of packets
+				// will be serialized which will take the size calculated below.
+				size_t size = Packet::CommonHeaderSize * ((this->GetCount() / MaxChunksPerPacket) + 1);
 
 				for (auto* chunk : this->chunks)
 				{

--- a/worker/include/RTC/RTCP/SenderReport.hpp
+++ b/worker/include/RTC/RTCP/SenderReport.hpp
@@ -143,14 +143,17 @@ namespace RTC
 			size_t Serialize(uint8_t* buffer) override;
 			size_t GetCount() const override
 			{
-				return 0;
+				return this->reports.size();
 			}
 			size_t GetSize() const override
 			{
-				size_t size = Packet::CommonHeaderSize;
+				// A serialized packet consists of a series of SR packets with
+				// one SR report each.
+				size_t size{ 0 };
 
 				for (auto* report : this->reports)
 				{
+					size += Packet::CommonHeaderSize;
 					size += report->GetSize();
 				}
 

--- a/worker/include/RTC/RTCP/SenderReport.hpp
+++ b/worker/include/RTC/RTCP/SenderReport.hpp
@@ -128,6 +128,13 @@ namespace RTC
 			{
 				this->reports.push_back(report);
 			}
+			void RemoveReport(SenderReport* report)
+			{
+				auto it = std::find(this->reports.begin(), this->reports.end(), report);
+
+				if (it != this->reports.end())
+					this->reports.erase(it);
+			}
 			Iterator Begin()
 			{
 				return this->reports.begin();

--- a/worker/include/RTC/RTCP/XR.hpp
+++ b/worker/include/RTC/RTCP/XR.hpp
@@ -102,6 +102,13 @@ namespace RTC
 			{
 				this->reports.push_back(report);
 			}
+			void RemoveReport(ExtendedReportBlock* report)
+			{
+				auto it = std::find(this->reports.begin(), this->reports.end(), report);
+
+				if (it != this->reports.end())
+					this->reports.erase(it);
+			}
 			uint32_t GetSsrc() const
 			{
 				return this->ssrc;

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -44,7 +44,7 @@ namespace RTC
 		{
 			return this->rtpStreams;
 		}
-		void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) override;
+		bool GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) override;
 		void NeedWorstRemoteFractionLost(uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost) override;
 		void ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket) override;
 		void ReceiveKeyFrameRequest(RTC::RTCP::FeedbackPs::MessageType messageType, uint32_t ssrc) override;

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -44,7 +44,7 @@ namespace RTC
 		{
 			return this->rtpStreams;
 		}
-		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
+		void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) override;
 		void NeedWorstRemoteFractionLost(uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost) override;
 		void ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket) override;
 		void ReceiveKeyFrameRequest(RTC::RTCP::FeedbackPs::MessageType messageType, uint32_t ssrc) override;

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -56,7 +56,7 @@ namespace RTC
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
 		void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) override;
-		void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) override;
+		bool GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -56,7 +56,7 @@ namespace RTC
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
 		void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) override;
-		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
+		void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -51,7 +51,7 @@ namespace RTC
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
 		void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) override;
-		void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) override;
+		bool GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -51,7 +51,7 @@ namespace RTC
 		void ApplyLayers() override;
 		uint32_t GetDesiredBitrate() const override;
 		void SendRtpPacket(RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) override;
-		void GetRtcp(RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs) override;
+		void GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs) override;
 		const std::vector<RTC::RtpStreamSend*>& GetRtpStreams() const override
 		{
 			return this->rtpStreams;

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -156,6 +156,8 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		packet->Serialize(RTC::RTCP::Buffer);
+
 		const uint8_t* data = packet->GetData();
 		size_t len          = packet->GetSize();
 

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -289,14 +289,9 @@ namespace RTC
 		packet->SetSequenceNumber(origSeq);
 	}
 
-	void PipeConsumer::GetRtcp(
-	  RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs)
+	void PipeConsumer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs)
 	{
 		MS_TRACE();
-
-		MS_ASSERT(
-		  std::find(this->rtpStreams.begin(), this->rtpStreams.end(), rtpStream) != this->rtpStreams.end(),
-		  "RTP stream does exist");
 
 		// Special condition for PipeConsumer since this method will be called in a loop for
 		// each stream in this PipeConsumer.
@@ -310,29 +305,32 @@ namespace RTC
 			return;
 		}
 
-		auto* report = rtpStream->GetRtcpSenderReport(nowMs);
-
-		if (!report)
-			return;
-
-		packet->AddSenderReport(report);
-
-		// Build SDES chunk for this sender.
-		auto* sdesChunk = rtpStream->GetRtcpSdesChunk();
-
-		packet->AddSdesChunk(sdesChunk);
-
-		auto* dlrr = rtpStream->GetRtcpXrDelaySinceLastRr(nowMs);
-
-		if (dlrr)
+		for (auto* rtpStream : this->rtpStreams)
 		{
-			auto* report = new RTC::RTCP::DelaySinceLastRr();
+			auto* report = rtpStream->GetRtcpSenderReport(nowMs);
 
-			report->AddSsrcInfo(dlrr);
-			packet->AddDelaySinceLastRr(report);
+			if (!report)
+				return;
+
+			packet->AddSenderReport(report);
+
+			// Build SDES chunk for this sender.
+			auto* sdesChunk = rtpStream->GetRtcpSdesChunk();
+
+			packet->AddSdesChunk(sdesChunk);
+
+			auto* dlrr = rtpStream->GetRtcpXrDelaySinceLastRr(nowMs);
+
+			if (dlrr)
+			{
+				auto* report = new RTC::RTCP::DelaySinceLastRr();
+
+				report->AddSsrcInfo(dlrr);
+				packet->AddDelaySinceLastRr(report);
+			}
+
+			this->lastRtcpSentTime = nowMs;
 		}
-
-		this->lastRtcpSentTime = nowMs;
 	}
 
 	void PipeConsumer::NeedWorstRemoteFractionLost(uint32_t /*mappedSsrc*/, uint8_t& worstRemoteFractionLost)

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -509,6 +509,8 @@ namespace RTC
 		if (!IsConnected())
 			return;
 
+		packet->Serialize(RTC::RTCP::Buffer);
+
 		const uint8_t* data = packet->GetData();
 		auto intLen         = static_cast<int>(packet->GetSize());
 

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -780,6 +780,8 @@ namespace RTC
 		if (!IsConnected())
 			return;
 
+		packet->Serialize(RTC::RTCP::Buffer);
+
 		const uint8_t* data = packet->GetData();
 		auto intLen         = static_cast<int>(packet->GetSize());
 

--- a/worker/src/RTC/RTCP/CompoundPacket.cpp
+++ b/worker/src/RTC/RTCP/CompoundPacket.cpp
@@ -67,6 +67,48 @@ namespace RTC
 		}
 
 		bool CompoundPacket::Add(
+		  SenderReport* senderReport, SdesChunk* sdesChunk, DelaySinceLastRr* delaySinceLastRrReport)
+		{
+			// Add the items into the packet.
+
+			if (senderReport)
+				this->senderReportPacket.AddReport(senderReport);
+
+			if (sdesChunk)
+				this->sdesPacket.AddChunk(sdesChunk);
+
+			if (delaySinceLastRrReport)
+				this->xrPacket.AddReport(delaySinceLastRrReport);
+
+			// New items can hold in the packet, report it.
+			if (GetSize() <= MaxSize)
+				return true;
+
+			// New items can not hold in the packet, remove them,
+			// delete and report it.
+
+			if (senderReport)
+			{
+				this->senderReportPacket.RemoveReport(senderReport);
+				delete senderReport;
+			}
+
+			if (sdesChunk)
+			{
+				this->sdesPacket.RemoveChunk(sdesChunk);
+				delete sdesChunk;
+			}
+
+			if (delaySinceLastRrReport)
+			{
+				this->xrPacket.RemoveReport(delaySinceLastRrReport);
+				delete delaySinceLastRrReport;
+			}
+
+			return false;
+		}
+
+		bool CompoundPacket::Add(
 		  std::vector<SenderReport*>& senderReports,
 		  std::vector<SdesChunk*>& sdesChunks,
 		  std::vector<DelaySinceLastRr*>& delaySinceLastRrReports)

--- a/worker/src/RTC/RTCP/CompoundPacket.cpp
+++ b/worker/src/RTC/RTCP/CompoundPacket.cpp
@@ -10,83 +10,137 @@ namespace RTC
 	{
 		/* Instance methods. */
 
+		size_t CompoundPacket::GetSize()
+		{
+			size_t size{ 0 };
+
+			if (this->senderReportPacket.GetCount() > 0u)
+			{
+				size += this->senderReportPacket.GetSize();
+			}
+			if (this->receiverReportPacket.GetCount() > 0u)
+			{
+				size += this->receiverReportPacket.GetSize();
+			}
+
+			if (this->sdesPacket.GetCount() > 0u)
+				size += this->sdesPacket.GetSize();
+
+			if (this->xrPacket.Begin() != this->xrPacket.End())
+				size += this->xrPacket.GetSize();
+
+			return size;
+		}
+
 		void CompoundPacket::Serialize(uint8_t* data)
 		{
 			MS_TRACE();
 
 			this->header = data;
 
-			// Calculate the total required size for the entire message.
-			if (HasSenderReport())
-			{
-				this->size = this->senderReportPacket.GetSize();
-
-				if (this->receiverReportPacket.GetCount() != 0u)
-				{
-					this->size += ReceiverReport::HeaderSize * this->receiverReportPacket.GetCount();
-				}
-			}
-			// If no sender nor receiver reports are present send an empty Receiver Report
-			// packet as the head of the compound packet.
-			else
-			{
-				this->size = this->receiverReportPacket.GetSize();
-			}
-
-			if (this->sdesPacket.GetCount() != 0u)
-				this->size += this->sdesPacket.GetSize();
-
-			if (this->xrPacket.Begin() != this->xrPacket.End())
-				this->size += this->xrPacket.GetSize();
-
 			// Fill it.
 			size_t offset{ 0 };
 
-			if (HasSenderReport())
+			MS_ASSERT(
+			  this->senderReportPacket.GetCount() > 0u || this->receiverReportPacket.GetCount() > 0u,
+			  "no Sender or Receiver report present");
+
+			if (this->senderReportPacket.GetCount() > 0u)
 			{
-				this->senderReportPacket.Serialize(this->header);
-				offset = this->senderReportPacket.GetSize();
-
-				// Fix header count field.
-				auto* header = reinterpret_cast<Packet::CommonHeader*>(this->header);
-
-				header->count = 0;
-
-				if (this->receiverReportPacket.GetCount() != 0u)
-				{
-					// Fix header length field.
-					size_t length =
-					  ((SenderReport::HeaderSize +
-					    (ReceiverReport::HeaderSize * this->receiverReportPacket.GetCount())) /
-					   4);
-
-					header->length = uint16_t{ htons(length) };
-
-					// Fix header count field.
-					header->count = this->receiverReportPacket.GetCount();
-
-					auto it = this->receiverReportPacket.Begin();
-
-					for (; it != this->receiverReportPacket.End(); ++it)
-					{
-						ReceiverReport* report = (*it);
-
-						report->Serialize(this->header + offset);
-						offset += ReceiverReport::HeaderSize;
-					}
-				}
-			}
-			else
-			{
-				this->receiverReportPacket.Serialize(this->header);
-				offset = this->receiverReportPacket.GetSize();
+				offset += this->senderReportPacket.Serialize(this->header);
 			}
 
-			if (this->sdesPacket.GetCount() != 0u)
+			if (this->receiverReportPacket.GetCount() > 0u)
+			{
+				offset += this->receiverReportPacket.Serialize(this->header + offset);
+			}
+
+			if (this->sdesPacket.GetCount() > 0u)
+			{
 				offset += this->sdesPacket.Serialize(this->header + offset);
+			}
 
 			if (this->xrPacket.Begin() != this->xrPacket.End())
-				this->xrPacket.Serialize(this->header + offset);
+			{
+				offset += this->xrPacket.Serialize(this->header + offset);
+			}
+		}
+
+		bool CompoundPacket::Add(
+		  std::vector<SenderReport*>& senderReports,
+		  std::vector<SdesChunk*>& sdesChunks,
+		  std::vector<DelaySinceLastRr*>& delaySinceLastRrReports)
+		{
+			// Add the items into the packet.
+
+			for (auto* report : senderReports)
+				this->senderReportPacket.AddReport(report);
+
+			for (auto* chunk : sdesChunks)
+				this->sdesPacket.AddChunk(chunk);
+
+			for (auto* report : delaySinceLastRrReports)
+				this->xrPacket.AddReport(report);
+
+			// New items can hold in the packet, report it.
+			if (GetSize() <= MaxSize)
+				return true;
+
+			// New items can not hold in the packet, remove them,
+			// delete and report it.
+
+			for (auto* report : senderReports)
+			{
+				this->senderReportPacket.RemoveReport(report);
+				delete report;
+			}
+
+			for (auto* chunk : sdesChunks)
+			{
+				this->sdesPacket.RemoveChunk(chunk);
+				delete chunk;
+			}
+
+			for (auto* report : delaySinceLastRrReports)
+			{
+				this->xrPacket.RemoveReport(report);
+				delete report;
+			}
+
+			return false;
+		}
+
+		bool CompoundPacket::Add(
+		  std::vector<ReceiverReport*>& receiverReports, ReceiverReferenceTime* receiverReferenceTimeReport)
+		{
+			// Add the items into the packet.
+
+			for (auto* report : receiverReports)
+				this->receiverReportPacket.AddReport(report);
+
+			if (receiverReferenceTimeReport)
+				this->xrPacket.AddReport(receiverReferenceTimeReport);
+
+			// New items can hold in the packet, report it.
+			if (GetSize() <= MaxSize)
+				return true;
+
+			// New items can not hold in the packet, remove them,
+			// delete and report it.
+
+			for (auto* report : receiverReports)
+			{
+				this->receiverReportPacket.RemoveReport(report);
+				delete report;
+			}
+
+			if (receiverReferenceTimeReport)
+			{
+				this->xrPacket.RemoveReport(receiverReferenceTimeReport);
+				delete receiverReferenceTimeReport;
+			}
+
+			return false;
 		}
 
 		void CompoundPacket::Dump()
@@ -119,8 +173,6 @@ namespace RTC
 		void CompoundPacket::AddSenderReport(SenderReport* report)
 		{
 			MS_TRACE();
-
-			MS_ASSERT(!HasSenderReport(), "a Sender Report is already present");
 
 			this->senderReportPacket.AddReport(report);
 		}

--- a/worker/src/RTC/RTCP/CompoundPacket.cpp
+++ b/worker/src/RTC/RTCP/CompoundPacket.cpp
@@ -111,7 +111,8 @@ namespace RTC
 		}
 
 		bool CompoundPacket::Add(
-		  std::vector<ReceiverReport*>& receiverReports, ReceiverReferenceTime* receiverReferenceTimeReport)
+		  std::vector<ReceiverReport*>& receiverReports,
+		  ReceiverReferenceTime* receiverReferenceTimeReport)
 		{
 			// Add the items into the packet.
 

--- a/worker/src/RTC/RTCP/Sdes.cpp
+++ b/worker/src/RTC/RTCP/Sdes.cpp
@@ -256,6 +256,7 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			MS_DUMP("<SdesPacket>");
 			for (auto* chunk : this->chunks)
 			{
 				chunk->Dump();

--- a/worker/src/RTC/RTCP/Sdes.cpp
+++ b/worker/src/RTC/RTCP/Sdes.cpp
@@ -179,6 +179,10 @@ namespace RTC
 			MS_DUMP("</SdesChunk>");
 		}
 
+		/* Static Class members */
+
+		size_t SdesPacket::MaxChunksPerPacket = 31;
+
 		/* Class methods. */
 
 		SdesPacket* SdesPacket::Parse(const uint8_t* data, size_t len)
@@ -215,11 +219,34 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			size_t offset = Packet::Serialize(buffer);
+			size_t offset   = 0;
+			size_t length   = 0;
+			uint8_t* header = { nullptr };
 
-			for (auto* chunk : this->chunks)
+			for (size_t i = 0; i < this->GetCount(); i++)
 			{
-				offset += chunk->Serialize(buffer + offset);
+				// Create a new SDES packet header for each 31 chunks.
+				if (i % MaxChunksPerPacket == 0)
+				{
+					// Reference current common header.
+					header = buffer + offset;
+					offset += Packet::Serialize(buffer + offset);
+
+					length = Packet::CommonHeaderSize;
+				}
+
+				// Serialize the next chunk.
+				auto chunkSize = chunks[i]->Serialize(buffer + offset);
+
+				offset += chunkSize;
+				length += chunkSize;
+
+				// Adjust the header count field.
+				reinterpret_cast<Packet::CommonHeader*>(header)->count =
+				  static_cast<uint8_t>((i % MaxChunksPerPacket) + 1);
+
+				// Adjust the header length field.
+				reinterpret_cast<Packet::CommonHeader*>(header)->length = uint16_t{ htons((length / 4) - 1) };
 			}
 
 			return offset;
@@ -229,7 +256,6 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			MS_DUMP("<SdesPacket>");
 			for (auto* chunk : this->chunks)
 			{
 				chunk->Dump();

--- a/worker/src/RTC/RTCP/SenderReport.cpp
+++ b/worker/src/RTC/RTCP/SenderReport.cpp
@@ -93,6 +93,9 @@ namespace RTC
 				offset += Packet::Serialize(buffer + offset);
 				offset += report->Serialize(buffer + offset);
 
+				// Adjust the header count field.
+				reinterpret_cast<Packet::CommonHeader*>(header)->count = 0;
+
 				// Adjust the header length field.
 				size_t length = Packet::CommonHeaderSize;
 				length += SenderReport::HeaderSize;

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -363,12 +363,9 @@ namespace RTC
 		packet->SetSequenceNumber(origSeq);
 	}
 
-	void SimpleConsumer::GetRtcp(
-	  RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs)
+	void SimpleConsumer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs)
 	{
 		MS_TRACE();
-
-		MS_ASSERT(rtpStream == this->rtpStream, "RTP stream does not match");
 
 		if (static_cast<float>((nowMs - this->lastRtcpSentTime) * 1.15) < this->maxRtcpInterval)
 			return;

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -957,12 +957,9 @@ namespace RTC
 		packet->RestorePayload();
 	}
 
-	void SimulcastConsumer::GetRtcp(
-	  RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs)
+	void SimulcastConsumer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs)
 	{
 		MS_TRACE();
-
-		MS_ASSERT(rtpStream == this->rtpStream, "RTP stream does not match");
 
 		if (static_cast<float>((nowMs - this->lastRtcpSentTime) * 1.15) < this->maxRtcpInterval)
 			return;

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -964,33 +964,26 @@ namespace RTC
 		if (static_cast<float>((nowMs - this->lastRtcpSentTime) * 1.15) < this->maxRtcpInterval)
 			return true;
 
-		std::vector<RTCP::SenderReport*> senderReports;
-		std::vector<RTCP::SdesChunk*> sdesChunks;
-		std::vector<RTCP::DelaySinceLastRr*> xrReports;
+		auto* senderReport = this->rtpStream->GetRtcpSenderReport(nowMs);
 
-		auto* report = this->rtpStream->GetRtcpSenderReport(nowMs);
-
-		if (!report)
+		if (!senderReport)
 			return true;
-
-		senderReports.push_back(report);
 
 		// Build SDES chunk for this sender.
 		auto* sdesChunk = this->rtpStream->GetRtcpSdesChunk();
-		sdesChunks.push_back(sdesChunk);
+
+		RTC::RTCP::DelaySinceLastRr* delaySinceLastRrReport{ nullptr };
 
 		auto* dlrr = this->rtpStream->GetRtcpXrDelaySinceLastRr(nowMs);
 
 		if (dlrr)
 		{
-			auto* report = new RTC::RTCP::DelaySinceLastRr();
-			report->AddSsrcInfo(dlrr);
-
-			xrReports.push_back(report);
+			delaySinceLastRrReport = new RTC::RTCP::DelaySinceLastRr();
+			delaySinceLastRrReport->AddSsrcInfo(dlrr);
 		}
 
 		// RTCP Compound packet buffer cannot hold the data.
-		if (!packet->Add(senderReports, sdesChunks, xrReports))
+		if (!packet->Add(senderReport, sdesChunk, delaySinceLastRrReport))
 			return false;
 
 		this->lastRtcpSentTime = nowMs;

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -957,36 +957,45 @@ namespace RTC
 		packet->RestorePayload();
 	}
 
-	void SimulcastConsumer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs)
+	bool SimulcastConsumer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs)
 	{
 		MS_TRACE();
 
 		if (static_cast<float>((nowMs - this->lastRtcpSentTime) * 1.15) < this->maxRtcpInterval)
-			return;
+			return true;
+
+		std::vector<RTCP::SenderReport*> senderReports;
+		std::vector<RTCP::SdesChunk*> sdesChunks;
+		std::vector<RTCP::DelaySinceLastRr*> xrReports;
 
 		auto* report = this->rtpStream->GetRtcpSenderReport(nowMs);
 
 		if (!report)
-			return;
+			return true;
 
-		packet->AddSenderReport(report);
+		senderReports.push_back(report);
 
 		// Build SDES chunk for this sender.
 		auto* sdesChunk = this->rtpStream->GetRtcpSdesChunk();
-
-		packet->AddSdesChunk(sdesChunk);
+		sdesChunks.push_back(sdesChunk);
 
 		auto* dlrr = this->rtpStream->GetRtcpXrDelaySinceLastRr(nowMs);
 
 		if (dlrr)
 		{
 			auto* report = new RTC::RTCP::DelaySinceLastRr();
-
 			report->AddSsrcInfo(dlrr);
-			packet->AddDelaySinceLastRr(report);
+
+			xrReports.push_back(report);
 		}
 
+		// RTCP Compound packet buffer cannot hold the data.
+		if (!packet->Add(senderReports, sdesChunks, xrReports))
+			return false;
+
 		this->lastRtcpSentTime = nowMs;
+
+		return true;
 	}
 
 	void SimulcastConsumer::NeedWorstRemoteFractionLost(

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -673,36 +673,45 @@ namespace RTC
 		packet->RestorePayload();
 	}
 
-	void SvcConsumer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs)
+	bool SvcConsumer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs)
 	{
 		MS_TRACE();
 
 		if (static_cast<float>((nowMs - this->lastRtcpSentTime) * 1.15) < this->maxRtcpInterval)
-			return;
+			return true;
+
+		std::vector<RTCP::SenderReport*> senderReports;
+		std::vector<RTCP::SdesChunk*> sdesChunks;
+		std::vector<RTCP::DelaySinceLastRr*> xrReports;
 
 		auto* report = this->rtpStream->GetRtcpSenderReport(nowMs);
 
 		if (!report)
-			return;
+			return true;
 
-		packet->AddSenderReport(report);
+		senderReports.push_back(report);
 
 		// Build SDES chunk for this sender.
 		auto* sdesChunk = this->rtpStream->GetRtcpSdesChunk();
-
-		packet->AddSdesChunk(sdesChunk);
+		sdesChunks.push_back(sdesChunk);
 
 		auto* dlrr = this->rtpStream->GetRtcpXrDelaySinceLastRr(nowMs);
 
 		if (dlrr)
 		{
 			auto* report = new RTC::RTCP::DelaySinceLastRr();
-
 			report->AddSsrcInfo(dlrr);
-			packet->AddDelaySinceLastRr(report);
+
+			xrReports.push_back(report);
 		}
 
+		// RTCP Compound packet buffer cannot hold the data.
+		if (!packet->Add(senderReports, sdesChunks, xrReports))
+			return false;
+
 		this->lastRtcpSentTime = nowMs;
+
+		return true;
 	}
 
 	void SvcConsumer::NeedWorstRemoteFractionLost(uint32_t /*mappedSsrc*/, uint8_t& worstRemoteFractionLost)

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -680,33 +680,26 @@ namespace RTC
 		if (static_cast<float>((nowMs - this->lastRtcpSentTime) * 1.15) < this->maxRtcpInterval)
 			return true;
 
-		std::vector<RTCP::SenderReport*> senderReports;
-		std::vector<RTCP::SdesChunk*> sdesChunks;
-		std::vector<RTCP::DelaySinceLastRr*> xrReports;
+		auto* senderReport = this->rtpStream->GetRtcpSenderReport(nowMs);
 
-		auto* report = this->rtpStream->GetRtcpSenderReport(nowMs);
-
-		if (!report)
+		if (!senderReport)
 			return true;
-
-		senderReports.push_back(report);
 
 		// Build SDES chunk for this sender.
 		auto* sdesChunk = this->rtpStream->GetRtcpSdesChunk();
-		sdesChunks.push_back(sdesChunk);
+
+		RTC::RTCP::DelaySinceLastRr* delaySinceLastRrReport{ nullptr };
 
 		auto* dlrr = this->rtpStream->GetRtcpXrDelaySinceLastRr(nowMs);
 
 		if (dlrr)
 		{
-			auto* report = new RTC::RTCP::DelaySinceLastRr();
-			report->AddSsrcInfo(dlrr);
-
-			xrReports.push_back(report);
+			delaySinceLastRrReport = new RTC::RTCP::DelaySinceLastRr();
+			delaySinceLastRrReport->AddSsrcInfo(dlrr);
 		}
 
 		// RTCP Compound packet buffer cannot hold the data.
-		if (!packet->Add(senderReports, sdesChunks, xrReports))
+		if (!packet->Add(senderReport, sdesChunk, delaySinceLastRrReport))
 			return false;
 
 		this->lastRtcpSentTime = nowMs;

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -673,12 +673,9 @@ namespace RTC
 		packet->RestorePayload();
 	}
 
-	void SvcConsumer::GetRtcp(
-	  RTC::RTCP::CompoundPacket* packet, RTC::RtpStreamSend* rtpStream, uint64_t nowMs)
+	void SvcConsumer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs)
 	{
 		MS_TRACE();
-
-		MS_ASSERT(rtpStream == this->rtpStream, "RTP stream does not match");
 
 		if (static_cast<float>((nowMs - this->lastRtcpSentTime) * 1.15) < this->maxRtcpInterval)
 			return;

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2245,7 +2245,6 @@ namespace RTC
 			// Send the RTCP compound packet if it's full.
 			if (!consumer->GetRtcp(packet.get(), nowMs))
 			{
-				packet->Serialize(RTC::RTCP::Buffer);
 				SendRtcpCompoundPacket(packet.get());
 
 				// Create a new compount packet.
@@ -2262,7 +2261,6 @@ namespace RTC
 			// Send the RTCP compound packet if it's full.
 			if (!producer->GetRtcp(packet.get(), nowMs))
 			{
-				packet->Serialize(RTC::RTCP::Buffer);
 				SendRtcpCompoundPacket(packet.get());
 
 				// Create a new compount packet.
@@ -2275,7 +2273,6 @@ namespace RTC
 		// Send the RTCP compound packet if there is any sender or receiver report.
 		if (packet->GetReceiverReportCount() > 0u || packet->GetSenderReportCount() > 0u)
 		{
-			packet->Serialize(RTC::RTCP::Buffer);
 			SendRtcpCompoundPacket(packet.get());
 		}
 	}

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -3030,34 +3030,12 @@ namespace RTC
 
 			SendRtcp(nowMs);
 
-			// Recalculate next RTCP interval.
-			if (!this->mapConsumers.empty())
-			{
-				// Transmission rate in kbps.
-				uint32_t rate{ 0 };
-
-				// Get the RTP sending rate.
-				for (auto& kv : this->mapConsumers)
-				{
-					auto* consumer = kv.second;
-
-					rate += consumer->GetTransmissionRate(nowMs) / 1000;
-				}
-
-				// Calculate bandwidth: 360 / transmission bandwidth in kbit/s.
-				if (rate != 0u)
-					interval = 360000 / rate;
-
-				if (interval > RTC::RTCP::MaxVideoIntervalMs)
-					interval = RTC::RTCP::MaxVideoIntervalMs;
-			}
-
 			/*
 			 * The interval between RTCP packets is varied randomly over the range
-			 * [0.5,1.5] times the calculated interval to avoid unintended synchronization
+			 * [1.0,1.5] times the calculated interval to avoid unintended synchronization
 			 * of all participants.
 			 */
-			interval *= static_cast<float>(Utils::Crypto::GetRandomUInt(5, 15)) / 10;
+			interval *= static_cast<float>(Utils::Crypto::GetRandomUInt(10, 15)) / 10;
 
 			this->rtcpTimer->Start(interval);
 		}

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -918,6 +918,8 @@ namespace RTC
 		if (!IsConnected())
 			return;
 
+		packet->Serialize(RTC::RTCP::Buffer);
+
 		const uint8_t* data = packet->GetData();
 		auto intLen         = static_cast<int>(packet->GetSize());
 

--- a/worker/test/src/RTC/RTCP/TestSenderReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestSenderReport.cpp
@@ -120,7 +120,7 @@ SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 		// Serialization must contain 3 SR packets.
 		packet.Serialize(buffer);
 
-		SenderReport* reports[count] { nullptr };
+		SenderReport* reports[count]{ nullptr };
 
 		auto* packet2 = static_cast<SenderReportPacket*>(Packet::Parse(buffer, sizeof(buffer)));
 

--- a/worker/test/src/RTC/RTCP/TestSenderReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestSenderReport.cpp
@@ -94,6 +94,71 @@ SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 		delete report;
 	}
 
+	SECTION("create SR packet multiple reports")
+	{
+		const size_t count = 3;
+
+		SenderReportPacket packet;
+
+		for (auto i = 1; i <= count; i++)
+		{
+			// Create report and add to packet.
+			SenderReport* report = new SenderReport();
+
+			report->SetSsrc(i);
+			report->SetNtpSec(i);
+			report->SetNtpFrac(i);
+			report->SetRtpTs(i);
+			report->SetPacketCount(i);
+			report->SetOctetCount(i);
+
+			packet.AddReport(report);
+		}
+
+		uint8_t buffer[1500] = { 0 };
+
+		// Serialization must contain 3 SR packets.
+		packet.Serialize(buffer);
+
+		SenderReport* reports[count] { nullptr };
+
+		auto* packet2 = static_cast<SenderReportPacket*>(Packet::Parse(buffer, sizeof(buffer)));
+
+		REQUIRE(packet2 != nullptr);
+
+		reports[0] = *(packet2->Begin());
+
+		auto* packet3 = static_cast<SenderReportPacket*>(packet2->GetNext());
+
+		REQUIRE(packet3 != nullptr);
+
+		reports[1] = *(packet3->Begin());
+
+		auto* packet4 = static_cast<SenderReportPacket*>(packet3->GetNext());
+
+		REQUIRE(packet4 != nullptr);
+
+		reports[2] = *(packet4->Begin());
+
+		for (auto i = 1; i <= count; i++)
+		{
+			auto* report = reports[i - 1];
+
+			REQUIRE(report != nullptr);
+
+			REQUIRE(report->GetSsrc() == i);
+			REQUIRE(report->GetNtpSec() == i);
+			REQUIRE(report->GetNtpFrac() == i);
+			REQUIRE(report->GetRtpTs() == i);
+			REQUIRE(report->GetPacketCount() == i);
+			REQUIRE(report->GetOctetCount() == i);
+		}
+
+		delete packet2;
+		delete packet3;
+		delete packet4;
+	}
+
 	SECTION("create SR")
 	{
 		// Create local report and check content.


### PR DESCRIPTION
Fixes #907

Enhances RTCP compound packet sending:
* It does now fill the RTCP compound packet as much as possible before sending:
  * Reduces the number of RTCP packets sent and the overhead given by smaller packets.
  * Reduces RTCP compound packet memory allocations since they are used much less now.

**NOTE:** Please read the changes commit by commit. 