### PR TITLE
ChannelMessageHandlers: Make RegisterHandler() not remove the existing handler if another one with same id is given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* `ChannelMessageHandlers`: Make `RegisterHandler()` not remove the existing handler if another one with same `id` is given (PR #952).
+
+
 ### 3.11.2
 
 * Fix installation issue in Linux due to a bug in ninja latest version 1.11.1 (PR #948).

--- a/node/tests/test-PipeTransport.js
+++ b/node/tests/test-PipeTransport.js
@@ -473,6 +473,17 @@ test('router.pipeToRouter() fails if both Routers belong to the same Worker', as
 		.rejects
 		.toThrow(Error);
 
+	// TODO: Temporal code to show an unexpected error.
+	{
+		// This is ok.
+		expect(videoProducer.closed).toBe(false);
+
+		// However these will fail since the handler Id does not exist in the worker.
+		// This is impossible and must be a bug.
+		await videoProducer.resume();
+		await videoProducer.pause();
+	}
+
 	router1bis.close();
 }, 2000);
 

--- a/node/tests/test-PipeTransport.js
+++ b/node/tests/test-PipeTransport.js
@@ -473,17 +473,6 @@ test('router.pipeToRouter() fails if both Routers belong to the same Worker', as
 		.rejects
 		.toThrow(Error);
 
-	// TODO: Temporal code to show an unexpected error.
-	{
-		// This is ok.
-		expect(videoProducer.closed).toBe(false);
-
-		// However these will fail since the handler Id does not exist in the worker.
-		// This is impossible and must be a bug.
-		await videoProducer.resume();
-		await videoProducer.pause();
-	}
-
 	router1bis.close();
 }, 2000);
 

--- a/node/tests/test-PipeTransport.js
+++ b/node/tests/test-PipeTransport.js
@@ -461,6 +461,21 @@ test('router.pipeToRouter() succeeds with video', async () =>
 	expect(pipeProducer.paused).toBe(true);
 }, 2000);
 
