### PR TITLE
avgDBov conflict

### DIFF
--- a/worker/src/RTC/AudioLevelObserver.cpp
+++ b/worker/src/RTC/AudioLevelObserver.cpp
@@ -156,7 +156,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		absl::btree_map<int8_t, RTC::Producer*> mapDBovsProducer;
+		absl::btree_map<RTC::Producer*, int8_t> mapDBovsProducer; 
 
 		for (auto& kv : this->mapProducerDBovs)
 		{
@@ -169,7 +169,7 @@ namespace RTC
 			auto avgDBov = -1 * static_cast<int8_t>(std::lround(dBovs.totalSum / dBovs.count));
 
 			if (avgDBov >= this->threshold)
-				mapDBovsProducer[avgDBov] = producer;
+				mapDBovsProducer[producer] = avgDBov;
 		}
 
 		// Clear the map.
@@ -189,8 +189,8 @@ namespace RTC
 
 				auto& jsonEntry = data[idx];
 
-				jsonEntry["producerId"] = rit->second->id;
-				jsonEntry["volume"]     = rit->first;
+				jsonEntry["producerId"] = rit->first->id;
+				jsonEntry["volume"]     = rit->second;
 			}
 
 			this->shared->channelNotifier->Emit(this->id, "volumes", data);


### PR DESCRIPTION
Background: 
- We use audioLevel to determine which producer's audio will be sent.
- mapDBovsProducer is a map that uses avgDBov as the key.
- avgDBov is an int value from -127 to 0. In fact, we will use threshold, which has a value from threshold to 0.

Facts:
When there are two producers in the router, their avgDBov within the interval may be the same (with probability 1/threshold), causing this producer to be overwritten by other producers. In this case, the sound of this producer will sound intermittent. The more producers in the room, the higher the probability of them colliding.
