### PR TITLE
Consumer: use a bitset instead of a set for supported payload types

### DIFF
--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -187,7 +187,9 @@ namespace RTC
 		struct RTC::RtpHeaderExtensionIds rtpHeaderExtensionIds;
 		const std::vector<uint8_t>* producerRtpStreamScores{ nullptr };
 		// Others.
-		absl::flat_hash_set<uint8_t> supportedCodecPayloadTypes;
+		// Whether a payload type is supported or not is represented in the
+		// corresponding position of the bitset.
+		std::bitset<128u> supportedCodecPayloadTypes;
 		uint64_t lastRtcpSentTime{ 0u };
 		uint16_t maxRtcpInterval{ 0u };
 		bool externallyManagedBitrate{ false };

--- a/worker/src/RTC/Consumer.cpp
+++ b/worker/src/RTC/Consumer.cpp
@@ -130,7 +130,7 @@ namespace RTC
 		for (auto& codec : this->rtpParameters.codecs)
 		{
 			if (codec.mimeType.IsMediaCodec())
-				this->supportedCodecPayloadTypes.insert(codec.payloadType);
+				this->supportedCodecPayloadTypes[codec.payloadType] = true;
 		}
 
 		// Fill media SSRCs vector.
@@ -192,7 +192,13 @@ namespace RTC
 		}
 
 		// Add supportedCodecPayloadTypes.
-		jsonObject["supportedCodecPayloadTypes"] = this->supportedCodecPayloadTypes;
+		jsonObject["supportedCodecPayloadTypes"] = json::array();
+
+		for (auto i = 0; i < 128; ++i)
+		{
+			if (this->supportedCodecPayloadTypes[i])
+				jsonObject["supportedCodecPayloadTypes"].push_back(i);
+		}
 
 		// Add paused.
 		jsonObject["paused"] = this->paused;

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -205,7 +205,7 @@ namespace RTC
 
 		// NOTE: This may happen if this Consumer supports just some codecs of those
 		// in the corresponding Producer.
-		if (this->supportedCodecPayloadTypes.find(payloadType) == this->supportedCodecPayloadTypes.end())
+		if (!this->supportedCodecPayloadTypes[payloadType])
 		{
 			MS_DEBUG_DEV("payload type not supported [payloadType:%" PRIu8 "]", payloadType);
 

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -270,7 +270,7 @@ namespace RTC
 
 		// NOTE: This may happen if this Consumer supports just some codecs of those
 		// in the corresponding Producer.
-		if (this->supportedCodecPayloadTypes.find(payloadType) == this->supportedCodecPayloadTypes.end())
+		if (!this->supportedCodecPayloadTypes[payloadType])
 		{
 			MS_DEBUG_DEV("payload type not supported [payloadType:%" PRIu8 "]", payloadType);
 

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -665,7 +665,7 @@ namespace RTC
 
 		// NOTE: This may happen if this Consumer supports just some codecs of those
 		// in the corresponding Producer.
-		if (this->supportedCodecPayloadTypes.find(payloadType) == this->supportedCodecPayloadTypes.end())
+		if (!this->supportedCodecPayloadTypes[payloadType])
 		{
 			MS_DEBUG_DEV("payload type not supported [payloadType:%" PRIu8 "]", payloadType);
 

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -563,7 +563,7 @@ namespace RTC
 
 		// NOTE: This may happen if this Consumer supports just some codecs of those
 		// in the corresponding Producer.
-		if (this->supportedCodecPayloadTypes.find(payloadType) == this->supportedCodecPayloadTypes.end())
+		if (!this->supportedCodecPayloadTypes[payloadType])
 		{
 			MS_DEBUG_DEV("payload type not supported [payloadType:%" PRIu8 "]", payloadType);
 


### PR DESCRIPTION
This is way more performant.
* Before the change, set.find() could take as much as half of the CPU time taken by RtpStreamSend::ReceivePacket().
* After the change, bitset[] CPU time is negligible.

Extra: It takes less space than the set.