### PR TITLE
mediasoup-worker prebuild: Fallback to local building if fetched binary doesn't run on current host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### Next
+
+* mediasoup-worker prebuild: Fallback to local building if fetched binary doesn't run on current host ([PR #1090](https://github.com/versatica/mediasoup/pull/1090)).
+
+
 ### 3.12.0
 
 * Automate and publish prebuilt `mediasoup-worker` binaries ([PR #1087](https://github.com/versatica/mediasoup/pull/1087), thanks to @barlock for his work in ([PR #1083](https://github.com/versatica/mediasoup/pull/1083)).

--- a/npm-scripts.js
+++ b/npm-scripts.js
@@ -530,7 +530,7 @@ async function downloadPrebuiltWorker()
 					// Give execution permission to the binary.
 					fs.chmodSync(WORKER_RELEASE_BIN_PATH, 0o775);
 				}
-				catch ()
+				catch (error)
 				{
 					logWarn(`downloadPrebuiltWorker() | failed to give execution permissions to the mediasoup-worker prebuilt binary: ${error}`);
 				}

--- a/npm-scripts.js
+++ b/npm-scripts.js
@@ -546,7 +546,7 @@ async function downloadPrebuiltWorker()
 					}
 					catch (error)
 					{
-						if (error.status !== 41)
+						if (error.status === 41)
 						{
 							resolve(true);
 						}

--- a/npm-scripts.js
+++ b/npm-scripts.js
@@ -529,46 +529,47 @@ async function downloadPrebuiltWorker()
 				{
 					// Give execution permission to the binary.
 					fs.chmodSync(WORKER_RELEASE_BIN_PATH, 0o775);
+				}
+				catch ()
+				{
+					logWarn(`downloadPrebuiltWorker() | failed to give execution permissions to the mediasoup-worker prebuilt binary: ${error}`);
+				}
 
-					// Let's confirm that the fetched mediasoup-worker prebuit binary does
-					// run in current host. This is to prevent weird issues related to
-					// different versions of libc in the system and so on.
-					// So run mediasoup-worker without the required MEDIASOUP_VERSION env and
-					// expect exit code 41 (see main.cpp).
+				// Let's confirm that the fetched mediasoup-worker prebuit binary does
+				// run in current host. This is to prevent weird issues related to
+				// different versions of libc in the system and so on.
+				// So run mediasoup-worker without the required MEDIASOUP_VERSION env and
+				// expect exit code 41 (see main.cpp).
 
-					logInfo(
-						'downloadPrebuiltWorker() | checking fetched mediasoup-worker prebuilt binary in current host'
-					);
+				logInfo(
+					'downloadPrebuiltWorker() | checking fetched mediasoup-worker prebuilt binary in current host'
+				);
 
-					try
-					{
-						execSync(`${WORKER_RELEASE_BIN_PATH}`, { stdio: [ 'ignore', 'ignore', 'ignore' ] });
-					}
-					catch (error)
-					{
-						if (error.status === 41)
-						{
-							resolve(true);
-						}
-						else
-						{
-							logError(
-								`downloadPrebuiltWorker() | fetched mediasoup-worker prebuilt binary fails to run in this host [status:${error.status}]`
-							);
-
-							fs.unlinkSync(WORKER_RELEASE_BIN_PATH);
-
-							resolve(false);
-						}
-					}
+				try
+				{
+					execSync(`${WORKER_RELEASE_BIN_PATH}`, { stdio: [ 'ignore', 'ignore', 'ignore' ] });
 				}
 				catch (error)
 				{
-					logError(
-						`downloadPrebuiltWorker() | failed to download mediasoup-worker prebuilt binary: ${error}`
-					);
+					if (error.status === 41)
+					{
+						resolve(true);
+					}
+					else
+					{
+						logError(
+							`downloadPrebuiltWorker() | fetched mediasoup-worker prebuilt binary fails to run in this host [status:${error.status}]`
+						);
 
-					resolve(false);
+						try
+						{
+							fs.unlinkSync(WORKER_RELEASE_BIN_PATH);
+						}
+						catch (error2)
+						{}
+
+						resolve(false);
+					}
 				}
 			})
 			.on('error', (error) =>

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -75,7 +75,8 @@ extern "C" int mediasoup_worker_run(
 		DepLibUV::RunLoop();
 		DepLibUV::ClassDestroy();
 
-		return 1;
+		// 40 is a custom exit code to notify "unknown error" to the Node library.
+		return 40;
 	}
 
 	try
@@ -99,7 +100,8 @@ extern "C" int mediasoup_worker_run(
 		DepLibUV::RunLoop();
 		DepLibUV::ClassDestroy();
 
-		return 1;
+		// 40 is a custom exit code to notify "unknown error" to the Node library.
+		return 40;
 	}
 
 	// Initialize the Logger.
@@ -130,7 +132,8 @@ extern "C" int mediasoup_worker_run(
 		DepLibUV::RunLoop();
 		DepLibUV::ClassDestroy();
 
-		return 1;
+		// 40 is a custom exit code to notify "unknown error" to the Node library.
+		return 40;
 	}
 
 	MS_DEBUG_TAG(info, "starting mediasoup-worker process [version:%s]", version);
@@ -193,7 +196,8 @@ extern "C" int mediasoup_worker_run(
 	{
 		MS_ERROR_STD("failure exit: %s", error.what());
 
-		return 1;
+		// 40 is a custom exit code to notify "unknown error" to the Node library.
+		return 40;
 	}
 }
 

--- a/worker/src/main.cpp
+++ b/worker/src/main.cpp
@@ -18,7 +18,8 @@ int main(int argc, char* argv[])
 	{
 		MS_ERROR_STD("you don't seem to be my real father!");
 
-		std::_Exit(EXIT_FAILURE);
+		// 41 is a custom exit code to notify about "missing MEDIASOUP_VERSION" env.
+		std::_Exit(41);
 	}
 
 	const std::string version = std::getenv("MEDIASOUP_VERSION");
@@ -40,13 +41,5 @@ int main(int argc, char* argv[])
 	  nullptr,
 	  nullptr);
 
-	switch (statusCode)
-	{
-		case 0:
-			std::_Exit(EXIT_SUCCESS);
-		case 1:
-			std::_Exit(EXIT_FAILURE);
-		case 42:
-			std::_Exit(42);
-	}
+	std::_Exit(statusCode);
 }


### PR DESCRIPTION
A workaround for issue #1089

Basically, try to run the fetched binary and, if it doesn't work as expected, fallback to building it locally.