### PR TITLE
RTC Logger

### DIFF
--- a/worker/include/RTC/RtcLogger.hpp
+++ b/worker/include/RTC/RtcLogger.hpp
@@ -41,11 +41,11 @@ namespace RTC
 
 		public:
 			uint64_t timestamp;
-			std::string recvTransportId{ "undefined" };
-			std::string sendTransportId{ "undefined" };
-			std::string routerId{ "undefined" };
-			std::string producerId{ "undefined" };
-			std::string consumerId{ "undefined" };
+			std::string recvTransportId{};
+			std::string sendTransportId{};
+			std::string routerId{};
+			std::string producerId{};
+			std::string consumerId{};
 			uint32_t recvRtpTimestamp;
 			uint32_t sendRtpTimestamp;
 			uint16_t recvSeqNumber;

--- a/worker/include/RTC/RtcLogger.hpp
+++ b/worker/include/RTC/RtcLogger.hpp
@@ -1,0 +1,57 @@
+#ifndef MS_RTC_RTC_LOGGER_HPP
+#define MS_RTC_RTC_LOGGER_HPP
+
+#include "common.hpp"
+#include <absl/container/flat_hash_map.h>
+
+namespace RTC
+{
+	namespace RtcLogger
+	{
+		class RtpPacket
+		{
+		public:
+			enum class DropReason : uint8_t
+			{
+				NONE = 0,
+				PRODUCER_NOT_FOUND,
+				RECV_RTP_STREAM_NOT_FOUND,
+				RECV_RTP_STREAM_DISCARDED,
+				CONSUMER_INACTIVE,
+				INVALID_TARGET_LAYER,
+				UNSUPPORTED_PAYLOAD_TYPE,
+				NOT_A_KEYFRAME,
+				SPATIAL_LAYER_MISMATCH,
+				TOO_HIGH_TIMESTAMP_EXTRA_NEEDED,
+				PACKET_PREVIOUS_TO_SPATIAL_LAYER_SWITCH,
+				DROPPED_BY_CODEC,
+				SEND_RTP_STREAM_DISCARDED,
+			};
+
+			static absl::flat_hash_map<DropReason, std::string> dropReason2String;
+
+			RtpPacket()  = default;
+			~RtpPacket() = default;
+			void Sent();
+			void Dropped(DropReason dropReason);
+
+		private:
+			void Log() const;
+			void Clear();
+
+		public:
+			uint64_t timestamp;
+			std::string recvTransportId{ "undefined" };
+			std::string sendTransportId{ "undefined" };
+			std::string routerId{ "undefined" };
+			std::string producerId{ "undefined" };
+			std::string consumerId{ "undefined" };
+			uint32_t rtpTimestamp;
+			uint16_t recvSeqNumber;
+			uint16_t sendSeqNumber;
+			bool dropped;
+			DropReason dropReason{ DropReason::NONE };
+		};
+	}; // namespace RtcLogger
+} // namespace RTC
+#endif

--- a/worker/include/RTC/RtcLogger.hpp
+++ b/worker/include/RTC/RtcLogger.hpp
@@ -46,7 +46,8 @@ namespace RTC
 			std::string routerId{ "undefined" };
 			std::string producerId{ "undefined" };
 			std::string consumerId{ "undefined" };
-			uint32_t rtpTimestamp;
+			uint32_t recvRtpTimestamp;
+			uint32_t sendRtpTimestamp;
 			uint16_t recvSeqNumber;
 			uint16_t sendSeqNumber;
 			bool dropped;

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -4,6 +4,7 @@
 #include "common.hpp"
 #include "Utils.hpp"
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
+#include "RTC/RtcLogger.hpp"
 #include <absl/container/flat_hash_map.h>
 #include <array>
 #include <nlohmann/json.hpp>
@@ -605,6 +606,9 @@ namespace RTC
 		void RestorePayload();
 
 		void ShiftPayload(size_t payloadOffset, size_t shift, bool expand = true);
+
+	public:
+		RtcLogger::RtpPacket logger;
 
 	private:
 		void ParseExtensions();

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -38,6 +38,12 @@ if get_option('ms_log_file_line')
   ]
 endif
 
