### PR TITLE
Only perform RTP inactivity checks on simulcast streams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ### NEXT
 
+* `RtpStreamRecv`: Only perform RTP inactivity check on simulcast streams ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
 * `SeqManager`: Properly remove old dropped entries ([PR #1054](https://github.com/versatica/mediasoup/pull/1054)).
 * libwebrtc: Upgrade trendline estimator to improve low bandwidth conditions ([PR #1055](https://github.com/versatica/mediasoup/pull/1055) by @ggarber).
 * libwebrtc: Fix bandwidth probation dead state ([PR #1031](https://github.com/versatica/mediasoup/pull/1031) by @vpalmisano).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### NEXT
 
-* `RtpStreamRecv`: Only perform RTP inactivity check on simulcast streams ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+* `RtpStreamRecv`: Only perform RTP inactivity check on simulcast streams ([PR #1061](https://github.com/versatica/mediasoup/pull/1061)).
 * `SeqManager`: Properly remove old dropped entries ([PR #1054](https://github.com/versatica/mediasoup/pull/1054)).
 * libwebrtc: Upgrade trendline estimator to improve low bandwidth conditions ([PR #1055](https://github.com/versatica/mediasoup/pull/1055) by @ggarber).
 * libwebrtc: Fix bandwidth probation dead state ([PR #1031](https://github.com/versatica/mediasoup/pull/1031) by @vpalmisano).

--- a/worker/include/RTC/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RtpStreamRecv.hpp
@@ -45,7 +45,8 @@ namespace RTC
 		RtpStreamRecv(
 		  RTC::RtpStreamRecv::Listener* listener,
 		  RTC::RtpStream::Params& params,
-		  unsigned int sendNackDelayMs);
+		  unsigned int sendNackDelayMs,
+		  bool useRtpInactivityCheck);
 		~RtpStreamRecv();
 
 		void FillJsonStats(json& jsonObject) override;
@@ -96,6 +97,7 @@ namespace RTC
 	private:
 		// Passed by argument.
 		unsigned int sendNackDelayMs{ 0u };
+		bool useRtpInactivityCheck{ false };
 		// Others.
 		// Packets expected at last interval.
 		uint32_t expectedPrior{ 0u };

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1223,8 +1223,11 @@ namespace RTC
 			}
 		}
 
+		// Only perform RTP inactivity check on simulcast.
+		auto useRtpInactivityCheck = this->type == RtpParameters::Type::SIMULCAST;
+
 		// Create a RtpStreamRecv for receiving a media stream.
-		auto* rtpStream = new RTC::RtpStreamRecv(this, params, SendNackDelay);
+		auto* rtpStream = new RTC::RtpStreamRecv(this, params, SendNackDelay, useRtpInactivityCheck);
 
 		// Insert into the maps.
 		this->mapSsrcRtpStream[ssrc]              = rtpStream;

--- a/worker/test/src/RTC/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/TestRtpStreamRecv.cpp
@@ -11,6 +11,7 @@ using namespace RTC;
 // 17: 16 bit mask + the initial sequence number.
 static constexpr size_t MaxRequestedPackets{ 17 };
 static constexpr unsigned int SendNackDelay{ 0u }; // In ms.
+static const bool UseRtpInactivityCheck{ false };
 
 SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 {
@@ -141,7 +142,7 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 	SECTION("NACK one packet")
 	{
 		RtpStreamRecvListener listener;
-		RtpStreamRecv rtpStream(&listener, params, SendNackDelay);
+		RtpStreamRecv rtpStream(&listener, params, SendNackDelay, UseRtpInactivityCheck);
 
 		packet->SetSequenceNumber(1);
 		rtpStream.ReceivePacket(packet);
@@ -170,7 +171,7 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 	SECTION("wrapping sequence numbers")
 	{
 		RtpStreamRecvListener listener;
-		RtpStreamRecv rtpStream(&listener, params, SendNackDelay);
+		RtpStreamRecv rtpStream(&listener, params, SendNackDelay, UseRtpInactivityCheck);
 
 		packet->SetSequenceNumber(0xfffe);
 		rtpStream.ReceivePacket(packet);
@@ -190,7 +191,7 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 	SECTION("require key frame")
 	{
 		RtpStreamRecvListener listener;
-		RtpStreamRecv rtpStream(&listener, params, SendNackDelay);
+		RtpStreamRecv rtpStream(&listener, params, SendNackDelay, UseRtpInactivityCheck);
 
 		packet->SetSequenceNumber(1);
 		rtpStream.ReceivePacket(packet);


### PR DESCRIPTION
We compute the received stream `score` based on many factors, including whether packets are being redeived or not. If the encoder in client side stops sending packets we (in mediasoup) assume that something is wrong (RTP inactivity timer fires) and set score to 0. This PR changes this behavior and only enables the RTP inactivity check on simulcast streams. Why? Because in simulcast we NEED this in order to detect when the higher streams stop so we can quickly switch consumers to the lower stream.

The thing is: From RTP protocol perspective, it's perfectly fine that a device stops sending RTP and it doesn't mean that its uplink connection is bad. It's just that the encoder decided to stop sending packets. This happens, for instance, in mobile apps using libwebrtc with camera enabled: when switching to another app the encoder stops sending more webcam RTP packets.