### PR TITLE
Replace static variables with regular class variables, remove unused includes

### DIFF
--- a/worker/include/Channel/ChannelNotifier.hpp
+++ b/worker/include/Channel/ChannelNotifier.hpp
@@ -13,12 +13,9 @@ namespace Channel
 		explicit ChannelNotifier(Channel::ChannelSocket* channel);
 
 	public:
-		static flatbuffers::FlatBufferBuilder bufferBuilder;
-
-	public:
-		flatbuffers::FlatBufferBuilder& GetBufferBuilder() const
+		flatbuffers::FlatBufferBuilder& GetBufferBuilder()
 		{
-			return ChannelNotifier::bufferBuilder;
+			return this->bufferBuilder;
 		}
 
 		template<class Body>
@@ -64,6 +61,8 @@ namespace Channel
 	private:
 		// Passed by argument.
 		Channel::ChannelSocket* channel{ nullptr };
+		// Others.
+		flatbuffers::FlatBufferBuilder bufferBuilder{};
 	};
 } // namespace Channel
 

--- a/worker/include/Channel/ChannelRequest.hpp
+++ b/worker/include/Channel/ChannelRequest.hpp
@@ -24,15 +24,12 @@ namespace Channel
 		static absl::flat_hash_map<FBS::Request::Method, const char*> method2String;
 
 	public:
-		static flatbuffers::FlatBufferBuilder bufferBuilder;
-
-	public:
 		ChannelRequest(Channel::ChannelSocket* channel, const FBS::Request::Request* request);
 		~ChannelRequest() = default;
 
-		flatbuffers::FlatBufferBuilder& GetBufferBuilder() const
+		flatbuffers::FlatBufferBuilder& GetBufferBuilder()
 		{
-			return bufferBuilder;
+			return this->bufferBuilder;
 		}
 		void Accept();
 		template<class Body>
@@ -42,7 +39,7 @@ namespace Channel
 
 			this->replied = true;
 
-			auto& builder = ChannelRequest::bufferBuilder;
+			auto& builder = this->bufferBuilder;
 			auto response = FBS::Response::CreateResponse(builder, this->id, true, type, body.Union());
 
 			auto message = FBS::Message::CreateMessage(
@@ -60,13 +57,14 @@ namespace Channel
 
 	private:
 		void Send(uint8_t* buffer, size_t size);
-		void Send(const flatbuffers::Offset<FBS::Response::Response>& reponse);
+		void SendResponse(const flatbuffers::Offset<FBS::Response::Response>& response);
 
 	public:
 		// Passed by argument.
 		Channel::ChannelSocket* channel{ nullptr };
 		const FBS::Request::Request* data{ nullptr };
 		// Others.
+		flatbuffers::FlatBufferBuilder bufferBuilder{};
 		uint32_t id{ 0u };
 		Method method;
 		const char* methodCStr;

--- a/worker/include/Channel/ChannelSocket.hpp
+++ b/worker/include/Channel/ChannelSocket.hpp
@@ -117,7 +117,7 @@ namespace Channel
 		ChannelWriteFn channelWriteFn{ nullptr };
 		ChannelWriteCtx channelWriteCtx{ nullptr };
 		uv_async_t* uvReadHandle{ nullptr };
-		flatbuffers::FlatBufferBuilder bufferBuilder{ 1024 };
+		flatbuffers::FlatBufferBuilder bufferBuilder{};
 	};
 } // namespace Channel
 

--- a/worker/src/Channel/ChannelNotification.cpp
+++ b/worker/src/Channel/ChannelNotification.cpp
@@ -4,7 +4,6 @@
 #include "Channel/ChannelNotification.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
-#include "Utils.hpp"
 
 namespace Channel
 {

--- a/worker/src/Channel/ChannelNotifier.cpp
+++ b/worker/src/Channel/ChannelNotifier.cpp
@@ -3,13 +3,9 @@
 
 #include "Channel/ChannelNotifier.hpp"
 #include "Logger.hpp"
-#include "FBS/notification_generated.h"
 
 namespace Channel
 {
-	/* Class variables. */
-	flatbuffers::FlatBufferBuilder ChannelNotifier::bufferBuilder;
-
 	ChannelNotifier::ChannelNotifier(Channel::ChannelSocket* channel) : channel(channel)
 	{
 		MS_TRACE();

--- a/worker/src/Channel/ChannelRequest.cpp
+++ b/worker/src/Channel/ChannelRequest.cpp
@@ -4,10 +4,6 @@
 #include "Channel/ChannelRequest.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
-#include "Utils.hpp"
-#include "FBS/message_generated.h"
-#include "FBS/request_generated.h"
-#include <flatbuffers/minireflect.h>
 
 namespace Channel
 {
@@ -81,9 +77,6 @@ namespace Channel
 	};
 	// clang-format on
 
-	/* Class methods. */
-	flatbuffers::FlatBufferBuilder ChannelRequest::bufferBuilder;
-
 	/* Instance methods. */
 
 	/**
@@ -122,11 +115,11 @@ namespace Channel
 
 		this->replied = true;
 
-		auto& builder = ChannelRequest::bufferBuilder;
+		auto& builder = this->bufferBuilder;
 		auto response =
 		  FBS::Response::CreateResponse(builder, this->id, true, FBS::Response::Body::NONE, 0);
 
-		Send(response);
+		this->SendResponse(response);
 	}
 
 	void ChannelRequest::Error(const char* reason)
@@ -137,11 +130,11 @@ namespace Channel
 
 		this->replied = true;
 
-		auto& builder = ChannelRequest::bufferBuilder;
+		auto& builder = this->bufferBuilder;
 		auto response = FBS::Response::CreateResponseDirect(
 		  builder, this->id, false /*accepted*/, FBS::Response::Body::NONE, 0, "Error" /*Error*/, reason);
 
-		Send(response);
+		this->SendResponse(response);
 	}
 
 	void ChannelRequest::TypeError(const char* reason)
@@ -152,11 +145,11 @@ namespace Channel
 
 		this->replied = true;
 
-		auto& builder = ChannelRequest::bufferBuilder;
+		auto& builder = this->bufferBuilder;
 		auto response = FBS::Response::CreateResponseDirect(
 		  builder, this->id, false /*accepted*/, FBS::Response::Body::NONE, 0, "TypeError" /*Error*/, reason);
 
-		Send(response);
+		this->SendResponse(response);
 	}
 
 	void ChannelRequest::Send(uint8_t* buffer, size_t size)
@@ -164,9 +157,9 @@ namespace Channel
 		this->channel->Send(buffer, size);
 	}
 
-	void ChannelRequest::Send(const flatbuffers::Offset<FBS::Response::Response>& response)
+	void ChannelRequest::SendResponse(const flatbuffers::Offset<FBS::Response::Response>& response)
 	{
-		auto& builder = ChannelRequest::bufferBuilder;
+		auto& builder = this->bufferBuilder;
 		auto message  = FBS::Message::CreateMessage(
       builder,
       FBS::Message::Type::RESPONSE,

--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -5,10 +5,6 @@
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
-#include "FBS/log_generated.h"
-#include "FBS/message_generated.h"
-#include "FBS/notification_generated.h"
-#include <cmath>   // std::ceil()
 #include <cstring> // std::memcpy(), std::memmove()
 
 namespace Channel


### PR DESCRIPTION
Not 100% sure, but I think this is a correct fix, but tests pass and Rust doesn't seem to fail with random memory-related bugs originating from C++ anymore.

Please, don't use static variables for mutable data going forward. Yes, it is convenient, but it is a bad practice IMHO.