+if get_option('ms_rtc_logger_rtp')
+  cpp_args += [
+    '-DMS_RTC_LOGGER_RTP',
+  ]
+endif
+
 common_sources = [
   'src/lib.cpp',
   'src/DepLibSRTP.cpp',

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -85,6 +85,7 @@ common_sources = [
   'src/RTC/Producer.cpp',
   'src/RTC/RateCalculator.cpp',
   'src/RTC/Router.cpp',
+  'src/RTC/RtcLogger.cpp',
   'src/RTC/RtpListener.cpp',
   'src/RTC/RtpObserver.cpp',
   'src/RTC/RtpPacket.cpp',

--- a/worker/meson_options.txt
+++ b/worker/meson_options.txt
@@ -1,2 +1,3 @@
 option('ms_log_trace', type : 'boolean', value : false, description : 'When enabled, logs the current method/function if current log level is "debug"')
 option('ms_log_file_line', type : 'boolean', value : false, description : 'When enabled, all the logging macros print more verbose information, including current file and line')
+option('ms_rtc_logger_rtp', type : 'boolean', value : false, description : 'When enabled, prints a line with information for each RTP packet')

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -262,6 +262,7 @@ namespace RTC
 		packet->SetSsrc(ssrc);
 		packet->SetSequenceNumber(seq);
 
+		packet->logger.sendRtpTimestamp = packet->GetTimestamp();
 		packet->logger.sendSeqNumber = seq;
 
 		if (isSyncPacket)

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -202,7 +202,11 @@ namespace RTC
 		MS_TRACE();
 
 		if (!IsActive())
+		{
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);
+
 			return;
+		}
 
 		auto payloadType = packet->GetPayloadType();
 
@@ -211,6 +215,8 @@ namespace RTC
 		if (!this->supportedCodecPayloadTypes[payloadType])
 		{
 			MS_DEBUG_DEV("payload type not supported [payloadType:%" PRIu8 "]", payloadType);
+
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE);
 
 			return;
 		}
@@ -223,7 +229,11 @@ namespace RTC
 		// If we need to sync, support key frames and this is not a key frame, ignore
 		// the packet.
 		if (syncRequired && this->keyFrameSupported && !packet->IsKeyFrame())
+		{
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+
 			return;
+		}
 
 		// Whether this is the first packet after re-sync.
 		const bool isSyncPacket = syncRequired;
@@ -251,6 +261,8 @@ namespace RTC
 		// Rewrite packet.
 		packet->SetSsrc(ssrc);
 		packet->SetSequenceNumber(seq);
+
+		packet->logger.sendSeqNumber = seq;
 
 		if (isSyncPacket)
 		{

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -265,7 +265,7 @@ namespace RTC
 		packet->SetSequenceNumber(seq);
 
 		packet->logger.sendRtpTimestamp = packet->GetTimestamp();
-		packet->logger.sendSeqNumber = seq;
+		packet->logger.sendSeqNumber    = seq;
 
 		if (isSyncPacket)
 		{

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -201,6 +201,8 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		packet->logger.consumerId = this->id;
+
 		if (!IsActive())
 		{
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -672,6 +672,8 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		packet->logger.producerId = this->id;
+
 		// Reset current packet.
 		this->currentRtpPacket = nullptr;
 
@@ -683,6 +685,8 @@ namespace RTC
 		if (!rtpStream)
 		{
 			MS_WARN_TAG(rtp, "no stream found for received packet [ssrc:%" PRIu32 "]", packet->GetSsrc());
+
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::RECV_RTP_STREAM_NOT_FOUND);
 
 			return ReceiveRtpPacketResult::DISCARDED;
 		}
@@ -705,6 +709,8 @@ namespace RTC
 				if (this->mapSsrcRtpStream.size() > numRtpStreamsBefore)
 					NotifyNewRtpStream(rtpStream);
 
+				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::RECV_RTP_STREAM_DISCARDED);
+
 				return result;
 			}
 		}
@@ -716,7 +722,11 @@ namespace RTC
 
 			// Process the packet.
 			if (!rtpStream->ReceiveRtxPacket(packet))
+			{
+				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::RECV_RTP_STREAM_NOT_FOUND);
+
 				return result;
+			}
 		}
 		// Should not happen.
 		else

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -706,6 +706,8 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		packet->logger.routerId = this->id;
+
 		auto& consumers = this->mapProducerConsumers.at(producer);
 
 		if (!consumers.empty())

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -52,20 +52,37 @@ namespace RTC
 #ifdef MS_RTC_LOGGER_RTP
 			MS_TRACE();
 
