### PR TITLE
Properly handle ksvc bandwidth allocation

### DIFF
--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -556,6 +556,7 @@ namespace RTC
 		auto nowMs = DepLibUV::GetTimeMs();
 		uint32_t desiredBitrate{ 0u };
 
+		// When using K-SVC each spatial layer is independent of the others.
 		if (this->encodingContext->IsKSvc())
 		{
 			// Let's iterate all spatial layers of the Producer (from highest to lowest) and

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -560,9 +560,9 @@ namespace RTC
 		{
 			// Let's iterate all spatial layers of the Producer (from highest to lowest) and
 			// obtain their bitrate. Choose the highest one.
-			// NOTE: When the Producer enables a higher stream, initially the bitrate of
-			// it could be less than the bitrate of a lower stream. That's why we
-			// iterate all streams here anyway.
+			// NOTE: When the Producer enables a higher spatial layer, initially the bitrate
+			// oft could be less than the bitrate of a lower one. That's why we iterate all
+			// spatial layers here anyway.
 			for (auto spatialLayer{ this->producerRtpStream->GetSpatialLayers() - 1 }; spatialLayer >= 0;
 			     --spatialLayer)
 			{


### PR DESCRIPTION
When we use VP9 with K-SVC configuration, the spatial layers are independent; this means that the bandwidth allocator, when it tries to increase the allocated layer,  should not take into account the lower spatial levels bitrates (same behaviour of the Simulcast case).