### PR TITLE
Fix: enable loading .env variables

### DIFF
--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { execSync, spawnSync } from 'child_process';
 import fetch from 'node-fetch';
 import tar from 'tar';
+import 'dotenv/config';
 
 const PKG = JSON.parse(fs.readFileSync('./package.json').toString());
 const IS_FREEBSD = os.platform() === 'freebsd';

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",
+        "dotenv": "^16.0.3",
         "h264-profile-level-id": "^1.0.1",
         "node-fetch": "^3.3.1",
         "supports-color": "^9.3.1",
@@ -2578,6 +2579,14 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/duplexer": {
@@ -8420,6 +8429,11 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ=="
     },
     "duplexer": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
   },
   "dependencies": {
     "debug": "^4.3.4",
+    "dotenv": "^16.0.3",
     "h264-profile-level-id": "^1.0.1",
     "node-fetch": "^3.3.1",
     "supports-color": "^9.3.1",


### PR DESCRIPTION
Install the "dotenv" package and import it in npm-scripts.mjs to be able to load environment variables found in a .env file: e.g. MEDIASOUP_SKIP_WORKER_PREBUILT_DOWNLOAD=true. 