-			std::cout << "{"
-			          << "timestamp: " << this->timestamp << ", recvTransportId: '"
-			          << this->recvTransportId << "'"
-			          << ", sendTransportId: '" << this->sendTransportId << "'"
-			          << ", routerId: '" << this->routerId << "'"
-			          << ", producerId: '" << this->producerId << "'"
-			          << ", consumerId: '" << this->consumerId << "'"
-			          << ", recvRtpTimestamp: " << this->recvRtpTimestamp
-			          << ", sendRtpTimestamp: " << this->sendRtpTimestamp
-			          << ", recvSeqNumber: " << this->recvSeqNumber
-			          << ", sendSeqNumber: " << this->sendSeqNumber
-			          << ", dropped: " << (this->dropped ? "true" : "false") << ", dropReason: '"
-			          << dropReason2String[this->dropReason] << "'"
-			          << "}" << std::endl;
+			std::cout << "{";
+			std::cout << "\"timestamp\": " << this->timestamp;
+
+			if (!this->recvTransportId.empty())
+			{
+				std::cout << ", \"recvTransportId\": \"" << this->recvTransportId << "\"";
+			}
+			if (!this->sendTransportId.empty())
+			{
+				std::cout << ", \"sendTransportId\": \"" << this->sendTransportId << "\"";
+			}
+			if (!this->routerId.empty())
+			{
+				std::cout << ", \"routerId\": \"" << this->routerId << "\"";
+			}
+			if (!this->producerId.empty())
+			{
+				std::cout << ", \"producerId\": \"" << this->producerId << "\"";
+			}
+			if (!this->consumerId.empty())
+			{
+				std::cout << ", \"consumerId\": \"" << this->consumerId << "\"";
+			}
+
+			std::cout << ", \"recvRtpTimestamp\": " << this->recvRtpTimestamp;
+			std::cout << ", \"sendRtpTimestamp\": " << this->sendRtpTimestamp;
+			std::cout << ", \"recvSeqNumber\": " << this->recvSeqNumber;
+			std::cout << ", \"sendSeqNumber\": " << this->sendSeqNumber;
+			std::cout << ", \"dropped\": " << (this->dropped ? "true" : "false");
+			std::cout << ", \"dropReason\": '" << dropReason2String[this->dropReason] << "'";
+			std::cout << "}" << std::endl;
 #endif
 		}
 

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -2,7 +2,6 @@
 // #define MS_LOG_DEV_LEVEL 3
 
 #include "RTC/RtcLogger.hpp"
-#include "Logger.hpp"
 
 namespace RTC
 {

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -30,6 +30,8 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			this->dropped = false;
+
 			Log();
 			Clear();
 		}

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -2,6 +2,7 @@
 // #define MS_LOG_DEV_LEVEL 3
 
 #include "RTC/RtcLogger.hpp"
