### PR TITLE
Reset RTP retransmission buffer upon RTP sequence number reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* `RtpStreamSend`: Reset RTP retransmission buffer upon RTP sequence number reset ([PR #1041](https://github.com/versatica/mediasoup/pull/1041)).
+
+
 ### 3.11.19
 
 * `SvcConsumer`: Properly handle VP9 K-SVC bandwidth allocation ([PR #1036](https://github.com/versatica/mediasoup/pull/1036) by @vpalmisano).

--- a/worker/include/RTC/RtpStream.hpp
+++ b/worker/include/RTC/RtpStream.hpp
@@ -175,6 +175,10 @@ namespace RTC
 	private:
 		void InitSeq(uint16_t seq);
 
+		/* Pure virtual method that must be implemented by the subclass. */
+	protected:
+		virtual void UserOnSequenceNumberReset() = 0;
+
 	protected:
 		// Given as argument.
 		RTC::RtpStream::Listener* listener{ nullptr };

--- a/worker/include/RTC/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RtpStreamRecv.hpp
@@ -80,6 +80,10 @@ namespace RTC
 		void CalculateJitter(uint32_t rtpTimestamp);
 		void UpdateScore();
 
+		/* Pure virtual methods inherited from RTC::RtpStream. */
+	public:
+		void UserOnSequenceNumberReset() override;
+
 		/* Pure virtual methods inherited from Timer. */
 	protected:
 		void OnTimer(Timer* timer) override;

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -53,6 +53,10 @@ namespace RTC
 		void FillRetransmissionContainer(uint16_t seq, uint16_t bitmask);
 		void UpdateScore(RTC::RTCP::ReceiverReport* report);
 
+		/* Pure virtual methods inherited from RTC::RtpStream. */
+	public:
+		void UserOnSequenceNumberReset() override;
+
 	private:
 		// Packets lost at last interval for score calculation.
 		uint32_t lostPriorScore{ 0u };

--- a/worker/src/RTC/RtpStream.cpp
+++ b/worker/src/RTC/RtpStream.cpp
@@ -212,6 +212,9 @@ namespace RTC
 
 				this->maxPacketTs = packet->GetTimestamp();
 				this->maxPacketMs = DepLibUV::GetTimeMs();
+
+				// Notify the subclass about it.
+				UserOnSequenceNumberReset();
 			}
 			else
 			{

--- a/worker/src/RTC/RtpStream.cpp
+++ b/worker/src/RTC/RtpStream.cpp
@@ -28,6 +28,7 @@ namespace RTC
 		MS_TRACE();
 
 		delete this->rtxStream;
+		this->rtxStream = nullptr;
 	}
 
 	void RtpStream::FillJson(json& jsonObject) const

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -836,6 +836,13 @@ namespace RTC
 		RtpStream::UpdateScore(score);
 	}
 
+	void RtpStreamRecv::UserOnSequenceNumberReset()
+	{
+		MS_TRACE();
+
+		// Nothing to do.
+	}
+
 	inline void RtpStreamRecv::OnTimer(Timer* timer)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -627,4 +627,14 @@ namespace RTC
 
 		RtpStream::UpdateScore(score);
 	}
+
+	void RtpStreamSend::UserOnSequenceNumberReset()
+	{
+		MS_TRACE();
+
+		if (this->retransmissionBuffer)
+		{
+			this->retransmissionBuffer->Clear();
+		}
+	}
 } // namespace RTC

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -632,6 +632,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		// Clear retransmission buffer.
 		if (this->retransmissionBuffer)
 		{
 			this->retransmissionBuffer->Clear();

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -123,11 +123,11 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 
 		REQUIRE(testRtpStreamListener.retransmittedPackets.size() == 5);
 
-		auto rtxPacket1 = testRtpStreamListener.retransmittedPackets[0];
-		auto rtxPacket2 = testRtpStreamListener.retransmittedPackets[1];
-		auto rtxPacket3 = testRtpStreamListener.retransmittedPackets[2];
-		auto rtxPacket4 = testRtpStreamListener.retransmittedPackets[3];
-		auto rtxPacket5 = testRtpStreamListener.retransmittedPackets[4];
+		auto* rtxPacket1 = testRtpStreamListener.retransmittedPackets[0];
+		auto* rtxPacket2 = testRtpStreamListener.retransmittedPackets[1];
+		auto* rtxPacket3 = testRtpStreamListener.retransmittedPackets[2];
+		auto* rtxPacket4 = testRtpStreamListener.retransmittedPackets[3];
+		auto* rtxPacket5 = testRtpStreamListener.retransmittedPackets[4];
 
 		testRtpStreamListener.retransmittedPackets.clear();
 
@@ -294,8 +294,8 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 
 		REQUIRE(testRtpStreamListener1.retransmittedPackets.size() == 2);
 
-		auto rtxPacket1 = testRtpStreamListener1.retransmittedPackets[0];
-		auto rtxPacket2 = testRtpStreamListener1.retransmittedPackets[1];
+		auto* rtxPacket1 = testRtpStreamListener1.retransmittedPackets[0];
+		auto* rtxPacket2 = testRtpStreamListener1.retransmittedPackets[1];
 
 		testRtpStreamListener1.retransmittedPackets.clear();
 
@@ -330,7 +330,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		auto* packet2 = CreateRtpPacket(rtpBuffer2, 21007, secondTs - 1);
 
 		// Create a RtpStreamSend instance.
-		TestRtpStreamListener testRtpStreamListener1;
+		TestRtpStreamListener testRtpStreamListener;
 
 		RtpStream::Params params1;
 
@@ -340,7 +340,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params1.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
 
 		std::string mid;
-		auto* stream = new RtpStreamSend(&testRtpStreamListener1, params1, mid);
+		auto* stream = new RtpStreamSend(&testRtpStreamListener, params1, mid);
 
 		// Receive all the packets.
 		SendRtpPacket({ { stream, params1.ssrc } }, packet1);
@@ -358,12 +358,12 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		// Process the NACK packet on stream1.
 		stream->ReceiveNack(&nackPacket);
 
-		REQUIRE(testRtpStreamListener1.retransmittedPackets.size() == 2);
+		REQUIRE(testRtpStreamListener.retransmittedPackets.size() == 2);
 
-		auto rtxPacket1 = testRtpStreamListener1.retransmittedPackets[0];
-		auto rtxPacket2 = testRtpStreamListener1.retransmittedPackets[1];
+		auto* rtxPacket1 = testRtpStreamListener.retransmittedPackets[0];
+		auto* rtxPacket2 = testRtpStreamListener.retransmittedPackets[1];
 
-		testRtpStreamListener1.retransmittedPackets.clear();
+		testRtpStreamListener.retransmittedPackets.clear();
 
 		CheckRtxPacket(rtxPacket1, packet1->GetSequenceNumber(), packet1->GetTimestamp());
 		CheckRtxPacket(rtxPacket2, packet2->GetSequenceNumber(), packet2->GetTimestamp());
@@ -386,7 +386,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		auto* packet3 = CreateRtpPacket(rtpBuffer3, 21008, thirdTs);
 
 		// Create a RtpStreamSend instance.
-		TestRtpStreamListener testRtpStreamListener1;
+		TestRtpStreamListener testRtpStreamListener;
 
 		RtpStream::Params params1;
 
@@ -396,14 +396,14 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params1.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
 
 		std::string mid;
-		auto* stream = new RtpStreamSend(&testRtpStreamListener1, params1, mid);
+		auto* stream = new RtpStreamSend(&testRtpStreamListener, params1, mid);
 
 		// Receive all the packets.
 		SendRtpPacket({ { stream, params1.ssrc } }, packet1);
 		SendRtpPacket({ { stream, params1.ssrc } }, packet2);
 		SendRtpPacket({ { stream, params1.ssrc } }, packet3);
 
-		// Create a NACK item that request for all the packets.
+		// Create a NACK item that requests for all packets.
 		RTCP::FeedbackRtpNackPacket nackPacket(0, params1.ssrc);
 		auto* nackItem = new RTCP::FeedbackRtpNackItem(21006, 0b0000000000000001);
 
@@ -415,13 +415,58 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		// Process the NACK packet on stream1.
 		stream->ReceiveNack(&nackPacket);
 
-		REQUIRE(testRtpStreamListener1.retransmittedPackets.size() == 1);
+		REQUIRE(testRtpStreamListener.retransmittedPackets.size() == 1);
 
-		auto rtxPacket2 = testRtpStreamListener1.retransmittedPackets[0];
+		auto* rtxPacket2 = testRtpStreamListener.retransmittedPackets[0];
 
-		testRtpStreamListener1.retransmittedPackets.clear();
+		testRtpStreamListener.retransmittedPackets.clear();
 
 		CheckRtxPacket(rtxPacket2, packet2->GetSequenceNumber(), packet2->GetTimestamp());
+
+		delete stream;
+	}
+
+	SECTION("packets get removed from the retransmission buffer if seq number of the stream is reset")
+	{
+		// This scenario reproduce the "too bad sequence number" and "bad sequence
+		// number" scenarios in RtpStream::UpdateSeq().
+		auto* packet1 = CreateRtpPacket(rtpBuffer1, 50001, 1000001);
+		auto* packet2 = CreateRtpPacket(rtpBuffer2, 50002, 1000002);
+		// Third packet has bad sequence number (its seq is more than MaxDropout=3000
+		// older than current max seq) and will be dropped.
+		auto* packet3 = CreateRtpPacket(rtpBuffer3, 40003, 1000003);
+		// Forth packet has seq=badSeq+1 so will be accepted and will trigger a
+		// stream reset.
+		auto* packet4 = CreateRtpPacket(rtpBuffer4, 40004, 1000004);
+
+		// Create a RtpStreamSend instance.
+		TestRtpStreamListener testRtpStreamListener;
+
+		RtpStream::Params params1;
+
+		params1.ssrc          = 1111;
+		params1.clockRate     = 90000;
+		params1.useNack       = true;
+		params1.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
+
+		std::string mid;
+		auto* stream = new RtpStreamSend(&testRtpStreamListener, params1, mid);
+
+		SendRtpPacket({ { stream, params1.ssrc } }, packet1);
+		SendRtpPacket({ { stream, params1.ssrc } }, packet2);
+		SendRtpPacket({ { stream, params1.ssrc } }, packet3);
+		SendRtpPacket({ { stream, params1.ssrc } }, packet4);
+
+		// Create a NACK item that requests for packets 1 and 2.
+		RTCP::FeedbackRtpNackPacket nackPacket2(0, params1.ssrc);
+		auto* nackItem2 = new RTCP::FeedbackRtpNackItem(50001, 0b0000000000000001);
+
+		nackPacket2.AddItem(nackItem2);
+
+		// Process the NACK packet on stream1.
+		stream->ReceiveNack(&nackPacket2);
+
+		REQUIRE(testRtpStreamListener.retransmittedPackets.size() == 0);
 
 		delete stream;
 	}


### PR DESCRIPTION
Related to #1037

Make `RtpStreamRecv` and `RtpStreamSend` classes be notified by their `RtpStream` parent when the stream seq number is reset so they can react on it. In case of `RtpStreamSend` it clears the entire buffer retransmission since stored packets probably won't make any sense.