### PR TITLE
Fix crash when using WebrtcServer

### DIFF
--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -307,10 +307,10 @@ namespace RTC
 		absl::flat_hash_map<uint32_t, RTC::Consumer*> mapSsrcConsumer;
 		absl::flat_hash_map<uint32_t, RTC::Consumer*> mapRtxSsrcConsumer;
 		Timer* rtcpTimer{ nullptr };
-		RTC::TransportCongestionControlClient* tccClient{ nullptr };
-		RTC::TransportCongestionControlServer* tccServer{ nullptr };
+		std::shared_ptr<RTC::TransportCongestionControlClient> tccClient{ nullptr };
+		std::shared_ptr<RTC::TransportCongestionControlServer> tccServer{ nullptr };
 #ifdef ENABLE_RTC_SENDER_BANDWIDTH_ESTIMATOR
-		RTC::SenderBandwidthEstimator* senderBwe{ nullptr };
+		std::shared_ptr<RTC::SenderBandwidthEstimator> senderBwe{ nullptr };
 #endif
 		// Others.
 		bool direct{ false }; // Whether this Transport allows PayloadChannel comm.

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2990,7 +2990,7 @@ namespace RTC
 			  [tccClientWeakPtr, &packetInfo, senderBweWeakPtr, &sentInfo](bool sent)
 			  {
 				  if (sent)
-				  {	
+				  {
 					  auto tccClient = tccClientWeakPtr.lock();
 					  if (tccClient)
 						  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
@@ -3011,7 +3011,7 @@ namespace RTC
 			  {
 				  if (sent)
 				  {
-				  	  auto tccClient = tccClientWeakPtr.lock();
+					  auto tccClient = tccClientWeakPtr.lock();
 					  if (tccClient)
 						  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
 				  }

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2515,7 +2515,6 @@ namespace RTC
 		{
 			this->transportWideCcSeq++;
 
-			auto* tccClient = this->tccClient;
 			webrtc::RtpPacketSendInfo packetInfo;
 
 			packetInfo.ssrc                      = packet->GetSsrc();
@@ -2600,7 +2599,6 @@ namespace RTC
 		{
 			this->transportWideCcSeq++;
 
-			auto* tccClient = this->tccClient;
 			webrtc::RtpPacketSendInfo packetInfo;
 
 			packetInfo.ssrc                      = packet->GetSsrc();

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2565,8 +2565,8 @@ namespace RTC
 
 					  if (senderBwe)
 					  {
-					  	  sentInfo.sentAtMs = DepLibUV::GetTimeMs();
-					  	  senderBwe->RtpPacketSent(sentInfo);
+						  sentInfo.sentAtMs = DepLibUV::GetTimeMs();
+						  senderBwe->RtpPacketSent(sentInfo);
 					  }
 				  }
 			  });
@@ -2580,7 +2580,7 @@ namespace RTC
 				  {
 					  auto tccClient = tccClientWeakPtr.lock();
 					  if (tccClient)
-					  	  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
+						  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
 				  }
 			  });
 
@@ -2663,7 +2663,7 @@ namespace RTC
 				  {
 					  auto tccClient = tccClientWeakPtr.lock();
 					  if (tccClient)
-					  	  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
+						  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
 				  }
 			  });
 
@@ -2998,7 +2998,7 @@ namespace RTC
 					  auto senderBwe = senderBweWeakPtr.lock();
 					  if (senderBwe)
 					  {
-					 	  sentInfo.sentAtMs = DepLibUV::GetTimeMs();
+						  sentInfo.sentAtMs = DepLibUV::GetTimeMs();
 						  senderBwe->RtpPacketSent(sentInfo);
 					  }
 				  }

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -228,20 +228,6 @@ namespace RTC
 		// Delete the RTCP timer.
 		delete this->rtcpTimer;
 		this->rtcpTimer = nullptr;
-
-		// Delete Transport-CC client.
-		delete this->tccClient;
-		this->tccClient = nullptr;
-
-		// Delete Transport-CC server.
-		delete this->tccServer;
-		this->tccServer = nullptr;
-
-#ifdef ENABLE_RTC_SENDER_BANDWIDTH_ESTIMATOR
-		// Delete Sender BWE.
-		delete this->senderBwe;
-		this->senderBwe = nullptr;
-#endif
 	}
 
 	void Transport::CloseProducersAndConsumers()
