### PR TITLE
SeqManager: Properly remove dropped entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* `SeqManager`: Properly remove old dropped entries ([PR #1054](https://github.com/versatica/mediasoup/pull/1054)).
+
+
 ### 3.11.21
 
 * Fix check division by zero in transport congestion control ([PR #1049](https://github.com/versatica/mediasoup/pull/1049) by @ggarber).

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -71,7 +71,7 @@ namespace RTC
 		// There are dropped inputs. Synchronize.
 		if (!this->dropped.empty())
 		{
-			// Set maxInput here if needed before calling ClearDropped.
+			// Set maxInput here if needed before calling ClearDropped().
 			if (this->started && IsSeqHigherThan(input, this->maxInput))
 			{
 				this->maxInput = input;

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -160,9 +160,7 @@ namespace RTC
 
 		const size_t previousDroppedSize = this->dropped.size();
 
-		auto it = this->dropped.begin();
-
-		for (; it != this->dropped.end();)
+		for (auto it = this->dropped.begin(); it != this->dropped.end();)
 		{
 			auto value = *it;
 

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -90,10 +90,7 @@ namespace RTC
 			// Dropped entries count that must be considered for the output.
 			size_t count{ 0 };
 
-			/*
-			 * Consider values lower than input and those higher that input
-			 * which belong to a previous cycle.
-			 */
+			// Consider values lower than input.
 			for (const auto& value : this->dropped)
 			{
 				if (IsSeqLowerThan(value, input))
@@ -116,15 +113,13 @@ namespace RTC
 		}
 		else
 		{
-			// New input is higher than the maximum seen. But less than acceptable units higher.
-			// Keep it as the maximum seen. See Drop().
+			// New input is higher than the maximum seen.
 			if (IsSeqHigherThan(input, this->maxInput))
 			{
 				this->maxInput = input;
 			}
 
-			// New output is higher than the maximum seen. But less than acceptable units higher.
-			// Keep it as the maximum seen. See Sync().
+			// New output is higher than the maximum seen.
 			if (IsSeqHigherThan(output, this->maxOutput))
 			{
 				this->maxOutput = output;
@@ -147,7 +142,7 @@ namespace RTC
 	}
 
 	/*
-	 * Delete droped inputs greater than maxInput that belong to a previous
+	 * Delete droped inputs greater than maxInput, which belong to a previous
 	 * cycle.
 	 */
 	template<typename T, uint8_t N>

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -58,6 +58,7 @@ namespace RTC
 		// Mark as dropped if 'input' is higher than anyone already processed.
 		if (SeqManager<T, N>::IsSeqHigherThan(input, this->maxInput))
 		{
+			this->maxInput = input;
 			this->dropped.insert(input);
 		}
 	}

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -666,11 +666,11 @@ SCENARIO("SeqManager", "[rtc][SeqMananger]")
 			{ 50886,     0, false, true  }, // Drop.
 			{  4806,  4805, false, false }, // Previously dropped.
 			{ 50774,     0, false, true  }, // Drop.
-			{ 50886, 50884, false, false }, // Previously dropped.
+			{ 50886,  4805, false, false }, // Previously dropped.
 			{ 22136,     0, false, true  }, // Drop.
-			{ 50774, 50884, false, false }, // Previously dropped.
+			{ 50774, 50773, false, false },
 			{ 30910,     0, false, true  }, // Drop.
-			{ 22136, 22135, false, false },
+			{ 22136, 50773, false, false }, // Previously dropped.
 			{ 48862,     0, false, true  }, // Drop.
 			{ 30910, 30909, false, false },
 			{ 56832,     0, false, true  }, // Drop.
@@ -695,9 +695,9 @@ SCENARIO("SeqManager", "[rtc][SeqMananger]")
 			{  3328,     0, false, true  }, // Drop.
 			{ 24589, 24588, false, false },
 			{   120,     0, false, true  }, // Drop.
-			{  3328,  3326, false, false },
+			{  3328, 24588, false, false }, // Previously dropped.
 			{ 30848,     0, false, true  }, // Drop.
-			{   120,  3326, false, false }, // Previously dropped.
+			{   120,   120, false, false },
 		};
 		// clang-format on
 
@@ -714,11 +714,11 @@ SCENARIO("SeqManager", "[rtc][SeqMananger]")
 			{ 65396 ,    0, false, true  }, // Drop.
 			{ 25855, 25854, false, false },
 			{ 29793 ,    0, false, true  }, // Drop.
-			{ 65396, 65395, false, false },
+			{ 65396, 25854, false, false }, // Previously dropped.
 			{ 25087,    0,  false, true  }, // Drop.
-			{ 29793, 29791, false, false },
+			{ 29793, 25854, false, false }, // Previously dropped.
 			{ 65535 ,    0, false, true  }, // Drop.
-			{ 25087, 29791, false, false }, // Previously dropped.
+			{ 25087, 25086, false, false },
 		};
 		// clang-format on
 

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -670,15 +670,15 @@ SCENARIO("SeqManager", "[rtc][SeqMananger]")
 			{ 22136,     0, false, true  }, // Drop.
 			{ 50774, 50884, false, false }, // Previously dropped.
 			{ 30910,     0, false, true  }, // Drop.
-			{ 22136, 22134, false, false },
+			{ 22136, 22135, false, false },
 			{ 48862,     0, false, true  }, // Drop.
 			{ 30910, 30909, false, false },
 			{ 56832,     0, false, true  }, // Drop.
 			{ 48862, 48861, false, false },
 			{     2,     0, false, true  }, // Drop.
-			{ 56832, 56828, false, false },
+			{ 56832, 48861, false, false }, // Previously dropped.
 			{   530,     0, false, true  }, // Drop.
-			{     2, 65534, false, false },
+			{     2, 48861, false, false }, // Previously dropped.
 		};
 		// clang-format on
 


### PR DESCRIPTION
Fixes #1037.

Keep dropped entries clean by removing those higher than this->maxInput.

This cleans both the `Insert()` and `ClearDropped()` methods. We remove those dropped entries which are from a previous sequence iteration.


STR with mediasoup-demo with single host:

Tab 1: roomId=loss&forceVP9=true&consume=false
Tab 2: roomId=loss&forceVP9=true&produce=false

In tab 2, select the preferred layers (0,0). Many packets are discarded by the codec

It takes few minutes until the seq number wraps ups. Wait for 1 or two wraps up. Vide in Tab 2 should be OK.