### PR TITLE
Allow simulcast with a single encoding (and N temporal layers)

### DIFF
--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -1064,7 +1064,7 @@ export function getConsumerRtpParameters(
 		{
 			const { temporalLayers } = parseScalabilityMode(scalabilityMode);
 
-			scalabilityMode = `S${consumableParams.encodings!.length}T${temporalLayers}`;
+			scalabilityMode = `L${consumableParams.encodings!.length}T${temporalLayers}`;
 		}
 
 		if (scalabilityMode)

--- a/node/src/tests/test-Consumer.ts
+++ b/node/src/tests/test-Consumer.ts
@@ -715,7 +715,7 @@ test('consumer.dump() succeeds', async () =>
 				{
 					ssrc : videoConsumer.rtpParameters.encodings?.[0].rtx?.ssrc
 				},
-				scalabilityMode : 'S4T1'
+				scalabilityMode : 'L4T1'
 			}
 		]);
 	expect(Array.isArray(data.consumableRtpEncodings)).toBe(true);

--- a/node/src/tests/test-ortc.ts
+++ b/node/src/tests/test-ortc.ts
@@ -469,7 +469,7 @@ test('getProducerRtpParametersMapping(), getConsumableRtpParameters(), getConsum
 	expect(typeof consumerRtpParameters.encodings?.[0].ssrc).toBe('number');
 	expect(typeof consumerRtpParameters.encodings?.[0].rtx).toBe('object');
 	expect(typeof consumerRtpParameters.encodings?.[0].rtx?.ssrc).toBe('number');
-	expect(consumerRtpParameters.encodings?.[0].scalabilityMode).toBe('S3T3');
+	expect(consumerRtpParameters.encodings?.[0].scalabilityMode).toBe('L3T3');
 	expect(consumerRtpParameters.encodings?.[0].maxBitrate).toBe(333333);
 
 	expect(consumerRtpParameters.headerExtensions).toEqual(

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -777,7 +777,7 @@ pub(crate) fn get_consumer_rtp_parameters(
         // If there is simulcast, mangle spatial layers in scalabilityMode.
         if consumable_params.encodings.len() > 1 {
             scalability_mode = format!(
-                "S{}T{}",
+                "L{}T{}",
                 consumable_params.encodings.len(),
                 scalability_mode.temporal_layers()
             )

--- a/rust/src/ortc/tests.rs
+++ b/rust/src/ortc/tests.rs
@@ -502,7 +502,7 @@ fn get_producer_rtp_parameters_mapping_get_consumable_rtp_parameters_get_consume
             .get(0)
             .unwrap()
             .scalability_mode,
-        ScalabilityMode::S3T3,
+        ScalabilityMode::L3T3,
     );
     assert_eq!(
         consumer_rtp_parameters

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -1047,7 +1047,7 @@ fn dump_succeeds() {
                         .unwrap()
                         .rtx,
                     dtx: None,
-                    scalability_mode: "S4T1".parse().unwrap(),
+                    scalability_mode: "L4T1".parse().unwrap(),
                     scale_resolution_down_by: None,
                     rid: None,
                     max_bitrate: None,

--- a/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
@@ -3,6 +3,7 @@
 
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
+#include "RTC/Codecs/Tools.hpp"
 #include "RTC/RtpDictionaries.hpp"
 #include <absl/container/flat_hash_set.h>
 
@@ -38,11 +39,29 @@ namespace RTC
 		if (rtpParameters.encodings.size() == 1)
 		{
 			auto& encoding = rtpParameters.encodings[0];
+			const auto* mediaCodec =
+			  rtpParameters.GetCodecForEncoding(const_cast<RTC::RtpEncodingParameters&>(encoding));
 
 			if (encoding.spatialLayers > 1 || encoding.temporalLayers > 1)
-				return RtpParameters::Type::SVC;
+			{
+				if (RTC::Codecs::Tools::IsValidTypeForCodec(RtpParameters::Type::SVC, mediaCodec->mimeType))
+				{
+					return RtpParameters::Type::SVC;
+				}
+				else if (RTC::Codecs::Tools::IsValidTypeForCodec(
+				           RtpParameters::Type::SIMULCAST, mediaCodec->mimeType))
+				{
+					return RtpParameters::Type::SIMULCAST;
+				}
+				else
+				{
+					return RtpParameters::Type::NONE;
+				}
+			}
 			else
+			{
 				return RtpParameters::Type::SIMPLE;
+			}
 		}
 		else if (rtpParameters.encodings.size() > 1)
 		{

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -30,9 +30,10 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// Ensure there are N > 1 encodings.
-		if (this->consumableRtpEncodings.size() <= 1u)
-			MS_THROW_TYPE_ERROR("invalid consumableRtpEncodings with size <= 1");
+		// We allow a single encoding in simulcast (so we can enable temporal layers
+		// with a single simulcast stream).
+		// NOTE: No need to check this->consumableRtpEncodings.size() > 0 here since
+		// it's already done in Consumer constructor.
 
 		auto& encoding = this->rtpParameters.encodings[0];
 


### PR DESCRIPTION
- Use case: VP8 or H264 with 1 single stream (1 spatial layer) and multiple temporal layers.
- Related to https://github.com/versatica/mediasoup-client/pull/248
- See new query params in mediasoup-demo: https://github.com/versatica/mediasoup-demo/#configuration-via-query-parameters


![CleanShot-2023-02-16-at-01 26 33](https://user-images.githubusercontent.com/16191/219228760-6faaef3f-9ca6-4777-8ec1-0da6ec05474d.gif)
