### PR TITLE
Fix seqno jumps when bwe is close to the lowest SVC layer

### DIFF
--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -1099,6 +1099,8 @@ namespace RTC
 			MS_DEBUG_TAG(
 			  svc, "target layers changed [spatial:-1, temporal:-1, consumerId:%s]", this->id.c_str());
 
+			this->syncRequired = true;
+
 			EmitLayersChange();
 
 			return;


### PR DESCRIPTION
It seems solving the issue described in https://github.com/versatica/mediasoup/issues/1069

![patched](https://user-images.githubusercontent.com/283319/233716000-2fd4329c-74f5-41b4-aab5-6cee6d7195e9.png)
[patch.pcapng.gz](https://github.com/versatica/mediasoup/files/11298624/patch.pcapng.gz)
