### PR TITLE
Add GH CI workflow to show Pull Request stats

### DIFF
--- a/.github/workflows/pull-request-stats.yml
+++ b/.github/workflows/pull-request-stats.yml
@@ -1,0 +1,18 @@
+name: Pull Request Stats
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  stats:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run pull request stats
+        uses: flowwer-dev/pull-request-stats@master
+        with:
+          period: 365
+          charts: true
+          disable-links: false
+          sort-by: 'COMMENTS'
+          telemetry: false

--- a/.github/workflows/pull-request-stats.yml
+++ b/.github/workflows/pull-request-stats.yml
@@ -14,5 +14,5 @@ jobs:
           period: 365
           charts: true
           disable-links: false
-          sort-by: 'COMMENTS'
+          sort-by: 'TIME'
           telemetry: false


### PR DESCRIPTION
- Based on https://github.com/marketplace/actions/pull-request-stats
- For feature testing purposes.