### PR TITLE
createWorker(): add libwebrtcFieldTrials option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 * Node: Migrate tests to TypeScript (PR #958).
 * Node: Remove compiled JavaScript from repository and compile TypeScript code on NPM `prepare` script on demand when installed via git (PR #954).
 * `Worker`: Add `RTC::Shared` singleton for RTC entities (PR #953).
-* `createWorker()`: Add `libwebrtcFieldTrials` option (PR #960).
 
 
 ### 3.11.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Node: Migrate tests to TypeScript (PR #958).
 * Node: Remove compiled JavaScript from repository and compile TypeScript code on NPM `prepare` script on demand when installed via git (PR #954).
 * `Worker`: Add `RTC::Shared` singleton for RTC entities (PR #953).
+* `createWorker()`: Add `libwebrtcFieldTrials` option (PR #960).
 
 
 ### 3.11.3

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -66,6 +66,8 @@ export type WorkerSettings =
 
 	/**
 	 * Field trials for libwebrtc.
+	 * @private
+	 *
 	 * NOTE: For advanced users only. An invalid value will make the worker crash.
 	 * Default value is
 	 * "WebRTC-Bwe-AlrLimitedBackoff/Enabled/".

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -65,6 +65,14 @@ export type WorkerSettings =
 	dtlsPrivateKeyFile?: string;
 
 	/**
+	 * Field trials for libwebrtc.
+	 * NOTE: For advanced users only. An invalid value will make the worker crash.
+	 * Default value is
+	 * "WebRTC-Bwe-AlrLimitedBackoff/Enabled/".
+	 */
+	libwebrtcFieldTrials?: string;
+
+	/**
 	 * Custom application data.
 	 */
 	appData?: Record<string, unknown>;
@@ -235,6 +243,7 @@ export class Worker extends EnhancedEventEmitter<WorkerEvents>
 			rtcMaxPort,
 			dtlsCertificateFile,
 			dtlsPrivateKeyFile,
+			libwebrtcFieldTrials,
 			appData
 		}: WorkerSettings)
 	{
@@ -277,6 +286,9 @@ export class Worker extends EnhancedEventEmitter<WorkerEvents>
 
 		if (typeof dtlsPrivateKeyFile === 'string' && dtlsPrivateKeyFile)
 			spawnArgs.push(`--dtlsPrivateKeyFile=${dtlsPrivateKeyFile}`);
+
+		if (typeof libwebrtcFieldTrials === 'string' && libwebrtcFieldTrials)
+			spawnArgs.push(`--libwebrtcFieldTrials=${libwebrtcFieldTrials}`);
 
 		logger.debug(
 			'spawning worker process: %s %s', spawnBin, spawnArgs.join(' '));

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -46,6 +46,7 @@ export async function createWorker(
 		rtcMaxPort = 59999,
 		dtlsCertificateFile,
 		dtlsPrivateKeyFile,
+		libwebrtcFieldTrials,
 		appData
 	}: WorkerSettings = {}
 ): Promise<Worker>
@@ -63,6 +64,7 @@ export async function createWorker(
 			rtcMaxPort,
 			dtlsCertificateFile,
 			dtlsPrivateKeyFile,
+			libwebrtcFieldTrials,
 			appData
 		});
 

--- a/node/src/tests/test-Worker.ts
+++ b/node/src/tests/test-Worker.ts
@@ -34,13 +34,14 @@ test('createWorker() succeeds', async () =>
 	// eslint-disable-next-line require-atomic-updates
 	worker = await createWorker(
 		{
-			logLevel            : 'debug',
-			logTags             : [ 'info' ],
-			rtcMinPort          : 0,
-			rtcMaxPort          : 9999,
-			dtlsCertificateFile : path.join(__dirname, 'data', 'dtls-cert.pem'),
-			dtlsPrivateKeyFile  : path.join(__dirname, 'data', 'dtls-key.pem'),
-			appData             : { bar: 456 }
+			logLevel             : 'debug',
+			logTags              : [ 'info' ],
+			rtcMinPort           : 0,
+			rtcMaxPort           : 9999,
+			dtlsCertificateFile  : path.join(__dirname, 'data', 'dtls-cert.pem'),
+			dtlsPrivateKeyFile   : path.join(__dirname, 'data', 'dtls-key.pem'),
+			libwebrtcFieldTrials : 'WebRTC-Bwe-AlrLimitedBackoff/Disabled/',
+			appData              : { bar: 456 }
 		});
 	expect(worker.constructor.name).toBe('Worker');
 	expect(typeof worker.pid).toBe('number');

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -386,7 +386,9 @@ impl Inner {
             ));
         }
 
-        spawn_args.push(format!("--libwebrtcFieldTrials={}", libwebrtc_field_trials.as_str()));
+        if let Some(libwebrtc_field_trials) = libwebrtc_field_trials {
+            spawn_args.push(format!("--libwebrtcFieldTrials={}", libwebrtc_field_trials.as_str()));
+        }
 
         let id = WorkerId::new();
         debug!(

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -387,7 +387,10 @@ impl Inner {
         }
 
         if let Some(libwebrtc_field_trials) = libwebrtc_field_trials {
-            spawn_args.push(format!("--libwebrtcFieldTrials={}", libwebrtc_field_trials.as_str()));
+            spawn_args.push(format!(
+                "--libwebrtcFieldTrials={}",
+                libwebrtc_field_trials.as_str()
+            ));
         }
 
         let id = WorkerId::new();

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -187,6 +187,7 @@ pub struct WorkerSettings {
     /// NOTE: For advanced users only. An invalid value will make the worker crash.
     /// Default value is
     /// "WebRTC-Bwe-AlrLimitedBackoff/Enabled/".
+    #[doc(hidden)]
     pub libwebrtc_field_trials: Option<String>,
     /// Function that will be called under worker thread before worker starts, can be used for
     /// pinning worker threads to CPU cores.

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -182,6 +182,12 @@ pub struct WorkerSettings {
     ///
     /// If `None`, a certificate is dynamically created.
     pub dtls_files: Option<WorkerDtlsFiles>,
+    /// Field trials for libwebrtc.
+    ///
+    /// NOTE: For advanced users only. An invalid value will make the worker crash.
+    /// Default value is
+    /// "WebRTC-Bwe-AlrLimitedBackoff/Enabled/".
+    pub libwebrtc_field_trials: Option<String>,
     /// Function that will be called under worker thread before worker starts, can be used for
     /// pinning worker threads to CPU cores.
     pub thread_initializer: Option<Arc<dyn Fn() + Send + Sync>>,
@@ -210,6 +216,7 @@ impl Default for WorkerSettings {
             ],
             rtc_ports_range: 10000..=59999,
             dtls_files: None,
+            libwebrtc_field_trials: None,
             thread_initializer: None,
             app_data: AppData::default(),
         }
@@ -223,6 +230,7 @@ impl fmt::Debug for WorkerSettings {
             log_tags,
             rtc_ports_range,
             dtls_files,
+            libwebrtc_field_trials,
             thread_initializer,
             app_data,
         } = self;
@@ -232,6 +240,7 @@ impl fmt::Debug for WorkerSettings {
             .field("log_tags", &log_tags)
             .field("rtc_ports_range", &rtc_ports_range)
             .field("dtls_files", &dtls_files)
+            .field("libwebrtc_field_trials", &libwebrtc_field_trials)
             .field(
                 "thread_initializer",
                 &thread_initializer.as_ref().map(|_| "ThreadInitializer"),
@@ -335,6 +344,7 @@ impl Inner {
             log_tags,
             rtc_ports_range,
             dtls_files,
+            libwebrtc_field_trials,
             thread_initializer,
             app_data,
         }: WorkerSettings,
@@ -375,6 +385,8 @@ impl Inner {
                     .expect("Paths are only expected to be utf8")
             ));
         }
+
+        spawn_args.push(format!("--libwebrtcFieldTrials={}", libwebrtc_field_trials.as_str()));
 
         let id = WorkerId::new();
         debug!(

--- a/rust/tests/integration/worker.rs
+++ b/rust/tests/integration/worker.rs
@@ -47,6 +47,8 @@ fn create_worker_succeeds() {
                     certificate: "tests/integration/data/dtls-cert.pem".into(),
                     private_key: "tests/integration/data/dtls-key.pem".into(),
                 });
+                settings.libwebrtc_field_trials =
+                    Some("WebRTC-Bwe-AlrLimitedBackoff/Disabled/".to_string());
                 settings.app_data = AppData::new(CustomAppData { bar: 456 });
 
                 settings

--- a/worker/include/Settings.hpp
+++ b/worker/include/Settings.hpp
@@ -38,6 +38,7 @@ public:
 		uint16_t rtcMaxPort{ 59999u };
 		std::string dtlsCertificateFile;
 		std::string dtlsPrivateKeyFile;
+		std::string libwebrtcFieldTrials{ "WebRTC-Bwe-AlrLimitedBackoff/Enabled/" };
 	};
 
 public:

--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -6,7 +6,6 @@
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include <cmath>   // std::ceil()
-#include <cstdio>  // sprintf()
 #include <cstring> // std::memcpy(), std::memmove()
 
 namespace Channel

--- a/worker/src/DepLibWebRTC.cpp
+++ b/worker/src/DepLibWebRTC.cpp
@@ -3,13 +3,13 @@
 
 #include "DepLibWebRTC.hpp"
 #include "Logger.hpp"
+#include "Settings.hpp"
 #include "system_wrappers/source/field_trial.h" // webrtc::field_trial
 #include <mutex>
 
 /* Static. */
 
 static std::once_flag globalInitOnce;
-static constexpr char FieldTrials[] = "WebRTC-Bwe-AlrLimitedBackoff/Enabled/";
 
 /* Static methods. */
 
@@ -17,7 +17,16 @@ void DepLibWebRTC::ClassInit()
 {
 	MS_TRACE();
 
-	std::call_once(globalInitOnce, [] { webrtc::field_trial::InitFieldTrialsFromString(FieldTrials); });
+	MS_DEBUG_TAG(
+	  info, "libwebrtc field trials: \"%s\"", Settings::configuration.libwebrtcFieldTrials.c_str());
+
+	std::call_once(
+	  globalInitOnce,
+	  []
+	  {
+		  webrtc::field_trial::InitFieldTrialsFromString(
+		    Settings::configuration.libwebrtcFieldTrials.c_str());
+	  });
 }
 
 void DepLibWebRTC::ClassDestroy()

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -5,6 +5,7 @@
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
 #include <usrsctp.h>
+#include <cstdio> // std::vsnprintf()
 #include <mutex>
 
 /* Static. */
@@ -40,7 +41,7 @@ inline static void sctpDebug(const char* format, ...)
 	va_list ap;
 
 	va_start(ap, format);
-	vsprintf(buffer, format, ap);
+	vsnprintf(buffer, 10000, format, ap);
 
 	// Remove the artificial carriage return set by usrsctp.
 	buffer[std::strlen(buffer) - 1] = '\0';

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -41,7 +41,7 @@ inline static void sctpDebug(const char* format, ...)
 	va_list ap;
 
 	va_start(ap, format);
-	vsnprintf(buffer, 10000, format, ap);
+	vsnprintf(buffer, sizeof(buffer), format, ap);
 
 	// Remove the artificial carriage return set by usrsctp.
 	buffer[std::strlen(buffer) - 1] = '\0';

--- a/worker/src/PayloadChannel/PayloadChannelSocket.cpp
+++ b/worker/src/PayloadChannel/PayloadChannelSocket.cpp
@@ -7,7 +7,6 @@
 #include "MediaSoupErrors.hpp"
 #include "PayloadChannel/PayloadChannelRequest.hpp"
 #include <cmath>   // std::ceil()
-#include <cstdio>  // sprintf()
 #include <cstring> // std::memcpy(), std::memmove()
 
 namespace PayloadChannel

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -483,8 +483,6 @@ namespace RTC
 			}
 			hexFingerprint[(size * 3) - 1] = '\0';
 
-			MS_DUMP("--- hexFingerprint1: <%s> (%zu chars)", hexFingerprint, strlen(hexFingerprint));
-
 			MS_DEBUG_TAG(dtls, "%-7s fingerprint: %s", algorithmString.c_str(), hexFingerprint);
 
 			// Store it in the vector.

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -9,7 +9,7 @@
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <uv.h>
-#include <cstdio>  // std::sprintf(), std::fopen()
+#include <cstdio>  // std::snprintf(), std::fopen()
 #include <cstring> // std::memcpy(), std::strcmp()
 
 #define LOG_OPENSSL_ERROR(desc)                                                                    \
@@ -479,9 +479,11 @@ namespace RTC
 			// Convert to hexadecimal format in uppercase with colons.
 			for (unsigned int i{ 0 }; i < size; ++i)
 			{
-				std::sprintf(hexFingerprint + (i * 3), "%.2X:", binaryFingerprint[i]);
+				std::snprintf(hexFingerprint + (i * 3), 4, "%.2X:", binaryFingerprint[i]);
 			}
 			hexFingerprint[(size * 3) - 1] = '\0';
+
+			MS_DUMP("--- hexFingerprint1: <%s> (%zu chars)", hexFingerprint, strlen(hexFingerprint));
 
 			MS_DEBUG_TAG(dtls, "%-7s fingerprint: %s", algorithmString.c_str(), hexFingerprint);
 
@@ -1134,7 +1136,7 @@ namespace RTC
 		// Convert to hexadecimal format in uppercase with colons.
 		for (unsigned int i{ 0 }; i < size; ++i)
 		{
-			std::sprintf(hexFingerprint + (i * 3), "%.2X:", binaryFingerprint[i]);
+			std::snprintf(hexFingerprint + (i * 3), 4, "%.2X:", binaryFingerprint[i]);
 		}
 		hexFingerprint[(size * 3) - 1] = '\0';
 

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -5,6 +5,7 @@
 #include "DepUsrSCTP.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
+#include <cstdio>  // std::snprintf()
 #include <cstdlib> // std::malloc(), std::free()
 #include <cstring> // std::memset(), std::memcpy()
 #include <string>

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -53,12 +53,13 @@ void Settings::SetConfiguration(int argc, char* argv[])
 	// clang-format off
 	struct option options[] =
 	{
-		{ "logLevel",            optional_argument, nullptr, 'l' },
-		{ "logTags",             optional_argument, nullptr, 't' },
-		{ "rtcMinPort",          optional_argument, nullptr, 'm' },
-		{ "rtcMaxPort",          optional_argument, nullptr, 'M' },
-		{ "dtlsCertificateFile", optional_argument, nullptr, 'c' },
-		{ "dtlsPrivateKeyFile",  optional_argument, nullptr, 'p' },
+		{ "logLevel",             optional_argument, nullptr, 'l' },
+		{ "logTags",              optional_argument, nullptr, 't' },
+		{ "rtcMinPort",           optional_argument, nullptr, 'm' },
+		{ "rtcMaxPort",           optional_argument, nullptr, 'M' },
+		{ "dtlsCertificateFile",  optional_argument, nullptr, 'c' },
+		{ "dtlsPrivateKeyFile",   optional_argument, nullptr, 'p' },
+		{ "libwebrtcFieldTrials", optional_argument, nullptr, 'W' },
 		{ nullptr, 0, nullptr, 0 }
 	};
 	// clang-format on
@@ -135,6 +136,14 @@ void Settings::SetConfiguration(int argc, char* argv[])
 			{
 				stringValue                                = std::string(optarg);
 				Settings::configuration.dtlsPrivateKeyFile = stringValue;
+
+				break;
+			}
+
+			case 'W':
+			{
+				stringValue                                  = std::string(optarg);
+				Settings::configuration.libwebrtcFieldTrials = stringValue;
 
 				break;
 			}
@@ -221,17 +230,22 @@ void Settings::PrintConfiguration()
 
 	MS_DEBUG_TAG(
 	  info,
-	  "  logLevel            : %s",
+	  "  logLevel             : %s",
 	  Settings::logLevel2String[Settings::configuration.logLevel].c_str());
-	MS_DEBUG_TAG(info, "  logTags             : %s", logTagsStream.str().c_str());
-	MS_DEBUG_TAG(info, "  rtcMinPort          : %" PRIu16, Settings::configuration.rtcMinPort);
-	MS_DEBUG_TAG(info, "  rtcMaxPort          : %" PRIu16, Settings::configuration.rtcMaxPort);
+	MS_DEBUG_TAG(info, "  logTags              : %s", logTagsStream.str().c_str());
+	MS_DEBUG_TAG(info, "  rtcMinPort           : %" PRIu16, Settings::configuration.rtcMinPort);
+	MS_DEBUG_TAG(info, "  rtcMaxPort           : %" PRIu16, Settings::configuration.rtcMaxPort);
 	if (!Settings::configuration.dtlsCertificateFile.empty())
 	{
 		MS_DEBUG_TAG(
-		  info, "  dtlsCertificateFile : %s", Settings::configuration.dtlsCertificateFile.c_str());
+		  info, "  dtlsCertificateFile  : %s", Settings::configuration.dtlsCertificateFile.c_str());
 		MS_DEBUG_TAG(
-		  info, "  dtlsPrivateKeyFile  : %s", Settings::configuration.dtlsPrivateKeyFile.c_str());
+		  info, "  dtlsPrivateKeyFile   : %s", Settings::configuration.dtlsPrivateKeyFile.c_str());
+	}
+	if (!Settings::configuration.libwebrtcFieldTrials.empty())
+	{
+		MS_DEBUG_TAG(
+		  info, "  libwebrtcFieldTrials : %s", Settings::configuration.libwebrtcFieldTrials.c_str());
 	}
 
 	MS_DEBUG_TAG(info, "</configuration>");

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -142,8 +142,16 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'W':
 			{
-				stringValue                                  = std::string(optarg);
-				Settings::configuration.libwebrtcFieldTrials = stringValue;
+				stringValue = std::string(optarg);
+
+				if (stringValue != Settings::configuration.libwebrtcFieldTrials)
+				{
+					MS_WARN_TAG(
+					  info,
+					  "overriding default value of libwebrtcFieldTrials may generate crashes in medoasoup-worker");
+
+					Settings::configuration.libwebrtcFieldTrials = stringValue;
+				}
 
 				break;
 			}

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -148,7 +148,7 @@ void Settings::SetConfiguration(int argc, char* argv[])
 				{
 					MS_WARN_TAG(
 					  info,
-					  "overriding default value of libwebrtcFieldTrials may generate crashes in medoasoup-worker");
+					  "overriding default value of libwebrtcFieldTrials may generate crashes in mediasoup-worker");
 
 					Settings::configuration.libwebrtcFieldTrials = stringValue;
 				}


### PR DESCRIPTION
Will be mostly useful in https://github.com/versatica/mediasoup/pull/922 once merged.

Default value of `libwebrtcFieldTrials` is `"WebRTC-Bwe-AlrLimitedBackoff/Enabled/"`. If changed, it must be modified in:

- `worker/include/Settings.hpp` (here is where the real default value is set).
- `node/src/Worker.ts` (online doc).
- `rust/src/worker.ts` (online doc).

### Bonus Tracks

- Use `snprintf` and `vsnprintf` instead of `sprintf` and `vsprintf` because the latter are deprecated.