### PR TITLE
Fix issue #989 to properly allocate bitrate in simulcast and SVC.

### DIFF
--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -500,7 +500,7 @@ namespace RTC
 					continue;
 				}
 
-				requiredBitrate = producerRtpStream->GetLayerBitrate(nowMs, 0, temporalLayer);
+				requiredBitrate = producerRtpStream->GetBitrate(nowMs, 0, temporalLayer);
 
 				// This is simulcast so we must substract the bitrate of the current temporal
 				// spatial layer if this is the temporal layer 0 of a higher spatial layer.

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -424,7 +424,7 @@ namespace RTC
 				}
 
 				requiredBitrate =
-				  this->producerRtpStream->GetLayerBitrate(nowMs, spatialLayer, temporalLayer);
+				  this->producerRtpStream->GetBitrate(nowMs, spatialLayer, temporalLayer);
 
 				MS_DEBUG_DEV(
 				  "testing layers %" PRIi16 ":%" PRIi16 " [virtual bitrate:%" PRIu32

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -423,8 +423,7 @@ namespace RTC
 					continue;
 				}
 
-				requiredBitrate =
-				  this->producerRtpStream->GetBitrate(nowMs, spatialLayer, temporalLayer);
+				requiredBitrate = this->producerRtpStream->GetBitrate(nowMs, spatialLayer, temporalLayer);
 
 				MS_DEBUG_DEV(
 				  "testing layers %" PRIi16 ":%" PRIi16 " [virtual bitrate:%" PRIu32


### PR DESCRIPTION
Mediasoup was wrongfully allocating bitrate for temporal layers, as it was getting bitrate for a specific temporal layer and not the sum of all temporal layers. Before fix, if we would look at required bitrate, we can see that layer 2:1 has lower bitrate that 2:0 which is wrong. :

`mediasoup:Channel [pid:14937] RTC::SimulcastConsumer::IncreaseLayer() | setting provisional layers to 2:0 [virtual bitrate:4405928, required bitrate:2261974] +0ms

  mediasoup:Channel [pid:14937] RTC::SimulcastConsumer::IncreaseLayer() | setting provisional layers to 2:1 [virtual bitrate:2143954, required bitrate:1951808] +0ms`
  
  After the fix we now see the proper values:
  ` mediasoup:Channel [pid:33559] RTC::SimulcastConsumer::IncreaseLayer() | setting provisional layers to 2:0 [virtual bitrate:11346749, required bitrate:1329069] +0ms
  
  mediasoup:Channel [pid:33559] RTC::SimulcastConsumer::IncreaseLayer() | setting provisional layers to 2:1 [virtual bitrate:10017680, required bitrate:3262380] +0ms
`
For VP9 it was even worse.