+test('router.pipeToRouter() fails if both Routers belong to the same Worker', async () =>
+{
+	const router1bis = await worker1.createRouter({ mediaCodecs });
+
+	await expect(router1.pipeToRouter(
+		{
+			producerId : videoProducer.id,
+			router     : router1bis
+		}))
+		.rejects
+		.toThrow(Error);
+
+	router1bis.close();
+}, 2000);
+
 test('router.createPipeTransport() with enableRtx succeeds', async () =>
 {
 	const pipeTransport = await router1.createPipeTransport(

--- a/worker/src/ChannelMessageHandlers.cpp
+++ b/worker/src/ChannelMessageHandlers.cpp
@@ -63,51 +63,56 @@ void ChannelMessageHandlers::RegisterHandler(
 {
 	MS_TRACE();
 
-	try
+	if (channelRequestHandler != nullptr)
 	{
-		if (channelRequestHandler != nullptr)
+		if (
+		  ChannelMessageHandlers::mapChannelRequestHandlers.find(id) !=
+		  ChannelMessageHandlers::mapChannelRequestHandlers.end())
 		{
-			if (
-			  ChannelMessageHandlers::mapChannelRequestHandlers.find(id) !=
-			  ChannelMessageHandlers::mapChannelRequestHandlers.end())
-			{
-				MS_THROW_ERROR("Channel request handler with ID %s already exists", id.c_str());
-			}
-
-			ChannelMessageHandlers::mapChannelRequestHandlers[id] = channelRequestHandler;
+			MS_THROW_ERROR("Channel request handler with ID %s already exists", id.c_str());
 		}
 
-		if (payloadChannelRequestHandler != nullptr)
-		{
-			if (
-			  ChannelMessageHandlers::mapPayloadChannelRequestHandlers.find(id) !=
-			  ChannelMessageHandlers::mapPayloadChannelRequestHandlers.end())
-			{
-				MS_THROW_ERROR("PayloadChannel request handler with ID %s already exists", id.c_str());
-			}
-
-			ChannelMessageHandlers::mapPayloadChannelRequestHandlers[id] = payloadChannelRequestHandler;
-		}
-
-		if (payloadChannelNotificationHandler != nullptr)
-		{
-			if (
-			  ChannelMessageHandlers::mapPayloadChannelNotificationHandlers.find(id) !=
-			  ChannelMessageHandlers::mapPayloadChannelNotificationHandlers.end())
-			{
-				MS_THROW_ERROR("PayloadChannel notification handler with ID %s already exists", id.c_str());
-			}
-
-			ChannelMessageHandlers::mapPayloadChannelNotificationHandlers[id] =
-			  payloadChannelNotificationHandler;
-		}
+		ChannelMessageHandlers::mapChannelRequestHandlers[id] = channelRequestHandler;
 	}
-	catch (const MediaSoupError& error)
-	{
-		// In case of error unregister everything.
-		ChannelMessageHandlers::UnregisterHandler(id);
 
-		throw;
+	if (payloadChannelRequestHandler != nullptr)
+	{
+		if (
+		  ChannelMessageHandlers::mapPayloadChannelRequestHandlers.find(id) !=
+		  ChannelMessageHandlers::mapPayloadChannelRequestHandlers.end())
+		{
+			if (channelRequestHandler != nullptr)
+			{
+				ChannelMessageHandlers::mapChannelRequestHandlers.erase(id);
+			}
+
+			MS_THROW_ERROR("PayloadChannel request handler with ID %s already exists", id.c_str());
+		}
+
+		ChannelMessageHandlers::mapPayloadChannelRequestHandlers[id] = payloadChannelRequestHandler;
+	}
+
+	if (payloadChannelNotificationHandler != nullptr)
+	{
+		if (
+		  ChannelMessageHandlers::mapPayloadChannelNotificationHandlers.find(id) !=
+		  ChannelMessageHandlers::mapPayloadChannelNotificationHandlers.end())
+		{
+			if (channelRequestHandler != nullptr)
+			{
+				ChannelMessageHandlers::mapChannelRequestHandlers.erase(id);
+			}
+
+			if (payloadChannelRequestHandler != nullptr)
+			{
+				ChannelMessageHandlers::mapPayloadChannelRequestHandlers.erase(id);
+			}
+
+			MS_THROW_ERROR("PayloadChannel notification handler with ID %s already exists", id.c_str());
+		}
+
+		ChannelMessageHandlers::mapPayloadChannelNotificationHandlers[id] =
+		  payloadChannelNotificationHandler;
 	}
 }
 


### PR DESCRIPTION
- Do not remove existing handler if an attempt to register a new one with same `id` happens. Tis prevents the following issue discovered while adding a new unit test:

```
FAIL  node/tests/test-PipeTransport.js
 ✓ router.pipeToRouter() succeeds with audio (24 ms)
 ✓ router.pipeToRouter() succeeds with video (21 ms)
 ### NEW TEST:
 ✓ router.pipeToRouter() fails if both Routers belong to the same Worker (32 ms)
 ✓ router.createPipeTransport() with enableRtx succeeds (6 ms)
 ✓ router.createPipeTransport() with invalid srtpParameters must fail (3 ms)
 ✓ router.createPipeTransport() with enableSrtp succeeds (9 ms)
 ✓ router.createPipeTransport() with fixed port succeeds (8 ms)
 ✓ transport.consume() for a pipe Producer succeeds (6 ms)
 ### UNRELATED FAILING TEST:
 ✕ producer.pause() and producer.resume() are transmitted to pipe Consumer (2 ms)
 ✓ producer.close() is transmitted to pipe Consumer (2 ms)
 ✓ router.pipeToRouter() succeeds with data (7 ms)
 ✓ transport.dataConsume() for a pipe DataProducer succeeds (2 ms)
 ✓ dataProducer.close() is transmitted to pipe DataConsumer (2 ms)
 ✓ router.pipeToRouter() called twice generates a single PipeTransport pair (14 ms)
 ✓ router.pipeToRouter() called in two Routers passing one to each other as argument generates a single a single PipeTransport pair (10 ms)

 ● producer.pause() and producer.resume() are transmitted to pipe Consumer

   Channel request handler with ID c9cba815-1128-4500-aa4f-7edbc135b889 not found [method:producer.resume]
```

It doesn't make sense that such a test fails with that error (producer not found in the worker). To simplify the error, I've added a temporal code in the new test that clearly shows the issue:

```ts
test('router.pipeToRouter() fails if both Routers belong to the same Worker', async () =>
{
	const router1bis = await worker1.createRouter({ mediaCodecs });

	await expect(router1.pipeToRouter(
		{
			producerId : videoProducer.id,
			router     : router1bis
		}))
		.rejects
		.toThrow(Error);

	// TODO: Temporal code to show an unexpected error.
	{
		// This is ok.
		expect(videoProducer.closed).toBe(false);

		// However these will fail since the handler Id does not exist in the worker.
		// This is impossible and must be a bug.
		await videoProducer.resume();
		await videoProducer.pause();
	}

	router1bis.close();
}, 2000);
```
