### PR TITLE
Fix wrong PictureID rolling over in VP9 and VP8

### DIFF
--- a/worker/include/RTC/Codecs/H264_SVC.hpp
+++ b/worker/include/RTC/Codecs/H264_SVC.hpp
@@ -71,7 +71,7 @@ namespace RTC
 				}
 
 			public:
-				RTC::SeqManager<uint16_t> pictureIdManager;
+				RTC::SeqManager<uint16_t, 15> pictureIdManager;
 				bool syncRequired{ false };
 			};
 

--- a/worker/include/RTC/Codecs/VP8.hpp
+++ b/worker/include/RTC/Codecs/VP8.hpp
@@ -96,7 +96,7 @@ namespace RTC
 				}
 
 			public:
-				RTC::SeqManager<uint16_t> pictureIdManager;
+				RTC::SeqManager<uint16_t, 15> pictureIdManager;
 				RTC::SeqManager<uint8_t> tl0PictureIndexManager;
 				bool syncRequired{ false };
 			};

--- a/worker/include/RTC/Codecs/VP9.hpp
+++ b/worker/include/RTC/Codecs/VP9.hpp
@@ -113,7 +113,7 @@ namespace RTC
 				}
 
 			public:
-				RTC::SeqManager<uint16_t> pictureIdManager;
+				RTC::SeqManager<uint16_t, 15> pictureIdManager;
 				bool syncRequired{ false };
 			};
 

