### PR TITLE
Fix bandwidth probation dead state

### DIFF
--- a/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/alr_detector.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/alr_detector.cc
@@ -113,8 +113,7 @@ absl::optional<int64_t> AlrDetector::GetApplicationLimitedRegionStartTime(
     int64_t at_time_ms) {
   if (!alr_started_time_ms_ && *last_send_time_ms_) {
     int64_t delta_time_ms = at_time_ms - *last_send_time_ms_;
-    // If ALR is stopped and we didn't sent any packets in the last for a while,
-    // force resuming the state.
+    // If ALR is stopped and we haven't sent any packets for a while, force start.
     if (delta_time_ms > 1000) {
       MS_WARN_TAG(bwe, "large delta_time_ms: %ld, forcing alr state change",
         delta_time_ms);

--- a/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/alr_detector.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/alr_detector.cc
@@ -62,6 +62,11 @@ AlrDetector::AlrDetector(
           experiment_settings
               ? experiment_settings->alr_stop_budget_level_percent / 100.0
               : kDefaultStopBudgetLevelRatio),
+      alr_timeout_(
+          "alr_timeout",
+          experiment_settings
+              ? experiment_settings->alr_timeout
+              : kDefaultAlrTimeout),
       alr_budget_(0, true) {
   ParseFieldTrial({&bandwidth_usage_ratio_, &start_budget_level_ratio_,
                    &stop_budget_level_ratio_},
@@ -114,7 +119,7 @@ absl::optional<int64_t> AlrDetector::GetApplicationLimitedRegionStartTime(
   if (!alr_started_time_ms_ && *last_send_time_ms_) {
     int64_t delta_time_ms = at_time_ms - *last_send_time_ms_;
     // If ALR is stopped and we haven't sent any packets for a while, force start.
-    if (delta_time_ms > 1000) {
+    if (delta_time_ms > alr_timeout_) {
       MS_WARN_TAG(bwe, "large delta_time_ms: %ld, forcing alr state change",
         delta_time_ms);
       alr_started_time_ms_.emplace(at_time_ms);

--- a/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/alr_detector.h
+++ b/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/alr_detector.h
@@ -43,6 +43,7 @@ class AlrDetector {
   // Returns time in milliseconds when the current application-limited region
   // started or empty result if the sender is currently not application-limited.
   absl::optional<int64_t> GetApplicationLimitedRegionStartTime() const;
+  absl::optional<int64_t> GetApplicationLimitedRegionStartTime(int64_t at_time_ms);
 
   void UpdateBudgetWithElapsedTime(int64_t delta_time_ms);
   void UpdateBudgetWithBytesSent(size_t bytes_sent);

--- a/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/alr_detector.h
+++ b/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/alr_detector.h
@@ -57,6 +57,7 @@ class AlrDetector {
   static constexpr double kDefaultBandwidthUsageRatio = 0.65;
   static constexpr double kDefaultStartBudgetLevelRatio = 0.80;
   static constexpr double kDefaultStopBudgetLevelRatio = 0.50;
+  static constexpr int    kDefaultAlrTimeout = 3000;
 
   AlrDetector(const WebRtcKeyValueConfig* key_value_config,
               absl::optional<AlrExperimentSettings> experiment_settings);
@@ -65,6 +66,7 @@ class AlrDetector {
   FieldTrialParameter<double>  bandwidth_usage_ratio_;
   FieldTrialParameter<double>  start_budget_level_ratio_;
   FieldTrialParameter<double>  stop_budget_level_ratio_;
+  FieldTrialParameter<int>     alr_timeout_;
 
   absl::optional<int64_t> last_send_time_ms_;
 

--- a/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_network_control.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/goog_cc_network_control.cc
@@ -195,7 +195,7 @@ NetworkControlUpdate GoogCcNetworkController::OnProcessInterval(
   }
   bandwidth_estimation_->UpdateEstimate(msg.at_time);
   absl::optional<int64_t> start_time_ms =
-      alr_detector_->GetApplicationLimitedRegionStartTime();
+      alr_detector_->GetApplicationLimitedRegionStartTime(msg.at_time.ms());
   probe_controller_->SetAlrStartTimeMs(start_time_ms);
 
   auto probes = probe_controller_->Process(msg.at_time.ms());

--- a/worker/deps/libwebrtc/libwebrtc/rtc_base/experiments/alr_experiment.cc
+++ b/worker/deps/libwebrtc/libwebrtc/rtc_base/experiments/alr_experiment.cc
@@ -26,7 +26,7 @@ const char AlrExperimentSettings::kScreenshareProbingBweExperimentName[] =
     "WebRTC-ProbingScreenshareBwe";
 const char AlrExperimentSettings::kStrictPacingAndProbingExperimentName[] =
     "WebRTC-StrictPacingAndProbing";
-const char kDefaultProbingScreenshareBweSettings[] = "1.0,2875,80,40,-60,3";
+const char kDefaultProbingScreenshareBweSettings[] = "1.0,2875,80,40,-60,3,3000";
 
 bool AlrExperimentSettings::MaxOneFieldTrialEnabled() {
   return AlrExperimentSettings::MaxOneFieldTrialEnabled(
@@ -71,12 +71,13 @@ AlrExperimentSettings::CreateFromFieldTrial(
   }
 
   AlrExperimentSettings settings;
-  if (sscanf(group_name.c_str(), "%f,%" PRId64 ",%d,%d,%d,%d",
+  if (sscanf(group_name.c_str(), "%f,%" PRId64 ",%d,%d,%d,%d,%d",
              &settings.pacing_factor, &settings.max_paced_queue_time,
              &settings.alr_bandwidth_usage_percent,
              &settings.alr_start_budget_level_percent,
              &settings.alr_stop_budget_level_percent,
-             &settings.group_id) == 6) {
+             &settings.group_id,
+             &settings.alr_timeout) == 7) {
     ret.emplace(settings);
     MS_DEBUG_TAG(bwe, "Using ALR experiment settings: "
                       "pacing factor: %f"
@@ -84,13 +85,15 @@ AlrExperimentSettings::CreateFromFieldTrial(
                      ", ALR bandwidth usage percent: %d"
                      ", ALR start budget level percent: %d"
                      ", ALR end budget level percent: %d"
-                     ", ALR experiment group ID: %d",
+                     ", ALR experiment group ID: %d"
+                     ", ALR timeout: %d",
                      settings.pacing_factor,
                      settings.max_paced_queue_time,
                      settings.alr_bandwidth_usage_percent,
                      settings.alr_start_budget_level_percent,
                      settings.alr_stop_budget_level_percent,
-                     settings.group_id);
+                     settings.group_id,
+                     settings.alr_timeout);
   } else {
     MS_DEBUG_TAG(bwe, "Failed to parse ALR experiment: %s", experiment_name);
   }

--- a/worker/deps/libwebrtc/libwebrtc/rtc_base/experiments/alr_experiment.h
+++ b/worker/deps/libwebrtc/libwebrtc/rtc_base/experiments/alr_experiment.h
@@ -24,6 +24,7 @@ struct AlrExperimentSettings {
   int alr_bandwidth_usage_percent;
   int alr_start_budget_level_percent;
   int alr_stop_budget_level_percent;
+  int alr_timeout;
   // Will be sent to the receive side for stats slicing.
   // Can be 0..6, because it's sent as a 3 bits value and there's also
   // reserved value to indicate absence of experiment.


### PR DESCRIPTION
Running some tests with high packet loss (~20%), in most cases the server stops sending any video packet and we never exit from that state, even if the network link improves.

Looking at the ALR detector (that should be activated when there are no RTP packets sent over the transport), it seems that it is falling into a dead state:

1. in `NetworkControlUpdate GoogCcNetworkController::OnProcessInterval` we periodically call `start_time_ms = alr_detector_->GetApplicationLimitedRegionStartTime()` setting the output value to `probe_controller_->SetAlrStartTimeMs(start_time_ms)`
2. the AlrDetector state is set by `AlrDetector::OnBytesSent`, so when the transport stops sending packets, we could end up in this state:
  ```
  } else if (alr_budget_.budget_ratio() < stop_budget_level_ratio_ &&
             alr_started_time_ms_) {
    state_changed = true;
    alr_started_time_ms_.reset();
  }
  ```

3. at this point `GoogCcNetworkController::OnProcessInterval` calls `probe_controller_->SetAlrStartTimeMs(<empty value>)` with this empty value set into the `ProbeController`, and the `ProbeController::Process` never calls `InitiateProbing`, so no more probing is created;
4. the bandwidth estimation is never tested again, so we never resume sending packets.

With this PR we use a `alr_timeout_` value (set to 3s by default). After that timeout, the ALR resumes sending probes.