### PR TITLE
Fix: Compilation error of Implicitly deleted defaulted constructor

### DIFF
--- a/worker/deps/libwebrtc/libwebrtc/api/transport/network_types.cc
+++ b/worker/deps/libwebrtc/libwebrtc/api/transport/network_types.cc
@@ -13,8 +13,7 @@
 #include <algorithm>
 
 namespace webrtc {
-// TODO(srte): Revert to using default after removing union member.
-StreamsConfig::StreamsConfig() {}
+StreamsConfig::StreamsConfig() = default;
 StreamsConfig::StreamsConfig(const StreamsConfig&) = default;
 StreamsConfig::~StreamsConfig() = default;
 

--- a/worker/deps/libwebrtc/libwebrtc/api/transport/network_types.h
+++ b/worker/deps/libwebrtc/libwebrtc/api/transport/network_types.h
@@ -34,9 +34,7 @@ struct StreamsConfig {
   Timestamp at_time = Timestamp::PlusInfinity();
   absl::optional<bool> requests_alr_probing;
   absl::optional<double> pacing_factor;
-  union {
-    absl::optional<DataRate> min_total_allocated_bitrate = absl::nullopt;
-  };
+  absl::optional<DataRate> min_total_allocated_bitrate = absl::nullopt;
   absl::optional<DataRate> max_padding_rate;
   absl::optional<DataRate> max_total_allocated_bitrate;
 };


### PR DESCRIPTION
Hi,
A compilation error exists as below
```
../../../deps/libwebrtc/libwebrtc/api/transport/network_types.cc:18:16: error: defaulting this copy constructor would delete it after its first declaration
StreamsConfig::StreamsConfig(const StreamsConfig&) = default;
               ^
../../../deps/libwebrtc/libwebrtc/api/transport/network_types.h:38:30: note: copy constructor of 'StreamsConfig' is implicitly deleted because variant field 'min_total_allocated_bitrate' has a non-trivial copy constructor
    absl::optional<DataRate> min_total_allocated_bitrate = absl::nullopt;
```
so have modified the source code as is in the latest WebRTC repo