### PR TITLE
Add support for RTCP NACK in OPUS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### Next
 
+* Add support for RTCP NACK in OPUS ([PR #1015](https://github.com/versatica/mediasoup/pull/1015)).
 * Update NPM deps.
 
 

--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -51,8 +51,9 @@ export type ConsumerOptions =
 	preferredLayers?: ConsumerLayers;
 
 	/**
-	 * Whether this Consumer should enable RTP retransmissions upon receipt of
-	 * RTCP NACK from the remote Consumer. If not set, it's by default true for
+	 * Whether this Consumer should enable RTP retransmissions, storing sent RTP
+	 * and processing the incoming RTCP NACK from the remote Consumer. 
+	 ....
 	 * video codecs and false for audio codecs. If set to true, NACK will be
 	 * enabled if both endpoints (mediasoup and the remote Consumer) support NACK
 	 * for this codec. When it comes to audio codecs, just OPUS supports NACK.

--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -57,7 +57,7 @@ export type ConsumerOptions =
 	 * enabled if both endpoints (mediasoup and the remote Consumer) support NACK
 	 * for this codec. When it comes to audio codecs, just OPUS supports NACK.
 	 */
-	enableNack?: boolean;
+	enableRtx?: boolean;
 
 	/**
 	 * Whether this Consumer should ignore DTX packets (only valid for Opus codec).

--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -52,11 +52,11 @@ export type ConsumerOptions =
 
 	/**
 	 * Whether this Consumer should enable RTP retransmissions, storing sent RTP
-	 * and processing the incoming RTCP NACK from the remote Consumer. 
-	 ....
-	 * video codecs and false for audio codecs. If set to true, NACK will be
-	 * enabled if both endpoints (mediasoup and the remote Consumer) support NACK
-	 * for this codec. When it comes to audio codecs, just OPUS supports NACK.
+	 * and processing the incoming RTCP NACK from the remote Consumer. If not set
+	 * it's true by default for video codecs and false for audio codecs. If set
+	 * to true, NACK will be enabled if both endpoints (mediasoup and the remote
+	 * Consumer) support NACK for this codec. When it comes to audio codecs, just
+	 * OPUS supports NACK.
 	 */
 	enableRtx?: boolean;
 

--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -51,6 +51,15 @@ export type ConsumerOptions =
 	preferredLayers?: ConsumerLayers;
 
 	/**
+	 * Whether this Consumer should enable RTP retransmissions upon receipt of
+	 * RTCP NACK from the remote Consumer. If not set, it's by default true for
+	 * video codecs and false for audio codecs. If set to true, NACK will be
+	 * enabled if both endpoints (mediasoup and the remote Consumer) support NACK
+	 * for this codec. When it comes to audio codecs, just OPUS supports NACK.
+	 */
+	enableNack?: boolean;
+
+	/**
 	 * Whether this Consumer should ignore DTX packets (only valid for Opus codec).
 	 * If set, DTX packets are not forwarded to the remote Consumer.
 	 */

--- a/node/src/PipeTransport.ts
+++ b/node/src/PipeTransport.ts
@@ -307,7 +307,11 @@ export class PipeTransport
 
 		// This may throw.
 		const rtpParameters = ortc.getPipeConsumerRtpParameters(
-			producer.consumableRtpParameters, this.#data.rtx);
+			{
+				consumableRtpParameters : producer.consumableRtpParameters,
+				enableRtx               : this.#data.rtx
+			}
+		);
 
 		const reqData =
 		{

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -660,7 +660,7 @@ export class Transport<Events extends TransportEvents = TransportEvents,
 			mid,
 			preferredLayers,
 			ignoreDtx = false,
-			enableNack,
+			enableRtx,
 			pipe = false,
 			appData
 		}: ConsumerOptions
@@ -691,22 +691,28 @@ export class Transport<Events extends TransportEvents = TransportEvents,
 			throw Error(`Producer with id "${producerId}" not found`);
 		}
 
-		// If enableNack is not given, set it to true if video and false if audio.
-		if (enableNack === undefined)
+		// If enableRtx is not given, set it to true if video and false if audio.
+		if (enableRtx === undefined)
 		{
 			if (producer.kind === 'video')
 			{
-				enableNack = true;
+				enableRtx = true;
 			}
 			else
 			{
-				enableNack = false;
+				enableRtx = false;
 			}
 		}
 
 		// This may throw.
 		const rtpParameters = ortc.getConsumerRtpParameters(
-			producer.consumableRtpParameters, rtpCapabilities!, pipe, enableNack);
+			{
+				consumableRtpParameters : producer.consumableRtpParameters,
+				remoteRtpCapabilities   : rtpCapabilities!,
+				pipe,
+				enableRtx
+			}
+		);
 
 		// Set MID.
 		if (!pipe)

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -694,14 +694,7 @@ export class Transport<Events extends TransportEvents = TransportEvents,
 		// If enableRtx is not given, set it to true if video and false if audio.
 		if (enableRtx === undefined)
 		{
-			if (producer.kind === 'video')
-			{
-				enableRtx = true;
-			}
-			else
-			{
-				enableRtx = false;
-			}
+			enableRtx = producer.kind === 'video';
 		}
 
 		// This may throw.

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -660,6 +660,7 @@ export class Transport<Events extends TransportEvents = TransportEvents,
 			mid,
 			preferredLayers,
 			ignoreDtx = false,
+			enableNack,
 			pipe = false,
 			appData
 		}: ConsumerOptions
@@ -690,9 +691,22 @@ export class Transport<Events extends TransportEvents = TransportEvents,
 			throw Error(`Producer with id "${producerId}" not found`);
 		}
 
+		// If enableNack is not given, set it to true if video and false if audio.
+		if (enableNack === undefined)
+		{
+			if (producer.kind === 'video')
+			{
+				enableNack = true;
+			}
+			else
+			{
+				enableNack = false;
+			}
+		}
+
 		// This may throw.
 		const rtpParameters = ortc.getConsumerRtpParameters(
-			producer.consumableRtpParameters, rtpCapabilities!, pipe);
+			producer.consumableRtpParameters, rtpCapabilities!, pipe, enableNack);
 
 		// Set MID.
 		if (!pipe)

