### PR TITLE
Refactor data consumer SCTP stream parameter handling

### DIFF
--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -6,6 +6,17 @@ import { TransportInternal } from './Transport';
 import { SctpStreamParameters } from './SctpParameters';
 import { AppData } from './types';
 
+/**
+ * SCTP stream parameters. Identical to {@link SctpStreamParameters} with the
+ * exception that the `streamId` is optional.
+ */
+type DataConsumerOptionsSctpStreamParameters = {
+	/**
+	 * SCTP stream id. If not provided, a free SCTP stream id will be assigned.
+	 */
+	streamId?: number;
+} & Omit<SctpStreamParameters, 'streamId'>;
+
 export type DataConsumerOptions<DataConsumerAppData extends AppData = AppData> =
 {
 	/**
@@ -14,28 +25,10 @@ export type DataConsumerOptions<DataConsumerAppData extends AppData = AppData> =
 	dataProducerId: string;
 
 	/**
-	 * Just if consuming over SCTP.
-	 * Whether data messages must be received in order. If true the messages will
-	 * be sent reliably. Defaults to the value in the DataProducer if it has type
-	 * 'sctp' or to true if it has type 'direct'.
+	 * SCTP parameters defining how the endpoint is sending the data.
+	 * Only if messages are sent over SCTP.
 	 */
-	ordered?: boolean;
-
-	/**
-	 * Just if consuming over SCTP.
-	 * When ordered is false indicates the time (in milliseconds) after which a
-	 * SCTP packet will stop being retransmitted. Defaults to the value in the
-	 * DataProducer if it has type 'sctp' or unset if it has type 'direct'.
-	 */
-	maxPacketLifeTime?: number;
-
-	/**
-	 * Just if consuming over SCTP.
-	 * When ordered is false indicates the maximum number of times a packet will
-	 * be retransmitted. Defaults to the value in the DataProducer if it has type
-	 * 'sctp' or unset if it has type 'direct'.
-	 */
-	maxRetransmits?: number;
+	sctpStreamParameters?: DataConsumerOptionsSctpStreamParameters;
 
 	/**
 	 * Custom application data.

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -1,7 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
-import * as utils from './utils';
 import * as ortc from './ortc';
 import { Channel } from './Channel';
 import { PayloadChannel } from './PayloadChannel';
@@ -922,30 +921,29 @@ export class Transport
 		if (this.constructor.name !== 'DirectTransport')
 		{
 			type = 'sctp';
-			sctpStreamParameters =
-				utils.clone(dataProducer.sctpStreamParameters) as SctpStreamParameters;
+			sctpStreamParameters = structuredClone(dataProducer.sctpStreamParameters);
 
 			// Override if given.
 			if (ordered !== undefined)
 			{
-				sctpStreamParameters.ordered = ordered;
+				sctpStreamParameters!.ordered = ordered;
 			}
 
 			if (maxPacketLifeTime !== undefined)
 			{
-				sctpStreamParameters.maxPacketLifeTime = maxPacketLifeTime;
+				sctpStreamParameters!.maxPacketLifeTime = maxPacketLifeTime;
 			}
 
 			if (maxRetransmits !== undefined)
 			{
-				sctpStreamParameters.maxRetransmits = maxRetransmits;
+				sctpStreamParameters!.maxRetransmits = maxRetransmits;
 			}
 
 			// This may throw.
 			sctpStreamId = this.getNextSctpStreamId();
 
 			this.#sctpStreamIds![sctpStreamId] = 1;
-			sctpStreamParameters.streamId = sctpStreamId;
+			sctpStreamParameters!.streamId = sctpStreamId;
 		}
 		// If this is a DirectTransport, sctpStreamParameters must not be used.
 		else

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -1,7 +1,6 @@
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import { Worker, WorkerSettings } from './Worker';
-import * as utils from './utils';
 import { supportedRtpCapabilities } from './supportedRtpCapabilities';
 import { RtpCapabilities } from './RtpParameters';
 import * as types from './types';
@@ -90,5 +89,5 @@ export async function createWorker<WorkerAppData extends AppData = AppData>(
  */
 export function getSupportedRtpCapabilities(): RtpCapabilities
 {
-	return utils.clone(supportedRtpCapabilities) as RtpCapabilities;
+	return structuredClone(supportedRtpCapabilities);
 }

--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -1,5 +1,6 @@
 import * as h264 from 'h264-profile-level-id';
 import * as utils from './utils';
+import { getSupportedRtpCapabilities } from '.';
 import { UnsupportedError } from './errors';
 import { supportedRtpCapabilities } from './supportedRtpCapabilities';
 import { parse as parseScalabilityMode } from './scalabilityModes';
@@ -729,9 +730,8 @@ export function generateRouterRtpCapabilities(
 		throw new TypeError('mediaCodecs must be an Array');
 	}
 
-	const clonedSupportedRtpCapabilities =
-		utils.clone(supportedRtpCapabilities) as RtpCapabilities;
-	const dynamicPayloadTypes = utils.clone(DynamicPayloadTypes) as number[];
+	const clonedSupportedRtpCapabilities = getSupportedRtpCapabilities();
+	const dynamicPayloadTypes = structuredClone(DynamicPayloadTypes);
 	const caps: RtpCapabilities =
 	{
 		codecs           : [],
@@ -756,7 +756,7 @@ export function generateRouterRtpCapabilities(
 		}
 
 		// Clone the supported codec.
-		const codec = utils.clone(matchedSupportedCodec) as RtpCodecCapability;
+		const codec = structuredClone(matchedSupportedCodec);
 
 		// If the given media codec has preferredPayloadType, keep it.
 		if (typeof mediaCodec.preferredPayloadType === 'number')
@@ -1040,11 +1040,11 @@ export function getConsumableRtpParameters(
 	}
 
 	// Clone Producer encodings since we'll mangle them.
-	const consumableEncodings = utils.clone(params.encodings) as RtpEncodingParameters[];
+	const consumableEncodings = structuredClone(params.encodings);
 
-	for (let i = 0; i < consumableEncodings.length; ++i)
+	for (let i = 0; i < (consumableEncodings?.length ?? 0); ++i)
 	{
-		const consumableEncoding = consumableEncodings[i];
+		const consumableEncoding = consumableEncodings![i];
 		const { mappedSsrc } = rtpMapping.encodings[i];
 
 		// Remove useless fields.
@@ -1138,8 +1138,7 @@ export function getConsumerRtpParameters(
 		validateRtpCodecCapability(capCodec);
 	}
 
-	const consumableCodecs =
-		utils.clone(consumableRtpParameters.codecs) as RtpCodecParameters[];
+	const consumableCodecs = structuredClone(consumableRtpParameters.codecs);
 
 	let rtxSupported = false;
 
@@ -1293,14 +1292,13 @@ export function getConsumerRtpParameters(
 	}
 	else
 	{
-		const consumableEncodings =
-			utils.clone(consumableRtpParameters.encodings) as RtpEncodingParameters[];
+		const consumableEncodings = structuredClone(consumableRtpParameters.encodings);
 		const baseSsrc = utils.generateRandomNumber();
 		const baseRtxSsrc = utils.generateRandomNumber();
 
-		for (let i = 0; i < consumableEncodings.length; ++i)
+		for (let i = 0; i < (consumableEncodings?.length ?? 0); ++i)
 		{
-			const encoding = consumableEncodings[i];
+			const encoding = consumableEncodings![i];
 
 			encoding.ssrc = baseSsrc + i;
 
@@ -1345,8 +1343,7 @@ export function getPipeConsumerRtpParameters(
 		rtcp             : consumableRtpParameters.rtcp
 	};
 
-	const consumableCodecs =
-		utils.clone(consumableRtpParameters.codecs) as RtpCodecParameters[];
+	const consumableCodecs = structuredClone(consumableRtpParameters.codecs);
 
 	for (const codec of consumableCodecs)
 	{
@@ -1373,14 +1370,13 @@ export function getPipeConsumerRtpParameters(
 			ext.uri !== 'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01'
 		));
 
-	const consumableEncodings =
-		utils.clone(consumableRtpParameters.encodings) as RtpEncodingParameters[];
+	const consumableEncodings = structuredClone(consumableRtpParameters.encodings);
 	const baseSsrc = utils.generateRandomNumber();
 	const baseRtxSsrc = utils.generateRandomNumber();
 
-	for (let i = 0; i < consumableEncodings.length; ++i)
+	for (let i = 0; i < (consumableEncodings?.length ?? 0); ++i)
 	{
-		const encoding = consumableEncodings[i];
+		const encoding = consumableEncodings![i];
 
 		encoding.ssrc = baseSsrc + i;
 

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -15,7 +15,7 @@ const dataProducerParameters: mediasoup.types.DataProducerOptions =
 {
 	sctpStreamParameters :
 	{
-		streamId          : 12345,
+		streamId          : 123,
 		ordered           : false,
 		maxPacketLifeTime : 5000
 	},
@@ -51,9 +51,11 @@ test('transport.consumeData() succeeds', async () =>
 
 	dataConsumer1 = await transport2.consumeData(
 		{
-			dataProducerId    : dataProducer.id,
-			maxPacketLifeTime : 4000,
-			appData           : { baz: 'LOL' }
+			dataProducerId       : dataProducer.id,
+			sctpStreamParameters : {
+				maxPacketLifeTime : 4000
+			},
+			appData              : { baz: 'LOL' }
 		});
 
 	expect(onObserverNewDataConsumer).toHaveBeenCalledTimes(1);
@@ -87,6 +89,20 @@ test('transport.consumeData() succeeds', async () =>
 				dataProducerIds : [],
 				dataConsumerIds : [ dataConsumer1.id ]
 			});
+}, 2000);
+
+test('transport.consumeData() with already used streamId rejects with Error', async () =>
+{
+	await expect(transport2.consumeData(
+		{
+			dataProducerId       : dataProducer.id,
+			sctpStreamParameters :
+			{
+				streamId : dataConsumer1.sctpStreamParameters!.streamId
+			}
+		}))
+		.rejects
+		.toThrow(Error);
 }, 2000);
 
 test('dataConsumer.dump() succeeds', async () =>

--- a/node/src/utils.ts
+++ b/node/src/utils.ts
@@ -1,19 +1,6 @@
 import { randomInt } from 'crypto';
 
 /**
- * Clones the given object/array.
- */
-export function clone(data: any): any
-{
-	if (typeof data !== 'object')
-	{
-		return {};
-	}
-
-	return JSON.parse(JSON.stringify(data));
-}
-
-/**
  * Generates a random positive integer.
  */
 export function generateRandomNumber()

--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "typescript": "^5.1.3"
       },
       "engines": {
-        "node": ">=16"
+        "node": ">=17"
       },
       "funding": {
         "type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "nodejs"
   ],
   "engines": {
-    "node": ">=16"
+    "node": ">=17"
   },
   "scripts": {
     "prepare": "node npm-scripts.mjs prepare",


### PR DESCRIPTION
The API of `DataConsumer` and `DataProducer` have been unified to use the same kind of parameters object when providing SCTP stream parameters and those parameters are always validated.

Previously, creating a `DataConsumer` from a `DataProducer` that has been created via `DirectTransport` was brittle since SCTP stream parameters cannot be inferred from the `DirectTransport`'s `DataProducer`.

It is now possible to provide the SCTP stream id for the consumer, too.

---

My primary motivation was to be able to set the SCTP stream id for the consumer and then I noticed that the current API is a bit brittle when used in combination with a `DirectTransport`, leaving me with an SCTP `DataConsumer` whose parameters were stuck at default **and** didn't match the original `DataProducer`.

I'm not sure how controversial this API change is but I'm certain you will tell me. :slightly_smiling_face:

(This builds on #1110, so I'm marking it as a draft for now.)