@@ -809,7 +795,8 @@ namespace RTC
 
 					if (createTccServer)
 					{
-						this->tccServer = new RTC::TransportCongestionControlServer(this, bweType, RTC::MtuSize);
+						this->tccServer =
+						  std::make_shared<RTC::TransportCongestionControlServer>(this, bweType, RTC::MtuSize);
 
 						if (this->maxIncomingBitrate != 0u)
 							this->tccServer->SetMaxIncomingBitrate(this->maxIncomingBitrate);
@@ -1014,7 +1001,7 @@ namespace RTC
 							consumer->SetExternallyManagedBitrate();
 						};
 
-						this->tccClient = new RTC::TransportCongestionControlClient(
+						this->tccClient = std::make_shared<RTC::TransportCongestionControlClient>(
 						  this, bweType, this->initialAvailableOutgoingBitrate, this->maxOutgoingBitrate);
 
 						if (IsConnected())
@@ -1061,8 +1048,8 @@ namespace RTC
 						consumer->SetExternallyManagedBitrate();
 					};
 
-					this->senderBwe =
-					  new RTC::SenderBandwidthEstimator(this, this->initialAvailableOutgoingBitrate);
+					this->senderBwe = std::make_shared<RTC::SenderBandwidthEstimator>(
+					  this, this->initialAvailableOutgoingBitrate);
 
 					if (IsConnected())
 						this->senderBwe->TransportConnected();

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2541,8 +2541,10 @@ namespace RTC
 			// Indicate the pacer (and prober) that a packet is to be sent.
 			this->tccClient->InsertPacket(packetInfo);
 
+			std::weak_ptr<RTC::TransportCongestionControlClient> tccClientWeakPtr(this->tccClient);
+
 #ifdef ENABLE_RTC_SENDER_BANDWIDTH_ESTIMATOR
-			auto* senderBwe = this->senderBwe;
+			std::weak_ptr<RTC::SenderBandwidthEstimator> senderBweWeakPtr(this->senderBwe);
 			RTC::SenderBandwidthEstimator::SentInfo sentInfo;
 
 			sentInfo.wideSeq     = this->transportWideCcSeq;
@@ -2550,25 +2552,36 @@ namespace RTC
 			sentInfo.sendingAtMs = DepLibUV::GetTimeMs();
 
 			auto* cb = new onSendCallback(
-			  [tccClient, &packetInfo, senderBwe, &sentInfo](bool sent)
+			  [tccClientWeakPtr, &packetInfo, senderBweWeakPtr, &sentInfo](bool sent)
 			  {
 				  if (sent)
 				  {
-					  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
+					  auto tccClient = tccClientWeakPtr.lock();
 
-					  sentInfo.sentAtMs = DepLibUV::GetTimeMs();
+					  if (tccClient)
+						  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
 
-					  senderBwe->RtpPacketSent(sentInfo);
+					  auto senderBwe = senderBweWeakPtr.lock();
+
+					  if (senderBwe)
+					  {
+					  	  sentInfo.sentAtMs = DepLibUV::GetTimeMs();
+					  	  senderBwe->RtpPacketSent(sentInfo);
+					  }
 				  }
 			  });
 
 			SendRtpPacket(consumer, packet, cb);
 #else
 			const auto* cb = new onSendCallback(
-			  [tccClient, &packetInfo](bool sent)
+			  [tccClientWeakPtr, &packetInfo](bool sent)
 			  {
 				  if (sent)
-					  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
+				  {
+					  auto tccClient = tccClientWeakPtr.lock();
+					  if (tccClient)
+					  	  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
+				  }
 			  });
 
 			SendRtpPacket(consumer, packet, cb);
@@ -2613,8 +2626,10 @@ namespace RTC
 			// Indicate the pacer (and prober) that a packet is to be sent.
 			this->tccClient->InsertPacket(packetInfo);
 
+			std::weak_ptr<RTC::TransportCongestionControlClient> tccClientWeakPtr(this->tccClient);
+
 #ifdef ENABLE_RTC_SENDER_BANDWIDTH_ESTIMATOR
-			auto* senderBwe = this->senderBwe;
+			std::weak_ptr<RTC::SenderBandwidthEstimator> senderBweWeakPtr = this->senderBwe;
 			RTC::SenderBandwidthEstimator::SentInfo sentInfo;
 
 			sentInfo.wideSeq     = this->transportWideCcSeq;
