### PR TITLE
Fix clippy lints from the latest Rust release

### DIFF
--- a/rust/examples/echo.rs
+++ b/rust/examples/echo.rs
@@ -51,6 +51,7 @@ struct TransportOptions {
 #[derive(Serialize, Message)]
 #[serde(tag = "action")]
 #[rtype(result = "()")]
+#[allow(clippy::large_enum_variant)]
 enum ServerMessage {
     /// Initialization message with consumer/producer transport options and Router's RTP
     /// capabilities necessary to establish WebRTC transport connection client-side

--- a/rust/examples/svc-simulcast.rs
+++ b/rust/examples/svc-simulcast.rs
@@ -64,6 +64,7 @@ struct TransportOptions {
 #[derive(Serialize, Message)]
 #[serde(tag = "action")]
 #[rtype(result = "()")]
+#[allow(clippy::large_enum_variant)]
 enum ServerMessage {
     /// Initialization message with consumer/producer transport options and Router's RTP
     /// capabilities necessary to establish WebRTC transport connection client-side

--- a/rust/examples/videoroom.rs
+++ b/rust/examples/videoroom.rs
@@ -354,6 +354,7 @@ mod participant {
         #[derive(Serialize, Message)]
         #[serde(tag = "action")]
         #[rtype(result = "()")]
+        #[allow(clippy::large_enum_variant)]
         pub enum ServerMessage {
             /// Initialization message with consumer/producer transport options and Router's RTP
             /// capabilities necessary to establish WebRTC transport connection client-side

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -2,7 +2,7 @@ use std::env;
 use std::process::Command;
 
 fn main() {
-    if std::env::var("DOCS_RS").is_ok() {
+    if env::var("DOCS_RS").is_ok() {
         // Skip everything when building docs on docs.rs
         return;
     }
@@ -60,7 +60,7 @@ fn main() {
     #[cfg(target_os = "macos")]
     {
         let path = Command::new("xcrun")
-            .args(&["--show-sdk-path"])
+            .arg("--show-sdk-path")
             .output()
             .expect("Failed to start")
             .stdout;
@@ -84,7 +84,7 @@ fn main() {
     if !Command::new("make")
         .arg("libmediasoup-worker")
         .env("MEDIASOUP_OUT_DIR", &mediasoup_out_dir)
-        .env("MEDIASOUP_BUILDTYPE", &build_type)
+        .env("MEDIASOUP_BUILDTYPE", build_type)
         // Force forward slashes on Windows too, otherwise Meson thinks path is not absolute 🤷
         .env("INSTALL_DIR", &out_dir.replace('\\', "/"))
         .spawn()


### PR DESCRIPTION
Those in example apps are just suppressed