### PR TITLE
Implement fake timers for unit tests

### DIFF
--- a/worker/deps/libwebrtc/libwebrtc/call/rtp_transport_controller_send.cc
+++ b/worker/deps/libwebrtc/libwebrtc/call/rtp_transport_controller_send.cc
@@ -19,7 +19,7 @@
 #include "system_wrappers/source/field_trial.h"
 #include "modules/congestion_controller/goog_cc/goog_cc_network_control.h"
 
-#include "DepLibUV.hpp"
+#include "handles/Timer.hpp"
 #include "Logger.hpp"
 #include "RTC/RTCP/FeedbackRtpTransport.hpp"
 
@@ -36,7 +36,7 @@ TargetRateConstraints ConvertConstraints(int min_bitrate_bps,
                                          int max_bitrate_bps,
                                          int start_bitrate_bps) {
   TargetRateConstraints msg;
-  msg.at_time = Timestamp::ms(DepLibUV::GetTimeMsInt64());
+  msg.at_time = Timestamp::ms(GetTimeMsInt64());
   msg.min_data_rate =
       min_bitrate_bps >= 0 ? DataRate::bps(min_bitrate_bps) : DataRate::Zero();
   msg.max_data_rate = max_bitrate_bps > 0 ? DataRate::bps(max_bitrate_bps)
@@ -63,7 +63,7 @@ RtpTransportControllerSend::RtpTransportControllerSend(
       observer_(nullptr),
       controller_factory_override_(controller_factory),
       process_interval_(controller_factory_override_->GetProcessInterval()),
-      last_report_block_time_(Timestamp::ms(DepLibUV::GetTimeMsInt64())),
+      last_report_block_time_(Timestamp::ms(GetTimeMsInt64())),
       send_side_bwe_with_overhead_(
           webrtc::field_trial::IsEnabled("WebRTC-SendSideBwe-WithOverhead")),
       transport_overhead_bytes_per_packet_(0),
@@ -147,7 +147,7 @@ void RtpTransportControllerSend::OnNetworkAvailability(bool network_available) {
   MS_DEBUG_DEV("<<<<< network_available:%s", network_available ? "true" : "false");
 
   NetworkAvailability msg;
-  msg.at_time = Timestamp::ms(DepLibUV::GetTimeMsInt64());
+  msg.at_time = Timestamp::ms(GetTimeMsInt64());
   msg.network_available = network_available;
 
   if (network_available_ == msg.network_available)
@@ -200,7 +200,7 @@ void RtpTransportControllerSend::OnReceivedEstimatedBitrate(uint32_t bitrate) {
   MS_DEBUG_DEV("<<<<< bitrate:%zu", bitrate);
 
   RemoteBitrateReport msg;
-  msg.receive_time = Timestamp::ms(DepLibUV::GetTimeMsInt64());
+  msg.receive_time = Timestamp::ms(GetTimeMsInt64());
   msg.bandwidth = DataRate::bps(bitrate);
 
   PostUpdates(controller_->OnRemoteBitrateReport(msg));
@@ -228,7 +228,7 @@ void RtpTransportControllerSend::OnAddPacket(
       packet_info,
       send_side_bwe_with_overhead_ ? transport_overhead_bytes_per_packet_.load()
                                    : 0,
-      Timestamp::ms(DepLibUV::GetTimeMsInt64()));
+      Timestamp::ms(GetTimeMsInt64()));
 }
 
 void RtpTransportControllerSend::OnTransportFeedback(
@@ -237,7 +237,7 @@ void RtpTransportControllerSend::OnTransportFeedback(
 
   absl::optional<TransportPacketsFeedback> feedback_msg =
       transport_feedback_adapter_.ProcessTransportFeedback(
-          feedback, Timestamp::ms(DepLibUV::GetTimeMsInt64()));
+          feedback, Timestamp::ms(GetTimeMsInt64()));
   if (feedback_msg)
     PostUpdates(controller_->OnTransportPacketsFeedback(*feedback_msg));
   pacer_.UpdateOutstandingData(
@@ -246,7 +246,7 @@ void RtpTransportControllerSend::OnTransportFeedback(
 
 void RtpTransportControllerSend::OnRemoteNetworkEstimate(
     NetworkStateEstimate estimate) {
-  estimate.update_time = Timestamp::ms(DepLibUV::GetTimeMsInt64());
+  estimate.update_time = Timestamp::ms(GetTimeMsInt64());
   controller_->OnNetworkStateEstimate(estimate);
 }
 
@@ -268,7 +268,7 @@ void RtpTransportControllerSend::MaybeCreateControllers() {
   control_handler_ = absl::make_unique<CongestionControlHandler>();
 
   initial_config_.constraints.at_time =
-      Timestamp::ms(DepLibUV::GetTimeMsInt64());
+      Timestamp::ms(GetTimeMsInt64());
 
   controller_ = controller_factory_override_->Create(initial_config_);
   process_interval_ = controller_factory_override_->GetProcessInterval();
@@ -283,7 +283,7 @@ void RtpTransportControllerSend::UpdateControllerWithTimeInterval() {
   MS_ASSERT(controller_, "controller not set");
 
   ProcessInterval msg;
-  msg.at_time = Timestamp::ms(DepLibUV::GetTimeMsInt64());
+  msg.at_time = Timestamp::ms(GetTimeMsInt64());
 
   PostUpdates(controller_->OnProcessInterval(msg));
 }
@@ -291,7 +291,7 @@ void RtpTransportControllerSend::UpdateControllerWithTimeInterval() {
 void RtpTransportControllerSend::UpdateStreamsConfig() {
   MS_DEBUG_DEV("<<<<<");
 
-  streams_config_.at_time = Timestamp::ms(DepLibUV::GetTimeMsInt64());
+  streams_config_.at_time = Timestamp::ms(GetTimeMsInt64());
   if (controller_)
     PostUpdates(controller_->OnStreamsConfig(streams_config_));
 }

--- a/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/alr_detector.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/congestion_controller/goog_cc/alr_detector.cc
@@ -14,7 +14,7 @@
 #include "modules/congestion_controller/goog_cc/alr_detector.h"
 #include "rtc_base/numerics/safe_conversions.h"
 
-#include "DepLibUV.hpp"
+#include "handles/Timer.hpp"
 #include "Logger.hpp"
 
 #include <absl/memory/memory.h>
@@ -85,7 +85,7 @@ void AlrDetector::OnBytesSent(size_t bytes_sent, int64_t send_time_ms) {
   bool state_changed = false;
   if (alr_budget_.budget_ratio() > start_budget_level_ratio_ &&
       !alr_started_time_ms_) {
-    alr_started_time_ms_.emplace(DepLibUV::GetTimeMsInt64());
+    alr_started_time_ms_.emplace(GetTimeMsInt64());
     state_changed = true;
   } else if (alr_budget_.budget_ratio() < stop_budget_level_ratio_ &&
              alr_started_time_ms_) {

--- a/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.cc
@@ -17,7 +17,7 @@
 #include "rtc_base/constructor_magic.h"
 
 #include "Logger.hpp"
-#include "DepLibUV.hpp"
+#include "handles/Timer.hpp"
 
 #include <math.h>
 #include <algorithm>
@@ -251,7 +251,7 @@ void RemoteBitrateEstimatorAbsSendTime::IncomingPacketInfo(
   uint32_t timestamp = send_time_24bits << kAbsSendTimeInterArrivalUpshift;
   int64_t send_time_ms = static_cast<int64_t>(timestamp) * kTimestampToMs;
 
-  int64_t now_ms = DepLibUV::GetTimeMsInt64();
+  int64_t now_ms = GetTimeMsInt64();
   // TODO(holmer): SSRCs are only needed for REMB, should be broken out from
   // here.
 

--- a/worker/include/RTC/RateCalculator.hpp
+++ b/worker/include/RTC/RateCalculator.hpp
@@ -2,7 +2,6 @@
 #define MS_RTC_RATE_CALCULATOR_HPP
 
 #include "common.hpp"
-#include "DepLibUV.hpp"
 #include "RTC/RtpPacket.hpp"
 
 namespace RTC

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -334,6 +334,7 @@ mediasoup_worker_test = executable(
   cpp_args: cpp_args + [
     '-DMS_LOG_STD',
     '-DMS_TEST',
+    '-DFAKE_TIMERS',
   ],
 )
 

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -3,6 +3,7 @@
 
 #include "RTC/RateCalculator.hpp"
 #include "Logger.hpp"
+#include "handles/Timer.hpp"
 #include <cmath> // std::trunc()
 
 namespace RTC
@@ -116,7 +117,7 @@ namespace RTC
 
 	void RtpDataCounter::Update(RTC::RtpPacket* packet)
 	{
-		const uint64_t nowMs = DepLibUV::GetTimeMs();
+		const uint64_t nowMs = GetTimeMs();
 
 		this->packets++;
 		this->rate.Update(packet->GetSize(), nowMs);

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -3,7 +3,6 @@
 #define USE_TREND_CALCULATOR
 
 #include "RTC/TransportCongestionControlClient.hpp"
-#include "DepLibUV.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include <libwebrtc/api/transport/network_types.h> // webrtc::TargetRateConstraints
@@ -114,7 +113,7 @@ namespace RTC
 		MS_TRACE();
 
 #ifdef USE_TREND_CALCULATOR
-		auto nowMs = DepLibUV::GetTimeMsInt64();
+		auto nowMs = GetTimeMsInt64();
 #endif
 
 		this->bitrates.desiredBitrate          = 0u;
@@ -306,7 +305,7 @@ namespace RTC
 		MS_TRACE();
 
 #ifdef USE_TREND_CALCULATOR
-		auto nowMs = DepLibUV::GetTimeMsInt64();
+		auto nowMs = GetTimeMsInt64();
 #endif
 
 		// Manage it via trending and increase it a bit to avoid immediate oscillations.
@@ -408,7 +407,7 @@ namespace RTC
 
 		webrtc::TargetRateConstraints constraints;
 
-		constraints.at_time       = webrtc::Timestamp::ms(DepLibUV::GetTimeMs());
+		constraints.at_time       = webrtc::Timestamp::ms(GetTimeMs());
 		constraints.min_data_rate = webrtc::DataRate::bps(this->bitrates.minBitrate);
 		constraints.max_data_rate = webrtc::DataRate::bps(this->bitrates.maxBitrate);
 		constraints.starting_rate = webrtc::DataRate::bps(this->bitrates.startBitrate);
@@ -434,14 +433,14 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		this->lastAvailableBitrateEventAtMs = DepLibUV::GetTimeMs();
+		this->lastAvailableBitrateEventAtMs = GetTimeMs();
 	}
 
 	void TransportCongestionControlClient::MayEmitAvailableBitrateEvent(uint32_t previousAvailableBitrate)
 	{
 		MS_TRACE();
 
-		const uint64_t nowMs = DepLibUV::GetTimeMsInt64();
+		const uint64_t nowMs = GetTimeMsInt64();
 		bool notify{ false };
 
 		// Ignore if first event.

--- a/worker/src/RTC/TransportCongestionControlServer.cpp
+++ b/worker/src/RTC/TransportCongestionControlServer.cpp
@@ -2,7 +2,6 @@
 // #define MS_LOG_DEV_LEVEL 3
 
 #include "RTC/TransportCongestionControlServer.hpp"
-#include "DepLibUV.hpp"
 #include "Logger.hpp"
 #include "RTC/RTCP/FeedbackPsRemb.hpp"
 #include <iterator> // std::ostream_iterator
@@ -275,7 +274,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		auto nowMs = DepLibUV::GetTimeMs();
+		auto nowMs = GetTimeMs();
 
 		// May fix unlimitedRembCounter.
 		if (this->unlimitedRembCounter > 0u && this->maxIncomingBitrate != 0u)

--- a/worker/src/handles/Timer.cpp
+++ b/worker/src/handles/Timer.cpp
@@ -6,6 +6,181 @@
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 
+#ifdef FAKE_TIMERS
+
+#include <map>
+
+int64_t FakeTimerManager::now =
+  1; // Don't start in 0 to avoid problems with timers that are set to run in 0.
+uint16_t FakeTimerManager::nextTimerId = 0;
+std::map<uint16_t, FakeTimerManager::Timer> FakeTimerManager::timers;
+
+uint16_t FakeTimerManager::GetNexTimerId()
+{
+	return FakeTimerManager::nextTimerId++;
+}
+
+void FakeTimerManager::StartTimer(
+  uint16_t timerId, uint64_t timeout, uint64_t repeat, std::function<void()> cb)
+{
+	FakeTimerManager::timers[timerId] = { FakeTimerManager::now + timeout, repeat, cb };
+}
+
+void FakeTimerManager::StopTimer(uint16_t timerId)
+{
+	FakeTimerManager::timers.erase(timerId);
+}
+
+bool FakeTimerManager::IsActive(uint16_t timerId)
+{
+	return FakeTimerManager::timers.find(timerId) != FakeTimerManager::timers.end();
+}
+
+int64_t FakeTimerManager::NextTimerTime()
+{
+	int64_t nextTime = -1;
+
+	for (auto& kv : FakeTimerManager::timers)
+	{
+		if (nextTime == -1 || kv.second.nextTime < nextTime)
+		{
+			nextTime = kv.second.nextTime;
+		}
+	}
+
+	return nextTime;
+}
+
+void FakeTimerManager::RunPending(int64_t now)
+{
+	FakeTimerManager::now = now;
+
+	auto copy = FakeTimerManager::timers;
+	for (auto& kv : copy)
+	{
+		if (kv.second.nextTime <= now)
+		{
+			auto it             = FakeTimerManager::timers.find(kv.first);
+			it->second.nextTime = kv.second.repeat != 0u ? now + kv.second.repeat : -1;
+			kv.second.cb();
+		}
+	}
+}
+
+void FakeTimerManager::RunLoop(int64_t maxTime)
+{
+	while (true)
+	{
+		uint64_t nextTime = FakeTimerManager::NextTimerTime();
+
+		if (nextTime == -1 || (maxTime != -1 && nextTime > maxTime))
+		{
+			break;
+		}
+
+		FakeTimerManager::RunPending(nextTime);
+	}
+}
+
+Timer::Timer(Listener* listener) : listener(listener)
+{
+	this->timerId = FakeTimerManager::GetNexTimerId();
+}
+
+Timer::~Timer()
+{
+	MS_TRACE();
+
+	if (!this->closed)
+	{
+		Close();
+	}
+}
+
+void Timer::Close()
+{
+	MS_TRACE();
+
+	if (this->closed)
+	{
+		return;
+	}
+
+	Stop();
+
+	this->closed = true;
+}
+
+void Timer::Start(uint64_t timeout, uint64_t repeat)
+{
+	MS_TRACE();
+
+	if (this->closed)
+	{
+		MS_THROW_ERROR("closed");
+	}
+
+	this->timeout = timeout;
+	this->repeat  = repeat;
+
+	FakeTimerManager::StartTimer(
+	  this->timerId, timeout, repeat, [this]() { this->listener->OnTimer(this); });
+}
+
+void Timer::Stop()
+{
+	MS_TRACE();
+
+	if (this->closed)
+	{
+		MS_THROW_ERROR("closed");
+	}
+
+	FakeTimerManager::StopTimer(this->timerId);
+}
+
+bool Timer::IsActive() const
+{
+	return FakeTimerManager::IsActive(this->timerId);
+}
+
+void Timer::Reset()
+{
+	MS_TRACE();
+
+	if (this->closed)
+	{
+		MS_THROW_ERROR("closed");
+	}
+
+	if (!this->IsActive())
+	{
+		return;
+	}
+
+	if (this->repeat == 0u)
+	{
+		return;
+	}
+
+	this->Start(this->repeat, this->repeat);
+}
+
+void Timer::Restart()
+{
+	MS_TRACE();
+
+	if (this->closed)
+	{
+		MS_THROW_ERROR("closed");
+	}
+
+	this->Stop();
+	this->Start(this->timeout, this->repeat);
+}
+
+#else // FAKE_TIMERS
+
 /* Static methods for UV callbacks. */
 
 inline static void onTimer(uv_timer_t* handle)
@@ -104,6 +279,11 @@ void Timer::Stop()
 	}
 }
 
+bool Timer::IsActive() const
+{
+	return uv_is_active(reinterpret_cast<uv_handle_t*>(this->uvHandle)) != 0;
+}
+
 void Timer::Reset()
 {
 	MS_TRACE();
@@ -161,4 +341,34 @@ inline void Timer::OnUvTimer()
 
 	// Notify the listener.
 	this->listener->OnTimer(this);
+}
+
+#endif // FAKE_TIMERS
+
+uint64_t GetTimeMs()
+{
+#if FAKE_TIMERS
+	return static_cast<uint64_t>(FakeTimerManager::GetTimeMs());
+#else
+	return uv_hrtime() / 1000000u;
+#endif
+}
+
+int64_t GetTimeMsInt64()
+{
+	return static_cast<int64_t>(GetTimeMs());
+}
+
+uint64_t GetTimeUs()
+{
+#if FAKE_TIMERS
+	return FakeTimerManager::GetTimeMs() * 1000;
+#else
+	return uv_hrtime() / 1000u;
+#endif
+}
+
+int64_t GetTimeUsInt64()
+{
+	return static_cast<int64_t>(GetTimeUs());
 }

--- a/worker/test/src/RTC/TestKeyFrameRequestManager.cpp
+++ b/worker/test/src/RTC/TestKeyFrameRequestManager.cpp
@@ -1,6 +1,7 @@
 #include "common.hpp"
 #include "DepLibUV.hpp"
 #include "RTC/KeyFrameRequestManager.hpp"
+#include "handles/Timer.hpp"
 #include <catch2/catch.hpp>
 
 using namespace RTC;
@@ -34,7 +35,7 @@ SCENARIO("KeyFrameRequestManager", "[rtp][keyframe]")
 		keyFrameRequestManager.KeyFrameNeeded(1111);
 
 		// Must run the loop here to consume the timer before doing the check.
-		DepLibUV::RunLoop();
+		FakeTimerManager::RunLoop();
 
 		REQUIRE(listener.onKeyFrameNeededTimesCalled == 2);
 	}
@@ -50,7 +51,7 @@ SCENARIO("KeyFrameRequestManager", "[rtp][keyframe]")
 		keyFrameRequestManager.KeyFrameNeeded(1111);
 
 		// Must run the loop here to consume the timer before doing the check.
-		DepLibUV::RunLoop();
+		FakeTimerManager::RunLoop();
 
 		REQUIRE(listener.onKeyFrameNeededTimesCalled == 2);
 	}
@@ -64,7 +65,7 @@ SCENARIO("KeyFrameRequestManager", "[rtp][keyframe]")
 		keyFrameRequestManager.KeyFrameReceived(1111);
 
 		// Must run the loop here to consume the timer before doing the check.
-		DepLibUV::RunLoop();
+		FakeTimerManager::RunLoop();
 
 		REQUIRE(listener.onKeyFrameNeededTimesCalled == 1);
 	}
@@ -78,7 +79,7 @@ SCENARIO("KeyFrameRequestManager", "[rtp][keyframe]")
 		keyFrameRequestManager.ForceKeyFrameNeeded(1111);
 
 		// Must run the loop here to consume the timer before doing the check.
-		DepLibUV::RunLoop();
+		FakeTimerManager::RunLoop();
 
 		REQUIRE(listener.onKeyFrameNeededTimesCalled == 3);
 	}
@@ -93,13 +94,8 @@ SCENARIO("KeyFrameRequestManager", "[rtp][keyframe]")
 		keyFrameRequestManager.KeyFrameReceived(1111);
 
 		// Must run the loop here to consume the timer before doing the check.
-		DepLibUV::RunLoop();
+		FakeTimerManager::RunLoop();
 
 		REQUIRE(listener.onKeyFrameNeededTimesCalled == 2);
 	}
-
-	// Must run the loop to wait for UV timers and close them.
-	// NOTE: Not really needed in this file since we run it in each SECTION in
-	// purpose.
-	DepLibUV::RunLoop();
 }

--- a/worker/test/src/RTC/TestRateCalculator.cpp
+++ b/worker/test/src/RTC/TestRateCalculator.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
-#include "DepLibUV.hpp"
 #include "RTC/RateCalculator.hpp"
+#include "handles/Timer.hpp"
 #include <catch2/catch.hpp>
 #include <vector>
 
@@ -25,7 +25,7 @@ void validate(RateCalculator& rate, uint64_t timeBase, std::vector<data>& input)
 
 SCENARIO("Bitrate calculator", "[rtp][bitrate]")
 {
-	uint64_t nowMs = DepLibUV::GetTimeMs();
+	uint64_t nowMs = GetTimeMs();
 
 	SECTION("receive single item per 1000 ms")
 	{


### PR DESCRIPTION
Implement support for fake timers (timers that run "faster than real time") to make unit tests faster and more predictable.

The approach taken in this PR is to have two implementations of the Timer class.  One based on LibUV and one based on a simple map keeping the list of timers (FakeTimerManager).   Which one is compiled depends on the FAKE_TIMERS macro being defined that is defined for the test target now.

One of the use cases is to be able to run long tests (f.e. bandwidth estimation tests that take seconds) in milliseconds in unit tests.   Existing tests like KeyFrameManagerTests are also faster now.

From a design point of view it also removes the dependency with DevLibUV from many files that should be LibUV agnostic. 

Maybe there is a better way to do this, it is open for discussion and I'm happy to take other approach if it makes more sense for mediasoup philosophy or close the PR if it doesn't make sense.