### PR TITLE
mediasoup-node: Fix appData for Transport and RtpObserver parent classes

### DIFF
--- a/node/src/ActiveSpeakerObserver.ts
+++ b/node/src/ActiveSpeakerObserver.ts
@@ -43,7 +43,7 @@ type RtpObserverObserverConstructorOptions<ActiveSpeakerObserverAppData> =
 const logger = new Logger('ActiveSpeakerObserver');
 
 export class ActiveSpeakerObserver<ActiveSpeakerObserverAppData extends AppData = AppData>
-	extends RtpObserver<ActiveSpeakerObserverEvents, ActiveSpeakerObserverAppData>
+	extends RtpObserver<ActiveSpeakerObserverAppData, ActiveSpeakerObserverEvents>
 {
 	/**
 	 * @private

--- a/node/src/AudioLevelObserver.ts
+++ b/node/src/AudioLevelObserver.ts
@@ -65,7 +65,7 @@ type AudioLevelObserverConstructorOptions<AudioLevelObserverAppData> =
 const logger = new Logger('AudioLevelObserver');
 
 export class AudioLevelObserver<AudioLevelObserverAppData extends AppData = AppData>
-	extends RtpObserver<AudioLevelObserverEvents, AudioLevelObserverAppData>
+	extends RtpObserver<AudioLevelObserverAppData, AudioLevelObserverEvents>
 {
 	/**
 	 * @private

--- a/node/src/DirectTransport.ts
+++ b/node/src/DirectTransport.ts
@@ -73,7 +73,7 @@ export type DirectTransportData =
 const logger = new Logger('DirectTransport');
 
 export class DirectTransport<DirectTransportAppData extends AppData = AppData>
-	extends Transport<DirectTransportEvents, DirectTransportObserverEvents, DirectTransportAppData>
+	extends Transport<DirectTransportAppData, DirectTransportEvents, DirectTransportObserverEvents>
 {
 	// DirectTransport data.
 	readonly #data: DirectTransportData;

--- a/node/src/PipeTransport.ts
+++ b/node/src/PipeTransport.ts
@@ -140,7 +140,7 @@ export type PipeTransportData =
 const logger = new Logger('PipeTransport');
 
 export class PipeTransport<PipeTransportAppData extends AppData = AppData>
-	extends Transport<PipeTransportEvents, PipeTransportObserverEvents, PipeTransportAppData>
+	extends Transport<PipeTransportAppData, PipeTransportEvents, PipeTransportObserverEvents>
 {
 	// PipeTransport data.
 	readonly #data: PipeTransportData;

--- a/node/src/PlainTransport.ts
+++ b/node/src/PlainTransport.ts
@@ -144,7 +144,7 @@ export type PlainTransportData =
 const logger = new Logger('PlainTransport');
 
 export class PlainTransport<PlainTransportAppData extends AppData = AppData>
-	extends Transport<PlainTransportEvents, PlainTransportObserverEvents, PlainTransportAppData>
+	extends Transport<PlainTransportAppData, PlainTransportEvents, PlainTransportObserverEvents>
 {
 	// PlainTransport data.
 	readonly #data: PlainTransportData;

--- a/node/src/RtpObserver.ts
+++ b/node/src/RtpObserver.ts
@@ -47,8 +47,8 @@ export type RtpObserverAddRemoveProducerOptions =
 };
 
 export class RtpObserver
-	<Events extends RtpObserverEvents = RtpObserverEvents,
-	RtpObserverAppData extends AppData = AppData>
+	<RtpObserverAppData extends AppData = AppData,
+	Events extends RtpObserverEvents = RtpObserverEvents>
 	extends EnhancedEventEmitter<Events>
 {
 	// Internal data.

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -137,9 +137,9 @@ type TransportData =
 const logger = new Logger('Transport');
 
 export class Transport
-	<Events extends TransportEvents = TransportEvents,
-	ObserverEvents extends TransportObserverEvents = TransportObserverEvents,
-	TransportAppData extends AppData = AppData>
+	<TransportAppData extends AppData = AppData,
+	Events extends TransportEvents = TransportEvents,
+	ObserverEvents extends TransportObserverEvents = TransportObserverEvents>
 	extends EnhancedEventEmitter<Events>
 {
 	// Internal data.

--- a/node/src/WebRtcTransport.ts
+++ b/node/src/WebRtcTransport.ts
@@ -211,7 +211,7 @@ export type WebRtcTransportData =
 const logger = new Logger('WebRtcTransport');
 
 export class WebRtcTransport<WebRtcTransportAppData extends AppData = AppData>
-	extends Transport<WebRtcTransportEvents, WebRtcTransportObserverEvents, WebRtcTransportAppData>
+	extends Transport<WebRtcTransportAppData, WebRtcTransportEvents, WebRtcTransportObserverEvents>
 {
 	// WebRtcTransport data.
 	readonly #data: WebRtcTransportData;


### PR DESCRIPTION
### Before

This fails at TypeScript level:

```ts
let transport: mediasoupTypes.Transport<{ foo: number }>;
let transport: mediasoupTypes.RtpObserver<{ foo: number }>;
```

Now it doesn't fail.