--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -1114,7 +1114,8 @@ export function canConsume(
 export function getConsumerRtpParameters(
 	consumableParams: RtpParameters,
 	caps: RtpCapabilities,
-	pipe: boolean
+	pipe: boolean,
+	enableNack: boolean
 ): RtpParameters
 {
 	const consumerParams: RtpParameters =
@@ -1221,6 +1222,17 @@ export function getConsumerRtpParameters(
 					fb.type !== 'transport-cc' &&
 					fb.type !== 'goog-remb'
 				));
+		}
+	}
+
+	// If enableNack is false, remove RTCP NACK support. If so, we remove all
+	// RTCP feedbacks with type 'nack' (including those whose parameter is 'pli').
+	if (!enableNack)
+	{
+		for (const codec of consumerParams.codecs)
+		{
+			codec.rtcpFeedback = codec.rtcpFeedback!
+				.filter((fb) => fb.type !== 'nack');
 		}
 	}
 

--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -1146,15 +1146,15 @@ export function getConsumerRtpParameters(
 
 	for (const codec of consumableCodecs)
 	{
-		const matchedCapCodec = remoteRtpCapabilities.codecs!
-			.find((capCodec) => matchCodecs(capCodec, codec, { strict: true }));
-
-		if (!matchedCapCodec)
+		if (!enableRtx && isRtxCodec(codec))
 		{
 			continue;
 		}
 
-		if (!enableRtx && isRtxCodec(codec))
+		const matchedCapCodec = remoteRtpCapabilities.codecs!
+			.find((capCodec) => matchCodecs(capCodec, codec, { strict: true }));
+
+		if (!matchedCapCodec)
 		{
 			continue;
 		}

--- a/node/src/supportedRtpCapabilities.ts
+++ b/node/src/supportedRtpCapabilities.ts
@@ -11,6 +11,7 @@ const supportedRtpCapabilities: RtpCapabilities =
 			channels     : 2,
 			rtcpFeedback :
 			[
+				{ type: 'nack' },
 				{ type: 'transport-cc' }
 			]
 		},
@@ -28,6 +29,7 @@ const supportedRtpCapabilities: RtpCapabilities =
 			},
 			rtcpFeedback :
 			[
+				{ type: 'nack' },
 				{ type: 'transport-cc' }
 			]
 		},
@@ -45,6 +47,7 @@ const supportedRtpCapabilities: RtpCapabilities =
 			},
 			rtcpFeedback :
 			[
+				{ type: 'nack' },
 				{ type: 'transport-cc' }
 			]
 		},
@@ -62,6 +65,7 @@ const supportedRtpCapabilities: RtpCapabilities =
 			},
 			rtcpFeedback :
 			[
+				{ type: 'nack' },
 				{ type: 'transport-cc' }
 			]
 		},

--- a/node/src/tests/test-Consumer.ts
+++ b/node/src/tests/test-Consumer.ts
@@ -499,13 +499,13 @@ test('transport.consume() succeeds', async () =>
 			});
 }, 2000);
 
-test('transport.consume() setting enableNack succeeds', async () =>
+test('transport.consume() setting enableRtx succeeds', async () =>
 {
 	const audioConsumer2 = await transport2.consume(
 		{
 			producerId      : audioProducer.id,
 			rtpCapabilities : consumerDeviceCapabilities,
-			enableNack      : true
+			enableRtx       : true
 		});
 
 	expect(audioConsumer2.kind).toBe('audio');

--- a/node/src/tests/test-Consumer.ts
+++ b/node/src/tests/test-Consumer.ts
@@ -499,7 +499,7 @@ test('transport.consume() succeeds', async () =>
 			});
 }, 2000);
 
-test('transport.consume() setting enableRtx succeeds', async () =>
+test('transport.consume() with enableRtx succeeds', async () =>
 {
 	const audioConsumer2 = await transport2.consume(
 		{

--- a/node/src/tests/test-Consumer.ts
+++ b/node/src/tests/test-Consumer.ts
@@ -152,7 +152,11 @@ const consumerDeviceCapabilities: mediasoup.types.RtpCapabilities =
 			kind                 : 'audio',
 			preferredPayloadType : 100,
 			clockRate            : 48000,
-			channels             : 2
+			channels             : 2,
+			rtcpFeedback         :
+			[
+				{ type: 'nack', parameter: '' }
+			]
 		},
 		{
 			mimeType             : 'video/H264',
@@ -493,6 +497,36 @@ test('transport.consume() succeeds', async () =>
 						videoPipeConsumer.id
 					])
 			});
+}, 2000);
+
+test('transport.consume() setting enableNack succeeds', async () =>
+{
+	const audioConsumer2 = await transport2.consume(
+		{
+			producerId      : audioProducer.id,
+			rtpCapabilities : consumerDeviceCapabilities,
+			enableNack      : true
+		});
+
+	expect(audioConsumer2.kind).toBe('audio');
+	expect(audioConsumer2.rtpParameters.codecs.length).toBe(1);
+	expect(audioConsumer2.rtpParameters.codecs[0]).toEqual(
+		{
+			mimeType    : 'audio/opus',
+			payloadType : 100,
+			clockRate   : 48000,
+			channels    : 2,
+			parameters  :
+			{
+				useinbandfec : 1,
+				usedtx       : 1,
+				foo          : 222.222,
+				bar          : '333'
+			},
+			rtcpFeedback : [ { type: 'nack', parameter: '' } ]
+		});
+
+	audioConsumer2.close();
 }, 2000);
 
 test('transport.consume() can be created with user provided mid', async () => 

--- a/node/src/tests/test-ortc.ts
+++ b/node/src/tests/test-ortc.ts
@@ -56,6 +56,7 @@ test('generateRouterRtpCapabilities() succeeds', () =>
 			},
 			rtcpFeedback :
 			[
+				{ type: 'nack', parameter: '' },
 				{ type: 'transport-cc', parameter: '' }
 			]
 		});
@@ -431,8 +432,12 @@ test('getProducerRtpParametersMapping(), getConsumableRtpParameters(), getConsum
 		]
 	};
 
-	const consumerRtpParameters =
-		ortc.getConsumerRtpParameters(consumableRtpParameters, remoteRtpCapabilities, false);
+	const consumerRtpParameters = ortc.getConsumerRtpParameters(
+		consumableRtpParameters,
+		remoteRtpCapabilities,
+		/* pipe */ false,
+		/* enableNack */ true
+	);
 
 	expect(consumerRtpParameters.codecs.length).toEqual(2);
 	expect(consumerRtpParameters.codecs[0]).toEqual(

--- a/node/src/tests/test-ortc.ts
+++ b/node/src/tests/test-ortc.ts
@@ -433,10 +433,12 @@ test('getProducerRtpParametersMapping(), getConsumableRtpParameters(), getConsum
 	};
 
 	const consumerRtpParameters = ortc.getConsumerRtpParameters(
-		consumableRtpParameters,
-		remoteRtpCapabilities,
-		/* pipe */ false,
-		/* enableNack */ true
+		{
+			consumableRtpParameters,
+			remoteRtpCapabilities,
+			pipe      : false,
+			enableRtx : true
+		}
 	);
 
 	expect(consumerRtpParameters.codecs.length).toEqual(2);
@@ -506,8 +508,12 @@ test('getProducerRtpParametersMapping(), getConsumableRtpParameters(), getConsum
 			mux         : true
 		});
 
