### PR TITLE
Fix crash with invalid arrival_time in libwebrtc bwe

### DIFF
--- a/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.cc
@@ -41,6 +41,11 @@ bool InterArrival::ComputeDeltas(uint32_t timestamp,
   MS_ASSERT(timestamp_delta != nullptr, "timestamp_delta is null");
   MS_ASSERT(arrival_time_delta_ms != nullptr, "arrival_time_delta_ms is null");
   MS_ASSERT(packet_size_delta != nullptr, "packet_size_delta is null");
+  // Ignore packets with invalid arrival time.
+  if (arrival_time_ms < 0) {
+    MS_WARN_TAG(bwe, "invalid arrival time %" PRIi64, arrival_time_ms);
+    return false;
+  }
   bool calculated_deltas = false;
   if (current_timestamp_group_.IsFirstPacket()) {
     // We don't have enough data to update the filter, so we store it until we


### PR DESCRIPTION
Tentative fix for #357

According to the assert `complete_time_ms` is <0 and it cannot be -1 because there is a check before for that.   So the value is probably int64.min().

This fix try to avoid ever setting `complete_time_ms` to any negative value what should prevent the crash from happening.