### PR TITLE
Avoid ASAN "new-delete-type-mismatch" harmless but noisy warning

### DIFF
--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -24,9 +24,9 @@ namespace Channel
 		}
 	}
 
-	inline static void onClose(uv_handle_t* handle)
+	inline static void onCloseAsync(uv_handle_t* handle)
 	{
-		delete handle;
+		delete reinterpret_cast<uv_async_t*>(handle);
 	}
 
 	/* Instance methods. */
@@ -100,7 +100,8 @@ namespace Channel
 
 		if (this->uvReadHandle)
 		{
-			uv_close(reinterpret_cast<uv_handle_t*>(this->uvReadHandle), static_cast<uv_close_cb>(onClose));
+			uv_close(
+			  reinterpret_cast<uv_handle_t*>(this->uvReadHandle), static_cast<uv_close_cb>(onCloseAsync));
 		}
 
 		if (this->consumerSocket)

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -11,9 +11,9 @@ thread_local uv_loop_t* DepLibUV::loop{ nullptr };
 
 /* Static methods for UV callbacks. */
 
-inline static void onClose(uv_handle_t* handle)
+inline static void onCloseLoop(uv_handle_t* handle)
 {
-	delete handle;
+	delete reinterpret_cast<uv_loop_t*>(handle);
 }
 
 inline static void onWalk(uv_handle_t* handle, void* /*arg*/)
@@ -27,7 +27,7 @@ inline static void onWalk(uv_handle_t* handle, void* /*arg*/)
 	  uv_has_ref(handle));
 
 	if (!uv_is_closing(handle))
-		uv_close(handle, onClose);
+		uv_close(handle, onCloseLoop);
 }
 
 /* Static methods. */

--- a/worker/src/PayloadChannel/PayloadChannelSocket.cpp
+++ b/worker/src/PayloadChannel/PayloadChannelSocket.cpp
@@ -25,9 +25,9 @@ namespace PayloadChannel
 		}
 	}
 
-	inline static void onClose(uv_handle_t* handle)
+	inline static void onCloseAsync(uv_handle_t* handle)
 	{
-		delete handle;
+		delete reinterpret_cast<uv_async_t*>(handle);
 	}
 
 	/* Instance methods. */
@@ -102,7 +102,8 @@ namespace PayloadChannel
 
 		if (this->uvReadHandle)
 		{
-			uv_close(reinterpret_cast<uv_handle_t*>(this->uvReadHandle), static_cast<uv_close_cb>(onClose));
+			uv_close(
+			  reinterpret_cast<uv_handle_t*>(this->uvReadHandle), static_cast<uv_close_cb>(onCloseAsync));
 		}
 
 		if (this->consumerSocket)

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -12,9 +12,16 @@
 
 /* Static methods for UV callbacks. */
 
-static inline void onClose(uv_handle_t* handle)
+// NOTE: We have different onCloseXxx() callbacks to avoid an ASAN warning by
+// ensuring that we call `delete xxx` with same type as `new xxx` before.
+static inline void onCloseUdp(uv_handle_t* handle)
 {
-	delete handle;
+	delete reinterpret_cast<uv_udp_t*>(handle);
+}
+
+static inline void onCloseTcp(uv_handle_t* handle)
+{
+	delete reinterpret_cast<uv_tcp_t*>(handle);
 }
 
 inline static void onFakeConnection(uv_stream_t* /*handle*/, int /*status*/)
