### PR TITLE
SimulcastConsumer: Fix frozen video when syncing keyframe is discarded due to too high RTP timestamp extra offset needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### NEXT
 
 * `SimulcastConsumer::GetDesiredBitrate()`: Choose the highest bitrate among all Producer streams ([PR #992](https://github.com/versatica/mediasoup/pull/992)).
+* `SimulcastConsumer`: Fix frozen video when syncing keyframe is discarded due to too high RTP timestamp extra offset needed ([PR #999](https://github.com/versatica/mediasoup/pull/999)).
 * Update NPM deps.
 
 

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -809,6 +809,10 @@ namespace RTC
 
 					this->keyFrameForTsOffsetRequested = true;
 
+					// Reset flags since we are discarding this key frame.
+					this->syncRequired       = false;
+					this->spatialLayerToSync = -1;
+
 					return;
 				}
 


### PR DESCRIPTION
- Fixes #990.
- Rationale here: https://github.com/versatica/mediasoup/issues/990#issuecomment-1409997273.
- Basically we should reset this->syncRequired` nor `this->spatialLayerToSync` when the keyframe that is supposed to switch to another spatial layer is discarded due to too high RTP timestamp extra offset needed.