### PR TITLE
PlainTransportOptions: add optional rtcpListenInfo

### DIFF
--- a/node/src/PlainTransport.ts
+++ b/node/src/PlainTransport.ts
@@ -36,6 +36,11 @@ type PlainTransportListenInfo =
 	 * Listening info.
 	 */
 	listenInfo: TransportListenInfo;
+
+	/**
+	 * Optional listening info for RTCP.
+	 */
+	rtcpListenInfo?: TransportListenInfo;
 };
 
 type PlainTransportListenIp =

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -646,7 +646,7 @@ export class Router<RouterAppData extends AppData = AppData>
 		}
 
 		// If rtcpMux is enabled, ignore rtcpListenInfo.
-		if (rtcpMux && rtcpListenInfo !== undefined)
+		if (rtcpMux)
 		{
 			logger.warn('createPlainTransport() | ignoring given rtcpListenInfo since rtcpMux is enabled');
 

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -615,6 +615,7 @@ export class Router<RouterAppData extends AppData = AppData>
 	async createPlainTransport<PlainTransportAppData extends AppData = AppData>(
 		{
 			listenInfo,
+			rtcpListenInfo,
 			listenIp,
 			port,
 			rtcpMux = true,
@@ -642,6 +643,14 @@ export class Router<RouterAppData extends AppData = AppData>
 		else if (appData && typeof appData !== 'object')
 		{
 			throw new TypeError('if given, appData must be an object');
+		}
+
+		// If rtcpMux is enabled, ignore rtcpListenInfo.
+		if (rtcpMux && rtcpListenInfo !== undefined)
+		{
+			logger.warn('createPlainTransport() | ignoring given rtcpListenInfo since rtcpMux is enabled');
+
+			rtcpListenInfo = undefined;
 		}
 
 		// Convert deprecated TransportListenIps to TransportListenInfos.
@@ -688,6 +697,16 @@ export class Router<RouterAppData extends AppData = AppData>
 				listenInfo!.sendBufferSize,
 				listenInfo!.recvBufferSize
 			),
+			rtcpListenInfo ? new FbsTransport.ListenInfoT(
+				rtcpListenInfo.protocol === 'udp'
+					? FbsTransportProtocol.UDP
+					: FbsTransportProtocol.TCP,
+				rtcpListenInfo.ip,
+				rtcpListenInfo.announcedIp,
+				rtcpListenInfo.port,
+				rtcpListenInfo.sendBufferSize,
+				rtcpListenInfo.recvBufferSize
+			) : undefined,
 			rtcpMux,
 			comedia,
 			enableSrtp,

--- a/node/src/tests/test-PlainTransport.ts
+++ b/node/src/tests/test-PlainTransport.ts
@@ -119,10 +119,13 @@ test('router.createPlainTransport() succeeds', async () =>
 
 	expect(typeof anotherTransport).toBe('object');
 
+	const rtpPort = await pickPort({ ip: '127.0.0.1', reserveTimeout: 0 });
+	const rtcpPort = await pickPort({ ip: '127.0.0.1', reserveTimeout: 0 });
 	const transport2 = await router.createPlainTransport(
 		{
-			listenInfo : { protocol: 'udp', ip: '127.0.0.1' },
-			rtcpMux    : false
+			listenInfo     : { protocol: 'udp', ip: '127.0.0.1', port: rtpPort },
+			rtcpListenInfo : { protocol: 'udp', ip: '127.0.0.1', port: rtcpPort },
+			rtcpMux        : false
 		});
 
 	expect(typeof transport2.id).toBe('string');
@@ -130,11 +133,11 @@ test('router.createPlainTransport() succeeds', async () =>
 	expect(transport2.appData).toEqual({});
 	expect(typeof transport2.tuple).toBe('object');
 	expect(transport2.tuple.localIp).toBe('127.0.0.1');
-	expect(typeof transport2.tuple.localPort).toBe('number');
+	expect(transport2.tuple.localPort).toBe(rtpPort);
 	expect(transport2.tuple.protocol).toBe('udp');
 	expect(typeof transport2.rtcpTuple).toBe('object');
 	expect(transport2.rtcpTuple?.localIp).toBe('127.0.0.1');
-	expect(typeof transport2.rtcpTuple?.localPort).toBe('number');
+	expect(transport2.rtcpTuple?.localPort).toBe(rtcpPort);
 	expect(transport2.rtcpTuple?.protocol).toBe('udp');
 	expect(transport2.sctpParameters).toBeUndefined();
 	expect(transport2.sctpState).toBeUndefined();

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -44,6 +44,8 @@ use std::sync::{Arc, Weak};
 pub struct PlainTransportOptions {
     /// Listening info.
     pub listen_info: ListenInfo,
+    /// Optional listening info for RTCP.
+    pub rtcp_listen_info: Option<ListenInfo>,
     /// Use RTCP-mux (RTP and RTCP in the same port).
     /// Default true.
     pub rtcp_mux: bool,
@@ -79,6 +81,7 @@ impl PlainTransportOptions {
     pub fn new(listen_info: ListenInfo) -> Self {
         Self {
             listen_info,
+            rtcp_listen_info: None,
             rtcp_mux: true,
             comedia: false,
             enable_sctp: false,

--- a/worker/fbs/plainTransport.fbs
+++ b/worker/fbs/plainTransport.fbs
@@ -6,6 +6,7 @@ namespace FBS.PlainTransport;
 table PlainTransportOptions {
   base:FBS.Transport.Options;
   listen_info:FBS.Transport.ListenInfo (required);
+  rtcp_listen_info:FBS.Transport.ListenInfo;
   rtcp_mux:bool;
   comedia:bool;
   enable_srtp:bool;

--- a/worker/include/RTC/PlainTransport.hpp
+++ b/worker/include/RTC/PlainTransport.hpp
@@ -77,6 +77,7 @@ namespace RTC
 		RTC::SrtpSession* srtpSendSession{ nullptr };
 		// Others.
 		ListenInfo listenInfo;
+		ListenInfo rtcpListenInfo;
 		bool rtcpMux{ true };
 		bool comedia{ false };
 		struct sockaddr_storage remoteAddrStorage;

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -88,13 +88,13 @@ namespace RTC
 			if (this->listenInfo.sendBufferSize != 0)
 			{
 				// NOTE: This may throw.
-				udpSocket->SetSendBufferSize(this->listenInfo.sendBufferSize);
+				this->udpSocket->SetSendBufferSize(this->listenInfo.sendBufferSize);
 			}
 
 			if (this->listenInfo.recvBufferSize != 0)
 			{
 				// NOTE: This may throw.
-				udpSocket->SetRecvBufferSize(this->listenInfo.recvBufferSize);
+				this->udpSocket->SetRecvBufferSize(this->listenInfo.recvBufferSize);
 			}
 
 			MS_DEBUG_TAG(


### PR DESCRIPTION
Fixes #1096

NOTE: PR targeting `flatbuffers` branch since it depends on the new `TransportListenInfo` type.