+#include "Logger.hpp"
 
 namespace RTC
 {
@@ -27,12 +28,16 @@ namespace RTC
 
 		void RtpPacket::Sent()
 		{
+			MS_TRACE();
+
 			Log();
 			Clear();
 		}
 
 		void RtpPacket::Dropped(DropReason dropReason)
 		{
+			MS_TRACE();
+
 			this->dropped    = true;
 			this->dropReason = dropReason;
 
@@ -43,6 +48,8 @@ namespace RTC
 		void RtpPacket::Log() const
 		{
 #ifdef MS_RTC_LOGGER_RTP
+			MS_TRACE();
+
 			std::cout << "{"
 			          << "timestamp: " << this->timestamp << ", recvTransportId: '"
 			          << this->recvTransportId << "'"
@@ -62,6 +69,8 @@ namespace RTC
 
 		void RtpPacket::Clear()
 		{
+			MS_TRACE();
+
 			this->sendTransportId = "undefined";
 			this->routerId        = "undefined";
 			this->producerId      = "undefined";

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -1,0 +1,70 @@
+#define MS_CLASS "RTC::RtcLogger"
+// #define MS_LOG_DEV_LEVEL 3
+
+#include "RTC/RtcLogger.hpp"
+#include "Logger.hpp"
+
+namespace RTC
+{
+	namespace RtcLogger
+	{
+		absl::flat_hash_map<RtpPacket::DropReason, std::string> RtpPacket::dropReason2String = {
+			{ RtpPacket::DropReason::NONE, "None" },
+			{ RtpPacket::DropReason::PRODUCER_NOT_FOUND, "ProducerNotFound" },
+			{ RtpPacket::DropReason::RECV_RTP_STREAM_NOT_FOUND, "RecvRtpStreamNotFound" },
+			{ RtpPacket::DropReason::RECV_RTP_STREAM_DISCARDED, "RecvRtpStreamDiscarded" },
+			{ RtpPacket::DropReason::CONSUMER_INACTIVE, "ConsumerInactive" },
+			{ RtpPacket::DropReason::INVALID_TARGET_LAYER, "InvalidTargetLayer" },
+			{ RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE, "UnsupportedPayloadType" },
+			{ RtpPacket::DropReason::NOT_A_KEYFRAME, "NotAKeyframe" },
+			{ RtpPacket::DropReason::SPATIAL_LAYER_MISMATCH, "SpatialLayerMismatch" },
+			{ RtpPacket::DropReason::TOO_HIGH_TIMESTAMP_EXTRA_NEEDED, "TooHighTimestampExtraNeeded" },
+			{ RtpPacket::DropReason::PACKET_PREVIOUS_TO_SPATIAL_LAYER_SWITCH,
+			  "PacketPreviousToSpatialLayerSwitch" },
+			{ RtpPacket::DropReason::DROPPED_BY_CODEC, "DroppedByCodec" },
+			{ RtpPacket::DropReason::SEND_RTP_STREAM_DISCARDED, "SendRtpStreamDiscarded" },
+		};
+
+		void RtpPacket::Sent()
+		{
+			Log();
+			Clear();
+		}
+
+		void RtpPacket::Dropped(DropReason dropReason)
+		{
+			this->dropped    = true;
+			this->dropReason = dropReason;
+
+			Log();
+			Clear();
+		}
+
+		void RtpPacket::Log() const
+		{
+			std::cout << "{"
+			          << "timestamp: " << this->timestamp << ", recvTransportId: '"
+			          << this->recvTransportId << "'"
+			          << ", sendTransportId: '" << this->sendTransportId << "'"
+			          << ", routerId: '" << this->routerId << "'"
+			          << ", producerId: '" << this->producerId << "'"
+			          << ", consumerId: '" << this->consumerId << "'"
+			          << ", rtpTimestamp: " << this->rtpTimestamp
+			          << ", recvSeqNumber: " << this->recvSeqNumber
+			          << ", sendSeqNumber: " << this->sendSeqNumber
+			          << ", dropped: " << (this->dropped ? "true" : "false") << ", dropReason: '"
+			          << dropReason2String[this->dropReason] << "'"
+			          << "}" << std::endl;
+		}
+
+		void RtpPacket::Clear()
+		{
+			this->sendTransportId = "undefined";
+			this->routerId        = "undefined";
+			this->producerId      = "undefined";
+			this->sendSeqNumber   = { 0 };
+			this->dropped         = { false };
+			this->dropReason      = { DropReason::NONE };
+		}
+	} // namespace RtcLogger
+} // namespace RTC

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -51,7 +51,8 @@ namespace RTC
 			          << ", routerId: '" << this->routerId << "'"
 			          << ", producerId: '" << this->producerId << "'"
 			          << ", consumerId: '" << this->consumerId << "'"
-			          << ", rtpTimestamp: " << this->rtpTimestamp
+			          << ", recvRtpTimestamp: " << this->recvRtpTimestamp
+			          << ", sendRtpTimestamp: " << this->sendRtpTimestamp
 			          << ", recvSeqNumber: " << this->recvSeqNumber
 			          << ", sendSeqNumber: " << this->sendSeqNumber
 			          << ", dropped: " << (this->dropped ? "true" : "false") << ", dropReason: '"

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -90,9 +90,9 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			this->sendTransportId = "undefined";
-			this->routerId        = "undefined";
-			this->producerId      = "undefined";
+			this->sendTransportId = {};
+			this->routerId        = {};
+			this->producerId      = {};
 			this->sendSeqNumber   = { 0 };
 			this->dropped         = { false };
 			this->dropReason      = { DropReason::NONE };

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -8,22 +8,23 @@ namespace RTC
 {
 	namespace RtcLogger
 	{
+		// clang-format off
 		absl::flat_hash_map<RtpPacket::DropReason, std::string> RtpPacket::dropReason2String = {
-			{ RtpPacket::DropReason::NONE, "None" },
-			{ RtpPacket::DropReason::PRODUCER_NOT_FOUND, "ProducerNotFound" },
-			{ RtpPacket::DropReason::RECV_RTP_STREAM_NOT_FOUND, "RecvRtpStreamNotFound" },
-			{ RtpPacket::DropReason::RECV_RTP_STREAM_DISCARDED, "RecvRtpStreamDiscarded" },
-			{ RtpPacket::DropReason::CONSUMER_INACTIVE, "ConsumerInactive" },
-			{ RtpPacket::DropReason::INVALID_TARGET_LAYER, "InvalidTargetLayer" },
-			{ RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE, "UnsupportedPayloadType" },
-			{ RtpPacket::DropReason::NOT_A_KEYFRAME, "NotAKeyframe" },
-			{ RtpPacket::DropReason::SPATIAL_LAYER_MISMATCH, "SpatialLayerMismatch" },
-			{ RtpPacket::DropReason::TOO_HIGH_TIMESTAMP_EXTRA_NEEDED, "TooHighTimestampExtraNeeded" },
-			{ RtpPacket::DropReason::PACKET_PREVIOUS_TO_SPATIAL_LAYER_SWITCH,
-			  "PacketPreviousToSpatialLayerSwitch" },
-			{ RtpPacket::DropReason::DROPPED_BY_CODEC, "DroppedByCodec" },
-			{ RtpPacket::DropReason::SEND_RTP_STREAM_DISCARDED, "SendRtpStreamDiscarded" },
+			{ RtpPacket::DropReason::NONE,                                    "None"                               },
+			{ RtpPacket::DropReason::PRODUCER_NOT_FOUND,                      "ProducerNotFound"                   },
+			{ RtpPacket::DropReason::RECV_RTP_STREAM_NOT_FOUND,               "RecvRtpStreamNotFound"              },
+			{ RtpPacket::DropReason::RECV_RTP_STREAM_DISCARDED,               "RecvRtpStreamDiscarded"             },
+			{ RtpPacket::DropReason::CONSUMER_INACTIVE,                       "ConsumerInactive"                   },
+			{ RtpPacket::DropReason::INVALID_TARGET_LAYER,                    "InvalidTargetLayer"                 },
+			{ RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE,                "UnsupportedPayloadType"             },
+			{ RtpPacket::DropReason::NOT_A_KEYFRAME,                          "NotAKeyframe"                       },
+			{ RtpPacket::DropReason::SPATIAL_LAYER_MISMATCH,                  "SpatialLayerMismatch"               },
+			{ RtpPacket::DropReason::TOO_HIGH_TIMESTAMP_EXTRA_NEEDED,         "TooHighTimestampExtraNeeded"        },
+			{ RtpPacket::DropReason::PACKET_PREVIOUS_TO_SPATIAL_LAYER_SWITCH, "PacketPreviousToSpatialLayerSwitch" },
+			{ RtpPacket::DropReason::DROPPED_BY_CODEC,                        "DroppedByCodec"                     },
+			{ RtpPacket::DropReason::SEND_RTP_STREAM_DISCARDED,               "SendRtpStreamDiscarded"             },
 		};
+		// clang-format on
 
 		void RtpPacket::Sent()
 		{

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -43,6 +43,7 @@ namespace RTC
 
 		void RtpPacket::Log() const
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			std::cout << "{"
 			          << "timestamp: " << this->timestamp << ", recvTransportId: '"
 			          << this->recvTransportId << "'"
@@ -56,6 +57,7 @@ namespace RTC
 			          << ", dropped: " << (this->dropped ? "true" : "false") << ", dropReason: '"
 			          << dropReason2String[this->dropReason] << "'"
 			          << "}" << std::endl;
+#endif
 		}
 
 		void RtpPacket::Clear()

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -142,9 +142,9 @@ namespace RTC
 		ParseExtensions();
 
 		// Initialize logger.
-		this->logger.timestamp     = DepLibUV::GetTimeMs();
-		this->logger.recvRtpTimestamp  = this->GetTimestamp();
-		this->logger.recvSeqNumber = this->GetSequenceNumber();
+		this->logger.timestamp        = DepLibUV::GetTimeMs();
+		this->logger.recvRtpTimestamp = this->GetTimestamp();
+		this->logger.recvSeqNumber    = this->GetSequenceNumber();
 	}
 
 	RtpPacket::~RtpPacket()

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -141,10 +141,13 @@ namespace RTC
 		// Parse RFC 5285 header extension.
 		ParseExtensions();
 
+// Avoid retrieving the time if RTC logger is disabled.
+#ifdef MS_RTC_LOGGER_RTP
 		// Initialize logger.
 		this->logger.timestamp        = DepLibUV::GetTimeMs();
 		this->logger.recvRtpTimestamp = this->GetTimestamp();
 		this->logger.recvSeqNumber    = this->GetSequenceNumber();
+#endif
 	}
 
 	RtpPacket::~RtpPacket()

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -2,6 +2,7 @@
 // #define MS_LOG_DEV_LEVEL 3
 
 #include "RTC/RtpPacket.hpp"
+#include "DepLibUV.hpp"
 #include "Logger.hpp"
 #include <cstring>  // std::memcpy(), std::memmove(), std::memset()
 #include <iterator> // std::ostream_iterator
@@ -139,6 +140,11 @@ namespace RTC
 
 		// Parse RFC 5285 header extension.
 		ParseExtensions();
+
+		// Initialize logger.
+		this->logger.timestamp     = DepLibUV::GetTimeMs();
+		this->logger.rtpTimestamp  = this->GetTimestamp();
+		this->logger.recvSeqNumber = this->GetSequenceNumber();
 	}
 
 	RtpPacket::~RtpPacket()

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -143,7 +143,7 @@ namespace RTC
 
 		// Initialize logger.
 		this->logger.timestamp     = DepLibUV::GetTimeMs();
-		this->logger.rtpTimestamp  = this->GetTimestamp();
+		this->logger.recvRtpTimestamp  = this->GetTimestamp();
 		this->logger.recvSeqNumber = this->GetSequenceNumber();
 	}
 

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -342,7 +342,7 @@ namespace RTC
 		packet->SetSequenceNumber(seq);
 
 		packet->logger.sendRtpTimestamp = packet->GetTimestamp();
-		packet->logger.sendSeqNumber = seq;
+		packet->logger.sendSeqNumber    = seq;
 
 		if (isSyncPacket)
 		{

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -265,8 +265,14 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		packet->logger.consumerId = this->id;
+
 		if (!IsActive())
+		{
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);
+
 			return;
+		}
 
 		auto payloadType = packet->GetPayloadType();
 
@@ -275,6 +281,8 @@ namespace RTC
 		if (!this->supportedCodecPayloadTypes[payloadType])
 		{
 			MS_DEBUG_DEV("payload type not supported [payloadType:%" PRIu8 "]", payloadType);
+
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE);
 
 			return;
 		}
@@ -292,13 +300,19 @@ namespace RTC
 
 			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::DROPPED_BY_CODEC);
