### PR TITLE
Fix racy Rust test

### DIFF
--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -593,10 +593,11 @@ fn consume_succeeds() {
             }
         }
 
+        let video_pipe_consumer;
         {
             assert!(router.can_consume(&video_producer.id(), &consumer_device_capabilities));
 
-            let video_pipe_consumer = transport_2
+            video_pipe_consumer = transport_2
                 .consume({
                     let mut options = ConsumerOptions::new(
                         video_producer.id(),


### PR DESCRIPTION
Fixes #935

There were two cases tested in one test and router dump was examined after each. However, due to entities being destroyed on worker asynchronously, it was racy and in rare cases old producer wasn't quite destroyed on the worker yet, appearing in its dump. I just split the test case into two since they are essentially independent.

If you ignore white spaces while checking the diff, you'll see how little code actually changed.