@@ -161,20 +168,41 @@ namespace RTC
 			switch (transport)
 			{
 				case Transport::UDP:
+				{
 					uvHandle = reinterpret_cast<uv_handle_t*>(new uv_udp_t());
 					err      = uv_udp_init_ex(
             DepLibUV::GetLoop(), reinterpret_cast<uv_udp_t*>(uvHandle), UV_UDP_RECVMMSG);
+
 					break;
+				}
 
 				case Transport::TCP:
+				{
 					uvHandle = reinterpret_cast<uv_handle_t*>(new uv_tcp_t());
 					err      = uv_tcp_init(DepLibUV::GetLoop(), reinterpret_cast<uv_tcp_t*>(uvHandle));
+
 					break;
+				}
 			}
 
 			if (err != 0)
 			{
-				delete uvHandle;
+				switch (transport)
+				{
+					case Transport::UDP:
+					{
+						delete reinterpret_cast<uv_udp_t*>(uvHandle);
+
+						break;
+					}
+
+					case Transport::TCP:
+					{
+						delete reinterpret_cast<uv_tcp_t*>(uvHandle);
+
+						break;
+					}
+				}
 
 				switch (transport)
 				{
@@ -259,7 +287,22 @@ namespace RTC
 				break;
 
 			// If it failed, close the handle and check the reason.
-			uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onClose));
+			switch (transport)
+			{
+				case Transport::UDP:
+				{
+					uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onCloseUdp));
+
+					break;
+				};
+
+				case Transport::TCP:
+				{
+					uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onCloseTcp));
+
+					break;
+				}
+			}
 
 			switch (err)
 			{
@@ -400,7 +443,22 @@ namespace RTC
 
 		if (err != 0)
 		{
-			delete uvHandle;
+			switch (transport)
+			{
+				case Transport::UDP:
+				{
+					delete reinterpret_cast<uv_udp_t*>(uvHandle);
+
+					break;
+				}
+
+				case Transport::TCP:
+				{
+					delete reinterpret_cast<uv_tcp_t*>(uvHandle);
+
+					break;
+				}
+			}
 
 			switch (transport)
 			{
@@ -426,7 +484,7 @@ namespace RTC
 				if (err != 0)
 				{
 					// If it failed, close the handle and check the reason.
-					uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onClose));
+					uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onCloseUdp));
 
 					MS_THROW_ERROR(
 					  "uv_udp_bind() failed [transport:%s, ip:'%s', port:%" PRIu16 "]: %s",
@@ -449,7 +507,7 @@ namespace RTC
 				if (err != 0)
 				{
 					// If it failed, close the handle and check the reason.
-					uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onClose));
+					uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onCloseTcp));
 
 					MS_THROW_ERROR(
 					  "uv_tcp_bind() failed [transport:%s, ip:'%s', port:%" PRIu16 "]: %s",
@@ -469,7 +527,7 @@ namespace RTC
 				if (err != 0)
 				{
 					// If it failed, close the handle and check the reason.
-					uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onClose));
+					uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onCloseTcp));
 
 					MS_THROW_ERROR(
 					  "uv_listen() failed [transport:%s, ip:'%s', port:%" PRIu16 "]: %s",

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -193,6 +193,8 @@ namespace RTC
 					{
 						delete reinterpret_cast<uv_udp_t*>(uvHandle);
 
+						MS_THROW_ERROR("uv_udp_init_ex() failed: %s", uv_strerror(err));
+
 						break;
 					}
 
@@ -200,19 +202,10 @@ namespace RTC
 					{
 						delete reinterpret_cast<uv_tcp_t*>(uvHandle);
 
+						MS_THROW_ERROR("uv_tcp_init() failed: %s", uv_strerror(err));
+
 						break;
 					}
-				}
-
-				switch (transport)
-				{
-					case Transport::UDP:
-						MS_THROW_ERROR("uv_udp_init_ex() failed: %s", uv_strerror(err));
-						break;
-
-					case Transport::TCP:
-						MS_THROW_ERROR("uv_tcp_init() failed: %s", uv_strerror(err));
-						break;
 				}
 			}
 
@@ -449,6 +442,8 @@ namespace RTC
 				{
 					delete reinterpret_cast<uv_udp_t*>(uvHandle);
 
+					MS_THROW_ERROR("uv_udp_init_ex() failed: %s", uv_strerror(err));
+
 					break;
 				}
 
@@ -456,19 +451,10 @@ namespace RTC
 				{
 					delete reinterpret_cast<uv_tcp_t*>(uvHandle);
 
+					MS_THROW_ERROR("uv_tcp_init() failed: %s", uv_strerror(err));
+
 					break;
 				}
-			}
-
-			switch (transport)
-			{
-				case Transport::UDP:
-					MS_THROW_ERROR("uv_udp_init_ex() failed: %s", uv_strerror(err));
-					break;
-
-				case Transport::TCP:
-					MS_THROW_ERROR("uv_tcp_init() failed: %s", uv_strerror(err));
-					break;
 			}
 		}
 

--- a/worker/src/handles/SignalsHandler.cpp
+++ b/worker/src/handles/SignalsHandler.cpp
@@ -13,9 +13,9 @@ inline static void onSignal(uv_signal_t* handle, int signum)
 	static_cast<SignalsHandler*>(handle->data)->OnUvSignal(signum);
 }
 
