### PR TITLE
Get Error subclasses in tests from mediasoup.types collection

### DIFF
--- a/node/src/tests/test-Consumer.ts
+++ b/node/src/tests/test-Consumer.ts
@@ -1,7 +1,6 @@
 import * as mediasoup from '../';
-import { UnsupportedError } from '../errors';
 
-const { createWorker } = mediasoup;
+const { createWorker, types: { UnsupportedError } } = mediasoup;
 
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;
@@ -529,7 +528,7 @@ test('transport.consume() with enableRtx succeeds', async () =>
 	audioConsumer2.close();
 }, 2000);
 
-test('transport.consume() can be created with user provided mid', async () => 
+test('transport.consume() can be created with user provided mid', async () =>
 {
 	const audioConsumer1 = await transport2.consume(
 		{

--- a/node/src/tests/test-Producer.ts
+++ b/node/src/tests/test-Producer.ts
@@ -1,7 +1,6 @@
 import * as mediasoup from '../';
-import { UnsupportedError } from '../errors';
 
-const { createWorker } = mediasoup;
+const { createWorker, types: { UnsupportedError } } = mediasoup;
 
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;

--- a/node/src/tests/test-Router.ts
+++ b/node/src/tests/test-Router.ts
@@ -1,7 +1,6 @@
 import * as mediasoup from '../';
-import { InvalidStateError } from '../errors';
 
-const { createWorker } = mediasoup;
+const { createWorker, types: { InvalidStateError } } = mediasoup;
 
 let worker: mediasoup.types.Worker;
 

--- a/node/src/tests/test-WebRtcServer.ts
+++ b/node/src/tests/test-WebRtcServer.ts
@@ -1,11 +1,10 @@
 // @ts-ignore
 import * as pickPort from 'pick-port';
 import * as mediasoup from '../';
-import { InvalidStateError } from '../errors';
 
-const { createWorker } = mediasoup;
+const { createWorker, types: { InvalidStateError, Worker } } = mediasoup;
 
-let worker: mediasoup.types.Worker;
+let worker: Worker;
 
 beforeEach(() => worker && !worker.closed && worker.close());
 afterEach(() => worker && !worker.closed && worker.close());

--- a/node/src/tests/test-Worker.ts
+++ b/node/src/tests/test-Worker.ts
@@ -2,11 +2,12 @@ import * as os from 'os';
 import * as process from 'process';
 import * as path from 'path';
 import * as mediasoup from '../';
-import { InvalidStateError } from '../errors';
 
-const { createWorker, observer } = mediasoup;
+const {
+	createWorker, observer, types: { InvalidStateError, Worker }
+} = mediasoup;
 
-let worker: mediasoup.types.Worker;
+let worker: Worker;
 
 beforeEach(() => worker && !worker.closed && worker.close());
 afterEach(() => worker && !worker.closed && worker.close());

--- a/node/src/tests/test-multiopus.ts
+++ b/node/src/tests/test-multiopus.ts
@@ -1,7 +1,6 @@
 import * as mediasoup from '../';
-import { UnsupportedError } from '../errors';
 
-const { createWorker } = mediasoup;
+const { createWorker, types: { UnsupportedError } } = mediasoup;
 
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;

--- a/node/src/tests/test-ortc.ts
+++ b/node/src/tests/test-ortc.ts
@@ -1,6 +1,7 @@
 import * as mediasoup from '../';
 import * as ortc from '../ortc';
-import { UnsupportedError } from '../errors';
+
+const { types: { UnsupportedError } } = mediasoup;
 
 test('generateRouterRtpCapabilities() succeeds', () =>
 {


### PR DESCRIPTION
Error subclasses are being directly imported from their path in tests, but they are already being exported on `mediasoup.types` object. This change get the error subclasses from it, so there's only a single Mediasoup import and all tests are run only against the public API as acceptance tests. Only remaining local import is `ortc.ts` file, that I have found no way to access it otherwise to using it directly (since they are all of them stateless pure functions, maybe moving the file to its own dependency package?), but that can be reviewed in another PR.

There are some extra minor changes, like end of lines whitespace removal done automatically, or a couple of files where the only remaining usage of of `mediasoup` namespace was to get the `Worker` class, so I've included it in the object destructuring for cleanest.