### PR TITLE
Worker: const correctness

### DIFF
--- a/worker/src/DepLibSRTP.cpp
+++ b/worker/src/DepLibSRTP.cpp
@@ -56,7 +56,7 @@ void DepLibSRTP::ClassInit()
 		{
 			MS_DEBUG_TAG(info, "libsrtp version: \"%s\"", srtp_get_version_string());
 
-			srtp_err_status_t err = srtp_init();
+			const srtp_err_status_t err = srtp_init();
 
 			if (DepLibSRTP::IsError(err))
 				MS_THROW_ERROR("srtp_init() failed: %s", DepLibSRTP::GetErrorString(err));

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -38,7 +38,7 @@ void DepLibUV::ClassInit()
 
 	DepLibUV::loop = new uv_loop_t;
 
-	int err = uv_loop_init(DepLibUV::loop);
+	const int err = uv_loop_init(DepLibUV::loop);
 
 	if (err != 0)
 		MS_ABORT("libuv loop initialization failed");
@@ -88,7 +88,7 @@ void DepLibUV::RunLoop()
 	// This should never happen.
 	MS_ASSERT(DepLibUV::loop != nullptr, "loop unset");
 
-	int ret = uv_run(DepLibUV::loop, UV_RUN_DEFAULT);
+	const int ret = uv_run(DepLibUV::loop, UV_RUN_DEFAULT);
 
 	MS_ASSERT(ret == 0, "uv_run() returned %s", uv_err_name(ret));
 }

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -236,8 +236,8 @@ void DepUsrSCTP::Checker::OnTimer(Timer* /*timer*/)
 {
 	MS_TRACE();
 
-	auto nowMs    = DepLibUV::GetTimeMs();
-	int elapsedMs = this->lastCalledAtMs ? static_cast<int>(nowMs - this->lastCalledAtMs) : 0;
+	auto nowMs          = DepLibUV::GetTimeMs();
+	const int elapsedMs = this->lastCalledAtMs ? static_cast<int>(nowMs - this->lastCalledAtMs) : 0;
 
 	usrsctp_handle_timers(elapsedMs);
 

--- a/worker/src/RTC/Codecs/H264.cpp
+++ b/worker/src/RTC/Codecs/H264.cpp
@@ -63,7 +63,7 @@ namespace RTC
 			// there is no frame-marking or if there is but keyframe was not detected above.
 			if (!frameMarking || !payloadDescriptor->isKeyFrame)
 			{
-				uint8_t nal = *data & 0x1F;
+				const uint8_t nal = *data & 0x1F;
 
 				switch (nal)
 				{
@@ -87,8 +87,8 @@ namespace RTC
 						// Iterate NAL units.
 						while (len >= 3)
 						{
-							auto naluSize  = Utils::Byte::Get2Bytes(data, offset);
-							uint8_t subnal = *(data + offset + sizeof(naluSize)) & 0x1F;
+							auto naluSize        = Utils::Byte::Get2Bytes(data, offset);
+							const uint8_t subnal = *(data + offset + sizeof(naluSize)) & 0x1F;
 
 							if (subnal == 7)
 							{
@@ -115,8 +115,8 @@ namespace RTC
 					case 28:
 					case 29:
 					{
-						uint8_t subnal   = *(data + 1) & 0x1F;
-						uint8_t startBit = *(data + 1) & 0x80;
+						const uint8_t subnal   = *(data + 1) & 0x1F;
+						const uint8_t startBit = *(data + 1) & 0x80;
 
 						if (subnal == 7 && startBit == 128)
 						{

--- a/worker/src/RTC/Codecs/H264_SVC.cpp
+++ b/worker/src/RTC/Codecs/H264_SVC.cpp
@@ -58,7 +58,7 @@ namespace RTC
 			// there is no frame-marking or if there is but keyframe was not detected above.
 			if (!frameMarking || !payloadDescriptor->isKeyFrame)
 			{
-				uint8_t nal = *data & 0x1F;
+				const uint8_t nal = *data & 0x1F;
 
 				switch (nal)
 				{
@@ -121,7 +121,7 @@ namespace RTC
 					case 28:
 					case 29:
 					{
-						uint8_t startBit = *(data + 1) & 0x80;
+						const uint8_t startBit = *(data + 1) & 0x80;
 
 						if (startBit == 128)
 						{
@@ -145,7 +145,7 @@ namespace RTC
 		  std::unique_ptr<H264_SVC::PayloadDescriptor> payloadDescriptor,
 		  bool isStartBit)
 		{
-			uint8_t nal = *data & 0x1F;
+			const uint8_t nal = *data & 0x1F;
 
 			switch (nal)
 			{
@@ -286,7 +286,7 @@ namespace RTC
 			}
 
 			// clang-format off
-			bool isOldPacket = false;
+			const bool isOldPacket = false;
 
 			// Upgrade current spatial layer if needed.
 			if (context->GetTargetSpatialLayer() > context->GetCurrentSpatialLayer())

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -223,7 +223,7 @@ namespace RTC
 			}
 
 			// clang-format off
-			bool isOldPacket = (
+			const bool isOldPacket = (
 				this->payloadDescriptor->hasPictureId &&
 				RTC::SeqManager<uint16_t, 15>::IsSeqLowerThan(
 					this->payloadDescriptor->pictureId,

--- a/worker/src/RTC/RTCP/Bye.cpp
+++ b/worker/src/RTC/RTCP/Bye.cpp
@@ -75,7 +75,7 @@ namespace RTC
 			}
 
 			// 32 bits padding.
-			size_t padding = (-offset) & 3;
+			const size_t padding = (-offset) & 3;
 
 			for (size_t i{ 0 }; i < padding; ++i)
 			{

--- a/worker/src/RTC/RTCP/FeedbackPsRpsi.cpp
+++ b/worker/src/RTC/RTCP/FeedbackPsRpsi.cpp
@@ -25,7 +25,7 @@ namespace RTC
 				isCorrect = false;
 			}
 
-			size_t paddingBytes = this->header->paddingBits / 8;
+			const size_t paddingBytes = this->header->paddingBits / 8;
 
 			if (paddingBytes > FeedbackPsRpsiItem::maxBitStringSize)
 			{
@@ -50,7 +50,7 @@ namespace RTC
 			this->header = reinterpret_cast<Header*>(this->raw);
 
 			// 32 bits padding.
-			size_t padding = (-length) & 3;
+			const size_t padding = (-length) & 3;
 
 			this->header->paddingBits = padding * 8;
 			this->header->zero        = 0;

--- a/worker/src/RTC/RTCP/FeedbackPsSli.cpp
+++ b/worker/src/RTC/RTCP/FeedbackPsSli.cpp
@@ -26,8 +26,8 @@ namespace RTC
 
 		size_t FeedbackPsSliItem::Serialize(uint8_t* buffer)
 		{
-			uint32_t compact = (this->first << 19) | (this->number << 6) | this->pictureId;
-			auto* header     = reinterpret_cast<Header*>(buffer);
+			const uint32_t compact = (this->first << 19) | (this->number << 6) | this->pictureId;
+			auto* header           = reinterpret_cast<Header*>(buffer);
 
 			header->compact = uint32_t{ htonl(compact) };
 			std::memcpy(buffer, header, HeaderSize);

--- a/worker/src/RTC/RTCP/FeedbackPsVbcm.cpp
+++ b/worker/src/RTC/RTCP/FeedbackPsVbcm.cpp
@@ -34,9 +34,9 @@ namespace RTC
 			// Copy the content.
 			std::memcpy(buffer + 8, this->header->value, GetLength());
 
-			size_t offset = 8 + GetLength();
+			const size_t offset = 8 + GetLength();
 			// 32 bits padding.
-			size_t padding = (-offset) & 3;
+			const size_t padding = (-offset) & 3;
 
 			for (size_t i{ 0 }; i < padding; ++i)
 			{

--- a/worker/src/RTC/RTCP/FeedbackRtpTmmb.cpp
+++ b/worker/src/RTC/RTCP/FeedbackRtpTmmb.cpp
@@ -23,10 +23,10 @@ namespace RTC
 			this->ssrc = Utils::Byte::Get4Bytes(data, 0);
 
 			// Read the 4 bytes block.
-			uint32_t compact = Utils::Byte::Get4Bytes(data, 4);
+			const uint32_t compact = Utils::Byte::Get4Bytes(data, 4);
 			// Read each component.
-			uint8_t exponent  = compact >> 26;            // 6 bits.
-			uint64_t mantissa = (compact >> 9) & 0x1ffff; // 17 bits.
+			const uint8_t exponent  = compact >> 26;            // 6 bits.
+			const uint64_t mantissa = (compact >> 9) & 0x1ffff; // 17 bits.
 
 			this->overhead = compact & 0x1ff; // 9 bits.
 			// Get the bitrate out of exponent and mantissa.

--- a/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
+++ b/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
@@ -265,7 +265,7 @@ namespace RTC
 			}
 
 			// 32 bits padding.
-			size_t padding = (-offset) & 3;
+			const size_t padding = (-offset) & 3;
 
 			for (size_t i{ 0u }; i < padding; ++i)
 			{
@@ -318,7 +318,7 @@ namespace RTC
 
 			// Deltas are represented as multiples of 250 us.
 			// NOTE: Read it as int 64 to detect long elapsed times.
-			int64_t delta64 = (timestamp - this->latestTimestamp) * 4;
+			const int64_t delta64 = (timestamp - this->latestTimestamp) * 4;
 
 			// clang-format off
 			if (
@@ -414,7 +414,7 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			uint16_t expected = this->packetStatusCount;
+			const uint16_t expected = this->packetStatusCount;
 			uint16_t lost{ 0u };
 
 			if (expected == 0u)

--- a/worker/src/RTC/RTCP/Packet.cpp
+++ b/worker/src/RTC/RTCP/Packet.cpp
@@ -204,7 +204,7 @@ namespace RTC
 
 			this->header = reinterpret_cast<CommonHeader*>(buffer);
 
-			size_t length = (GetSize() / 4) - 1;
+			const size_t length = (GetSize() / 4) - 1;
 
 			// Fill the common header.
 			this->header->version    = 2;

--- a/worker/src/RTC/RTCP/ReceiverReport.cpp
+++ b/worker/src/RTC/RTCP/ReceiverReport.cpp
@@ -86,7 +86,7 @@ namespace RTC
 
 			std::unique_ptr<ReceiverReportPacket> packet(new ReceiverReportPacket(header));
 
-			uint32_t ssrc =
+			const uint32_t ssrc =
 			  Utils::Byte::Get4Bytes(reinterpret_cast<uint8_t*>(header), Packet::CommonHeaderSize);
 
 			packet->SetSsrc(ssrc);

--- a/worker/src/RTC/RTCP/Sdes.cpp
+++ b/worker/src/RTC/RTCP/Sdes.cpp
@@ -119,7 +119,7 @@ namespace RTC
 				return nullptr;
 			}
 
-			uint32_t ssrc = Utils::Byte::Get4Bytes(data, 0);
+			const uint32_t ssrc = Utils::Byte::Get4Bytes(data, 0);
 
 			std::unique_ptr<SdesChunk> chunk(new SdesChunk(ssrc));
 
@@ -156,7 +156,7 @@ namespace RTC
 			}
 
 			// 32 bits padding.
-			size_t padding = (-offset) & 3;
+			const size_t padding = (-offset) & 3;
 
 			for (size_t i{ 0 }; i < padding; ++i)
 			{

--- a/worker/src/RTC/RTCP/SenderReport.cpp
+++ b/worker/src/RTC/RTCP/SenderReport.cpp
@@ -65,7 +65,7 @@ namespace RTC
 			auto* header = const_cast<CommonHeader*>(reinterpret_cast<const CommonHeader*>(data));
 
 			std::unique_ptr<SenderReportPacket> packet(new SenderReportPacket(header));
-			size_t offset = Packet::CommonHeaderSize;
+			const size_t offset = Packet::CommonHeaderSize;
 
 			SenderReport* report = SenderReport::Parse(data + offset, len - offset);
 

--- a/worker/src/RTC/RTCP/XR.cpp
+++ b/worker/src/RTC/RTCP/XR.cpp
@@ -71,7 +71,7 @@ namespace RTC
 
 			std::unique_ptr<ExtendedReportPacket> packet(new ExtendedReportPacket(header));
 
-			uint32_t ssrc =
+			const uint32_t ssrc =
 			  Utils::Byte::Get4Bytes(reinterpret_cast<uint8_t*>(header), Packet::CommonHeaderSize);
 
 			packet->SetSsrc(ssrc);

--- a/worker/src/RTC/RTCP/XrDelaySinceLastRr.cpp
+++ b/worker/src/RTC/RTCP/XrDelaySinceLastRr.cpp
@@ -94,7 +94,7 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			size_t length = static_cast<uint16_t>((SsrcInfo::BodySize * this->ssrcInfos.size() / 4));
+			const size_t length = static_cast<uint16_t>((SsrcInfo::BodySize * this->ssrcInfos.size() / 4));
 
 			// Fill the common header.
 			this->header->blockType = static_cast<uint8_t>(this->type);

--- a/worker/src/handles/TcpConnectionHandler.cpp
+++ b/worker/src/handles/TcpConnectionHandler.cpp
@@ -135,7 +135,7 @@ void TcpConnectionHandler::Setup(
 	MS_TRACE();
 
 	// Set the UV handle.
-	int err = uv_tcp_init(DepLibUV::GetLoop(), this->uvHandle);
+	const int err = uv_tcp_init(DepLibUV::GetLoop(), this->uvHandle);
 
 	if (err != 0)
 	{
@@ -205,7 +205,7 @@ void TcpConnectionHandler::Write(
 		return;
 	}
 
-	size_t totalLen = len1 + len2;
+	const size_t totalLen = len1 + len2;
 	uv_buf_t buffers[2];
 	int written{ 0 };
 	int err;
@@ -246,8 +246,8 @@ void TcpConnectionHandler::Write(
 		written = 0;
 	}
 
-	size_t pendingLen = totalLen - written;
-	auto* writeData   = new UvWriteData(pendingLen);
+	const size_t pendingLen = totalLen - written;
+	auto* writeData         = new UvWriteData(pendingLen);
 
 	writeData->req.data = static_cast<void*>(writeData);
 
@@ -269,7 +269,7 @@ void TcpConnectionHandler::Write(
 
 	writeData->cb = cb;
 
-	uv_buf_t buffer = uv_buf_init(reinterpret_cast<char*>(writeData->store), pendingLen);
+	const uv_buf_t buffer = uv_buf_init(reinterpret_cast<char*>(writeData->store), pendingLen);
 
 	err = uv_write(
 	  &writeData->req,

--- a/worker/src/handles/TcpServerHandler.cpp
+++ b/worker/src/handles/TcpServerHandler.cpp
@@ -117,7 +117,7 @@ void TcpServerHandler::AcceptTcpConnection(TcpConnectionHandler* connection)
 	}
 
 	// Accept the connection.
-	int err = uv_accept(
+	const int err = uv_accept(
 	  reinterpret_cast<uv_stream_t*>(this->uvHandle),
 	  reinterpret_cast<uv_stream_t*>(connection->GetUvHandle()));
 

--- a/worker/src/handles/Timer.cpp
+++ b/worker/src/handles/Timer.cpp
@@ -27,7 +27,7 @@ Timer::Timer(Listener* listener) : listener(listener)
 	this->uvHandle       = new uv_timer_t;
 	this->uvHandle->data = static_cast<void*>(this);
 
-	int err = uv_timer_init(DepLibUV::GetLoop(), this->uvHandle);
+	const int err = uv_timer_init(DepLibUV::GetLoop(), this->uvHandle);
 
 	if (err != 0)
 	{
@@ -71,7 +71,7 @@ void Timer::Start(uint64_t timeout, uint64_t repeat)
 	if (uv_is_active(reinterpret_cast<uv_handle_t*>(this->uvHandle)) != 0)
 		Stop();
 
-	int err = uv_timer_start(this->uvHandle, static_cast<uv_timer_cb>(onTimer), timeout, repeat);
+	const int err = uv_timer_start(this->uvHandle, static_cast<uv_timer_cb>(onTimer), timeout, repeat);
 
 	if (err != 0)
 		MS_THROW_ERROR("uv_timer_start() failed: %s", uv_strerror(err));
@@ -84,7 +84,7 @@ void Timer::Stop()
 	if (this->closed)
 		MS_THROW_ERROR("closed");
 
-	int err = uv_timer_stop(this->uvHandle);
+	const int err = uv_timer_stop(this->uvHandle);
 
 	if (err != 0)
 		MS_THROW_ERROR("uv_timer_stop() failed: %s", uv_strerror(err));
@@ -103,7 +103,7 @@ void Timer::Reset()
 	if (this->repeat == 0u)
 		return;
 
-	int err =
+	const int err =
 	  uv_timer_start(this->uvHandle, static_cast<uv_timer_cb>(onTimer), this->repeat, this->repeat);
 
 	if (err != 0)
@@ -120,7 +120,7 @@ void Timer::Restart()
 	if (uv_is_active(reinterpret_cast<uv_handle_t*>(this->uvHandle)) != 0)
 		Stop();
 
-	int err =
+	const int err =
 	  uv_timer_start(this->uvHandle, static_cast<uv_timer_cb>(onTimer), this->timeout, this->repeat);
 
 	if (err != 0)

--- a/worker/src/handles/UdpSocketHandler.cpp
+++ b/worker/src/handles/UdpSocketHandler.cpp
@@ -101,7 +101,7 @@ void UdpSocketHandler::Close()
 	this->uvHandle->data = nullptr;
 
 	// Don't read more.
-	int err = uv_udp_recv_stop(this->uvHandle);
+	const int err = uv_udp_recv_stop(this->uvHandle);
 
 	if (err != 0)
 		MS_ABORT("uv_udp_recv_stop() failed: %s", uv_strerror(err));
@@ -149,7 +149,7 @@ void UdpSocketHandler::Send(
 	// then build a uv_req_t and use uv_udp_send().
 
 	uv_buf_t buffer = uv_buf_init(reinterpret_cast<char*>(const_cast<uint8_t*>(data)), len);
-	int sent        = uv_udp_try_send(this->uvHandle, &buffer, 1, addr);
+	const int sent  = uv_udp_try_send(this->uvHandle, &buffer, 1, addr);
 
 	// Entire datagram was sent. Done.
 	if (sent == static_cast<int>(len))

--- a/worker/src/handles/UnixStreamSocket.cpp
+++ b/worker/src/handles/UnixStreamSocket.cpp
@@ -197,15 +197,15 @@ void UnixStreamSocket::Write(const uint8_t* data, size_t len)
 		written = 0;
 	}
 
-	size_t pendingLen = len - written;
-	auto* writeData   = new UvWriteData(pendingLen);
+	const size_t pendingLen = len - written;
+	auto* writeData         = new UvWriteData(pendingLen);
 
 	writeData->req.data = static_cast<void*>(writeData);
 	std::memcpy(writeData->store, data + written, pendingLen);
 
 	buffer = uv_buf_init(reinterpret_cast<char*>(writeData->store), pendingLen);
 
-	int err = uv_write(
+	const int err = uv_write(
 	  &writeData->req,
 	  reinterpret_cast<uv_stream_t*>(this->uvHandle),
 	  &buffer,


### PR DESCRIPTION
I wish clang-tidy could automatically do this for the repo but there are different problems:

* If does not detect all cases.
* It detects false positives, so cannot be automated otherwise the code would not compile.

It requires some manual action...