### PR TITLE
[mediasoup-worker] Require C++17, Meson >= 1.1.0 and update subprojects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### NEXT
 
-* `Worker`: Require C++17 and update subprojects ([PR #1081](https://github.com/versatica/mediasoup/pull/1081)).
+* `Worker`: Require C++17, Meson >= 1.1.0 and update subprojects ([PR #1081](https://github.com/versatica/mediasoup/pull/1081)).
 
 
 ### 3.11.24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* `Worker`: Require C++17 and update subprojects ([PR #1081](https://github.com/versatica/mediasoup/pull/1081)).
+
+
 ### 3.11.24
 
 * `SeqManager`: Fix performance regression ([PR #1068](https://github.com/versatica/mediasoup/pull/1068), thanks to @vpalmisano for properly reporting).

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -20,7 +20,7 @@ PIP_DIR = $(MEDIASOUP_OUT_DIR)/pip
 INSTALL_DIR ?= $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
 BUILD_DIR ?= $(INSTALL_DIR)/build
 MESON ?= $(PIP_DIR)/bin/meson
-MESON_VERSION ?= 0.61.5
+MESON_VERSION ?= 1.1.0
 # `MESON_ARGS` can be used to provide extra configuration parameters to Meson,
 # such as adding defines or changing optimization options. For instance, use
 # `MESON_ARGS="-Dms_log_trace=true -Dms_log_file_line=true" npm i` to compile

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -6,7 +6,7 @@ project(
     'cpp_std=c++17',
     'default_library=static',
   ],
-  meson_version: '>= 0.58',
+  meson_version: '>= 1.1.0',
 )
 
 cpp_args = [

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -3,7 +3,7 @@ project(
   ['c', 'cpp'],
   default_options : [
     'warning_level=1',
-    'cpp_std=c++11',
+    'cpp_std=c++17',
     'default_library=static',
   ],
   meson_version: '>= 0.58',

--- a/worker/subprojects/abseil-cpp.wrap
+++ b/worker/subprojects/abseil-cpp.wrap
@@ -1,18 +1,22 @@
 [wrap-file]
-directory = abseil-cpp-20211102.0
-source_url = https://github.com/abseil/abseil-cpp/archive/20211102.0.tar.gz
-source_filename = abseil-cpp-20211102.0.tar.gz
-source_hash = dcf71b9cba8dc0ca9940c4b316a0c796be8fab42b070bb6b7cab62b48f0e66c4
-patch_filename = abseil-cpp_20211102.0-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20211102.0-2/get_patch
-patch_hash = 9463930367b0db984435350c7d7614e400faa8811a7e9a2def5a63ff39fdb325
+directory = abseil-cpp-20230125.1
+source_url = https://github.com/abseil/abseil-cpp/archive/20230125.1.tar.gz
+source_filename = abseil-cpp-20230125.1.tar.gz
+source_hash = 81311c17599b3712069ded20cca09a62ab0bf2a89dfa16993786c8782b7ed145
+patch_filename = abseil-cpp_20230125.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20230125.1-1/get_patch
+patch_hash = a920ab28067e433d7ead2d564a4f511628f498f0723f7f94d19317877787ef39
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20230125.1-1/abseil-cpp-20230125.1.tar.gz
+wrapdb_version = 20230125.1-1
 
 [provide]
 absl_base = absl_base_dep
 absl_container = absl_container_dep
 absl_debugging = absl_debugging_dep
+absl_log = absl_log_dep
 absl_flags = absl_flags_dep
 absl_hash = absl_hash_dep
+absl_crc = absl_crc_dep
 absl_numeric = absl_numeric_dep
 absl_random = absl_random_dep
 absl_status = absl_status_dep
@@ -20,4 +24,3 @@ absl_strings = absl_strings_dep
 absl_synchronization = absl_synchronization_dep
 absl_time = absl_time_dep
 absl_types = absl_types_dep
-

--- a/worker/subprojects/abseil-cpp.wrap
+++ b/worker/subprojects/abseil-cpp.wrap
@@ -1,22 +1,19 @@
 [wrap-file]
-directory = abseil-cpp-20230125.1
-source_url = https://github.com/abseil/abseil-cpp/archive/20230125.1.tar.gz
-source_filename = abseil-cpp-20230125.1.tar.gz
-source_hash = 81311c17599b3712069ded20cca09a62ab0bf2a89dfa16993786c8782b7ed145
-patch_filename = abseil-cpp_20230125.1-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20230125.1-1/get_patch
-patch_hash = a920ab28067e433d7ead2d564a4f511628f498f0723f7f94d19317877787ef39
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20230125.1-1/abseil-cpp-20230125.1.tar.gz
-wrapdb_version = 20230125.1-1
+directory = abseil-cpp-20220623.0
+source_url = https://github.com/abseil/abseil-cpp/archive/20220623.0.tar.gz
+source_filename = abseil-cpp-20220623.0.tar.gz
+source_hash = 4208129b49006089ba1d6710845a45e31c59b0ab6bff9e5788a87f55c5abd602
+patch_filename = abseil-cpp_20220623.0-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20220623.0-2/get_patch
+patch_hash = d19cb16610d9310658a815ebcd87a9e2966aafbd57964341c0d1a3a3778c03b6
+wrapdb_version = 20220623.0-2
 
 [provide]
 absl_base = absl_base_dep
 absl_container = absl_container_dep
 absl_debugging = absl_debugging_dep
-absl_log = absl_log_dep
 absl_flags = absl_flags_dep
 absl_hash = absl_hash_dep
-absl_crc = absl_crc_dep
 absl_numeric = absl_numeric_dep
 absl_random = absl_random_dep
 absl_status = absl_status_dep

--- a/worker/subprojects/libuv.wrap
+++ b/worker/subprojects/libuv.wrap
@@ -3,10 +3,11 @@ directory = libuv-v1.44.2
 source_url = https://dist.libuv.org/dist/v1.44.2/libuv-v1.44.2.tar.gz
 source_filename = libuv-v1.44.2.tar.gz
 source_hash = ccfcdc968c55673c6526d8270a9c8655a806ea92468afcbcabc2b16040f03cb4
-patch_filename = libuv_1.44.2-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/libuv_1.44.2-1/get_patch
-patch_hash = c77f6104cffd53f697c3030fccbfd5cc684b59772e8f24529b01908ee27bd751
-wrapdb_version = 1.44.2-1
+patch_filename = libuv_1.44.2-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/libuv_1.44.2-2/get_patch
+patch_hash = 12a0850e1c925811f54bb022339d3105afaed8bc006b197351006c9c841f06ce
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/libuv_1.44.2-2/libuv-v1.44.2.tar.gz
+wrapdb_version = 1.44.2-2
 
 [provide]
 libuv = libuv_dep

--- a/worker/subprojects/openssl.wrap
+++ b/worker/subprojects/openssl.wrap
@@ -1,12 +1,13 @@
 [wrap-file]
-directory = openssl-3.0.7
-source_url = https://www.openssl.org/source/openssl-3.0.7.tar.gz
-source_filename = openssl-3.0.72.tar.gz
-source_hash = 83049d042a260e696f62406ac5c08bf706fd84383f945cf21bd61e9ed95c396e
-patch_filename = openssl_3.0.7-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/openssl_3.0.7-1/get_patch
-patch_hash = 8f04d911dc22d1dddc6a192ab27d6d8275976a252bd9c73e09f95f1f927e42b5
-wrapdb_version = 3.0.7-1
+directory = openssl-3.0.8
+source_url = https://www.openssl.org/source/openssl-3.0.8.tar.gz
+source_filename = openssl-3.0.8.tar.gz
+source_hash = 6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e
+patch_filename = openssl_3.0.8-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/openssl_3.0.8-1/get_patch
+patch_hash = 12d9c884174a91ccd1aa9230e9567c019f8a582ce46c98736f99a5200b4f2514
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/openssl_3.0.8-1/openssl-3.0.8.tar.gz
+wrapdb_version = 3.0.8-1
 
 [provide]
 libcrypto = libcrypto_dep


### PR DESCRIPTION
Fixes #1080

- We could just require C++14 but let's move to C++17.
- Also update required meson version to 1.1.0.

**TODO:** Once published, update installation requirements in website.