### PR TITLE
RTCP: Fix trailing space needed by srtp_protect_rtcp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### 3.10.11
 
-* Fix trailing space needed by srtp_protect_rtcp.
+* RTCP: Fix trailing space needed by srtp_protect_rtcp() (PR #929).
 
 
 ### 3.10.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### 3.10.11
+
+* Fix trailing space needed by srtp_protect_rtcp.
+
+
 ### 3.10.10
 
 * Fix the JSON serialization for the payload channel `rtp` event (PR #926 by @mhammo).

--- a/worker/include/RTC/RTCP/CompoundPacket.hpp
+++ b/worker/include/RTC/RTCP/CompoundPacket.hpp
@@ -18,10 +18,10 @@ namespace RTC
 		{
 		public:
 			// Maximum size for a CompundPacket, leaving free space for encryption.
-			// 144 is the maximum number of octects that will be added to an RTP packet
-			// by srtp_protect().
+			// SRTP_MAX_TRAILER_LEN+4 is the maximum number of octects that will be
+			// added to an RTCP packet by srtp_protect_rtcp().
 			// srtp.h: SRTP_MAX_TRAILER_LEN (SRTP_MAX_TAG_LEN + SRTP_MAX_MKI_LEN)
-			constexpr static size_t MaxSize{ RTC::MtuSize - 144u };
+			constexpr static size_t MaxSize{ RTC::MtuSize - 148u };
 
 		public:
 			CompoundPacket() = default;


### PR DESCRIPTION
RTCP needs 4 bytes more than RTP when SRTP protecting.

This could mean that the last RTCP report in a compound packet (if full) was undecryptable and hence unreadable by the receiver.

This would affect the RTCP compound packet generation.