@@ -2622,25 +2637,34 @@ namespace RTC
 			sentInfo.sendingAtMs = DepLibUV::GetTimeMs();
 
 			auto* cb = new onSendCallback(
-			  [tccClient, &packetInfo, senderBwe, &sentInfo](bool sent)
+			  [tccClientWeakPtr, &packetInfo, senderBweWeakPtr, &sentInfo](bool sent)
 			  {
 				  if (sent)
 				  {
-					  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
+					  auto tccClient = tccClientWeakPtr.lock();
+					  if (tccClient)
+						  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
 
-					  sentInfo.sentAtMs = DepLibUV::GetTimeMs();
-
-					  senderBwe->RtpPacketSent(sentInfo);
+					  auto senderBwe = senderBweWeakPtr.lock();
+					  if (senderBwe)
+					  {
+						  sentInfo.sentAtMs = DepLibUV::GetTimeMs();
+						  senderBwe->RtpPacketSent(sentInfo);
+					  }
 				  }
 			  });
 
 			SendRtpPacket(consumer, packet, cb);
 #else
 			const auto* cb = new onSendCallback(
-			  [tccClient, &packetInfo](bool sent)
+			  [tccClientWeakPtr, &packetInfo](bool sent)
 			  {
 				  if (sent)
-					  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
+				  {
+					  auto tccClient = tccClientWeakPtr.lock();
+					  if (tccClient)
+					  	  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
+				  }
 			  });
 
 			SendRtpPacket(consumer, packet, cb);
@@ -2951,8 +2975,10 @@ namespace RTC
 			// Indicate the pacer (and prober) that a packet is to be sent.
 			this->tccClient->InsertPacket(packetInfo);
 
+			std::weak_ptr<RTC::TransportCongestionControlClient> tccClientWeakPtr(this->tccClient);
+
 #ifdef ENABLE_RTC_SENDER_BANDWIDTH_ESTIMATOR
-			auto* senderBwe = this->senderBwe;
+			std::weak_ptr<RTC::SenderBandwidthEstimator> senderBweWeakPtr = this->senderBwe;
 			RTC::SenderBandwidthEstimator::SentInfo sentInfo;
 
 			sentInfo.wideSeq     = this->transportWideCcSeq;
@@ -2961,25 +2987,34 @@ namespace RTC
 			sentInfo.sendingAtMs = DepLibUV::GetTimeMs();
 
 			auto* cb = new onSendCallback(
-			  [tccClient, &packetInfo, senderBwe, &sentInfo](bool sent)
+			  [tccClientWeakPtr, &packetInfo, senderBweWeakPtr, &sentInfo](bool sent)
 			  {
 				  if (sent)
-				  {
-					  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
+				  {	
+					  auto tccClient = tccClientWeakPtr.lock();
+					  if (tccClient)
+						  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
 
-					  sentInfo.sentAtMs = DepLibUV::GetTimeMs();
-
-					  senderBwe->RtpPacketSent(sentInfo);
+					  auto senderBwe = senderBweWeakPtr.lock();
+					  if (senderBwe)
+					  {
+					 	  sentInfo.sentAtMs = DepLibUV::GetTimeMs();
+						  senderBwe->RtpPacketSent(sentInfo);
+					  }
 				  }
 			  });
 
 			SendRtpPacket(nullptr, packet, cb);
 #else
 			const auto* cb = new onSendCallback(
-			  [tccClient, &packetInfo](bool sent)
+			  [tccClientWeakPtr, &packetInfo](bool sent)
 			  {
 				  if (sent)
-					  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
+				  {
+				  	  auto tccClient = tccClientWeakPtr.lock();
+					  if (tccClient)
+						  tccClient->PacketSent(packetInfo, DepLibUV::GetTimeMsInt64());
+				  }
 			  });
 
 			SendRtpPacket(nullptr, packet, cb);


### PR DESCRIPTION
When using WebrtcServer, the lifecycle of udpsocket maybe longer than WebrtcTransport.
If the rtp data is sent asynchronously, the WebrtcTransport may desotryed before the data has been sent.
It' will crash in the data sent callback, we should use weak_ptr to avoid this.