### PR TITLE
worker: Add Transport::Destroying() protected method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### Next
+
+* `Worker`: Add `Transport::Destroying()` protected method ([PR #1114](https://github.com/versatica/mediasoup/pull/1114)).
+
+
 ### 3.12.5
 
 * `DataConsumer`: Fix removed 'bufferedamountlow' notification ([PR #1113](https://github.com/versatica/mediasoup/pull/1113)).

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -144,6 +144,7 @@ namespace RTC
 
 	protected:
 		// Must be called from the subclass.
+		void Destroying();
 		void Connected();
 		void Disconnected();
 		void DataReceived(size_t len)

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -28,6 +28,10 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		// Tell the Transport parent class that we are about to destroy
+		// the class instance.
+		Destroying();
+
 		this->shared->channelMessageRegistrator->UnregisterHandler(this->id);
 	}
 

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -117,6 +117,10 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		// Tell the Transport parent class that we are about to destroy
+		// the class instance.
+		Destroying();
+
 		this->shared->channelMessageRegistrator->UnregisterHandler(this->id);
 
 		delete this->udpSocket;

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -206,6 +206,10 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		// Tell the Transport parent class that we are about to destroy
+		// the class instance.
+		Destroying();
+
 		this->shared->channelMessageRegistrator->UnregisterHandler(this->id);
 
 		delete this->udpSocket;

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -182,9 +182,6 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// Set the destroying flag.
-		this->destroying = true;
-
 		// The destructor must delete and clear everything silently.
 
 		// Delete all Producers.
@@ -1592,6 +1589,13 @@ namespace RTC
 				MS_ERROR("unknown event '%s'", notification->event.c_str());
 			}
 		}
+	}
+
+	void Transport::Destroying()
+	{
+		MS_TRACE();
+
+		this->destroying = true;
 	}
 
 	void Transport::Connected()

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -300,6 +300,11 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		// We need to tell the Transport parent class that we are about to destroy
+		// the class instance. This is because child's destructor runs before
+		// parent's destructor. See comment in Transport::OnSctpAssociationSendData().
+		Destroying();
+
 		this->shared->channelMessageRegistrator->UnregisterHandler(this->id);
 
 		// Must delete the DTLS transport first since it will generate a DTLS alert


### PR DESCRIPTION
Must be called by `Transport` child classes at the top of their destructors.

Related to https://mediasoup.discourse.group/t/rarely-crashes-on-sendsctpdata-when-enablesctp-is-enabled/5340/

@nazar-pc as told in the forum, this bug only affected Rust although I think that it could perfectly affect mediasoup Node as well.