### PR TITLE
Migrate npm-scripts.js to npm-scripts.mjs (ES Module)

### DIFF
--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -50,7 +50,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      # We need to install some NPM production deps for npm-scripts.js to work.
+      # We need to install some NPM production deps for npm-scripts.mjs to work.
       - run: npm ci --ignore-scripts --omit=dev
       - run: npm run worker:build
       # Publish prebuild binaries on tag.

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      # We need to install some NPM production deps for npm-scripts.js to work.
+      # We need to install some NPM production deps for npm-scripts.mjs to work.
       - run: npm ci --ignore-scripts --omit=dev
       - run: npm run install-clang-tools
         # TODO: Maybe fix this one day.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### Next
+
+Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://github.com/versatica/mediasoup/pull/1093)).
+
+
 ### 3.12.2
 
 * CI: Use `ubuntu-20.04` to build mediasoup-worker prebuilt on Linux ([PR #1092](https://github.com/versatica/mediasoup/pull/1092)).

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -1,9 +1,9 @@
-const process = require('process');
-const os = require('os');
-const fs = require('fs');
-const { execSync, spawnSync } = require('child_process');
-const fetch = require('node-fetch');
-const tar = require('tar');
+import process from 'process';
+import os from 'os';
+import fs from 'fs';
+import { execSync, spawnSync } from 'child_process';
+import fetch from 'node-fetch';
+import tar from 'tar';
 
 const PKG = JSON.parse(fs.readFileSync('./package.json').toString());
 const IS_FREEBSD = os.platform() === 'freebsd';
@@ -98,8 +98,8 @@ async function run()
 
 		case 'typescript:watch':
 		{
-			// NOTE: Load dep here since it's a devDependency.
-			const { TscWatchClient } = require('tsc-watch/client');
+			// NOTE: Load dep on demand since it's a devDependency.
+			const { TscWatchClient } = await import('tsc-watch/client.js');
 
 			const watch = new TscWatchClient();
 
@@ -200,8 +200,8 @@ async function run()
 
 			try
 			{
-				octokit = getOctokit();
-				versionChanges = getVersionChanges();
+				octokit = await getOctokit();
+				versionChanges = await getVersionChanges();
 			}
 			catch (error)
 			{
@@ -357,7 +357,7 @@ function lintNode()
 {
 	logInfo('lintNode()');
 
-	executeCmd('eslint -c node/.eslintrc.js --max-warnings 0 node/src node/.eslintrc.js npm-scripts.js worker/scripts/gulpfile.js');
+	executeCmd('eslint -c node/.eslintrc.js --max-warnings 0 node/src node/.eslintrc.js npm-scripts.mjs worker/scripts/gulpfile.js');
 }
 
 function lintWorker()
@@ -599,7 +599,7 @@ async function uploadMacArmPrebuiltWorker()
 		return;
 	}
 
-	const octokit = getOctokit();
+	const octokit = await getOctokit();
 
 	logInfo('uploadMacArmPrebuiltWorker() | getting release info');
 
@@ -623,15 +623,15 @@ async function uploadMacArmPrebuiltWorker()
 		});
 }
 
