### PR TITLE
Node: make types.ts only export types rather than the entire class/code

### DIFF
--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -1,23 +1,24 @@
-export * from './Worker';
-export * from './WebRtcServer';
-export * from './Router';
-export * from './Transport';
-export * from './WebRtcTransport';
-export * from './PlainTransport';
-export * from './PipeTransport';
-export * from './DirectTransport';
-export * from './Producer';
-export * from './Consumer';
-export * from './DataProducer';
-export * from './DataConsumer';
-export * from './RtpObserver';
-export * from './ActiveSpeakerObserver';
-export * from './AudioLevelObserver';
-export * from './RtpParameters';
-export * from './SctpParameters';
-export * from './SrtpParameters';
+export type * from './Worker';
+export type * from './WebRtcServer';
+export type * from './Router';
+export type * from './Transport';
+export type * from './WebRtcTransport';
+export type * from './PlainTransport';
+export type * from './PipeTransport';
+export type * from './DirectTransport';
+export type * from './Producer';
+export type * from './Consumer';
+export type * from './DataProducer';
+export type * from './DataConsumer';
+export type * from './RtpObserver';
+export type * from './ActiveSpeakerObserver';
+export type * from './AudioLevelObserver';
+export type * from './RtpParameters';
+export type * from './SctpParameters';
+export type * from './SrtpParameters';
+// We cannot export only the type of error classes because those are useless.
 export * from './errors';
-export { ScalabilityMode } from './scalabilityModes';
+export type { ScalabilityMode } from './scalabilityModes';
 
 export type AppData =
 {


### PR DESCRIPTION
Same as in https://github.com/versatica/mediasoup-client/issues/273

**NOTE:** This was done and later reverted here https://github.com/versatica/mediasoup/commit/a9a34ca8948eb19cf25aa6cd0374581bd786b362 because it requires typescript >= 5 in the apps that import mediasoup. We'll do this again once we can assume that all users use typescript >= 5.