### PR TITLE
fix: fix the json serialization for the payload channel rtp event

### DIFF
--- a/worker/src/PayloadChannel/PayloadChannelNotifier.cpp
+++ b/worker/src/PayloadChannel/PayloadChannelNotifier.cpp
@@ -31,7 +31,7 @@ namespace PayloadChannel
 		notification.append(targetId);
 		notification.append("\",\"event\":\"");
 		notification.append(event);
-		notification.append("}");
+		notification.append("\"}");
 
 		PayloadChannelNotifier::payloadChannel->Send(notification, payload, payloadLen);
 	}


### PR DESCRIPTION
The rust package throws the following errors when trying to ingest DirectTransport's `rtp` event from the C++ process.

```
[2022-10-18T13:52:32Z ERROR mediasoup::worker] worker[id:6f303805-5d89-48e2-813c-7a2e1709770e] unexpected payload channel data: {"targetId":"49a8b34a-b64f-49d7-81f5-09fd10c20d00","event":"rtp}
[2022-10-18T13:52:32Z ERROR mediasoup::worker] worker[id:6f303805-5d89-48e2-813c-7a2e1709770e] unexpected payload channel data: {"targetId":"49a8b34a-b64f-49d7-81f5-09fd10c20d00","event":"rtp}
[2022-10-18T13:52:32Z ERROR mediasoup::worker] worker[id:6f303805-5d89-48e2-813c-7a2e1709770e] unexpected payload channel data: {"targetId":"fc977b9b-0632-493d-b964-a93691d52083","event":"rtp}
[2022-10-18T13:52:32Z ERROR mediasoup::worker] worker[id:6f303805-5d89-48e2-813c-7a2e1709770e] unexpected payload channel data: {"targetId":"49a8b34a-b64f-49d7-81f5-09fd10c20d00","event":"rtp}
[2022-10-18T13:52:32Z ERROR mediasoup::worker] worker[id:6f303805-5d89-48e2-813c-7a2e1709770e] unexpected payload channel data: {"targetId":"49a8b34a-b64f-49d7-81f5-09fd10c20d00","event":"rtp}
```

The error shows what the issue is, a serialization issue for payload channel events that do not use the json data parameter.
I've applied the below fix locally and the error has disappeared, and I'm able to ingest and use the media data.

