### PR TITLE
CI: Use ubuntu-20.04 to build mediasoup-worker prebuilt on Linux

### DIFF
--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -18,9 +18,9 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          # For Linux let's use an old version of Ubuntu (20.04) so it builds
-          # the binary using an old version of GLib which will work in Linux
-          # hosts running more modern GLib versions.
+          # For Linux let's use an old version of Ubuntu (20.04) that builds the
+          # mediasoup-worker binary using an old version of GLib, so it will work
+          # on Linux hosts running more modern GLib versions.
           # See https://github.com/versatica/mediasoup/issues/1089.
           - os: ubuntu-20.04
             cc: gcc

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -18,7 +18,11 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - os: ubuntu-22.04
+          # For Linux let's use an old version of Ubuntu (20.04) so it builds
+          # the binary using an old version of GLib which will work in Linux
+          # hosts running more modern GLib versions.
+          # See https://github.com/versatica/mediasoup/issues/1089.
+          - os: ubuntu-20.04
             cc: gcc
             cxx: g++
           - os: macos-12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### Next
+
+* CI: Use `ubuntu-20.04` to build mediasoup-worker prebuilt on Linux ([PR #1092](https://github.com/versatica/mediasoup/pull/1092)).
+
+
 ### 3.12.1
 
 * mediasoup-worker prebuild: Fallback to local building if fetched binary doesn't run on current host ([PR #1090](https://github.com/versatica/mediasoup/pull/1090)).


### PR DESCRIPTION
Fixes #1089