### PR TITLE
Export workerBin absolute path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Next
+
+* Export `workerBin` absolute path ([PR #1123](https://github.com/versatica/mediasoup/pull/1123)).
+
+
 ### 3.12.7
 
 * `SimulcastConsumer`: Fix lack of "layerschange" event when all streams in the producer die ([PR #1122](https://github.com/versatica/mediasoup/pull/1122)).

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -126,7 +126,7 @@ In order to instruct the mediasoup Node.js module to use the `Debug` mediasoup-w
 MEDIASOUP_BUILDTYPE=Debug node myapp.js
 ```
 
-If the "MEDIASOUP_WORKER_BIN" environment variable is set, mediasoup will use the it as mediasoup-worker binary and **won't** compile the binary:
+If the "MEDIASOUP_WORKER_BIN" environment variable is set (it must be an absolute file path), mediasoup will use the it as mediasoup-worker binary and **won't** compile the binary:
 
 ```bash
 MEDIASOUP_WORKER_BIN="/home/xxx/src/foo/mediasoup-worker" node myapp.js

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -195,7 +195,7 @@ export type WorkerObserverEvents =
 // If env MEDIASOUP_WORKER_BIN is given, use it as worker binary.
 // Otherwise if env MEDIASOUP_BUILDTYPE is 'Debug' use the Debug binary.
 // Otherwise use the Release binary.
-const workerBin = process.env.MEDIASOUP_WORKER_BIN
+export const workerBin = process.env.MEDIASOUP_WORKER_BIN
 	? process.env.MEDIASOUP_WORKER_BIN
 	: process.env.MEDIASOUP_BUILDTYPE === 'Debug'
 		? path.join(__dirname, '..', '..', 'worker', 'out', 'Debug', 'mediasoup-worker')

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -1,6 +1,6 @@
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
-import { Worker, WorkerSettings } from './Worker';
+import { workerBin, Worker, WorkerSettings } from './Worker';
 import * as utils from './utils';
 import { supportedRtpCapabilities } from './supportedRtpCapabilities';
 import { RtpCapabilities } from './RtpParameters';
@@ -35,6 +35,11 @@ const observer = new EnhancedEventEmitter<ObserverEvents>();
  * Observer.
  */
 export { observer };
+
+/**
+ * Full path of the mediasoup-worker binary.
+ */
+export { workerBin };
 
 /**
  * Create a Worker.

--- a/node/src/tests/test-Worker.ts
+++ b/node/src/tests/test-Worker.ts
@@ -11,6 +11,17 @@ let worker: mediasoup.types.Worker;
 beforeEach(() => worker && !worker.closed && worker.close());
 afterEach(() => worker && !worker.closed && worker.close());
 
+test('Worker.workerBin matches mediasoup-worker absolute path', async () =>
+{
+	const workerBin = process.env.MEDIASOUP_WORKER_BIN
+		? process.env.MEDIASOUP_WORKER_BIN
+		: process.env.MEDIASOUP_BUILDTYPE === 'Debug'
+			? path.join(__dirname, '..', '..', '..', 'worker', 'out', 'Debug', 'mediasoup-worker')
+			: path.join(__dirname, '..', '..', '..', 'worker', 'out', 'Release', 'mediasoup-worker');
+
+	expect(mediasoup.workerBin).toBe(workerBin);
+});
+
 test('createWorker() succeeds', async () =>
 {
 	const onObserverNewWorker = jest.fn();


### PR DESCRIPTION
Assuming we are in `/home/manolo/projects/my-media-server/src/index.mjs`:

```ts
import { workerBin } from 'mediasoup';

console.log('workerBin:', workerBin);
```

will typically produce this output (which may mary depending on NPM version of project setup, etc):

```
workerBin: /home/manolo/projects/my-media-server/node_modules/mediasoup/worker/out/Release/mediasoup-worker
```

*NOTE:* This API addition doesn't make sense in Rust since mediasoup-rust doesn't run a separate mediasoup-worker process.