-function getOctokit()
+async function getOctokit()
 {
 	if (!process.env.GITHUB_TOKEN)
 	{
 		throw new Error('missing GITHUB_TOKEN environment variable');
 	}
 
-	// NOTE: Load dep here since it's a devDependency.
-	const { Octokit } = require('@octokit/rest');
+	// NOTE: Load dep on demand since it's a devDependency.
+	const { Octokit } = await import('@octokit/rest');
 
 	const octokit = new Octokit(
 		{
@@ -641,12 +641,12 @@ function getOctokit()
 	return octokit;
 }
 
-function getVersionChanges()
+async function getVersionChanges()
 {
 	logInfo('getVersionChanges()');
 
-	// NOTE: Load dep here since it's a devDependency.
-	const marked = require('marked');
+	// NOTE: Load dep on demand since it's a devDependency.
+	const marked = await import('marked');
 
 	const changelog = fs.readFileSync('./CHANGELOG.md').toString();
 	const entries = marked.lexer(changelog);
@@ -692,19 +692,19 @@ function executeCmd(command, exitOnError = true)
 function logInfo(message)
 {
 	// eslint-disable-next-line no-console
-	console.log(`npm-scripts.js \x1b[36m[INFO] [${task}]\x1b\[0m`, message);
+	console.log(`npm-scripts \x1b[36m[INFO] [${task}]\x1b\[0m`, message);
 }
 
 function logWarn(message)
 {
 	// eslint-disable-next-line no-console
-	console.warn(`npm-scripts.js \x1b[33m[WARN] [${task}]\x1b\[0m`, message);
+	console.warn(`npm-scripts \x1b[33m[WARN] [${task}]\x1b\[0m`, message);
 }
 
 function logError(message)
 {
 	// eslint-disable-next-line no-console
-	console.error(`npm-scripts.js \x1b[31m[ERROR] [${task}]\x1b\[0m`, message);
+	console.error(`npm-scripts \x1b[31m[ERROR] [${task}]\x1b\[0m`, message);
 }
 
 function exitWithError()

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@octokit/rest": "^19.0.11",
         "@types/debug": "^4.1.8",
         "@types/jest": "^29.5.1",
-        "@types/node": "^18.16.16",
+        "@types/node": "^20.2.5",
         "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.59.7",
         "@typescript-eslint/parser": "^5.59.7",
@@ -1531,9 +1531,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.16.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
-      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==",
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -7692,9 +7692,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.16.16",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
-      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==",
+      "version": "20.2.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.2.5.tgz",
+      "integrity": "sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==",
       "dev": true
     },
     "@types/normalize-package-data": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "debug": "^4.3.4",
         "h264-profile-level-id": "^1.0.1",
-        "node-fetch": "^2.6.11",
+        "node-fetch": "^3.3.1",
         "supports-color": "^9.3.1",
         "tar": "^6.1.15",
         "uuid": "^9.0.0"
@@ -21,7 +21,7 @@
         "@octokit/rest": "^19.0.11",
         "@types/debug": "^4.1.8",
         "@types/jest": "^29.5.1",
-        "@types/node": "^18.15.11",
+        "@types/node": "^18.16.16",
         "@types/uuid": "^9.0.1",
         "@typescript-eslint/eslint-plugin": "^5.59.7",
         "@typescript-eslint/parser": "^5.59.7",
@@ -1339,6 +1339,26 @@
         "node": ">= 14"
       }
     },
+    "node_modules/@octokit/request/node_modules/node-fetch": {
+      "version": "2.6.11",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@octokit/rest": {
       "version": "19.0.11",
       "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-19.0.11.tgz",
@@ -1511,9 +1531,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "version": "18.16.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==",
       "dev": true
     },
     "node_modules/@types/normalize-package-data": {
@@ -2375,6 +2395,14 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -2959,6 +2987,28 @@
         "bser": "2.1.1"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -3034,6 +3084,17 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
     },
     "node_modules/from": {
       "version": "0.1.7",
@@ -4632,23 +4693,39 @@
       "integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
       "dev": true
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/node-int64": {
@@ -5992,7 +6069,8 @@
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "node_modules/trim-newlines": {
       "version": "4.0.2",
@@ -6255,15 +6333,25 @@
         "makeerror": "1.0.12"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "node_modules/whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
@@ -7411,6 +7499,17 @@
         "is-plain-object": "^5.0.0",
         "node-fetch": "^2.6.7",
         "universal-user-agent": "^6.0.0"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.11",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
+          "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+          "dev": true,
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "@octokit/request-error": {
@@ -7593,9 +7692,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "18.15.11",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.15.11.tgz",
-      "integrity": "sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==",
+      "version": "18.16.16",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.16.16.tgz",
+      "integrity": "sha512-NpaM49IGQQAUlBhHMF82QH80J08os4ZmyF9MkpCzWAGuOHqE4gTEbhzd7L3l5LmWuZ6E0OiC1FweQ4tsiW35+g==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -8197,6 +8296,11 @@
         }
       }
     },
+    "data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
+    },
     "debug": {
       "version": "4.3.4",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
@@ -8626,6 +8730,15 @@
         "bser": "2.1.1"
       }
     },
+    "fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "requires": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      }
+    },
     "file-entry-cache": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -8680,6 +8793,14 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
+    },
+    "formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "requires": {
+        "fetch-blob": "^3.1.2"
+      }
     },
     "from": {
       "version": "0.1.7",
@@ -9856,12 +9977,19 @@
       "integrity": "sha512-qN8v/s2PAJwGUtr1/hYTpNKlD6Y9rc4p8KSmJXyGdYGZsDGKXrGThikLFP9OCHFeLeEpQzPwiAtdIvBLqm//Hw==",
       "dev": true
     },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
+    },
     "node-fetch": {
-      "version": "2.6.11",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.11.tgz",
-      "integrity": "sha512-4I6pdBY1EthSqDmJkiNk3JIT8cswwR9nfeW/cPdUagJYEQG7R95WRH74wpz7ma8Gh/9dI9FP+OU+0E4FvtA55w==",
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.1.tgz",
+      "integrity": "sha512-cRVc/kyto/7E5shrWca1Wsea4y6tL9iYJE5FBCius3JQfb/4P4I295PfhgbJQBLTx6lATE4z+wK0rPM4VS2uow==",
       "requires": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       }
     },
     "node-int64": {
@@ -10790,7 +10918,8 @@
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "dev": true
     },
     "trim-newlines": {
       "version": "4.0.2",
@@ -10957,15 +11086,22 @@
         "makeerror": "1.0.12"
       }
     },
