### PR TITLE
Fix issue 932

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* Fix worker crash due to `std::out_of_range` exception (PR #933).
+
+
 ### 3.10.11
 
 * RTCP: Fix trailing space needed by srtp_protect_rtcp() (PR #929).

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -36,6 +36,7 @@ namespace RTC
 			// clang-format off
 			return (
 				RTC::Consumer::IsActive() &&
+				this->producerRtpStreams.size() > 0 &&
 				std::any_of(
 					this->producerRtpStreams.begin(),
 					this->producerRtpStreams.end(),

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -36,7 +36,6 @@ namespace RTC
 			// clang-format off
 			return (
 				RTC::Consumer::IsActive() &&
-				this->producerRtpStreams.size() > 0 &&
 				std::any_of(
 					this->producerRtpStreams.begin(),
 					this->producerRtpStreams.end(),

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -453,7 +453,7 @@ namespace RTC
 			// This can be null.
 			auto* producerRtpStream = this->producerRtpStreams.at(spatialLayer);
 
-			// Producer stream does not exist or it's not good. Ignore.
+			// Producer stream does not exist. Ignore.
 			if (!producerRtpStream)
 				continue;
 

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -627,7 +627,7 @@ namespace RTC
 		auto nowMs = DepLibUV::GetTimeMs();
 		uint32_t desiredBitrate{ 0u };
 
-		for (int16_t sIdx{ static_cast<int16_t>(this->producerRtpStreams.size() - 1) }; sIdx >= 0; --sIdx)
+		for (auto sIdx{ static_cast<int16_t>(this->producerRtpStreams.size() - 1) }; sIdx >= 0; --sIdx)
 		{
 			auto* producerRtpStream = this->producerRtpStreams.at(sIdx);
 

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -627,7 +627,7 @@ namespace RTC
 		auto nowMs = DepLibUV::GetTimeMs();
 		uint32_t desiredBitrate{ 0u };
 
-		for (size_t sIdx{ this->producerRtpStreams.size() - 1 }; sIdx >= 0; --sIdx)
+		for (int16_t sIdx{ static_cast<int16_t>(this->producerRtpStreams.size() - 1) }; sIdx >= 0; --sIdx)
 		{
 			auto* producerRtpStream = this->producerRtpStreams.at(sIdx);
 


### PR DESCRIPTION
Hopefully fixes #932

We've been looking for all calls to `.at()` and other calls that may produce `std::out_of_range` as explained in https://github.com/versatica/mediasoup/issues/932#issuecomment-1292176319. 