### PR TITLE
Fix check division by zero in transport congestion control

### DIFF
--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -220,8 +220,12 @@ namespace RTC
 		{
 			if (!result.received)
 				lost_packets += 1;
+		}	
+		
+		if (expected_packets > 0)
+		{
+			this->UpdatePacketLoss(static_cast<double>(lost_packets) / expected_packets);
 		}
-		this->UpdatePacketLoss(static_cast<double>(lost_packets) / expected_packets);
 
 		if (this->rtpTransportControllerSend == nullptr)
 		{

--- a/worker/src/RTC/TransportCongestionControlServer.cpp
+++ b/worker/src/RTC/TransportCongestionControlServer.cpp
@@ -240,7 +240,10 @@ namespace RTC
 				lost_packets += 1;
 		}
 
-		this->UpdatePacketLoss(static_cast<double>(lost_packets) / expected_packets);
+		if (expected_packets > 0)
+		{
+			this->UpdatePacketLoss(static_cast<double>(lost_packets) / expected_packets);
+		}
 
 		// Create a new feedback packet.
 		this->transportCcFeedbackPacket.reset(new RTC::RTCP::FeedbackRtpTransportPacket(


### PR DESCRIPTION
Add check for expected packets in case an empty TransportFeedback RTCP packet is sent or received with 0 packet statuses.  