### PR TITLE
RtpPacket: optimize UpdateMid()

### DIFF
--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -315,7 +315,7 @@ namespace RTC
 			return true;
 		}
 
-		bool UpdateMid(const std::string& mid);
+		void UpdateMid(const std::string& mid);
 
 		bool ReadRid(std::string& rid) const
 		{

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -533,7 +533,7 @@ namespace RTC
 		MS_ASSERT(ptr == this->payload, "wrong ptr calculation");
 	}
 
-	bool RtpPacket::UpdateMid(const std::string& mid)
+	void RtpPacket::UpdateMid(const std::string& mid)
 	{
 		MS_TRACE();
 
@@ -541,25 +541,25 @@ namespace RTC
 		uint8_t* extenValue = GetExtension(this->midExtensionId, extenLen);
 
 		if (!extenValue)
-			return false;
+			return;
+
+		size_t midLen = mid.length();
 
 		// Here we assume that there is MidMaxLength available bytes, even if now
 		// they are padding bytes.
-		if (mid.size() > RTC::MidMaxLength)
+		if (midLen > RTC::MidMaxLength)
 		{
 			MS_ERROR(
 			  "no enough space for MID value [MidMaxLength:%" PRIu8 ", mid:'%s']",
 			  RTC::MidMaxLength,
 			  mid.c_str());
 
-			return false;
+			return;
 		}
 
-		std::memcpy(extenValue, mid.c_str(), mid.size());
+		std::memcpy(extenValue, mid.c_str(), midLen);
 
-		SetExtensionLength(this->midExtensionId, mid.size());
-
-		return true;
+		SetExtensionLength(this->midExtensionId, midLen);
 	}
 
 	/**


### PR DESCRIPTION
* Make it void since the return value is not used anywhere.
* Cache the mid string size to avoid calling it multiple times.