### PR TITLE
Fix consuming data producer from direct transport by data consumer on non-direct transport

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# 0.11.4
+
+* Fix consuming data producer from direct transport by data consumer on non-direct transport.
+
 # 0.11.3
 
 * Updates from mediasoup TypeScript `3.10.13..=3.11.8`.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup"
-version = "0.11.3"
+version = "0.11.4"
 description = "Cutting Edge WebRTC Video Conferencing in Rust"
 categories = ["api-bindings", "multimedia", "network-programming"]
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]


### PR DESCRIPTION
Should fix issue reported in https://mediasoup.discourse.group/t/rust-confusion-about-dataconsumers-dataproducers/4956

The fix here is to create default SCTP stream parameters (ordered stream) in case producer was created on direct transport.

@RemiKalbe can you confirm, please?