--- a/worker/include/RTC/SeqManager.hpp
+++ b/worker/include/RTC/SeqManager.hpp
@@ -7,11 +7,11 @@
 
 namespace RTC
 {
-	template<typename T>
+	template<typename T, unsigned int N = 0>
 	class SeqManager
 	{
 	public:
-		static constexpr T MaxValue = std::numeric_limits<T>::max();
+		static constexpr T MaxValue = (N == 0) ? std::numeric_limits<T>::max() : ((1 << N) - 1);
 
 	public:
 		struct SeqLowerThan

--- a/worker/include/RTC/SeqManager.hpp
+++ b/worker/include/RTC/SeqManager.hpp
@@ -7,7 +7,9 @@
 
 namespace RTC
 {
-	template<typename T, unsigned int N = 0>
+	// T is the base type (uint16_t, uint32_t, ...).
+	// N is the max number of bits used in T.
+	template<typename T, uint8_t N = 0>
 	class SeqManager
 	{
 	public:
@@ -27,6 +29,7 @@ namespace RTC
 	private:
 		static const SeqLowerThan isSeqLowerThan;
 		static const SeqHigherThan isSeqHigherThan;
+		static T Delta(const T lhs, const T rhs);
 
 	public:
 		static bool IsSeqLowerThan(const T lhs, const T rhs);

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -295,6 +295,7 @@ mediasoup_worker_test = executable(
     'test/src/RTC/TestTrendCalculator.cpp',
     'test/src/RTC/TestRtpEncodingParameters.cpp',
     'test/src/RTC/Codecs/TestVP8.cpp',
+    'test/src/RTC/Codecs/TestVP9.cpp',
     'test/src/RTC/Codecs/TestH264.cpp',
     'test/src/RTC/Codecs/TestH264_SVC.cpp',
     'test/src/RTC/RTCP/TestFeedbackPsAfb.cpp',

--- a/worker/src/RTC/Codecs/VP8.cpp
+++ b/worker/src/RTC/Codecs/VP8.cpp
@@ -258,7 +258,7 @@ namespace RTC
 				this->payloadDescriptor->hasPictureId &&
 				this->payloadDescriptor->hasTlIndex &&
 				this->payloadDescriptor->hasTl0PictureIndex &&
-				!RTC::SeqManager<uint16_t>::IsSeqLowerThan(
+				!RTC::SeqManager<uint16_t, 15>::IsSeqLowerThan(
 					this->payloadDescriptor->pictureId,
 					context->pictureIdManager.GetMaxInput())
 			)

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -213,7 +213,7 @@ namespace RTC
 			// clang-format off
 			bool isOldPacket = (
 				this->payloadDescriptor->hasPictureId &&
-				RTC::SeqManager<uint16_t>::IsSeqLowerThan(
+				RTC::SeqManager<uint16_t, 15>::IsSeqLowerThan(
 					this->payloadDescriptor->pictureId,
 					context->pictureIdManager.GetMaxInput())
 			);

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -43,6 +43,7 @@ namespace RTC
 	T SeqManager<T, N>::Delta(const T lhs, const T rhs)
 	{
 		T value = (lhs > rhs) ? (lhs - rhs) : (MaxValue - rhs + lhs);
+
 		return value & MaxValue;
 	}
 

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -7,39 +7,46 @@
 
 namespace RTC
 {
-	template<typename T, unsigned int N>
+	template<typename T, uint8_t N>
 	bool SeqManager<T, N>::SeqLowerThan::operator()(const T lhs, const T rhs) const
 	{
 		return ((rhs > lhs) && (rhs - lhs <= MaxValue / 2)) ||
 		       ((lhs > rhs) && (lhs - rhs > MaxValue / 2));
 	}
 
-	template<typename T, unsigned int N>
+	template<typename T, uint8_t N>
 	bool SeqManager<T, N>::SeqHigherThan::operator()(const T lhs, const T rhs) const
 	{
 		return ((lhs > rhs) && (lhs - rhs <= MaxValue / 2)) ||
 		       ((rhs > lhs) && (rhs - lhs > MaxValue / 2));
 	}
 
-	template<typename T, unsigned int N>
+	template<typename T, uint8_t N>
 	const typename SeqManager<T, N>::SeqLowerThan SeqManager<T, N>::isSeqLowerThan{};
 
-	template<typename T, unsigned int N>
+	template<typename T, uint8_t N>
 	const typename SeqManager<T, N>::SeqHigherThan SeqManager<T, N>::isSeqHigherThan{};
 
-	template<typename T, unsigned int N>
+	template<typename T, uint8_t N>
 	bool SeqManager<T, N>::IsSeqLowerThan(const T lhs, const T rhs)
 	{
 		return isSeqLowerThan(lhs, rhs);
 	}
 
-	template<typename T, unsigned int N>
+	template<typename T, uint8_t N>
 	bool SeqManager<T, N>::IsSeqHigherThan(const T lhs, const T rhs)
 	{
 		return isSeqHigherThan(lhs, rhs);
 	}
 
-	template<typename T, unsigned int N>
+	template<typename T, uint8_t N>
+	T SeqManager<T, N>::Delta(const T lhs, const T rhs)
+	{
+		T value = (lhs > rhs) ? (lhs - rhs) : (MaxValue - rhs + lhs);
+		return value & MaxValue;
+	}
+
+	template<typename T, uint8_t N>
 	void SeqManager<T, N>::Sync(T input)
 	{
 		// Update base.
@@ -52,7 +59,7 @@ namespace RTC
 		this->dropped.clear();
 	}
 
-	template<typename T, unsigned int N>
+	template<typename T, uint8_t N>
 	void SeqManager<T, N>::Drop(T input)
 	{
 		// Mark as dropped if 'input' is higher than anyone already processed.
@@ -62,13 +69,13 @@ namespace RTC
 		}
 	}
 
-	template<typename T, unsigned int N>
+	template<typename T, uint8_t N>
 	void SeqManager<T, N>::Offset(T offset)
 	{
 		this->base = (this->base + offset) & MaxValue;
 	}
 
-	template<typename T, unsigned int N>
+	template<typename T, uint8_t N>
 	bool SeqManager<T, N>::Input(const T input, T& output)
 	{
 		auto base = this->base;
@@ -105,8 +112,8 @@ namespace RTC
 
 		output = (input + base) & MaxValue;
 
-		T idelta = input - this->maxInput;
-		T odelta = output - this->maxOutput;
+		T idelta = SeqManager<T, N>::Delta(input, this->maxInput);
+		T odelta = SeqManager<T, N>::Delta(output, this->maxOutput);
 
 		// New input is higher than the maximum seen. But less than acceptable units higher.
 		// Keep it as the maximum seen. See Drop().
@@ -121,13 +128,13 @@ namespace RTC
 		return true;
 	}
 
-	template<typename T, unsigned int N>
+	template<typename T, uint8_t N>
 	T SeqManager<T, N>::GetMaxInput() const
 	{
 		return this->maxInput;
 	}
 
-	template<typename T, unsigned int N>
+	template<typename T, uint8_t N>
 	T SeqManager<T, N>::GetMaxOutput() const
 	{
 		return this->maxOutput;
@@ -136,7 +143,7 @@ namespace RTC
 	// Explicit instantiation to have all SeqManager definitions in this file.
 	template class SeqManager<uint8_t>;
 	template class SeqManager<uint16_t>;
-	template class SeqManager<uint16_t, 15>; // For PictureID (15bits).
+	template class SeqManager<uint16_t, 15>; // For PictureID (15 bits).
 	template class SeqManager<uint32_t>;
 
 } // namespace RTC

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -7,43 +7,43 @@
 
 namespace RTC
 {
-	template<typename T>
-	bool SeqManager<T>::SeqLowerThan::operator()(const T lhs, const T rhs) const
+	template<typename T, unsigned int N>
+	bool SeqManager<T, N>::SeqLowerThan::operator()(const T lhs, const T rhs) const
 	{
 		return ((rhs > lhs) && (rhs - lhs <= MaxValue / 2)) ||
 		       ((lhs > rhs) && (lhs - rhs > MaxValue / 2));
 	}
 
-	template<typename T>
-	bool SeqManager<T>::SeqHigherThan::operator()(const T lhs, const T rhs) const
+	template<typename T, unsigned int N>
+	bool SeqManager<T, N>::SeqHigherThan::operator()(const T lhs, const T rhs) const
 	{
 		return ((lhs > rhs) && (lhs - rhs <= MaxValue / 2)) ||
 		       ((rhs > lhs) && (rhs - lhs > MaxValue / 2));
 	}
 
-	template<typename T>
-	const typename SeqManager<T>::SeqLowerThan SeqManager<T>::isSeqLowerThan{};
+	template<typename T, unsigned int N>
+	const typename SeqManager<T, N>::SeqLowerThan SeqManager<T, N>::isSeqLowerThan{};
 
-	template<typename T>
-	const typename SeqManager<T>::SeqHigherThan SeqManager<T>::isSeqHigherThan{};
+	template<typename T, unsigned int N>
+	const typename SeqManager<T, N>::SeqHigherThan SeqManager<T, N>::isSeqHigherThan{};
 
-	template<typename T>
-	bool SeqManager<T>::IsSeqLowerThan(const T lhs, const T rhs)
+	template<typename T, unsigned int N>
+	bool SeqManager<T, N>::IsSeqLowerThan(const T lhs, const T rhs)
 	{
 		return isSeqLowerThan(lhs, rhs);
 	}
 
-	template<typename T>
-	bool SeqManager<T>::IsSeqHigherThan(const T lhs, const T rhs)
+	template<typename T, unsigned int N>
+	bool SeqManager<T, N>::IsSeqHigherThan(const T lhs, const T rhs)
 	{
 		return isSeqHigherThan(lhs, rhs);
 	}
 
-	template<typename T>
-	void SeqManager<T>::Sync(T input)
+	template<typename T, unsigned int N>
+	void SeqManager<T, N>::Sync(T input)
 	{
 		// Update base.
-		this->base = this->maxOutput - input;
+		this->base = (this->maxOutput - input) & MaxValue;
 
 		// Update maxInput.
 		this->maxInput = input;
@@ -52,24 +52,24 @@ namespace RTC
 		this->dropped.clear();
 	}
 
-	template<typename T>
-	void SeqManager<T>::Drop(T input)
+	template<typename T, unsigned int N>
+	void SeqManager<T, N>::Drop(T input)
 	{
 		// Mark as dropped if 'input' is higher than anyone already processed.
-		if (SeqManager<T>::IsSeqHigherThan(input, this->maxInput))
+		if (SeqManager<T, N>::IsSeqHigherThan(input, this->maxInput))
 		{
 			this->dropped.insert(input);
 		}
 	}
 
-	template<typename T>
-	void SeqManager<T>::Offset(T offset)
+	template<typename T, unsigned int N>
+	void SeqManager<T, N>::Offset(T offset)
 	{
-		this->base += offset;
+		this->base = (this->base + offset) & MaxValue;
 	}
 
-	template<typename T>
-	bool SeqManager<T>::Input(const T input, T& output)
+	template<typename T, unsigned int N>
+	bool SeqManager<T, N>::Input(const T input, T& output)
 	{
 		auto base = this->base;
 
@@ -78,10 +78,10 @@ namespace RTC
 		{
 			// Delete dropped inputs older than input - MaxValue/2.
 			size_t droppedCount = this->dropped.size();
-			auto it             = this->dropped.lower_bound(input - MaxValue / 2);
-
+			size_t threshold    = (input - MaxValue / 2) & MaxValue;
+			auto it             = this->dropped.lower_bound(threshold);
 			this->dropped.erase(this->dropped.begin(), it);
-			this->base -= (droppedCount - this->dropped.size());
+			this->base = (this->base - (droppedCount - this->dropped.size())) & MaxValue;
 
 			// Count dropped entries before 'input' in order to adapt the base.
 			droppedCount = this->dropped.size();
@@ -100,10 +100,10 @@ namespace RTC
 				droppedCount -= std::distance(it, this->dropped.end());
 			}
 
-			base = this->base - droppedCount;
+			base = (this->base - droppedCount) & MaxValue;
 		}
 
-		output = input + base;
+		output = (input + base) & MaxValue;
 
 		T idelta = input - this->maxInput;
 		T odelta = output - this->maxOutput;
@@ -121,14 +121,14 @@ namespace RTC
 		return true;
 	}
 
-	template<typename T>
-	T SeqManager<T>::GetMaxInput() const
+	template<typename T, unsigned int N>
+	T SeqManager<T, N>::GetMaxInput() const
 	{
 		return this->maxInput;
 	}
 
-	template<typename T>
-	T SeqManager<T>::GetMaxOutput() const
+	template<typename T, unsigned int N>
+	T SeqManager<T, N>::GetMaxOutput() const
 	{
 		return this->maxOutput;
 	}
@@ -136,6 +136,7 @@ namespace RTC
 	// Explicit instantiation to have all SeqManager definitions in this file.
 	template class SeqManager<uint8_t>;
 	template class SeqManager<uint16_t>;
+	template class SeqManager<uint16_t, 15>; // For PictureID (15bits).
 	template class SeqManager<uint32_t>;
 
 } // namespace RTC

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -586,6 +586,7 @@ namespace RTC
 				MS_DEBUG_TAG(rtp, "sync key frame received");
 
 			this->rtpSeqManager.Sync(packet->GetSequenceNumber() - 1);
+			this->encodingContext->SyncRequired();
 
 			this->syncRequired = false;
 		}

--- a/worker/test/src/RTC/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP8.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC;
 
-constexpr uint16_t kMaxPictureId = (1 << 15) - 1;
+constexpr uint16_t MaxPictureId = (1 << 15) - 1;
 
 SCENARIO("parse VP8 payload descriptor", "[codecs][vp8]")
 {
@@ -307,7 +307,7 @@ SCENARIO("process VP8 payload descriptor", "[codecs][vp8]")
 		context.SetTargetTemporalLayer(0);
 
 		// Frame 1.
-		auto forwarded = ProcessPacket(context, kMaxPictureId, 0, 0);
+		auto forwarded = ProcessPacket(context, MaxPictureId, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 1);
 		REQUIRE(forwarded->tl0PictureIndex == 1);

--- a/worker/test/src/RTC/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP8.cpp
@@ -5,6 +5,8 @@
 
 using namespace RTC;
 
+constexpr uint16_t kMaxPictureId = (1 << 15) - 1;
+
 SCENARIO("parse VP8 payload descriptor", "[codecs][vp8]")
 {
 	SECTION("parse payload descriptor")
@@ -305,7 +307,7 @@ SCENARIO("process VP8 payload descriptor", "[codecs][vp8]")
 		context.SetTargetTemporalLayer(0);
 
 		// Frame 1
-		auto forwarded = ProcessPacket(context, 32767, 0, 0);
+		auto forwarded = ProcessPacket(context, kMaxPictureId, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 1);
 		REQUIRE(forwarded->tl0PictureIndex == 1);

--- a/worker/test/src/RTC/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP8.cpp
@@ -276,19 +276,19 @@ SCENARIO("process VP8 payload descriptor", "[codecs][vp8]")
 		context.SetCurrentTemporalLayer(0);
 		context.SetTargetTemporalLayer(0);
 
-		// Frame 1
+		// Frame 1.
 		auto forwarded = ProcessPacket(context, 0, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 0);
 		REQUIRE(forwarded->tl0PictureIndex == 0);
 
-		// Frame 2 gets lost
+		// Frame 2 gets lost.
 
-		// Frame 3
+		// Frame 3.
 		forwarded = ProcessPacket(context, 2, 1, 1);
 		REQUIRE_FALSE(forwarded);
 
-		// Frame 2 retransmitted
+		// Frame 2 retransmitted.
 		forwarded = ProcessPacket(context, 1, 1, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 1);
@@ -306,19 +306,19 @@ SCENARIO("process VP8 payload descriptor", "[codecs][vp8]")
 		context.SetCurrentTemporalLayer(0);
 		context.SetTargetTemporalLayer(0);
 
-		// Frame 1
+		// Frame 1.
 		auto forwarded = ProcessPacket(context, kMaxPictureId, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 1);
 		REQUIRE(forwarded->tl0PictureIndex == 1);
 
-		// Frame 2
+		// Frame 2.
 		forwarded = ProcessPacket(context, 0, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 2);
 		REQUIRE(forwarded->tl0PictureIndex == 1);
 
-		// Frame 3
+		// Frame 3.
 		forwarded = ProcessPacket(context, 1, 0, 1);
 		REQUIRE_FALSE(forwarded);
 	}

--- a/worker/test/src/RTC/Codecs/TestVP9.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP9.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC;
 
-constexpr uint16_t kMaxPictureId = (1 << 15) - 1;
+constexpr uint16_t MaxPictureId = (1 << 15) - 1;
 
 Codecs::VP9::PayloadDescriptor* CreateVP9Packet(
   uint8_t* buffer, size_t bufferLen, uint16_t pictureId, uint8_t tlIndex)
@@ -62,9 +62,9 @@ SCENARIO("process VP9 payload descriptor", "[codecs][vp9]")
 		context.SetTargetSpatialLayer(0);
 
 		// Frame 1.
-		auto forwarded = ProcessVP9Packet(context, kMaxPictureId, 0);
+		auto forwarded = ProcessVP9Packet(context, MaxPictureId, 0);
 		REQUIRE(forwarded);
-		REQUIRE(forwarded->pictureId == kMaxPictureId);
+		REQUIRE(forwarded->pictureId == MaxPictureId);
 
 		// Frame 2.
 		forwarded = ProcessVP9Packet(context, 0, 0);

--- a/worker/test/src/RTC/Codecs/TestVP9.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP9.cpp
@@ -61,17 +61,17 @@ SCENARIO("process VP9 payload descriptor", "[codecs][vp9]")
 		context.SetCurrentSpatialLayer(0);
 		context.SetTargetSpatialLayer(0);
 
-		// Frame 1
+		// Frame 1.
 		auto forwarded = ProcessVP9Packet(context, kMaxPictureId, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == kMaxPictureId);
 
-		// Frame 2
+		// Frame 2.
 		forwarded = ProcessVP9Packet(context, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 0);
 
-		// Frame 3
+		// Frame 3.
 		forwarded = ProcessVP9Packet(context, 1, 1);
 		REQUIRE_FALSE(forwarded);
 	}

--- a/worker/test/src/RTC/Codecs/TestVP9.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP9.cpp
@@ -1,0 +1,76 @@
+#include "common.hpp"
+#include "RTC/Codecs/VP9.hpp"
+#include <catch2/catch.hpp>
+#include <cstring> // std::memcmp()
+
+using namespace RTC;
+
+Codecs::VP9::PayloadDescriptor* CreateVP9Packet(
+  uint8_t* buffer, size_t bufferLen, uint16_t pictureId, uint8_t tlIndex)
+{
+	buffer[0]             = 0xAD; // I and L bits
+	uint16_t netPictureId = htons(pictureId);
+	std::memcpy(buffer + 1, &netPictureId, 2);
+	buffer[1] |= 0x80;
+	buffer[3] = tlIndex << 6;
+
+	auto* payloadDescriptor = Codecs::VP9::Parse(buffer, bufferLen);
+
+	REQUIRE(payloadDescriptor);
+
+	return payloadDescriptor;
+}
+
+std::unique_ptr<Codecs::VP9::PayloadDescriptor> ProcessVP9Packet(
+  Codecs::VP9::EncodingContext& context, uint16_t pictureId, uint8_t tlIndex)
+{
+	// clang-format off
+	uint8_t buffer[] =
+	{
+		0xAD, 0x80, 0x00, 0x00, 0x00, 0x00
+	};
+	// clang-format on
+	bool marker;
+	auto* payloadDescriptor = CreateVP9Packet(buffer, sizeof(buffer), pictureId, tlIndex);
+	std::unique_ptr<Codecs::VP9::PayloadDescriptorHandler> payloadDescriptorHandler(
+	  new Codecs::VP9::PayloadDescriptorHandler(payloadDescriptor));
+
+	if (payloadDescriptorHandler->Process(&context, buffer, marker))
+	{
+		return std::unique_ptr<Codecs::VP9::PayloadDescriptor>(Codecs::VP9::Parse(buffer, sizeof(buffer)));
+	}
+
+	return nullptr;
+}
+
+SCENARIO("process VP9 payload descriptor", "[codecs][vp9]")
+{
+	SECTION("drop packets that belong to other temporal layers after rolling over pictureID")
+	{
+		RTC::Codecs::EncodingContext::Params params;
+		params.spatialLayers  = 1;
+		params.temporalLayers = 3;
+
+		Codecs::VP9::EncodingContext context(params);
+		context.SyncRequired();
+		context.SetCurrentTemporalLayer(0);
+		context.SetTargetTemporalLayer(0);
+
+		context.SetCurrentSpatialLayer(0);
+		context.SetTargetSpatialLayer(0);
+
+		// Frame 1
+		auto forwarded = ProcessVP9Packet(context, 32767, 0);
+		REQUIRE(forwarded);
+		REQUIRE(forwarded->pictureId == 32767);
+
+		// Frame 2
+		forwarded = ProcessVP9Packet(context, 0, 0);
+		REQUIRE(forwarded);
+		REQUIRE(forwarded->pictureId == 0);
+
+		// Frame 3
+		forwarded = ProcessVP9Packet(context, 1, 1);
+		REQUIRE_FALSE(forwarded);
+	}
+}

--- a/worker/test/src/RTC/Codecs/TestVP9.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP9.cpp
@@ -5,6 +5,8 @@
 
 using namespace RTC;
 
+constexpr uint16_t kMaxPictureId = (1 << 15) - 1;
+
 Codecs::VP9::PayloadDescriptor* CreateVP9Packet(
   uint8_t* buffer, size_t bufferLen, uint16_t pictureId, uint8_t tlIndex)
 {
@@ -60,9 +62,9 @@ SCENARIO("process VP9 payload descriptor", "[codecs][vp9]")
 		context.SetTargetSpatialLayer(0);
 
 		// Frame 1
-		auto forwarded = ProcessVP9Packet(context, 32767, 0);
+		auto forwarded = ProcessVP9Packet(context, kMaxPictureId, 0);
 		REQUIRE(forwarded);
-		REQUIRE(forwarded->pictureId == 32767);
+		REQUIRE(forwarded->pictureId == kMaxPictureId);
 
 		// Frame 2
 		forwarded = ProcessVP9Packet(context, 0, 0);

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -21,8 +21,8 @@ struct TestSeqManagerInput
 	T offset{ 0 };
 };
 
-template<typename T>
-void validate(SeqManager<T>& seqManager, std::vector<TestSeqManagerInput<T>>& inputs)
+template<typename T, unsigned int N>
+void validate(SeqManager<T, N>& seqManager, std::vector<TestSeqManagerInput<T>>& inputs)
 {
 	for (auto& element : inputs)
 	{
@@ -55,6 +55,11 @@ SCENARIO("SeqManager", "[rtc]")
 		REQUIRE(SeqManager<uint16_t>::IsSeqHigherThan(0, 65000) == true);
 	}
 
+	SECTION("0 is greater than 32500 in range 15")
+	{
+		REQUIRE(SeqManager<uint16_t, 15>::IsSeqHigherThan(0, 32500) == true);
+	}
+
 	SECTION("receive ordered numbers, no sync, no drop")
 	{
 		// clang-format off
@@ -76,7 +81,9 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format on
 
 		SeqManager<uint16_t> seqManager;
+		SeqManager<uint16_t, 15> seqManager2;
 		validate(seqManager, inputs);
+		validate(seqManager2, inputs);
 	}
 
 	SECTION("receive ordered numbers, sync, no drop")
@@ -96,7 +103,9 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format on
 
 		SeqManager<uint16_t> seqManager;
+		SeqManager<uint16_t, 15> seqManager2;
 		validate(seqManager, inputs);
+		validate(seqManager2, inputs);
 	}
 
 	SECTION("receive ordered numbers, sync, drop")
@@ -121,7 +130,9 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format on
 
 		SeqManager<uint16_t> seqManager;
+		SeqManager<uint16_t, 15> seqManager2;
 		validate(seqManager, inputs);
+		validate(seqManager2, inputs);
 	}
 
 	SECTION("receive ordered wrapped numbers")
@@ -154,7 +165,9 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format on
 
 		SeqManager<uint16_t> seqManager;
+		SeqManager<uint16_t, 15> seqManager2;
 		validate(seqManager, inputs);
+		validate(seqManager2, inputs);
 	}
 
 	SECTION("receive mixed numbers with a big jump, drop before jump")
@@ -172,7 +185,9 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format on
 
 		SeqManager<uint16_t> seqManager;
+		SeqManager<uint16_t, 15> seqManager2;
 		validate(seqManager, inputs);
+		validate(seqManager2, inputs);
 	}
 
 	SECTION("receive mixed numbers with a big jump, drop after jump")
@@ -189,7 +204,9 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format on
 
 		SeqManager<uint16_t> seqManager;
+		SeqManager<uint16_t, 15> seqManager2;
 		validate(seqManager, inputs);
+		validate(seqManager2, inputs);
 	}
 
 	SECTION("drop, receive numbers newer and older than the one dropped")
