### PR TITLE
Github CI: Remove deprecated Ubuntu 18.04

### DIFF
--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -8,12 +8,6 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - os: ubuntu-18.04
-            cc: gcc
-            cxx: g++
-          - os: ubuntu-18.04
-            cc: clang
-            cxx: clang++
           - os: ubuntu-20.04
             cc: gcc
             cxx: g++

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### NEXT
+
+* Github workflow: Remove deprecated Ubuntu version 18.04 ([PR #1033](https://github.com/versatica/mediasoup/pull/1033)).
+
 
 ### 3.11.16
 


### PR DESCRIPTION
The version is deprecated and will be removed by 4/1/23.