### PR TITLE
SeqManager: performance, invert std::distance range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### 3.11.24
+
+* `SeqManager`: Fix performance regression ([PR #1068](https://github.com/versatica/mediasoup/pull/1068), thanks to @vpalmisano for properly reporting).
+
+
 ### 3.11.23
 
 * Node: Fix `appData` for `Transport` and `RtpObserver` parent classes  ([PR #1066](https://github.com/versatica/mediasoup/pull/1066)).

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -59,7 +59,10 @@ namespace RTC
 		if (SeqManager<T, N>::IsSeqHigherThan(input, this->maxInput))
 		{
 			this->maxInput = input;
-			this->dropped.insert(input);
+			// Insert input in the last position.
+			// Explicitly indicate insert() to add the input at the end, which is
+			// more performant.
+			this->dropped.insert(this->dropped.end(), input);
 
 			ClearDropped();
 		}

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -104,15 +104,13 @@ namespace RTC
 		// There are dropped inputs, calculate 'base' for this input.
 		else
 		{
+			auto droppedCount = this->dropped.size();
+
 			// Get the first dropped input which is higher than or equal 'input'.
 			auto it = this->dropped.lower_bound(input);
 
-			// There are dropped inputs lower than 'input'.
-			if (it != this->dropped.begin())
-			{
-				auto count = std::distance(this->dropped.begin(), it);
-				base       = (this->base - count) & MaxValue;
-			}
+			droppedCount -= std::distance(it, this->dropped.end());
+			base = (this->base - droppedCount) & MaxValue;
 		}
 
 	done:


### PR DESCRIPTION
Fixes #1067.

There are way more dropped elements in the range `[begin(), input]` than in `[input, end()]` and `std::distance` complexity is linear.


All tests pass and performance has gone to normal.

@vpalmisano, could you please give it a try too for double confirmation? Thanks.