-	const pipeConsumerRtpParameters =
-		ortc.getPipeConsumerRtpParameters(consumableRtpParameters);
+	const pipeConsumerRtpParameters = ortc.getPipeConsumerRtpParameters(
+		{
+			consumableRtpParameters,
+			enableRtx : false
+		}
+	);
 
 	expect(pipeConsumerRtpParameters.codecs.length).toEqual(1);
 	expect(pipeConsumerRtpParameters.codecs[0]).toEqual(

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -670,7 +670,9 @@ pub(crate) fn get_consumer_rtp_parameters(
         {
             *codec.rtcp_feedback_mut() = matched_cap_codec.rtcp_feedback().clone();
 
-            codec.rtcp_feedback_mut().retain(|fb| enable_rtx || fb != &RtcpFeedback::Nack);
+            codec
+                .rtcp_feedback_mut()
+                .retain(|fb| enable_rtx || fb != &RtcpFeedback::Nack);
 
             consumer_params.codecs.push(codec);
         }

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -668,8 +668,10 @@ pub(crate) fn get_consumer_rtp_parameters(
             .iter()
             .find(|cap_codec| match_codecs(cap_codec.deref().into(), (&codec).into(), true).is_ok())
         {
+            // TODO: Remove this.
             // *codec.rtcp_feedback_mut() = matched_cap_codec.rtcp_feedback().clone();
 
+            // TODO: This doesn't compile. Fix it.
             *codec.rtcp_feedback_mut() = matched_cap_codec
                 .rtcp_feedback().clone()
                 .retain(|fb| enable_rtx || fb != &RtcpFeedback::Nack);
@@ -745,16 +747,6 @@ pub(crate) fn get_consumer_rtp_parameters(
             codec
                 .rtcp_feedback_mut()
                 .retain(|fb| !matches!(fb, RtcpFeedback::GoogRemb | RtcpFeedback::TransportCc));
-        }
-    }
-
-    // If enable_rtx is false, remove RTCP NACK support. If so, we remove all
-    // RTCP feedbacks with type 'nack' (including those whose parameter is 'pli').
-    if !enable_rtx {
-        for codec in &mut consumer_params.codecs {
-            codec
-                .rtcp_feedback_mut()
-                .retain(|fb| fb != &RtcpFeedback::Nack);
         }
     }
 

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -641,25 +641,25 @@ pub(crate) fn can_consume(
 /// codecs' RTCP feedback and header extensions, and also enables or disabled RTX.
 #[allow(clippy::suspicious_operation_groupings)]
 pub(crate) fn get_consumer_rtp_parameters(
-    consumable_params: &RtpParameters,
-    caps: &RtpCapabilities,
+    consumable_rtp_parameters: &RtpParameters,
+    remote_rtp_capabilities: &RtpCapabilities,
     pipe: bool,
-    enable_nack: bool,
+    enable_rtx: bool,
 ) -> Result<RtpParameters, ConsumerRtpParametersError> {
     let mut consumer_params = RtpParameters {
-        rtcp: consumable_params.rtcp.clone(),
+        rtcp: consumable_rtp_parameters.rtcp.clone(),
         ..RtpParameters::default()
     };
 
-    for cap_codec in &caps.codecs {
+    for cap_codec in &remote_rtp_capabilities.codecs {
         validate_rtp_codec_capability(cap_codec)
             .map_err(ConsumerRtpParametersError::InvalidCapabilities)?;
     }
 
     let mut rtx_supported = false;
 
-    for mut codec in consumable_params.codecs.clone() {
-        if let Some(matched_cap_codec) = caps
+    for mut codec in consumable_rtp_parameters.codecs.clone() {
+        if let Some(matched_cap_codec) = remote_rtp_capabilities
             .codecs
             .iter()
             .find(|cap_codec| match_codecs(cap_codec.deref().into(), (&codec).into(), true).is_ok())
@@ -698,11 +698,12 @@ pub(crate) fn get_consumer_rtp_parameters(
         return Err(ConsumerRtpParametersError::NoCompatibleMediaCodecs);
     }
 
-    consumer_params.header_extensions = consumable_params
+    consumer_params.header_extensions = consumable_rtp_parameters
         .header_extensions
         .iter()
         .filter(|ext| {
-            caps.header_extensions
+            remote_rtp_capabilities
+                .header_extensions
                 .iter()
                 .any(|cap_ext| cap_ext.preferred_id == ext.id && cap_ext.uri == ext.uri)
         })
@@ -738,9 +739,9 @@ pub(crate) fn get_consumer_rtp_parameters(
         }
     }
 
-    // If enable_nack is false, remove RTCP NACK support. If so, we remove all
+    // If enable_rtx is false, remove RTCP NACK support. If so, we remove all
     // RTCP feedbacks with type 'nack' (including those whose parameter is 'pli').
-    if !enable_nack {
+    if !enable_rtx {
         for codec in &mut consumer_params.codecs {
             codec
                 .rtcp_feedback_mut()
@@ -749,7 +750,7 @@ pub(crate) fn get_consumer_rtp_parameters(
     }
 
     if pipe {
-        for ((encoding, ssrc), rtx_ssrc) in consumable_params
+        for ((encoding, ssrc), rtx_ssrc) in consumable_rtp_parameters
             .encodings
             .iter()
             .zip(generate_ssrc()..)
@@ -777,19 +778,19 @@ pub(crate) fn get_consumer_rtp_parameters(
             });
         }
 
-        // If any of the consumable_params.encodings has scalability_mode, process it
+        // If any of the consumable_rtp_parameters.encodings has scalability_mode, process it
         // (assume all encodings have the same value).
-        let mut scalability_mode = consumable_params
+        let mut scalability_mode = consumable_rtp_parameters
             .encodings
             .get(0)
             .map(|encoding| encoding.scalability_mode.clone())
             .unwrap_or_default();
 
         // If there is simulcast, mangle spatial layers in scalabilityMode.
-        if consumable_params.encodings.len() > 1 {
+        if consumable_rtp_parameters.encodings.len() > 1 {
             scalability_mode = format!(
                 "L{}T{}",
-                consumable_params.encodings.len(),
+                consumable_rtp_parameters.encodings.len(),
                 scalability_mode.temporal_layers()
             )
             .parse()
@@ -799,7 +800,7 @@ pub(crate) fn get_consumer_rtp_parameters(
         consumer_encoding.scalability_mode = scalability_mode;
 
         // Use the maximum max_bitrate in any encoding and honor it in the Consumer's encoding.
-        consumer_encoding.max_bitrate = consumable_params
+        consumer_encoding.max_bitrate = consumable_rtp_parameters
             .encodings
             .iter()
             .map(|encoding| encoding.max_bitrate)
@@ -818,7 +819,7 @@ pub(crate) fn get_consumer_rtp_parameters(
 /// It keeps all original consumable encodings and removes support for BWE. If
 /// enableRtx is false, it also removes RTX and NACK support.
 pub(crate) fn get_pipe_consumer_rtp_parameters(
-    consumable_params: &RtpParameters,
+    consumable_rtp_parameters: &RtpParameters,
     enable_rtx: bool,
 ) -> RtpParameters {
     let mut consumer_params = RtpParameters {
@@ -826,10 +827,10 @@ pub(crate) fn get_pipe_consumer_rtp_parameters(
         codecs: vec![],
         header_extensions: vec![],
         encodings: vec![],
-        rtcp: consumable_params.rtcp.clone(),
+        rtcp: consumable_rtp_parameters.rtcp.clone(),
     };
 
-    for codec in &consumable_params.codecs {
+    for codec in &consumable_rtp_parameters.codecs {
         if !enable_rtx && codec.is_rtx() {
             continue;
         }
@@ -845,7 +846,7 @@ pub(crate) fn get_pipe_consumer_rtp_parameters(
     }
 
     // Reduce RTP extensions by disabling transport MID and BWE related ones.
-    consumer_params.header_extensions = consumable_params
+    consumer_params.header_extensions = consumable_rtp_parameters
         .header_extensions
         .iter()
         .filter(|ext| {
@@ -859,7 +860,7 @@ pub(crate) fn get_pipe_consumer_rtp_parameters(
         .cloned()
         .collect();
 
-    for ((encoding, ssrc), rtx_ssrc) in consumable_params
+    for ((encoding, ssrc), rtx_ssrc) in consumable_rtp_parameters
         .encodings
         .iter()
         .zip(generate_ssrc()..)

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -659,6 +659,10 @@ pub(crate) fn get_consumer_rtp_parameters(
     let mut rtx_supported = false;
 
     for mut codec in consumable_rtp_parameters.codecs.clone() {
+        if !enable_rtx && codec.is_rtx() {
+            continue;
+        }
+
         if let Some(matched_cap_codec) = remote_rtp_capabilities
             .codecs
             .iter()

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -668,13 +668,9 @@ pub(crate) fn get_consumer_rtp_parameters(
             .iter()
             .find(|cap_codec| match_codecs(cap_codec.deref().into(), (&codec).into(), true).is_ok())
         {
-            // TODO: Remove this.
-            // *codec.rtcp_feedback_mut() = matched_cap_codec.rtcp_feedback().clone();
+            *codec.rtcp_feedback_mut() = matched_cap_codec.rtcp_feedback().clone();
 
-            // TODO: This doesn't compile. Fix it.
-            *codec.rtcp_feedback_mut() = matched_cap_codec
-                .rtcp_feedback().clone()
-                .retain(|fb| enable_rtx || fb != &RtcpFeedback::Nack);
+            codec.rtcp_feedback_mut().retain(|fb| enable_rtx || fb != &RtcpFeedback::Nack);
 
             consumer_params.codecs.push(codec);
         }

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -668,11 +668,12 @@ pub(crate) fn get_consumer_rtp_parameters(
             .iter()
             .find(|cap_codec| match_codecs(cap_codec.deref().into(), (&codec).into(), true).is_ok())
         {
-            *codec.rtcp_feedback_mut() = matched_cap_codec.rtcp_feedback().clone();
-
-            codec
-                .rtcp_feedback_mut()
-                .retain(|fb| enable_rtx || fb != &RtcpFeedback::Nack);
+            *codec.rtcp_feedback_mut() = matched_cap_codec
+                .rtcp_feedback()
+                .iter()
+                .filter(|&&fb| enable_rtx || fb != RtcpFeedback::Nack)
+                .copied()
+                .collect();
 
             consumer_params.codecs.push(codec);
         }

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -644,6 +644,7 @@ pub(crate) fn get_consumer_rtp_parameters(
     consumable_params: &RtpParameters,
     caps: &RtpCapabilities,
     pipe: bool,
+    enable_nack: bool
 ) -> Result<RtpParameters, ConsumerRtpParametersError> {
     let mut consumer_params = RtpParameters {
         rtcp: consumable_params.rtcp.clone(),
@@ -734,6 +735,16 @@ pub(crate) fn get_consumer_rtp_parameters(
             codec
                 .rtcp_feedback_mut()
                 .retain(|fb| !matches!(fb, RtcpFeedback::GoogRemb | RtcpFeedback::TransportCc));
+        }
+    }
+
+    // If enable_nack is false, remove RTCP NACK support. If so, we remove all
+    // RTCP feedbacks with type 'nack' (including those whose parameter is 'pli').
+    if !enable_nack {
+        for codec in &mut consumer_params.codecs {
+            codec
+                .rtcp_feedback_mut()
+                .retain(|fb| fb != &RtcpFeedback::Nack);
         }
     }
 

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -644,7 +644,7 @@ pub(crate) fn get_consumer_rtp_parameters(
     consumable_params: &RtpParameters,
     caps: &RtpCapabilities,
     pipe: bool,
-    enable_nack: bool
+    enable_nack: bool,
 ) -> Result<RtpParameters, ConsumerRtpParametersError> {
     let mut consumer_params = RtpParameters {
         rtcp: consumable_params.rtcp.clone(),

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -668,7 +668,12 @@ pub(crate) fn get_consumer_rtp_parameters(
             .iter()
             .find(|cap_codec| match_codecs(cap_codec.deref().into(), (&codec).into(), true).is_ok())
         {
-            *codec.rtcp_feedback_mut() = matched_cap_codec.rtcp_feedback().clone();
+            // *codec.rtcp_feedback_mut() = matched_cap_codec.rtcp_feedback().clone();
+
+            *codec.rtcp_feedback_mut() = matched_cap_codec
+                .rtcp_feedback().clone()
+                .retain(|fb| enable_rtx || fb != &RtcpFeedback::Nack);
+
             consumer_params.codecs.push(codec);
         }
     }

--- a/rust/src/ortc/tests.rs
+++ b/rust/src/ortc/tests.rs
@@ -51,10 +51,7 @@ fn generate_router_rtp_capabilities_succeeds() {
                     ("useinbandfec", 1_u32.into()),
                     ("foo", "bar".into()),
                 ]),
-                rtcp_feedback: vec![
-                    RtcpFeedback::Nack,
-                    RtcpFeedback::TransportCc,
-                ],
+                rtcp_feedback: vec![RtcpFeedback::Nack, RtcpFeedback::TransportCc,],
             },
             RtpCodecCapabilityFinalized::Video {
                 mime_type: MimeTypeVideo::Vp8,
@@ -454,9 +451,13 @@ fn get_producer_rtp_parameters_mapping_get_consumable_rtp_parameters_get_consume
         ],
     };
 
-    let consumer_rtp_parameters =
-        get_consumer_rtp_parameters(&consumable_rtp_parameters, &remote_rtp_capabilities, false, true)
-            .expect("Failed to get consumer RTP parameters");
+    let consumer_rtp_parameters = get_consumer_rtp_parameters(
+        &consumable_rtp_parameters,
+        &remote_rtp_capabilities,
+        false,
+        true,
+    )
+    .expect("Failed to get consumer RTP parameters");
 
     assert_eq!(
         consumer_rtp_parameters.codecs,

--- a/rust/src/ortc/tests.rs
+++ b/rust/src/ortc/tests.rs
@@ -51,7 +51,10 @@ fn generate_router_rtp_capabilities_succeeds() {
                     ("useinbandfec", 1_u32.into()),
                     ("foo", "bar".into()),
                 ]),
-                rtcp_feedback: vec![RtcpFeedback::TransportCc],
+                rtcp_feedback: vec![
+                    RtcpFeedback::Nack,
+                    RtcpFeedback::TransportCc,
+                ],
             },
             RtpCodecCapabilityFinalized::Video {
                 mime_type: MimeTypeVideo::Vp8,
@@ -452,7 +455,7 @@ fn get_producer_rtp_parameters_mapping_get_consumable_rtp_parameters_get_consume
     };
 
     let consumer_rtp_parameters =
-        get_consumer_rtp_parameters(&consumable_rtp_parameters, &remote_rtp_capabilities, false)
+        get_consumer_rtp_parameters(&consumable_rtp_parameters, &remote_rtp_capabilities, false, true)
             .expect("Failed to get consumer RTP parameters");
 
     assert_eq!(

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -77,11 +77,11 @@ pub struct ConsumerOptions {
     /// Preferred spatial and temporal layer for simulcast or SVC media sources.
     /// If `None`, the highest ones are selected.
     pub preferred_layers: Option<ConsumerLayers>,
-    /// Whether this Consumer should enable RTP retransmissions upon receipt of RTCP NACK
-    /// from the remote Consumer. If not set, it's by default true for video codecs and false
-    /// for audio codecs. If set to true, NACK will be enabled if both endpoints (mediasoup
-    /// and the remote Consumer) support NACK for this codec. When it comes to audio codecs,
-    /// just OPUS supports NACK.
+    /// Whether this Consumer should enable RTP retransmissions, storing sent RTP and processing the
+    /// incoming RTCP NACK from the remote Consumer. If not set it's true by default for video codecs
+    /// and false for audio codecs. If set to true, NACK will be enabled if both endpoints (mediasoup
+    /// and the remote Consumer) support NACK for this codec. When it comes to audio codecs, just
+    ///  OPUS supports NACK.
     pub enable_rtx: Option<bool>,
     /// Whether this Consumer should ignore DTX packets (only valid for Opus codec).
     /// If set, DTX packets are not forwarded to the remote Consumer.

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -77,6 +77,12 @@ pub struct ConsumerOptions {
     /// Preferred spatial and temporal layer for simulcast or SVC media sources.
     /// If `None`, the highest ones are selected.
     pub preferred_layers: Option<ConsumerLayers>,
+    /// Whether this Consumer should enable RTP retransmissions upon receipt of RTCP NACK
+    /// from the remote Consumer. If not set, it's by default true for video codecs and false
+    /// for audio codecs. If set to true, NACK will be enabled if both endpoints (mediasoup
+    /// and the remote Consumer) support NACK for this codec. When it comes to audio codecs,
+    /// just OPUS supports NACK.
+    pub enable_nack: Option<bool>,
     /// Whether this Consumer should ignore DTX packets (only valid for Opus codec).
     /// If set, DTX packets are not forwarded to the remote Consumer.
     pub ignore_dtx: bool,
@@ -96,6 +102,7 @@ impl ConsumerOptions {
             paused: false,
             preferred_layers: None,
             ignore_dtx: false,
+            enable_nack: None,
             pipe: false,
             mid: None,
             app_data: AppData::default(),

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -82,7 +82,7 @@ pub struct ConsumerOptions {
     /// for audio codecs. If set to true, NACK will be enabled if both endpoints (mediasoup
     /// and the remote Consumer) support NACK for this codec. When it comes to audio codecs,
     /// just OPUS supports NACK.
-    pub enable_nack: Option<bool>,
+    pub enable_rtx: Option<bool>,
     /// Whether this Consumer should ignore DTX packets (only valid for Opus codec).
     /// If set, DTX packets are not forwarded to the remote Consumer.
     pub ignore_dtx: bool,
@@ -102,7 +102,7 @@ impl ConsumerOptions {
             paused: false,
             preferred_layers: None,
             ignore_dtx: false,
-            enable_nack: None,
+            enable_rtx: None,
             pipe: false,
             mid: None,
             app_data: AppData::default(),

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -523,15 +523,7 @@ pub(super) trait TransportImpl: TransportGeneric {
             }
         };
 
-        let computed_enable_nack: bool;
-
-        if let Some(flag) = enable_rtx {
-            computed_enable_nack = flag;
-        } else if producer.kind() == MediaKind::Video {
-            computed_enable_nack = true;
-        } else {
-            computed_enable_nack = false;
-        }
+        let enable_rtx = enable_rtx.unwrap_or(producer.kind() == MediaKind::Video);
 
         let rtp_parameters = if transport_type == TransportType::Pipe {
             ortc::get_pipe_consumer_rtp_parameters(producer.consumable_rtp_parameters(), rtx)
@@ -540,7 +532,7 @@ pub(super) trait TransportImpl: TransportGeneric {
                 producer.consumable_rtp_parameters(),
                 &rtp_capabilities,
                 pipe,
-                computed_enable_nack,
+                enable_rtx,
             )
             .map_err(ConsumeError::BadConsumerRtpParameters)?;
 

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -508,7 +508,7 @@ pub(super) trait TransportImpl: TransportGeneric {
             paused,
             mid,
             preferred_layers,
-            enable_nack,
+            enable_rtx,
             ignore_dtx,
             pipe,
             app_data,
@@ -525,7 +525,7 @@ pub(super) trait TransportImpl: TransportGeneric {
 
         let computed_enable_nack: bool;
 
-        if let Some(flag) = enable_nack {
+        if let Some(flag) = enable_rtx {
             computed_enable_nack = flag;
         } else if producer.kind() == MediaKind::Video {
             computed_enable_nack = true;

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -540,7 +540,7 @@ pub(super) trait TransportImpl: TransportGeneric {
                 producer.consumable_rtp_parameters(),
                 &rtp_capabilities,
                 pipe,
-                computed_enable_nack
+                computed_enable_nack,
             )
             .map_err(ConsumeError::BadConsumerRtpParameters)?;
 

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -13,7 +13,7 @@ pub use crate::ortc::{
 };
 use crate::producer::{Producer, ProducerId, ProducerOptions};
 use crate::router::Router;
-use crate::rtp_parameters::RtpEncodingParameters;
+use crate::rtp_parameters::{MediaKind, RtpEncodingParameters};
 use crate::sctp_parameters::SctpStreamParameters;
 use crate::worker::{Channel, PayloadChannel, RequestError};
 use crate::{ortc, uuid_based_wrapper_type};
@@ -508,6 +508,7 @@ pub(super) trait TransportImpl: TransportGeneric {
             paused,
             mid,
             preferred_layers,
+            enable_nack,
             ignore_dtx,
             pipe,
             app_data,
@@ -522,6 +523,16 @@ pub(super) trait TransportImpl: TransportGeneric {
             }
         };
 
+        let computed_enable_nack: bool;
+
+        if let Some(flag) = enable_nack {
+            computed_enable_nack = flag;
+        } else if producer.kind() == MediaKind::Video {
+            computed_enable_nack = true;
+        } else {
+            computed_enable_nack = false;
+        }
+
         let rtp_parameters = if transport_type == TransportType::Pipe {
             ortc::get_pipe_consumer_rtp_parameters(producer.consumable_rtp_parameters(), rtx)
         } else {
@@ -529,6 +540,7 @@ pub(super) trait TransportImpl: TransportGeneric {
                 producer.consumable_rtp_parameters(),
                 &rtp_capabilities,
                 pipe,
+                computed_enable_nack
             )
             .map_err(ConsumeError::BadConsumerRtpParameters)?;
 

--- a/rust/src/supported_rtp_capabilities.rs
+++ b/rust/src/supported_rtp_capabilities.rs
@@ -26,7 +26,10 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                 clock_rate: NonZeroU32::new(48000).unwrap(),
                 channels: NonZeroU8::new(2).unwrap(),
                 parameters: RtpCodecParametersParameters::default(),
-                rtcp_feedback: vec![RtcpFeedback::TransportCc],
+                rtcp_feedback: vec![
+                    RtcpFeedback::Nack,
+                    RtcpFeedback::TransportCc,
+                ],
             },
             RtpCodecCapability::Audio {
                 mime_type: MimeTypeAudio::MultiChannelOpus,
@@ -39,7 +42,10 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                     ("num_streams", 2_u32.into()),
                     ("coupled_streams", 2_u32.into()),
                 ]),
-                rtcp_feedback: vec![RtcpFeedback::TransportCc],
+                rtcp_feedback: vec![
+                    RtcpFeedback::Nack,
+                    RtcpFeedback::TransportCc,
+                ],
             },
             RtpCodecCapability::Audio {
                 mime_type: MimeTypeAudio::MultiChannelOpus,
@@ -52,7 +58,10 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                     ("num_streams", 4_u32.into()),
                     ("coupled_streams", 2_u32.into()),
                 ]),
-                rtcp_feedback: vec![RtcpFeedback::TransportCc],
+                rtcp_feedback: vec![
+                    RtcpFeedback::Nack,
+                    RtcpFeedback::TransportCc,
+                ],
             },
             RtpCodecCapability::Audio {
                 mime_type: MimeTypeAudio::MultiChannelOpus,
@@ -65,7 +74,10 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                     ("num_streams", 5_u32.into()),
                     ("coupled_streams", 3_u32.into()),
                 ]),
-                rtcp_feedback: vec![RtcpFeedback::TransportCc],
+                rtcp_feedback: vec![
+                    RtcpFeedback::Nack,
+                    RtcpFeedback::TransportCc,
+                ],
             },
             RtpCodecCapability::Audio {
                 mime_type: MimeTypeAudio::Pcmu,

--- a/rust/src/supported_rtp_capabilities.rs
+++ b/rust/src/supported_rtp_capabilities.rs
@@ -26,10 +26,7 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                 clock_rate: NonZeroU32::new(48000).unwrap(),
                 channels: NonZeroU8::new(2).unwrap(),
                 parameters: RtpCodecParametersParameters::default(),
-                rtcp_feedback: vec![
-                    RtcpFeedback::Nack,
-                    RtcpFeedback::TransportCc,
-                ],
+                rtcp_feedback: vec![RtcpFeedback::Nack, RtcpFeedback::TransportCc],
             },
             RtpCodecCapability::Audio {
                 mime_type: MimeTypeAudio::MultiChannelOpus,
@@ -42,10 +39,7 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                     ("num_streams", 2_u32.into()),
                     ("coupled_streams", 2_u32.into()),
                 ]),
-                rtcp_feedback: vec![
-                    RtcpFeedback::Nack,
-                    RtcpFeedback::TransportCc,
-                ],
+                rtcp_feedback: vec![RtcpFeedback::Nack, RtcpFeedback::TransportCc],
             },
             RtpCodecCapability::Audio {
                 mime_type: MimeTypeAudio::MultiChannelOpus,
@@ -58,10 +52,7 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                     ("num_streams", 4_u32.into()),
                     ("coupled_streams", 2_u32.into()),
                 ]),
-                rtcp_feedback: vec![
-                    RtcpFeedback::Nack,
-                    RtcpFeedback::TransportCc,
-                ],
+                rtcp_feedback: vec![RtcpFeedback::Nack, RtcpFeedback::TransportCc],
             },
             RtpCodecCapability::Audio {
                 mime_type: MimeTypeAudio::MultiChannelOpus,
@@ -74,10 +65,7 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                     ("num_streams", 5_u32.into()),
                     ("coupled_streams", 3_u32.into()),
                 ]),
-                rtcp_feedback: vec![
-                    RtcpFeedback::Nack,
-                    RtcpFeedback::TransportCc,
-                ],
+                rtcp_feedback: vec![RtcpFeedback::Nack, RtcpFeedback::TransportCc],
             },
             RtpCodecCapability::Audio {
                 mime_type: MimeTypeAudio::Pcmu,

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -712,10 +712,8 @@ fn consume_with_enable_rtx_succeeds() {
 
         let audio_consumer = transport_2
             .consume({
-                let mut options = ConsumerOptions::new(
-                    audio_producer.id(),
-                    consumer_device_capabilities.clone(),
-                );
+                let mut options =
+                    ConsumerOptions::new(audio_producer.id(), consumer_device_capabilities.clone());
                 options.enable_rtx = Some(true);
                 options
             })

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -199,7 +199,7 @@ fn consumer_device_capabilities() -> RtpCapabilities {
                 clock_rate: NonZeroU32::new(48000).unwrap(),
                 channels: NonZeroU8::new(2).unwrap(),
                 parameters: RtpCodecParametersParameters::default(),
-                rtcp_feedback: vec![],
+                rtcp_feedback: vec![RtcpFeedback::Nack],
             },
             RtpCodecCapability::Video {
                 mime_type: MimeTypeVideo::H264,
@@ -695,6 +695,51 @@ fn consume_succeeds() {
                 assert_eq!(transport_2_dump.consumer_ids, expected_consumer_ids);
             }
         }
+    });
+}
+
+#[test]
+fn consume_with_enable_rtx_succeeds() {
+    future::block_on(async move {
+        let (_executor_guard, _worker, _router, transport_1, transport_2) = init().await;
+
+        let audio_producer = transport_1
+            .produce(audio_producer_options())
+            .await
+            .expect("Failed to produce audio");
+
+        let consumer_device_capabilities = consumer_device_capabilities();
+
+        let audio_consumer = transport_2
+            .consume({
+                let mut options = ConsumerOptions::new(
+                    audio_producer.id(),
+                    consumer_device_capabilities.clone(),
+                );
+                options.enable_rtx = Some(true);
+                options
+            })
+            .await
+            .expect("Failed to consume audio");
+
+        assert_eq!(audio_consumer.kind(), MediaKind::Audio);
+        assert_eq!(audio_consumer.rtp_parameters().mid, Some("0".to_string()));
+        assert_eq!(
+            audio_consumer.rtp_parameters().codecs,
+            vec![RtpCodecParameters::Audio {
+                mime_type: MimeTypeAudio::Opus,
+                payload_type: 100,
+                clock_rate: NonZeroU32::new(48000).unwrap(),
+                channels: NonZeroU8::new(2).unwrap(),
+                parameters: RtpCodecParametersParameters::from([
+                    ("useinbandfec", 1_u32.into()),
+                    ("usedtx", 1_u32.into()),
+                    ("foo", "222.222".into()),
+                    ("bar", "333".into()),
+                ]),
+                rtcp_feedback: vec![RtcpFeedback::Nack],
+            }]
+        );
     });
 }
 

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -12,8 +12,10 @@ namespace RTC
 	public:
 		// Minimum retransmission buffer size (ms).
 		const static uint32_t MinRetransmissionDelayMs;
-		// Maximum retransmission buffer size (ms).
-		const static uint32_t MaxRetransmissionDelayMs;
+		// Maximum retransmission buffer size for video (ms).
+		const static uint32_t MaxRetransmissionDelayForVideoMs;
+		// Maximum retransmission buffer size for audio (ms).
+		const static uint32_t MaxRetransmissionDelayForAudioMs;
 
 	public:
 		class Listener : public RTC::RtpStream::Listener
@@ -46,7 +48,7 @@ namespace RTC
 		// Special container that stores `StorageItem*` elements addressable by
 		// their `uint16_t` sequence number, while only taking as little memory as
 		// necessary to store the range covering a maximum of
-		// MaxRetransmissionDelayMs milliseconds.
+		// MaxRetransmissionDelayForVideoMs or MaxRetransmissionDelayForAudioMs ms.
 		class StorageItemBuffer
 		{
 		public:
@@ -101,6 +103,7 @@ namespace RTC
 		uint32_t sentPriorScore{ 0u }; // Packets sent at last interval for score calculation.
 		StorageItemBuffer storageItemBuffer;
 		std::string mid;
+		uint32_t maxRetransmissionDelayMs;
 		uint32_t retransmissionBufferSize;
 		uint16_t rtxSeq{ 0u };
 		RTC::RtpDataCounter transmissionCounter;

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -22,7 +22,7 @@ namespace RTC
 
 	const uint32_t RtpStreamSend::MinRetransmissionDelayMs{ 200u };
 	const uint32_t RtpStreamSend::MaxRetransmissionDelayForVideoMs{ 2000u };
-	const uint32_t RtpStreamSend::MaxRetransmissionDelayForAudioMs{ 2000u };
+	const uint32_t RtpStreamSend::MaxRetransmissionDelayForAudioMs{ 1000u };
 
 	void RtpStreamSend::StorageItem::Reset()
 	{

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -4,6 +4,7 @@
 #include "RTC/RtpStreamSend.hpp"
 #include "Logger.hpp"
 #include "Utils.hpp"
+#include "RTC/RtpDictionaries.hpp"
 #include "RTC/SeqManager.hpp"
 
 namespace RTC
@@ -19,10 +20,9 @@ namespace RTC
 
 	/* Class Static. */
 
-	// Minimum retransmission buffer size (ms).
 	const uint32_t RtpStreamSend::MinRetransmissionDelayMs{ 200u };
-	// Maximum retransmission buffer size (ms).
-	const uint32_t RtpStreamSend::MaxRetransmissionDelayMs{ 2000u };
+	const uint32_t RtpStreamSend::MaxRetransmissionDelayForVideoMs{ 2000u };
+	const uint32_t RtpStreamSend::MaxRetransmissionDelayForAudioMs{ 2000u };
 
 	void RtpStreamSend::StorageItem::Reset()
 	{
@@ -168,10 +168,33 @@ namespace RTC
 
 	RtpStreamSend::RtpStreamSend(
 	  RTC::RtpStreamSend::Listener* listener, RTC::RtpStream::Params& params, std::string& mid)
-	  : RTC::RtpStream::RtpStream(listener, params, 10), mid(mid),
-	    retransmissionBufferSize(RtpStreamSend::MaxRetransmissionDelayMs)
+	  : RTC::RtpStream::RtpStream(listener, params, 10), mid(mid)
 	{
 		MS_TRACE();
+
+		switch (params.mimeType.type)
+		{
+			case RTC::RtpCodecMimeType::Type::VIDEO:
+			{
+				this->maxRetransmissionDelayMs = RtpStreamSend::MaxRetransmissionDelayForVideoMs;
+				this->retransmissionBufferSize = RtpStreamSend::MaxRetransmissionDelayForVideoMs;
+
+				break;
+			}
+
+			case RTC::RtpCodecMimeType::Type::AUDIO:
+			{
+				this->maxRetransmissionDelayMs = RtpStreamSend::MaxRetransmissionDelayForAudioMs;
+				this->retransmissionBufferSize = RtpStreamSend::MaxRetransmissionDelayForAudioMs;
+
+				break;
+			}
+
+			case RTC::RtpCodecMimeType::Type::UNSET:
+			{
+				MS_ABORT("codec mimeType not set");
+			}
+		}
 	}
 
 	RtpStreamSend::~RtpStreamSend()
@@ -329,13 +352,13 @@ namespace RTC
 			this->hasRtt = true;
 		}
 
-		// Smoothly change retransmission buffer size towards RTT + 100ms, but not more than
-		// MaxRetransmissionDelayMs.
+		// Smoothly change retransmission buffer size towards RTT + 100ms, but not
+		// more than this->maxRetransmissionDelayMs.
 		auto newRetransmissionBufferSize = static_cast<uint32_t>(this->rtt + 100.0);
 		auto avgRetransmissionBufferSize =
 		  (this->retransmissionBufferSize * 7 + newRetransmissionBufferSize) / 8;
 		this->retransmissionBufferSize = std::max(
-		  std::min(avgRetransmissionBufferSize, RtpStreamSend::MaxRetransmissionDelayMs),
+		  std::min(avgRetransmissionBufferSize, this->maxRetransmissionDelayMs),
 		  RtpStreamSend::MinRetransmissionDelayMs);
 
 		this->packetsLost  = report->GetTotalLost();
@@ -543,7 +566,7 @@ namespace RTC
 		const auto bufferSize = this->storageItemBuffer.GetBufferSize();
 
 		// Go through all buffer items starting with the first and free all storage
-		// items that contain packets older than MaxRetransmissionDelayMs.
+		// items that contain packets older than this->maxRetransmissionDelayMs.
 		for (size_t i{ 0 }; i < bufferSize && this->storageItemBuffer.GetBufferSize() != 0; ++i)
 		{
 			auto* storageItem = this->storageItemBuffer.GetFirst();
@@ -645,8 +668,8 @@ namespace RTC
 				{
 					// Do nothing.
 				}
-				// Don't resend the packet if older than MaxRetransmissionDelayMs ms.
-				else if (diffMs > MaxRetransmissionDelayMs)
+				// Don't resend the packet if older than this->maxRetransmissionDelayMs ms.
+				else if (diffMs > this->maxRetransmissionDelayMs)
 				{
 					if (!tooOldPacketFound)
 					{
@@ -655,7 +678,7 @@ namespace RTC
 						  "ignoring retransmission for too old packet "
 						  "[seq:%" PRIu16 ", max age:%" PRIu32 "ms, packet age:%" PRIu32 "ms]",
 						  packet->GetSequenceNumber(),
-						  MaxRetransmissionDelayMs,
+						  this->maxRetransmissionDelayMs,
 						  diffMs);
 
 						tooOldPacketFound = true;

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -319,11 +319,11 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		delete stream2;
 	}
 
-	SECTION("packets get retransmitted as long as they don't exceed MaxRetransmissionDelayMs")
+	SECTION("packets get retransmitted as long as they don't exceed MaxRetransmissionDelayForVideoMs")
 	{
 		uint32_t clockRate = 90000;
 		uint32_t firstTs   = 1533790901;
-		uint32_t diffTs    = RtpStreamSend::MaxRetransmissionDelayMs * clockRate / 1000;
+		uint32_t diffTs    = RtpStreamSend::MaxRetransmissionDelayForVideoMs * clockRate / 1000;
 		uint32_t secondTs  = firstTs + diffTs;
 
 		auto* packet1 = CreateRtpPacket(rtpBuffer1, 21006, firstTs);
@@ -371,11 +371,11 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		delete stream;
 	}
 
-	SECTION("packets don't get retransmitted if MaxRetransmissionDelayMs is exceeded")
+	SECTION("packets don't get retransmitted if MaxRetransmissionDelayForVideoMs is exceeded")
 	{
 		uint32_t clockRate = 90000;
 		uint32_t firstTs   = 1533790901;
-		uint32_t diffTs    = RtpStreamSend::MaxRetransmissionDelayMs * clockRate / 1000;
+		uint32_t diffTs    = RtpStreamSend::MaxRetransmissionDelayForVideoMs * clockRate / 1000;
 		uint32_t secondTs  = firstTs + diffTs;
 
 		auto* packet1 = CreateRtpPacket(rtpBuffer1, 21006, firstTs);


### PR DESCRIPTION
Inspired by PR #997 by @t-mullen.

### Details

- This PR enables RTP retransmission for OPUS codec in mediasoup by adding NACK support into all supported configurations of OPUS codec.
- `ConsumerOptions` given to `transport.consume()` get a new `enableRtx` boolean option. If unset, it's `true` for video codecs and `false` for audio codecs (default behavior). If set to `true` and if the consuming device supports RTCP NACK for opus, then mediasoup will honour NACK received from the device and will retransmitted requested OPUS RTP packets.
- Currently just libwebrtc supports NACK for OPUS and it does it without using RTX codec, and we do the same in mediasoup.

### Bonus Tracks

- `RtpStreamSend`:  Use 1000ms as max retransmission delay for audio streams (keep using 2000ms for video streams as before).
