### PR TITLE
libwebrtc fixes and updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * `DataConsumer`: Fix `bufferedAmount` type to be a number again (PR #936).
 * `ActiveSpeakerObserver`: Fix 'dominantspeaker' event by having a single `Producer` as argument rather than an array with a single `Producer` into it (PR #941).
 * `ActiveSpeakerObserver`: Fix memory leak (PR #942).
+* Fix some libwebrtc issues (PR #944).
 * Update NPM deps.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@
 
 ### 3.10.11
 
-* RTCP: Fix trailing space needed by srtp_protect_rtcp() (PR #929).
+* RTCP: Fix trailing space needed by `srtp_protect_rtcp()` (PR #929).
 
 
 ### 3.10.10

--- a/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_network_control.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_network_control.cc
@@ -431,7 +431,7 @@ NetworkControlUpdate GoogCcNetworkController::OnTransportPacketsFeedback(
   for (const auto& feedback : feedbacks) {
     TimeDelta feedback_rtt =
         report.feedback_time - feedback.sent_packet.send_time;
-    TimeDelta min_pending_time = feedback.receive_time - max_recv_time;
+    TimeDelta min_pending_time = max_recv_time - feedback.receive_time;
     TimeDelta propagation_rtt = feedback_rtt - min_pending_time;
     max_feedback_rtt = std::max(max_feedback_rtt, feedback_rtt);
     min_propagation_rtt = std::min(min_propagation_rtt, propagation_rtt);


### PR DESCRIPTION
- Fix calculation of feedback min_pending_time in goog_cc
  - Fixes #849
  - Issue in libwebrtc: https://bugs.chromium.org/p/webrtc/issues/detail?id=13106
  - Commit in libwebrtc: https://webrtc.googlesource.com/src/+/d65dc979b17cdc7cd359aada59e5bce8a6f1b8ce%5E%21/ -
Fix signed-to-unsigned overflow in send_side_bandwidth_estimation.cc
  - Fixes #872
  - Issue in libwebrtc: https://bugs.chromium.org/p/webrtc/issues/detail?id=14272
  - Commit in libwebrtc: https://webrtc.googlesource.com/src/+/9804aa5f6ad26a45338d685da66497c3bbd88ca6%5E%21/

**NOTE:** Some changes are already present in ongoing PR https://github.com/versatica/mediasoup/pull/922 but it's not yet merged. CC @sarumjanuch