### PR TITLE
RtpRetransmissionBuffer: consider the case of packet with newest timestamp but "old" seq number

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* `RtpRetransmissionBuffer`: consider the case of packet with newest timestamp but "old" seq number ([PR #1039](https://github.com/versatica/mediasoup/pull/1039)).
+
+
 ### 3.11.17
 
 * Add `transport.setMinOutgoingBitrate()` method ([PR #1038](https://github.com/versatica/mediasoup/pull/1038), credits to @ jcague).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### NEXT
 
-* `RtpRetransmissionBuffer`: consider the case of packet with newest timestamp but "old" seq number ([PR #1039](https://github.com/versatica/mediasoup/pull/1039)).
+* `RtpRetransmissionBuffer`: Consider the case of packet with newest timestamp but "old" seq number ([PR #1039](https://github.com/versatica/mediasoup/pull/1039)).
 
 
 ### 3.11.17

--- a/worker/include/RTC/RtpRetransmissionBuffer.hpp
+++ b/worker/include/RTC/RtpRetransmissionBuffer.hpp
@@ -46,7 +46,7 @@ namespace RTC
 		Item* GetNewest() const;
 		void RemoveOldest();
 		void RemoveOldest(uint16_t numItems);
-		void ClearTooOld();
+		bool ClearTooOld(uint32_t newestTimestamp);
 		bool IsTooOld(uint32_t timestamp, uint32_t newestTimestamp) const;
 		Item* FillItem(
 		  Item* item, RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket) const;

--- a/worker/src/RTC/RtpRetransmissionBuffer.cpp
+++ b/worker/src/RTC/RtpRetransmissionBuffer.cpp
@@ -86,9 +86,9 @@ namespace RTC
 
 		// Clear too old packets in the buffer.
 		// NOTE: Here we must consider the case in which, due for example to huge
-		// packet loss, received packet has higher timestamp than the newest packet
-		// in the buffer and, if so, use it to clear too old packets rather than
-		// the newest packet in the buffer.
+		// packet loss, received packet has higher timestamp but "older" seq number
+		// than the newest packet in the buffer and, if so, use it to clear too old
+		// packets rather than the newest packet in the buffer.
 		auto newestTimestamp =
 		  RTC::SeqManager<uint32_t>::IsSeqHigherThan(timestamp, newestItem->timestamp)
 		    ? timestamp

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -12,7 +12,7 @@ namespace RTC
 	/* Static. */
 
 	// Limit max number of items in the retransmission buffer.
-	static constexpr size_t RetransmissionBufferMaxItems{ 5000u };
+	static constexpr size_t RetransmissionBufferMaxItems{ 2500u };
 	// 17: 16 bit mask + the initial sequence number.
 	static constexpr size_t MaxRequestedPackets{ 17u };
 	thread_local static std::vector<RTC::RtpRetransmissionBuffer::Item*> RetransmissionContainer(

--- a/worker/test/src/RTC/TestRtpRetransmissionBuffer.cpp
+++ b/worker/test/src/RTC/TestRtpRetransmissionBuffer.cpp
@@ -230,6 +230,29 @@ SCENARIO("RtpRetransmissionBuffer", "[rtp][rtx]")
 		// clang-format on
 	}
 
+	SECTION("packet with very newest timestamp is inserted as newest item despite its seq is old")
+	{
+		uint16_t maxItems{ 4 };
+		uint32_t maxRetransmissionDelayMs{ 2000u };
+		uint32_t clockRate{ 90000 };
+
+		RtpMyRetransmissionBuffer myRetransmissionBuffer(maxItems, maxRetransmissionDelayMs, clockRate);
+
+		// Scenario based on https://github.com/versatica/mediasoup/issues/1037.
+
+		myRetransmissionBuffer.Insert(24816, 1024930187);
+		myRetransmissionBuffer.Insert(24980, 1025106407);
+		myRetransmissionBuffer.Insert(18365, 1026593387);
+
+		// clang-format off
+		myRetransmissionBuffer.AssertBuffer(
+			{
+				{ true, 18365, 1026593387 }
+			}
+		);
+		// clang-format on
+	}
+
 	SECTION("fuzzer generated packets")
 	{
 		uint16_t maxItems{ 2500u };


### PR DESCRIPTION
Fixes #1037

### Details:

- We must consider the case in which, due for example to huge packet loss, received packet has higher timestamp but "older" seq number than the newest packet in the buffer and, if so, use it to clear too old packets rather than the newest packet in the buffer.
- Bonus track: restore buffer size to 2500 since increasing it didn't indeed help (it shouldn't help as proven).