### PR TITLE
GitHub CI: Cancel in progress workflows

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -2,11 +2,17 @@ name: mediasoup-node
 
 on: [push, pull_request]
 
+concurrency:
+  # Cancel a currently running workflow from the same PR, branch or tag when a
+  # new workflow is triggered.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     strategy:
       matrix:
-        # Different Node versions on Ubuntu, the latest Node on other platforms
+        # Different Node versions on Ubuntu, the latest Node on other platforms.
         ci:
           - os: ubuntu-22.04
             node: 16

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -2,6 +2,12 @@ name: mediasoup-rust
 
 on: [push, pull_request]
 
+concurrency:
+  # Cancel a currently running workflow from the same PR, branch or tag when a
+  # new workflow is triggered.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -2,6 +2,12 @@ name: mediasoup-worker
 
 on: [push, pull_request]
 
+concurrency:
+  # Cancel a currently running workflow from the same PR, branch or tag when a
+  # new workflow is triggered.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   ci:
     strategy:
@@ -31,7 +37,7 @@ jobs:
             cxx: cl
         # A single Node.js version should be fine for C++.
         node:
-          - 16
+          - 18
 
     runs-on: ${{ matrix.build.os }}
 
@@ -66,4 +72,5 @@ jobs:
 
       - run: npm run worker:build
       - run: npm run test:worker
+        # TODO: Maybe fix this one day.
         if: runner.os != 'Windows'

--- a/.github/workflows/pull-request-stats.yml
+++ b/.github/workflows/pull-request-stats.yml
@@ -1,8 +1,9 @@
 name: Pull Request Stats
 
 on:
+  # Run it every Monday at 1PM UTC.
   schedule:
-    - cron: "0 13 * * 1" # Run it every Monday at 1PM UTC.
+    - cron: "0 13 * * 1"
 
 jobs:
   stats:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### NEXT
 
-* Github workflow: Remove deprecated Ubuntu version 18.04 ([PR #1033](https://github.com/versatica/mediasoup/pull/1033)).
+* GitHub CI: Remove deprecated Ubuntu version 18.04 ([PR #1033](https://github.com/versatica/mediasoup/pull/1033)).
+* GitHub CI: Cancel in progress workflows ([PR #1034](https://github.com/versatica/mediasoup/pull/1034)).
 
 
 ### 3.11.16


### PR DESCRIPTION
- Cancel a currently running workflow from the same PR, branch or tag when a new workflow is triggered.
- Bonus track: Use Node 18 (LTS) in mediasoup-worker.yaml instead of Node 16.