### PR TITLE
libwebrtc: replace MS_ASSERT with MS_ERROR

### DIFF
--- a/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/delay_based_bwe.cc
@@ -252,8 +252,14 @@ bool DelayBasedBwe::LatestEstimate(std::vector<uint32_t>* ssrcs,
   // thread.
   //RTC_DCHECK(ssrcs);
   //RTC_DCHECK(bitrate);
-  MS_ASSERT(ssrcs, "ssrcs must be != null");
-  MS_ASSERT(bitrate, "bitrate must be != null");
+  if (!ssrcs) {
+    MS_ERROR("ssrcs must be != null");
+    return false;
+  }
+  if (!bitrate) {
+    MS_ERROR("bitrate must be != null");
+    return false;
+  }
 
   if (!rate_control_.ValidEstimate())
     return false;

--- a/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/probe_bitrate_estimator.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/probe_bitrate_estimator.cc
@@ -64,7 +64,10 @@ absl::optional<DataRate> ProbeBitrateEstimator::HandleProbeAndEstimateBitrate(
   int cluster_id = packet_feedback.sent_packet.pacing_info.probe_cluster_id;
 
   //RTC_DCHECK_NE(cluster_id, PacedPacketInfo::kNotAProbe);
-  MS_ASSERT(cluster_id != PacedPacketInfo::kNotAProbe, "cluster_id == kNotAProbe");
+  if (cluster_id == PacedPacketInfo::kNotAProbe) {
+    MS_ERROR("cluster_id == kNotAProbe");
+    return absl::nullopt;
+  }
 
   EraseOldClusters(packet_feedback.receive_time);
 
@@ -91,12 +94,14 @@ absl::optional<DataRate> ProbeBitrateEstimator::HandleProbeAndEstimateBitrate(
       // packet_feedback.sent_packet.pacing_info.probe_cluster_min_probes, 0);
   // RTC_DCHECK_GT(packet_feedback.sent_packet.pacing_info.probe_cluster_min_bytes,
                 // 0);
-  MS_ASSERT(
-    packet_feedback.sent_packet.pacing_info.probe_cluster_min_probes > 0,
-    "probe_cluster_min_probes must be > 0");
-  MS_ASSERT(
-    packet_feedback.sent_packet.pacing_info.probe_cluster_min_bytes > 0,
-    "probe_cluster_min_bytes must be > 0");
+  if (packet_feedback.sent_packet.pacing_info.probe_cluster_min_probes <= 0) {
+    MS_ERROR("probe_cluster_min_probes must be > 0");
+    return absl::nullopt;
+  }
+  if (packet_feedback.sent_packet.pacing_info.probe_cluster_min_bytes <= 0) {
+    MS_ERROR("probe_cluster_min_bytes must be > 0");
+    return absl::nullopt;
+  }
 
   int min_probes =
       packet_feedback.sent_packet.pacing_info.probe_cluster_min_probes *

--- a/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/probe_controller.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/probe_controller.cc
@@ -251,9 +251,15 @@ std::vector<ProbeClusterConfig> ProbeController::InitiateExponentialProbing(
   //RTC_DCHECK(network_available_);
   //RTC_DCHECK(state_ == State::kInit);
   //RTC_DCHECK_GT(start_bitrate_bps_, 0);
-  MS_ASSERT(network_available_, "network not available");
-  MS_ASSERT(state_ == State::kInit, "state_ must be State::kInit");
-  MS_ASSERT(start_bitrate_bps_ > 0, "start_bitrate_bps_ must be > 0");
+  if (!network_available_) {
+    MS_ERROR("network not available");
+  }
+  if (state_ != State::kInit) {
+    MS_ERROR("state_ must be State::kInit");
+  }
+  if (start_bitrate_bps_ <= 0) {
+    MS_ERROR("start_bitrate_bps_ must be > 0");
+  }
 
   // When probing at 1.8 Mbps ( 6x 300), this represents a threshold of
   // 1.2 Mbps to continue probing.

--- a/worker/deps/libwebrtc/libwebrtc/modules/pacing/bitrate_prober.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/pacing/bitrate_prober.cc
@@ -271,14 +271,8 @@ void BitrateProber::ProbeSent(int64_t now_ms, size_t bytes) {
 int64_t BitrateProber::GetNextProbeTime(const ProbeCluster& cluster) {
   // RTC_CHECK_GT(cluster.pace_info.send_bitrate_bps, 0);
   // RTC_CHECK_GE(cluster.time_started_ms, 0);
-  if (cluster.pace_info.send_bitrate_bps <= 0) {
-    MS_ERROR("cluster.pace_info.send_bitrate_bps must be > 0");
-    return 0;
-  }
-  if (cluster.time_started_ms <= 0) {
-    MS_ERROR("cluster.time_started_ms must be > 0");
-    return 0;
-  }
+  MS_ASSERT(cluster.pace_info.send_bitrate_bps > 0, "cluster.pace_info.send_bitrate_bps must be > 0");
+  MS_ASSERT(cluster.time_started_ms > 0, "cluster.time_started_ms must be > 0");
 
   // Compute the time delta from the cluster start to ensure probe bitrate stays
   // close to the target bitrate. Result is in milliseconds.

--- a/worker/deps/libwebrtc/libwebrtc/modules/pacing/bitrate_prober.h
+++ b/worker/deps/libwebrtc/libwebrtc/modules/pacing/bitrate_prober.h
@@ -66,7 +66,7 @@ class BitrateProber {
   int TimeUntilNextProbe(int64_t now_ms);
 
   // Information about the current probing cluster.
-  PacedPacketInfo CurrentCluster() const;
+  absl::optional<PacedPacketInfo> CurrentCluster() const;
 
   // Returns the minimum number of bytes that the prober recommends for
   // the next probe.

--- a/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.cc
@@ -38,12 +38,28 @@ bool InterArrival::ComputeDeltas(uint32_t timestamp,
                                  uint32_t* timestamp_delta, // send_delta.
                                  int64_t* arrival_time_delta_ms, // recv_delta.
                                  int* packet_size_delta) {
-  MS_ASSERT(timestamp_delta != nullptr, "timestamp_delta is null");
-  MS_ASSERT(arrival_time_delta_ms != nullptr, "arrival_time_delta_ms is null");
-  MS_ASSERT(packet_size_delta != nullptr, "packet_size_delta is null");
+  if (timestamp_delta == nullptr) {
+    MS_ERROR("timestamp_delta is null");
+
+    return false;
+  }
+
+  if (arrival_time_delta_ms == nullptr) {
+    MS_ERROR("arrival_time_delta_ms is null");
+
+    return false;
+  }
+
+  if (packet_size_delta == nullptr) {
+    MS_ERROR("packet_size_delta is null");
+
+    return false;
+  }
+
   // Ignore packets with invalid arrival time.
   if (arrival_time_ms < 0) {
     MS_WARN_TAG(bwe, "invalid arrival time %" PRIi64, arrival_time_ms);
+
     return false;
   }
   bool calculated_deltas = false;
@@ -94,7 +110,11 @@ bool InterArrival::ComputeDeltas(uint32_t timestamp,
         num_consecutive_reordered_packets_ = 0;
       }
 
-      MS_ASSERT(*arrival_time_delta_ms >= 0, "arrival_time_delta_ms is < 0");
+      if (*arrival_time_delta_ms < 0) {
+        MS_ERROR("arrival_time_delta_ms is < 0");
+
+        return false;
+      }
 
       *packet_size_delta = static_cast<int>(current_timestamp_group_.size) -
                            static_cast<int>(prev_timestamp_group_.size);
@@ -161,10 +181,12 @@ bool InterArrival::BelongsToBurst(int64_t arrival_time_ms,
     return false;
   }
 
-  MS_ASSERT(
-    current_timestamp_group_.complete_time_ms >= 0,
-    "current_timestamp_group_.complete_time_ms < 0 [current_timestamp_group_.complete_time_ms:%" PRIi64 "]",
-    current_timestamp_group_.complete_time_ms);
+  if (current_timestamp_group_.complete_time_ms < 0) {
+    MS_ERROR("current_timestamp_group_.complete_time_ms < 0 [current_timestamp_group_.complete_time_ms:%" PRIi64 "]",
+      current_timestamp_group_.complete_time_ms);
+
+    return false;
+  }
 
   int64_t arrival_time_delta_ms =
       arrival_time_ms - current_timestamp_group_.complete_time_ms;

--- a/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/inter_arrival.cc
@@ -40,19 +40,14 @@ bool InterArrival::ComputeDeltas(uint32_t timestamp,
                                  int* packet_size_delta) {
   if (timestamp_delta == nullptr) {
     MS_ERROR("timestamp_delta is null");
-
     return false;
   }
-
   if (arrival_time_delta_ms == nullptr) {
     MS_ERROR("arrival_time_delta_ms is null");
-
     return false;
   }
-
   if (packet_size_delta == nullptr) {
     MS_ERROR("packet_size_delta is null");
-
     return false;
   }
 

--- a/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/overuse_estimator.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/overuse_estimator.cc
@@ -108,11 +108,8 @@ void OveruseEstimator::Update(int64_t t_delta,
       E_[0][0] + E_[1][1] >= 0 &&
       E_[0][0] * E_[1][1] - E_[0][1] * E_[1][0] >= 0 && E_[0][0] >= 0;
 
-  MS_ASSERT(positive_semi_definite, "positive_semi_definite is not true");
-
   if (!positive_semi_definite) {
-    MS_ERROR("The over-use estimator's covariance matrix is no longer "
-           "semi-definite.");
+    MS_ERROR("the over-use estimator's covariance matrix is no longer semi-definite");
   }
 
   slope_ = slope_ + K[0] * residual;

--- a/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.cc
@@ -236,7 +236,11 @@ void RemoteBitrateEstimatorAbsSendTime::IncomingPacketInfo(
     uint32_t send_time_24bits,
     size_t payload_size,
     uint32_t ssrc) {
-  MS_ASSERT(send_time_24bits < (1ul << 24), "invalid sendTime24bits value");
+  // RTC_CHECK(send_time_24bits < (1ul << 24));
+  if (send_time_24bits >= (1ul << 24)) {
+    MS_ERROR("invalid sendTime24bits value");
+    return;
+  }
 
   if (!uma_recorded_) {
     uma_recorded_ = true;


### PR DESCRIPTION
- Fixes #986
- Let's use `MS_ERROR` instead of `MS_WARN_TAG(bwe)` to make these errors as visible as possible.
- Sometimes use more modern libwebrtc code such as the usage of `absl::optional` somewhere in code diff.
- Original `RTC_DCHECK` in libwebrtc does NOT abort so we must only show error logs and, depending on each case, do early return or not. If not, it means that code below keeps running with inconsistent data. I've tried to return earlier as much as possible but it's not always possible. In fact, `RTC_CHECK` **does abort* even in Release mode. However, `RTC_DCHECK` just logs it.