+
 			return;
 		}
 
 		// If we need to sync, support key frames and this is not a key frame, ignore
 		// the packet.
 		if (this->syncRequired && this->keyFrameSupported && !packet->IsKeyFrame())
+		{
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+
 			return;
+		}
 
 		// Whether this is the first packet after re-sync.
 		const bool isSyncPacket = this->syncRequired;
@@ -326,6 +340,8 @@ namespace RTC
 		// Rewrite packet.
 		packet->SetSsrc(this->rtpParameters.encodings[0].ssrc);
 		packet->SetSequenceNumber(seq);
+
+		packet->logger.sendSeqNumber = seq;
 
 		if (isSyncPacket)
 		{

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -341,6 +341,7 @@ namespace RTC
 		packet->SetSsrc(this->rtpParameters.encodings[0].ssrc);
 		packet->SetSequenceNumber(seq);
 
+		packet->logger.sendRtpTimestamp = packet->GetTimestamp();
 		packet->logger.sendSeqNumber = seq;
 
 		if (isSyncPacket)

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -950,6 +950,7 @@ namespace RTC
 		packet->SetSequenceNumber(seq);
 		packet->SetTimestamp(timestamp);
 
+		packet->logger.sendRtpTimestamp = timestamp;
 		packet->logger.sendSeqNumber = seq;
 
 		if (isSyncPacket)

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -951,7 +951,7 @@ namespace RTC
 		packet->SetTimestamp(timestamp);
 
 		packet->logger.sendRtpTimestamp = timestamp;
-		packet->logger.sendSeqNumber = seq;
+		packet->logger.sendSeqNumber    = seq;
 
 		if (isSyncPacket)
 		{

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -664,11 +664,21 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		packet->logger.consumerId = this->id;
+
 		if (!IsActive())
+		{
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);
+
 			return;
+		}
 
 		if (this->targetTemporalLayer == -1)
+		{
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::INVALID_TARGET_LAYER);
+
 			return;
+		}
 
 		auto payloadType = packet->GetPayloadType();
 
