### PR TITLE
fix downloaded prebuilt binary check on Windows

### DIFF
--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -4,6 +4,7 @@ import fs from 'fs';
 import { execSync, spawnSync } from 'child_process';
 import fetch from 'node-fetch';
 import tar from 'tar';
+import path from 'path';
 
 const PKG = JSON.parse(fs.readFileSync('./package.json').toString());
 const IS_FREEBSD = os.platform() === 'freebsd';
@@ -551,8 +552,9 @@ async function downloadPrebuiltWorker()
 
 				try
 				{
+					const resolvedBinPath = path.resolve(WORKER_RELEASE_BIN_PATH);
 					execSync(
-						`${WORKER_RELEASE_BIN_PATH}`,
+						resolvedBinPath,
 						{
 							stdio : [ 'ignore', 'ignore', 'ignore' ],
 							// Ensure no env is passed to avoid accidents.


### PR DESCRIPTION
The download prebuilt binary on Windows always failed because execSync can not found exec file path.
```
execSync(
	`${WORKER_RELEASE_BIN_PATH}`,
```
Use path.resolve to convert it to absolute path should be executed by execSync.
```
const resolvedBinPath = path.resolve(WORKER_RELEASE_BIN_PATH);
execSync(
	resolvedBinPath,
```