### PR TITLE
Meson: Pin ninja version to 1.10.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* Meson: Pin `ninja` version to 1.10.2.4 to avoid segfault in Linux using `ninja` latest version 1.11.1 (PR #).
+
+
 ### 3.11.1
 
 * `ActiveSpeakerObserver`: Revert 'dominantspeaker' event changes in PR #941 to avoid breaking changes (PR #947).

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -34,7 +34,6 @@ MESON_ARGS ?= ""
 PIP_BUILD_BINARIES = $(shell [ -f /etc/NIXOS -o -d /etc/guix ] && echo "--no-binary :all:")
 # Let's use a specific version of ninja to avoid issues like this one:
 # https://mediasoup.discourse.group/t/partly-solved-could-not-detect-ninja-v1-8-2-or-newer/
-# https://mediasoup.discourse.group/t/partly-solved-could-not-detect-ninja-v1-8-2-or-newer/
 NINJA_VERSION ?= 1.10.2.4
 
 # Disable `*.pyc` files creation.

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -32,8 +32,10 @@ MESON_ARGS ?= ""
 # Workaround for NixOS and Guix that don't work with pre-built binaries, see:
 # https://github.com/NixOS/nixpkgs/issues/142383.
 PIP_BUILD_BINARIES = $(shell [ -f /etc/NIXOS -o -d /etc/guix ] && echo "--no-binary :all:")
-# Let's use a specific version of ninja to avoid issues like this one:
+# Let's use a specific version of ninja to avoid version 1.11.1 due to a bug in
+# Meson:
 # https://mediasoup.discourse.group/t/partly-solved-could-not-detect-ninja-v1-8-2-or-newer/
+# https://github.com/ninja-build/ninja/issues/2211
 NINJA_VERSION ?= 1.10.2.4
 
 # Disable `*.pyc` files creation.

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -32,6 +32,10 @@ MESON_ARGS ?= ""
 # Workaround for NixOS and Guix that don't work with pre-built binaries, see:
 # https://github.com/NixOS/nixpkgs/issues/142383.
 PIP_BUILD_BINARIES = $(shell [ -f /etc/NIXOS -o -d /etc/guix ] && echo "--no-binary :all:")
+# Let's use a specific version of ninja to avoid issues like this one:
+# https://mediasoup.discourse.group/t/partly-solved-could-not-detect-ninja-v1-8-2-or-newer/
+# https://mediasoup.discourse.group/t/partly-solved-could-not-detect-ninja-v1-8-2-or-newer/
+NINJA_VERSION ?= 1.10.2.4
 
 # Disable `*.pyc` files creation.
 export PYTHONDONTWRITEBYTECODE = 1
@@ -95,7 +99,7 @@ ifeq ($(wildcard $(PIP_DIR)),)
 		echo "Installation failed, likely because PIP is unavailable, if you are on Debian/Ubuntu or derivative please install the python3-pip package"
 	# Install `meson` and `ninja` using `pip` into custom location, so we don't
 	# depend on system-wide installation.
-	$(PYTHON) -m pip install --upgrade --target=$(PIP_DIR) $(PIP_BUILD_BINARIES) meson==$(MESON_VERSION) ninja
+	$(PYTHON) -m pip install --upgrade --target=$(PIP_DIR) $(PIP_BUILD_BINARIES) meson==$(MESON_VERSION) ninja==$(NINJA_VERSION)
 endif
 
 setup: meson-ninja


### PR DESCRIPTION
- Avoid issue in Linux using `ninja` latest version 1.11.1 which returns error code 245 instead of 0 when running `ninja --version`, which makes Meson fail.
- Thanks Vittorio Palmisano @vpalmisano.

More info:

- https://mediasoup.discourse.group/t/partly-solved-could-not-detect-ninja-v1-8-2-or-newer
- https://github.com/ninja-build/ninja/issues/2211
- https://github.com/ninja-build/ninja/issues/2212