@@ -677,6 +687,8 @@ namespace RTC
 		if (!this->supportedCodecPayloadTypes[payloadType])
 		{
 			MS_DEBUG_DEV("payload type not supported [payloadType:%" PRIu8 "]", payloadType);
+
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE);
 
 			return;
 		}
@@ -690,7 +702,11 @@ namespace RTC
 		{
 			// Ignore if not a key frame.
 			if (!packet->IsKeyFrame())
+			{
+				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+
 				return;
+			}
 
 			shouldSwitchCurrentSpatialLayer = true;
 
@@ -702,12 +718,18 @@ namespace RTC
 		// drop it.
 		else if (spatialLayer != this->currentSpatialLayer)
 		{
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::SPATIAL_LAYER_MISMATCH);
+
 			return;
 		}
 
 		// If we need to sync and this is not a key frame, ignore the packet.
 		if (this->syncRequired && !packet->IsKeyFrame())
+		{
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+
 			return;
+		}
 
 		// Whether this is the first packet after re-sync.
 		const bool isSyncPacket = this->syncRequired;
@@ -814,6 +836,8 @@ namespace RTC
 					this->syncRequired       = false;
 					this->spatialLayerToSync = -1;
 
+					packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::TOO_HIGH_TIMESTAMP_EXTRA_NEEDED);
+
 					return;
 				}
 
