### PR TITLE
Replace `clone` in utils with `structuredClone` everywhere

### DIFF
--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -1,7 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
-import * as utils from './utils';
 import * as ortc from './ortc';
 import { Channel } from './Channel';
 import { PayloadChannel } from './PayloadChannel';
@@ -922,30 +921,29 @@ export class Transport
 		if (this.constructor.name !== 'DirectTransport')
 		{
 			type = 'sctp';
-			sctpStreamParameters =
-				utils.clone(dataProducer.sctpStreamParameters) as SctpStreamParameters;
+			sctpStreamParameters = structuredClone(dataProducer.sctpStreamParameters);
 
 			// Override if given.
 			if (ordered !== undefined)
 			{
-				sctpStreamParameters.ordered = ordered;
+				sctpStreamParameters!.ordered = ordered;
 			}
 
 			if (maxPacketLifeTime !== undefined)
 			{
-				sctpStreamParameters.maxPacketLifeTime = maxPacketLifeTime;
+				sctpStreamParameters!.maxPacketLifeTime = maxPacketLifeTime;
 			}
 
 			if (maxRetransmits !== undefined)
 			{
-				sctpStreamParameters.maxRetransmits = maxRetransmits;
+				sctpStreamParameters!.maxRetransmits = maxRetransmits;
 			}
 
 			// This may throw.
 			sctpStreamId = this.getNextSctpStreamId();
 
 			this.#sctpStreamIds![sctpStreamId] = 1;
-			sctpStreamParameters.streamId = sctpStreamId;
+			sctpStreamParameters!.streamId = sctpStreamId;
 		}
 		// If this is a DirectTransport, sctpStreamParameters must not be used.
 		else

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -1,7 +1,6 @@
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import { Worker, WorkerSettings } from './Worker';
-import * as utils from './utils';
 import { supportedRtpCapabilities } from './supportedRtpCapabilities';
 import { RtpCapabilities } from './RtpParameters';
 import * as types from './types';
@@ -90,5 +89,5 @@ export async function createWorker<WorkerAppData extends AppData = AppData>(
  */
 export function getSupportedRtpCapabilities(): RtpCapabilities
 {
-	return utils.clone(supportedRtpCapabilities) as RtpCapabilities;
+	return structuredClone(supportedRtpCapabilities);
 }

--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -1,5 +1,6 @@
 import * as h264 from 'h264-profile-level-id';
 import * as utils from './utils';
+import { getSupportedRtpCapabilities } from '.';
 import { UnsupportedError } from './errors';
 import { supportedRtpCapabilities } from './supportedRtpCapabilities';
 import { parse as parseScalabilityMode } from './scalabilityModes';
@@ -729,9 +730,8 @@ export function generateRouterRtpCapabilities(
 		throw new TypeError('mediaCodecs must be an Array');
 	}
 
-	const clonedSupportedRtpCapabilities =
-		utils.clone(supportedRtpCapabilities) as RtpCapabilities;
-	const dynamicPayloadTypes = utils.clone(DynamicPayloadTypes) as number[];
+	const clonedSupportedRtpCapabilities = getSupportedRtpCapabilities();
+	const dynamicPayloadTypes = structuredClone(DynamicPayloadTypes);
 	const caps: RtpCapabilities =
 	{
 		codecs           : [],
@@ -756,7 +756,7 @@ export function generateRouterRtpCapabilities(
 		}
 
 		// Clone the supported codec.
-		const codec = utils.clone(matchedSupportedCodec) as RtpCodecCapability;
+		const codec = structuredClone(matchedSupportedCodec);
 
 		// If the given media codec has preferredPayloadType, keep it.
 		if (typeof mediaCodec.preferredPayloadType === 'number')
@@ -1040,11 +1040,11 @@ export function getConsumableRtpParameters(
 	}
 
 	// Clone Producer encodings since we'll mangle them.
-	const consumableEncodings = utils.clone(params.encodings) as RtpEncodingParameters[];
+	const consumableEncodings = structuredClone(params.encodings);
 
-	for (let i = 0; i < consumableEncodings.length; ++i)
+	for (let i = 0; i < (consumableEncodings?.length ?? 0); ++i)
 	{
-		const consumableEncoding = consumableEncodings[i];
+		const consumableEncoding = consumableEncodings![i];
 		const { mappedSsrc } = rtpMapping.encodings[i];
 
 		// Remove useless fields.
@@ -1138,8 +1138,7 @@ export function getConsumerRtpParameters(
 		validateRtpCodecCapability(capCodec);
 	}
 
-	const consumableCodecs =
-		utils.clone(consumableRtpParameters.codecs) as RtpCodecParameters[];
+	const consumableCodecs = structuredClone(consumableRtpParameters.codecs);
 
 	let rtxSupported = false;
 
@@ -1293,14 +1292,13 @@ export function getConsumerRtpParameters(
 	}
 	else
 	{
-		const consumableEncodings =
-			utils.clone(consumableRtpParameters.encodings) as RtpEncodingParameters[];
+		const consumableEncodings = structuredClone(consumableRtpParameters.encodings);
 		const baseSsrc = utils.generateRandomNumber();
 		const baseRtxSsrc = utils.generateRandomNumber();
 
-		for (let i = 0; i < consumableEncodings.length; ++i)
+		for (let i = 0; i < (consumableEncodings?.length ?? 0); ++i)
 		{
-			const encoding = consumableEncodings[i];
+			const encoding = consumableEncodings![i];
 
 			encoding.ssrc = baseSsrc + i;
 
@@ -1345,8 +1343,7 @@ export function getPipeConsumerRtpParameters(
 		rtcp             : consumableRtpParameters.rtcp
 	};
 
-	const consumableCodecs =
-		utils.clone(consumableRtpParameters.codecs) as RtpCodecParameters[];
+	const consumableCodecs = structuredClone(consumableRtpParameters.codecs);
 
 	for (const codec of consumableCodecs)
 	{
@@ -1373,14 +1370,13 @@ export function getPipeConsumerRtpParameters(
 			ext.uri !== 'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01'
 		));
 
-	const consumableEncodings =
-		utils.clone(consumableRtpParameters.encodings) as RtpEncodingParameters[];
+	const consumableEncodings = structuredClone(consumableRtpParameters.encodings);
 	const baseSsrc = utils.generateRandomNumber();
 	const baseRtxSsrc = utils.generateRandomNumber();
 
-	for (let i = 0; i < consumableEncodings.length; ++i)
+	for (let i = 0; i < (consumableEncodings?.length ?? 0); ++i)
 	{
-		const encoding = consumableEncodings[i];
+		const encoding = consumableEncodings![i];
 
 		encoding.ssrc = baseSsrc + i;
 

--- a/node/src/utils.ts
+++ b/node/src/utils.ts
@@ -1,19 +1,6 @@
 import { randomInt } from 'crypto';
 
 /**
- * Clones the given object/array.
- */
-export function clone(data: any): any
-{
-	if (typeof data !== 'object')
-	{
-		return {};
-	}
-
-	return JSON.parse(JSON.stringify(data));
-}
-
-/**
  * Generates a random positive integer.
  */
 export function generateRandomNumber()

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "typescript": "^5.1.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=17"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "nodejs"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=17"
   },
   "scripts": {
     "prepare": "node npm-scripts.mjs prepare",


### PR DESCRIPTION
`structuredClone` should be much more clean (and potentially efficient) to clone an object recursively. It also prevented some type casting.

Hopefully bumping to Node 17 is acceptable [considering that Node 16 is almost EOL](https://github.com/nodejs/release#release-schedule).