+    "web-streams-polyfill": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz",
+      "integrity": "sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q=="
+    },
     "webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
     },
     "whatwg-url": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
       "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dev": true,
       "requires": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "@octokit/rest": "^19.0.11",
     "@types/debug": "^4.1.8",
     "@types/jest": "^29.5.1",
-    "@types/node": "^18.16.16",
+    "@types/node": "^20.2.5",
     "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.59.7",
     "@typescript-eslint/parser": "^5.59.7",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "worker/Makefile",
     "worker/meson.build",
     "worker/meson_options.txt",
-    "npm-scripts.js"
+    "npm-scripts.mjs"
   ],
   "keywords": [
     "webrtc",
@@ -48,25 +48,25 @@
     "node": ">=16"
   },
   "scripts": {
-    "prepare": "node npm-scripts.js prepare",
-    "postinstall": "node npm-scripts.js postinstall",
-    "typescript:build": "node npm-scripts.js typescript:build",
-    "typescript:watch": "node npm-scripts.js typescript:watch",
-    "worker:build": "node npm-scripts.js worker:build",
-    "worker:prebuild": "node npm-scripts.js worker:prebuild",
+    "prepare": "node npm-scripts.mjs prepare",
+    "postinstall": "node npm-scripts.mjs postinstall",
+    "typescript:build": "node npm-scripts.mjs typescript:build",
+    "typescript:watch": "node npm-scripts.mjs typescript:watch",
+    "worker:build": "node npm-scripts.mjs worker:build",
+    "worker:prebuild": "node npm-scripts.mjs worker:prebuild",
     "lint": "npm run lint:node && npm run lint:worker",
-    "lint:node": "node npm-scripts.js lint:node",
-    "lint:worker": "node npm-scripts.js lint:worker",
-    "format:worker": "node npm-scripts.js format:worker",
+    "lint:node": "node npm-scripts.mjs lint:node",
+    "lint:worker": "node npm-scripts.mjs lint:worker",
+    "format:worker": "node npm-scripts.mjs format:worker",
     "test": "npm run test:node && npm run test:worker",
-    "test:node": "node npm-scripts.js test:node",
-    "test:worker": "node npm-scripts.js test:worker",
-    "coverage:node": "node npm-scripts.js coverage:node",
-    "install-deps:node": "node npm-scripts.js install-deps:node",
-    "install-clang-tools": "node npm-scripts.js install-clang-tools",
-    "release:check": "node npm-scripts.js release:check",
-    "release": "node npm-scripts.js release",
-    "release:upload-mac-arm-prebuilt-worker": "node npm-scripts.js release:upload-mac-arm-prebuilt-worker"
+    "test:node": "node npm-scripts.mjs test:node",
+    "test:worker": "node npm-scripts.mjs test:worker",
+    "coverage:node": "node npm-scripts.mjs coverage:node",
+    "install-deps:node": "node npm-scripts.mjs install-deps:node",
+    "install-clang-tools": "node npm-scripts.mjs install-clang-tools",
+    "release:check": "node npm-scripts.mjs release:check",
+    "release": "node npm-scripts.mjs release",
+    "release:upload-mac-arm-prebuilt-worker": "node npm-scripts.mjs release:upload-mac-arm-prebuilt-worker"
   },
   "jest": {
     "verbose": true,
@@ -89,7 +89,7 @@
   "dependencies": {
     "debug": "^4.3.4",
     "h264-profile-level-id": "^1.0.1",
-    "node-fetch": "^2.6.11",
+    "node-fetch": "^3.3.1",
     "supports-color": "^9.3.1",
     "tar": "^6.1.15",
     "uuid": "^9.0.0"
@@ -98,7 +98,7 @@
     "@octokit/rest": "^19.0.11",
     "@types/debug": "^4.1.8",
     "@types/jest": "^29.5.1",
-    "@types/node": "^18.15.11",
+    "@types/node": "^18.16.16",
     "@types/uuid": "^9.0.1",
     "@typescript-eslint/eslint-plugin": "^5.59.7",
     "@typescript-eslint/parser": "^5.59.7",


### PR DESCRIPTION
Avoid CommonJS gradually and use ES Module (import/export). This change is also needed to be able to use `node-fetch` version 3 (instead of using unmaintained version 2 forever).