@@ -206,7 +223,9 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format on
 
 		SeqManager<uint16_t> seqManager;
+		SeqManager<uint16_t, 15> seqManager2;
 		validate(seqManager, inputs);
+		validate(seqManager2, inputs);
 	}
 
 	SECTION("receive mixed numbers, sync, drop")
@@ -284,7 +303,9 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format on
 
 		SeqManager<uint16_t> seqManager;
+		SeqManager<uint16_t, 15> seqManager2;
 		validate(seqManager, inputs);
+		validate(seqManager2, inputs);
 	}
 
 	SECTION("drop many inputs at the beginning (using uint16_t)")
@@ -325,7 +346,9 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format on
 
 		SeqManager<uint16_t> seqManager;
+		SeqManager<uint16_t, 15> seqManager2;
 		validate(seqManager, inputs);
+		validate(seqManager2, inputs);
 	}
 
 	SECTION("drop many inputs at the beginning (using uint8_t)")
@@ -366,6 +389,64 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format on
 
 		SeqManager<uint8_t> seqManager;
+		validate(seqManager, inputs);
+	}
+
+	SECTION("receive mixed numbers, sync, drop in range 15")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{     0,  0, false, false },
+			{     1,  1, false, false },
+			{     2,  2, false, false },
+			{     3,  3, false, false },
+			{     7,  7, false, false },
+			{     6,  0, false,  true }, // drop.
+			{     8,  8, false, false },
+			{    10, 10, false, false },
+			{     9,  9, false, false },
+			{    11, 11, false, false },
+			{     0, 12,  true, false }, // sync.
+			{     2, 14, false, false },
+			{     3, 15, false, false },
+			{     4, 16, false, false },
+			{     5, 17, false, false },
+			{     6, 18, false, false },
+			{     7, 19, false, false },
+			{     8, 20, false, false },
+			{     9, 21, false, false },
+			{    10, 22, false, false },
+			{     9,  0, false,  true }, // drop.
+			{    61, 23,  true, false }, // sync.
+			{    62, 24, false, false },
+			{    63, 25, false, false },
+			{    64, 26, false, false },
+			{    65, 27, false, false },
+			{    11, 28,  true, false }, // sync.
+			{    12, 29, false, false },
+			{    13, 30, false, false },
+			{    14, 31, false, false },
+			{    15, 32, false, false },
+			{     1, 33,  true, false }, // sync.
+			{     2, 34, false, false },
+			{     3, 35, false, false },
+			{     4, 36, false, false },
+			{     5, 37, false, false },
+			{ 32767, 38,  true, false }, // sync.
+			{ 32768, 39, false, false },
+			{ 32769, 40, false, false },
+			{     0, 41,  true, false }, // sync.
+			{     1, 42, false, false },
+			{     3,  0, false,  true }, // drop.
+			{     4, 44, false, false },
+			{     5, 45, false, false },
+			{     6, 46, false, false },
+			{     7, 47, false, false }
+		};
+		// clang-format on
+
+		SeqManager<uint16_t, 15> seqManager;
 		validate(seqManager, inputs);
 	}
 
