### PR TITLE
Fix type of `bufferedAmount` value in JSON

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Transport: Remove duplicate call to method (PR #931).
 * RTCP: Adjust maximum compound packet size (PR #934).
+* Fix `bufferedAmount` type to be a number again (PR #936).
 
 
 ### 3.10.12

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -209,10 +209,10 @@ namespace RTC
 				// Trigger 'bufferedamountlow' now.
 				if (this->bufferedAmount <= this->bufferedAmountLowThreshold)
 				{
-					std::string data(R"({"bufferedAmount":")");
+					std::string data(R"({"bufferedAmount":)");
 
 					data.append(std::to_string(this->bufferedAmount));
-					data.append("\"}");
+					data.append("}");
 				}
 				// Force the trigger of 'bufferedamountlow' once there is less or same
 				// buffered data than the given threshold.
@@ -350,10 +350,10 @@ namespace RTC
 			this->forceTriggerBufferedAmountLow = false;
 
 			// Notify the Node DataConsumer.
-			std::string data(R"({"bufferedAmount":")");
+			std::string data(R"({"bufferedAmount":)");
 
 			data.append(std::to_string(this->bufferedAmount));
-			data.append("\"}");
+			data.append("}");
 
 			Channel::ChannelNotifier::Emit(this->id, "bufferedamountlow", data);
 		}


### PR DESCRIPTION
Fixes #930, which is a regression introduced in #893 where value changed from being a number to a string.