### PR TITLE
Properly handle errors on `setInterval()`

### DIFF
--- a/node/src/tests/test-DirectTransport.ts
+++ b/node/src/tests/test-DirectTransport.ts
@@ -152,6 +152,7 @@ test('dataProducer.send() succeeds', async () =>
 	});
 
 	// Send messages over the sctpSendStream created above.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	for await (const _ of setInterval(0))
 	{
 		const id = ++lastSentMessageId;

--- a/node/src/tests/test-node-sctp.ts
+++ b/node/src/tests/test-node-sctp.ts
@@ -178,6 +178,7 @@ test('ordered DataProducer delivers all SCTP messages to the DataConsumer', asyn
 	});
 
 	// Send SCTP messages over the sctpSendStream created above.
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
 	for await (const _ of setInterval(10))
 	{
 		const id = ++lastSentMessageId;


### PR DESCRIPTION
I've found a bug on the tests where if `dataProducer.send(message, ppid);` throws an exception, that's unhandled and the full tests crashes. This PR replaces `setTimeout()` for Node.js promised one, so instead of errors happening in a error handler function that ends up to global scope, now they are properly captured by the scope of the async function.