### PR TITLE
Update libsrtp2 to 2.5.0

### DIFF
--- a/worker/subprojects/libsrtp2.wrap
+++ b/worker/subprojects/libsrtp2.wrap
@@ -1,8 +1,9 @@
 [wrap-file]
-directory = libsrtp-2.4.2
-source_url = https://github.com/cisco/libsrtp/archive/refs/tags/v2.4.2.zip
-source_filename = libsrtp-2.4.2.zip
-source_hash = 35b1ae7a6256224feb058f1feb42170537a44896340f80e77b49cc59af686a82
+directory = libsrtp-2.5.0
+source_url = https://github.com/cisco/libsrtp/archive/refs/tags/v2.5.0.tar.gz
+source_filename = libsrtp-2.5.0.tar.gz
+source_hash = 8a43ef8e9ae2b665292591af62aa1a4ae41e468b6d98d8258f91478735da4e09
+wrapdb_version = 2.5.0-1
 
 [provide]
 libsrtp2 = libsrtp2_dep


### PR DESCRIPTION
Nothing major this time, but they implemented explicit support for OpenSSL 3, so less warnings on our side :slightly_smiling_face: 

Fixes #1001