@@ -422,6 +503,62 @@ SCENARIO("SeqManager", "[rtc]")
 		// clang-format on
 
 		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
+
+	SECTION("drop many inputs at the beginning (using uint16_t range 15 with high values)")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{     1,     1, false, false },
+			{     2,     0, false,  true }, // drop.
+			{     3,     0, false,  true }, // drop.
+			{     4,     0, false,  true }, // drop.
+			{     5,     0, false,  true }, // drop.
+			{     6,     0, false,  true }, // drop.
+			{     7,     0, false,  true }, // drop.
+			{     8,     0, false,  true }, // drop.
+			{     9,     0, false,  true }, // drop.
+			{ 16384, 16376, false, false },
+			{ 16385, 16377, false, false },
+			{ 16386, 16378, false, false },
+			{ 16387, 16379, false, false },
+			{ 16388, 16380, false, false },
+			{ 16389, 16381, false, false },
+			{ 16390, 16382, false, false },
+			{ 16391, 16383, false, false },
+			{ 16392, 16384, false, false },
+			{ 16393, 16385, false, false },
+			{ 16394, 16386, false, false },
+			{ 16395, 16387, false, false },
+			{ 16396, 16388, false, false }
+		};
+		// clang-format on
+
+		SeqManager<uint16_t, 15> seqManager;
+		validate(seqManager, inputs);
+	}
+
+	SECTION("sync and drop some input near max-value in a 15bit range")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{ 32762,  1,  true, false },
+			{ 32763,  2, false, false },
+			{ 32764,  3, false, false },
+			{ 32765,  0, false, true  },
+			{ 32766,  0, false, true  },
+			{ 32767,  4, false, false },
+			{     0,  5, false, false },
+			{     1,  6, false, false },
+			{     2,  7, false, false },
+			{     3,  8, false, false }
+		};
+		// clang-format on
+
+		SeqManager<uint16_t, 15> seqManager;
 		validate(seqManager, inputs);
 	}
 }

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -11,7 +11,8 @@ constexpr uint16_t kMaxNumberFor15Bits = (1 << 15) - 1;
 template<typename T>
 struct TestSeqManagerInput
 {
-	TestSeqManagerInput(T input, T output, bool sync = false, bool drop = false, T offset = 0, int64_t maxInput = -1)
+	TestSeqManagerInput(
+	  T input, T output, bool sync = false, bool drop = false, T offset = 0, int64_t maxInput = -1)
 	  : input(input), output(output), sync(sync), drop(drop), offset(offset), maxInput(maxInput)
 	{
 	}
@@ -47,7 +48,8 @@ void validate(SeqManager<T, N>& seqManager, std::vector<TestSeqManagerInput<T>>&
 
 			// Covert to string because otherwise Catch will print uint8_t as char.
 			REQUIRE(std::to_string(output) == std::to_string(element.output));
-			if (element.maxInput != -1) {
+			if (element.maxInput != -1)
+			{
 				REQUIRE(std::to_string(element.maxInput) == std::to_string(seqManager.GetMaxInput()));
 			}
 		}


### PR DESCRIPTION
VP9 and VP8 payloads include the PictureID. This field has a length of 15 bits, but VP8.cpp and VP9.cpp were using a SeqManager with uint16_t, which is 16 bits. 

This may cause different issues. I've reproduced very low framerates in VP9/SVC, but there could also be video artifacts, frozen videos, etc. VP8 also translates PictureIDs so that it could have an additional impact. The problem I saw is that we were marking all VP9/VP8 packets as `isOldPacket` after rolling over the PictureID. So we started to send higher temporal and spatial layers, and it broke VP9/SVC decoding.

I'm adding a bit length parameter when creating the SeqManager (`SeqManager<uint16_t, 15>`) to handle PictureID properly. I've added some tests for this case too.