### PR TITLE
Fix buffer overflow in RtpStreamSend

### DIFF
--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -106,7 +106,7 @@ namespace RTC
 		}
 		else
 		{
-			// Buffer is already full
+			// Buffer is already full.
 			if (bufferSize == static_cast<size_t>(MaxSeq) + 1)
 			{
 				auto idx{ static_cast<uint16_t>(this->startSeq - seq) };


### PR DESCRIPTION
I believe this fixes #975. Review with whitespace changes ignored, there is very little change here (added one more `if` branch).

Would be nice to write a regression test case for this though.

This is supposed to be an alternative to #1023