### PR TITLE
Fix SIGSEGV at RTC::WebRtcTransport::OnIceServerTupleRemoved()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### Next
 
+* Fix SIGSEGV at `RTC::WebRtcTransport::OnIceServerTupleRemoved()` (PR #915, credits to @ybybwdwd).
+
 
 ### 3.10.7
 

--- a/worker/src/RTC/IceServer.cpp
+++ b/worker/src/RTC/IceServer.cpp
@@ -296,27 +296,23 @@ namespace RTC
 		if (!removedTuple)
 			return;
 
+		// Notify the listener.
+		this->listener->OnIceServerTupleRemoved(this, removedTuple);
+
+		// Remove it from the list of tuples.
+		// NOTE: Do it after notifying the listener since the listener may need to
+		// use/read the tuple being removed so we cannot free it yet.
+		this->tuples.erase(it);
+
 		// If this is the selected tuple, do things.
 		if (removedTuple == this->selectedTuple)
 		{
 			this->selectedTuple = nullptr;
 
-			// Mark the first tuple as selected tuple (if any).
-			// NOTE: The tuple being removed is still in the list.
-			if (this->tuples.size() >= 2)
+			// MArk next tuple as selected one.
+			if (this->tuples.begin() != this->tuples.end())
 			{
-				for (auto it2 = this->tuples.begin(); it2 != this->tuples.end(); ++it2)
-				{
-					RTC::TransportTuple* storedTuple = std::addressof(*it2);
-
-					// Ignore the tuple being removed (which was the previously selected one).
-					if (!storedTuple->Compare(removedTuple))
-					{
-						SetSelectedTuple(storedTuple);
-
-						break;
-					}
-				}
+				SetSelectedTuple(std::addressof(*this->tuples.begin()));
 			}
 			// Or just emit 'disconnected'.
 			else

--- a/worker/src/RTC/IceServer.cpp
+++ b/worker/src/RTC/IceServer.cpp
@@ -323,14 +323,6 @@ namespace RTC
 				this->listener->OnIceServerDisconnected(this);
 			}
 		}
-
-		// Notify the listener.
-		this->listener->OnIceServerTupleRemoved(this, removedTuple);
-
-		// Remove it from the list of tuples.
-		// NOTE: Do it after notifying the listener since the listener may need to
-		// use/read the tuple being removed so we cannot free it yet.
-		this->tuples.erase(it);
 	}
 
 	void IceServer::ForceSelectedTuple(const RTC::TransportTuple* tuple)

--- a/worker/src/RTC/IceServer.cpp
+++ b/worker/src/RTC/IceServer.cpp
@@ -309,7 +309,7 @@ namespace RTC
 		{
 			this->selectedTuple = nullptr;
 
-			// MArk next tuple as selected one.
+			// Mark the first tuple as selected tuple (if any).
 			if (this->tuples.begin() != this->tuples.end())
 			{
 				SetSelectedTuple(std::addressof(*this->tuples.begin()));

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -1278,7 +1278,9 @@ namespace RTC
 
 		// If this is a TCP tuple, close its underlaying TCP connection.
 		if (tuple->GetProtocol() == RTC::TransportTuple::Protocol::TCP && !tuple->IsClosed())
+		{
 			tuple->Close();
+		}
 	}
 
 	inline void WebRtcTransport::OnIceServerSelectedTuple(


### PR DESCRIPTION
- Fixes #883

### Details

As @ybybwdwd said in in https://github.com/versatica/mediasoup/issues/883#issuecomment-1261976426:

- `IceServer` manages a list of `TransportTuples` instances in a `std::list`. Those are **not** pointers.
- When `IceServer` removes a tuple from the list (for different reasons), it removes it from its `std::list`, which means that the removed `TransportTuple` is **freed**. And then it notifies `WebRtcTransport` via `this->listener->OnIceServerTupleRemoved(this, removedTuple);`.
- Problem was that `WebRtcTransport` reads tuple data (`tuple->GetProtocol()` etc) within its `OnIceServerTupleRemoved()` method, so it's reading freed memory!, so crash.


Solution is to first notify the listener (`WebRtcTransport`) then remove it from the list (so free it after used).