@@ -854,6 +878,9 @@ namespace RTC
 			if (SeqManager<uint16_t>::IsSeqLowerThan(
 			      packet->GetSequenceNumber(), this->snReferenceSpatialLayer))
 			{
+				packet->logger.Dropped(
+				  RtcLogger::RtpPacket::DropReason::PACKET_PREVIOUS_TO_SPATIAL_LAYER_SWITCH);
+
 				return;
 			}
 			else if (SeqManager<uint16_t>::IsSeqHigherThan(
@@ -898,6 +925,8 @@ namespace RTC
 			{
 				this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
+				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::DROPPED_BY_CODEC);
+
 				return;
 			}
 
@@ -920,6 +949,8 @@ namespace RTC
 		packet->SetSsrc(this->rtpParameters.encodings[0].ssrc);
 		packet->SetSequenceNumber(seq);
 		packet->SetTimestamp(timestamp);
+
+		packet->logger.sendSeqNumber = seq;
 
 		if (isSyncPacket)
 		{
@@ -959,6 +990,8 @@ namespace RTC
 			  origSsrc,
 			  origSeq,
 			  origTimestamp);
+
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::SEND_RTP_STREAM_DISCARDED);
 		}
 
 		// Restore packet fields.

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -690,7 +690,7 @@ namespace RTC
 		packet->SetSequenceNumber(seq);
 
 		packet->logger.sendRtpTimestamp = packet->GetTimestamp();
-		packet->logger.sendSeqNumber = seq;
+		packet->logger.sendSeqNumber    = seq;
 
 		if (marker)
 		{

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -687,6 +687,7 @@ namespace RTC
 		packet->SetSsrc(this->rtpParameters.encodings[0].ssrc);
 		packet->SetSequenceNumber(seq);
 
+		packet->logger.sendRtpTimestamp = packet->GetTimestamp();
 		packet->logger.sendSeqNumber = seq;
 
 		if (marker)

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -594,7 +594,11 @@ namespace RTC
 		MS_TRACE();
 
 		if (!IsActive())
+		{
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);
+
 			return;
+		}
 
 		// clang-format off
 		if (
@@ -603,6 +607,8 @@ namespace RTC
 		)
 		// clang-format on
 		{
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::INVALID_TARGET_LAYER);
+
 			return;
 		}
 
@@ -614,12 +620,18 @@ namespace RTC
 		{
 			MS_DEBUG_DEV("payload type not supported [payloadType:%" PRIu8 "]", payloadType);
 
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE);
+
 			return;
 		}
 
 		// If we need to sync and this is not a key frame, ignore the packet.
 		if (this->syncRequired && !packet->IsKeyFrame())
+		{
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+
 			return;
+		}
 
 		// Whether this is the first packet after re-sync.
 		const bool isSyncPacket = this->syncRequired;
@@ -645,6 +657,8 @@ namespace RTC
 		if (!packet->ProcessPayload(this->encodingContext.get(), marker))
 		{
 			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
+
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::DROPPED_BY_CODEC);
 
 			return;
 		}
@@ -672,6 +686,8 @@ namespace RTC
 		// Rewrite packet.
 		packet->SetSsrc(this->rtpParameters.encodings[0].ssrc);
 		packet->SetSequenceNumber(seq);
