### PR TITLE
Transport: remove duplicate call to method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ### NEXT
 
+* Transport: remove duplicate call to method (PR #931)
+
 
 ### 3.10.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### NEXT
 
-* Transport: remove duplicate call to method (PR #931)
+* Transport: Remove duplicate call to method (PR #931).
 
 
 ### 3.10.12

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2241,33 +2241,39 @@ namespace RTC
 		for (auto& kv : this->mapConsumers)
 		{
 			auto* consumer = kv.second;
+			auto rtcpAdded = consumer->GetRtcp(packet.get(), nowMs);
 
-			// Send the RTCP compound packet if it's full.
-			if (!consumer->GetRtcp(packet.get(), nowMs))
+			// RTCP data couldn't be added because the Compound packet is full.
+			// Send the RTCP compound packet and request for RTCP again.
+			if (!rtcpAdded)
 			{
 				SendRtcpCompoundPacket(packet.get());
 
 				// Create a new compount packet.
 				packet.reset(new RTC::RTCP::CompoundPacket());
-			}
 
-			consumer->GetRtcp(packet.get(), nowMs);
+				// Retrieve the RTCP again.
+				consumer->GetRtcp(packet.get(), nowMs);
+			}
 		}
 
 		for (auto& kv : this->mapProducers)
 		{
 			auto* producer = kv.second;
+			auto rtcpAdded = producer->GetRtcp(packet.get(), nowMs);
 
-			// Send the RTCP compound packet if it's full.
-			if (!producer->GetRtcp(packet.get(), nowMs))
+			// RTCP data couldn't be added because the Compound packet is full.
+			// Send the RTCP compound packet and request for RTCP again.
+			if (!rtcpAdded)
 			{
 				SendRtcpCompoundPacket(packet.get());
 
 				// Create a new compount packet.
 				packet.reset(new RTC::RTCP::CompoundPacket());
-			}
 
-			producer->GetRtcp(packet.get(), nowMs);
+				// Retrieve the RTCP again.
+				producer->GetRtcp(packet.get(), nowMs);
+			}
 		}
 
 		// Send the RTCP compound packet if there is any sender or receiver report.


### PR DESCRIPTION
We were calling twice Producer->GetRtcp() and Consumer->GetRtcp().

Those calls were not having any effect because the above methods just return if they are called before than expected, so the second call had no effect.