### PR TITLE
Fix jitter calculation in RtpStreamRecv

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Next
 
 * `Worker`: Add `Transport::Destroying()` protected method ([PR #1114](https://github.com/versatica/mediasoup/pull/1114)).
+* `RtpStreamRecv`: Fix jitter calculation ([PR #1117](https://github.com/versatica/mediasoup/pull/1117), thanks to @penguinol). ).
 
 
 ### 3.12.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### Next
 
 * `Worker`: Add `Transport::Destroying()` protected method ([PR #1114](https://github.com/versatica/mediasoup/pull/1114)).
-* `RtpStreamRecv`: Fix jitter calculation ([PR #1117](https://github.com/versatica/mediasoup/pull/1117), thanks to @penguinol). ).
+* `RtpStreamRecv`: Fix jitter calculation ([PR #1117](https://github.com/versatica/mediasoup/pull/1117), thanks to @penguinol).
 
 
 ### 3.12.5

--- a/worker/include/RTC/RTCP/ReceiverReport.hpp
+++ b/worker/include/RTC/RTCP/ReceiverReport.hpp
@@ -102,9 +102,9 @@ namespace RTC
 			{
 				return uint32_t{ ntohl(this->header->jitter) };
 			}
-			void SetJitter(uint32_t jitter)
+			void SetJitter(float jitter)
 			{
-				this->header->jitter = uint32_t{ htonl(jitter) };
+				this->header->jitter = uint32_t{ htonl(static_cast<uint32_t>(jitter)) };
 			}
 			uint32_t GetLastSenderReport() const
 			{

--- a/worker/include/RTC/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RtpStreamRecv.hpp
@@ -114,8 +114,9 @@ namespace RTC
 		uint64_t lastSrReceived{ 0u };
 		// Relative transit time for prev packet.
 		int32_t transit{ 0u };
-		// Jitter in RTP timestamp units.
-		uint32_t jitter{ 0u };
+		// Jitter in RTP timestamp units. As per spec it's kept as floating value
+		// although it's exposed as integer in the stats.
+		float jitter{ 0 };
 		uint8_t firSeqNumber{ 0u };
 		uint32_t reportedPacketLost{ 0u };
 		std::unique_ptr<RTC::NackGenerator> nackGenerator;

--- a/worker/include/RTC/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RtpStreamRecv.hpp
@@ -114,7 +114,7 @@ namespace RTC
 		uint64_t lastSrReceived{ 0u };
 		// Relative transit time for prev packet.
 		int32_t transit{ 0u };
-		// Jitter in ms.
+		// Jitter in RTP timestamp units.
 		uint32_t jitter{ 0u };
 		uint8_t firSeqNumber{ 0u };
 		uint32_t reportedPacketLost{ 0u };

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -692,15 +692,14 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		if (this->params.clockRate == 0u)
+		if (GetClockRate() == 0u)
 		{
 			return;
 		}
 
 		// NOTE: Based on https://github.com/versatica/mediasoup/issues/1018.
-		auto transit = static_cast<int>(
-		  DepLibUV::GetTimeMs() - (static_cast<uint64_t>(rtpTimestamp) * 1000 / this->params.clockRate));
-		int d = transit - this->transit;
+		auto transit = static_cast<int>((DepLibUV::GetTimeMs() * GetClockRate() / 1000) - rtpTimestamp);
+		int d        = transit - this->transit;
 
 		// First transit calculation, save and return.
 		if (this->transit == 0)

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -236,7 +236,7 @@ namespace RTC
 		RTC::RtpStream::FillJsonStats(jsonObject);
 
 		jsonObject["type"]        = "inbound-rtp";
-		jsonObject["jitter"]      = this->jitter;
+		jsonObject["jitter"]      = static_cast<uint32_t>(this->jitter);
 		jsonObject["packetCount"] = this->transmissionCounter.GetPacketCount();
 		jsonObject["byteCount"]   = this->transmissionCounter.GetBytes();
 		jsonObject["bitrate"]     = this->transmissionCounter.GetBitrate(nowMs);
@@ -716,7 +716,7 @@ namespace RTC
 			d = -d;
 		}
 
-		this->jitter += (1. / 16.) * (static_cast<double>(d) - this->jitter);
+		this->jitter += (1. / 16.) * (static_cast<float>(d) - this->jitter);
 	}
 
 	void RtpStreamRecv::UpdateScore()


### PR DESCRIPTION
- Inspired by PR #1108.
- Calculate `jitter` in RTP timestamp units (as per spec) rather than milliseconds.
- Also, and as per spec, make `this->jitter` be a `float` despite we convert it to `uint32_t` when generating stats.