### PR TITLE
Update OpenSSL to 3.0.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Node: Migrate tests to TypeScript (PR #958).
 * Node: Remove compiled JavaScript from repository and compile TypeScript code on NPM `prepare` script on demand when installed via git (PR #954).
 * `Worker`: Add `RTC::Shared` singleton for RTC entities (PR #953).
+* Update OpenSSL to 3.0.7.
 
 
 ### 3.11.3

--- a/worker/subprojects/openssl.wrap
+++ b/worker/subprojects/openssl.wrap
@@ -1,14 +1,14 @@
 [wrap-file]
-directory = openssl-3.0.2
-source_url = https://www.openssl.org/source/openssl-3.0.2.tar.gz
-source_filename = openssl-3.0.2.tar.gz
-source_hash = 98e91ccead4d4756ae3c9cde5e09191a8e586d9f4d50838e7ec09d6411dfdb63
-patch_filename = openssl_3.0.2-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/openssl_3.0.2-1/get_patch
-patch_hash = 762ab4ea94d02178d6a1d3eb63409c2c4d61315d358391cdac62df15211174d4
+directory = openssl-3.0.7
+source_url = https://www.openssl.org/source/openssl-3.0.7.tar.gz
+source_filename = openssl-3.0.72.tar.gz
+source_hash = 83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e
+patch_filename = openssl_3.0.7-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/openssl_3.0.7-1/get_patch
+patch_hash = 8f04d911dc22d1dddc6a192ab27d6d8275976a252bd9c73e09f95f1f927e42b5
+wrapdb_version = 3.0.7-1
 
 [provide]
 libcrypto = libcrypto_dep
 libssl = libssl_dep
 openssl = openssl_dep
-


### PR DESCRIPTION
They have a new command in recent Meson version, `meson wrap update openssl` is what can be used now.

Resolves #939