-inline static void onClose(uv_handle_t* handle)
+inline static void onCloseSignal(uv_handle_t* handle)
 {
-	delete handle;
+	delete reinterpret_cast<uv_signal_t*>(handle);
 }
 
 /* Instance methods. */
@@ -44,7 +44,7 @@ void SignalsHandler::Close()
 
 	for (auto* uvHandle : this->uvHandles)
 	{
-		uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onClose));
+		uv_close(reinterpret_cast<uv_handle_t*>(uvHandle), static_cast<uv_close_cb>(onCloseSignal));
 	}
 }
 

--- a/worker/src/handles/TcpServerHandler.cpp
+++ b/worker/src/handles/TcpServerHandler.cpp
@@ -20,9 +20,9 @@ inline static void onConnection(uv_stream_t* handle, int status)
 		server->OnUvConnection(status);
 }
 
-inline static void onClose(uv_handle_t* handle)
+inline static void onCloseTcp(uv_handle_t* handle)
 {
-	delete handle;
+	delete reinterpret_cast<uv_tcp_t*>(handle);
 }
 
 /* Instance methods. */
@@ -43,7 +43,7 @@ TcpServerHandler::TcpServerHandler(uv_tcp_t* uvHandle) : uvHandle(uvHandle)
 
 	if (err != 0)
 	{
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
+		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onCloseTcp));
 
 		MS_THROW_ERROR("uv_listen() failed: %s", uv_strerror(err));
 	}
@@ -51,7 +51,7 @@ TcpServerHandler::TcpServerHandler(uv_tcp_t* uvHandle) : uvHandle(uvHandle)
 	// Set local address.
 	if (!SetLocalAddress())
 	{
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
+		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onCloseTcp));
 
 		MS_THROW_ERROR("error setting local IP and port");
 	}
@@ -84,7 +84,7 @@ void TcpServerHandler::Close()
 		delete connection;
 	}
 
-	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
+	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onCloseTcp));
 }
 
 void TcpServerHandler::Dump() const

--- a/worker/src/handles/Timer.cpp
+++ b/worker/src/handles/Timer.cpp
@@ -13,9 +13,9 @@ inline static void onTimer(uv_timer_t* handle)
 	static_cast<Timer*>(handle->data)->OnUvTimer();
 }
 
-inline static void onClose(uv_handle_t* handle)
+inline static void onCloseTimer(uv_handle_t* handle)
 {
-	delete handle;
+	delete reinterpret_cast<uv_timer_t*>(handle);
 }
 
 /* Instance methods. */
@@ -59,7 +59,7 @@ void Timer::Close()
 
 	this->closed = true;
 
-	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
+	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onCloseTimer));
 }
 
 void Timer::Start(uint64_t timeout, uint64_t repeat)

--- a/worker/src/handles/UdpSocketHandler.cpp
+++ b/worker/src/handles/UdpSocketHandler.cpp
@@ -45,9 +45,9 @@ inline static void onSend(uv_udp_send_t* req, int status)
 	delete sendData;
 }
 
-inline static void onClose(uv_handle_t* handle)
+inline static void onCloseUdp(uv_handle_t* handle)
 {
-	delete handle;
+	delete reinterpret_cast<uv_udp_t*>(handle);
 }
 
 /* Instance methods. */
@@ -66,7 +66,7 @@ UdpSocketHandler::UdpSocketHandler(uv_udp_t* uvHandle) : uvHandle(uvHandle)
 
 	if (err != 0)
 	{
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
+		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onCloseUdp));
 
 		MS_THROW_ERROR("uv_udp_recv_start() failed: %s", uv_strerror(err));
 	}
@@ -74,7 +74,7 @@ UdpSocketHandler::UdpSocketHandler(uv_udp_t* uvHandle) : uvHandle(uvHandle)
 	// Set local address.
 	if (!SetLocalAddress())
 	{
-		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
+		uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onCloseUdp));
 
 		MS_THROW_ERROR("error setting local IP and port");
 	}
@@ -106,7 +106,7 @@ void UdpSocketHandler::Close()
 	if (err != 0)
 		MS_ABORT("uv_udp_recv_stop() failed: %s", uv_strerror(err));
 
-	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onClose));
+	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onCloseUdp));
 }
 
 void UdpSocketHandler::Dump() const


### PR DESCRIPTION
Fixes #1128

Ensure we call `delete xxxx` with same type than `new xxxx`.