+
+		packet->logger.sendSeqNumber = seq;
 
 		if (marker)
 		{

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -593,6 +593,8 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		packet->logger.consumerId = this->id;
+
 		if (!IsActive())
 		{
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1692,6 +1692,8 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		packet->logger.recvTransportId = this->id;
+
 		// Apply the Transport RTP header extension ids so the RTP listener can use them.
 		packet->SetMidExtensionId(this->recvRtpHeaderExtensionIds.mid);
 		packet->SetRidExtensionId(this->recvRtpHeaderExtensionIds.rid);
@@ -1712,6 +1714,8 @@ namespace RTC
 
 		if (!producer)
 		{
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::PRODUCER_NOT_FOUND);
+
 			MS_WARN_TAG(
 			  rtp,
 			  "no suitable Producer for received RTP packet [ssrc:%" PRIu32 ", payloadType:%" PRIu8 "]",
@@ -2662,6 +2666,9 @@ namespace RTC
 	inline void Transport::OnConsumerSendRtpPacket(RTC::Consumer* consumer, RTC::RtpPacket* packet)
 	{
 		MS_TRACE();
+
+		packet->logger.sendTransportId = this->id;
+		packet->logger.Sent();
 
 		// Update abs-send-time if present.
 		packet->UpdateAbsSendTime(DepLibUV::GetTimeMs());

--- a/worker/src/handles/UnixStreamSocket.cpp
+++ b/worker/src/handles/UnixStreamSocket.cpp
@@ -81,7 +81,6 @@ UnixStreamSocket::UnixStreamSocket(int fd, size_t bufferSize, UnixStreamSocket::
 		MS_THROW_ERROR_STD("uv_pipe_init() failed: %s", uv_strerror(err));
 	}
 
-	std::cout << "file descriptor: " << +fd << std::endl;
 	err = uv_pipe_open(this->uvHandle, fd);
 
 	if (err != 0)

--- a/worker/src/handles/UnixStreamSocket.cpp
+++ b/worker/src/handles/UnixStreamSocket.cpp
@@ -81,6 +81,7 @@ UnixStreamSocket::UnixStreamSocket(int fd, size_t bufferSize, UnixStreamSocket::
 		MS_THROW_ERROR_STD("uv_pipe_init() failed: %s", uv_strerror(err));
 	}
 
+	std::cout << "file descriptor: " << +fd << std::endl;
 	err = uv_pipe_open(this->uvHandle, fd);
 
 	if (err != 0)


### PR DESCRIPTION
The idea is having a way to see the lifetime of each RTP packet in a single entry (ie: log line). How it arrived (seq num, timestamp, etc) and how it left mediasoup. If it didn't leave, it shows the reason.

Router, Producer, Consumer, Transport IDs are present in each record for a reason.

This initial implementation is purely internal and just logs to stdout the info. A future work would send this via unix socket using flatbuffers which would allow processing the data at application level.

For convenience and readability I have not surrounded every call to the logger with `MS_RTC_LOGGER_RTP`, but the code that prints out the line. I can do it though if preferred.

Initially I thought `RtcLogger` could be a logger for more than RTP but at the moment I think this serves for RTP only at least for now.  Having said this, I could add the definition of the logger and the implementation in the corresponding `RtpPacket.[hpp|cpp]` files. Thoughts @ibc?


```txt
  mediasoup:Worker (stdout) {timestamp: 601293210, recvTransportId: 'a9d0c20c-3f2a-42fd-acce-cd1b519fcac5', sendTransportId: 'undefined', routerId: 'a86746e5-8b72-42cc-9834-1617c6276586', producerId: 'f82380e9-f8e9-4a15-9aa3-676327376623', consumerId: 'ba16321a-1544-4ebf-ac70-3926633f8621', recvRtpTimestamp: 2583604420, sendRtpTimestamp: 0, recvSeqNumber: 9168, sendSeqNumber: 0, dropped: true, dropReason: 'SpatialLayerMismatch'} +0ms
  mediasoup:Worker (stdout) {timestamp: 601293210, recvTransportId: 'a9d0c20c-3f2a-42fd-acce-cd1b519fcac5', sendTransportId: 'undefined', routerId: 'a86746e5-8b72-42cc-9834-1617c6276586', producerId: 'f82380e9-f8e9-4a15-9aa3-676327376623', consumerId: 'ba16321a-1544-4ebf-ac70-3926633f8621', recvRtpTimestamp: 3197226919, sendRtpTimestamp: 0, recvSeqNumber: 5030, sendSeqNumber: 0, dropped: true, dropReason: 'SpatialLayerMismatch'} +0ms
  mediasoup:Worker (stdout) {timestamp: 601293226, recvTransportId: '8b7b112b-c7ca-432c-b8eb-cb2d95ffdf76', sendTransportId: '11e55319-7c14-4f9c-a188-6fb70c4ee5a6', routerId: 'a86746e5-8b72-42cc-9834-1617c6276586', producerId: '416d422c-d1c0-4988-a6e1-939776a92762', consumerId: '489eed52-208a-4fe5-b369-445f42cd99b9', recvRtpTimestamp: 2356655251, sendRtpTimestamp: 0, recvSeqNumber: 12899, sendSeqNumber: 315, dropped: false, dropReason: 'None'} +15ms
  mediasoup:Worker (stdout) {timestamp: 601293226, recvTransportId: 'a9d0c20c-3f2a-42fd-acce-cd1b519fcac5', sendTransportId: 'bfcc1c8b-5950-4539-898e-bd5df834e672', routerId: 'a86746e5-8b72-42cc-9834-1617c6276586', producerId: 'a8501f8f-f5a9-4c56-9761-ab16a9b1b1d1', consumerId: 'e7dede0b-69a4-4d3a-a8ee-5b850e219254', recvRtpTimestamp: 529869993, sendRtpTimestamp: 0, recvSeqNumber: 12436, sendSeqNumber: 313, dropped: false, dropReason: 'None'} +0ms
```

NOTE: Yes, currently logs are printed to stdout using `std::cout`. I know this is not done anywhere like this. It's intentional. Not written in stone though.