### PR TITLE
FBS enhancements

### DIFF
--- a/rust/src/fbs.rs
+++ b/rust/src/fbs.rs
@@ -13999,7 +13999,7 @@ mod root {
                 /// The field `name` in the table `Parameter`
                 pub name: ::planus::alloc::string::String,
                 /// The field `value` in the table `Parameter`
-                pub value: ::core::option::Option<self::Value>,
+                pub value: self::Value,
             }
 
             impl Parameter {
@@ -14013,7 +14013,7 @@ mod root {
                 pub fn create(
                     builder: &mut ::planus::Builder,
                     field_name: impl ::planus::WriteAs<::planus::Offset<str>>,
-                    field_value: impl ::planus::WriteAsOptionalUnion<self::Value>,
+                    field_value: impl ::planus::WriteAsUnion<self::Value>,
                 ) -> ::planus::Offset<Self> {
                     let prepared_name = field_name.prepare(builder);
                     let prepared_value = field_value.prepare(builder);
@@ -14021,22 +14021,14 @@ mod root {
                     let mut table_writer: ::planus::table_writer::TableWriter<10> =
                         ::core::default::Default::default();
                     table_writer.write_entry::<::planus::Offset<str>>(0);
-                    if prepared_value.is_some() {
-                        table_writer.write_entry::<::planus::Offset<self::Value>>(2);
-                    }
-                    if prepared_value.is_some() {
-                        table_writer.write_entry::<u8>(1);
-                    }
+                    table_writer.write_entry::<::planus::Offset<self::Value>>(2);
+                    table_writer.write_entry::<u8>(1);
 
                     unsafe {
                         table_writer.finish(builder, |object_writer| {
                             object_writer.write::<_, _, 4>(&prepared_name);
-                            if let ::core::option::Option::Some(prepared_value) = prepared_value {
-                                object_writer.write::<_, _, 4>(&prepared_value.offset());
-                            }
-                            if let ::core::option::Option::Some(prepared_value) = prepared_value {
-                                object_writer.write::<_, _, 1>(&prepared_value.tag());
-                            }
+                            object_writer.write::<_, _, 4>(&prepared_value.offset());
+                            object_writer.write::<_, _, 1>(&prepared_value.tag());
                         });
                     }
                     builder.current_offset()
@@ -14096,17 +14088,10 @@ mod root {
                 #[allow(clippy::type_complexity)]
                 pub fn value<T1>(self, value: T1) -> ParameterBuilder<(T0, T1)>
                 where
-                    T1: ::planus::WriteAsOptionalUnion<self::Value>,
+                    T1: ::planus::WriteAsUnion<self::Value>,
                 {
                     let (v0,) = self.0;
                     ParameterBuilder((v0, value))
-                }
-
-                /// Sets the [`value` field](Parameter#structfield.value) to null.
-                #[inline]
-                #[allow(clippy::type_complexity)]
-                pub fn value_as_null(self) -> ParameterBuilder<(T0, ())> {
-                    self.value(())
                 }
             }
 
@@ -14123,7 +14108,7 @@ mod root {
 
             impl<
                     T0: ::planus::WriteAs<::planus::Offset<str>>,
-                    T1: ::planus::WriteAsOptionalUnion<self::Value>,
+                    T1: ::planus::WriteAsUnion<self::Value>,
                 > ::planus::WriteAs<::planus::Offset<Parameter>> for ParameterBuilder<(T0, T1)>
             {
                 type Prepared = ::planus::Offset<Parameter>;
@@ -14136,7 +14121,7 @@ mod root {
 
             impl<
                     T0: ::planus::WriteAs<::planus::Offset<str>>,
-                    T1: ::planus::WriteAsOptionalUnion<self::Value>,
+                    T1: ::planus::WriteAsUnion<self::Value>,
                 > ::planus::WriteAsOptional<::planus::Offset<Parameter>>
                 for ParameterBuilder<(T0, T1)>
             {
@@ -14153,7 +14138,7 @@ mod root {
 
             impl<
                     T0: ::planus::WriteAs<::planus::Offset<str>>,
-                    T1: ::planus::WriteAsOptionalUnion<self::Value>,
+                    T1: ::planus::WriteAsUnion<self::Value>,
                 > ::planus::WriteAsOffset<Parameter> for ParameterBuilder<(T0, T1)>
             {
                 #[inline]
@@ -14176,10 +14161,8 @@ mod root {
 
                 /// Getter for the [`value` field](Parameter#structfield.value).
                 #[inline]
-                pub fn value(
-                    &self,
-                ) -> ::planus::Result<::core::option::Option<self::ValueRef<'a>>> {
-                    self.0.access_union(1, "Parameter", "value")
+                pub fn value(&self) -> ::planus::Result<self::ValueRef<'a>> {
+                    self.0.access_union_required(1, "Parameter", "value")
                 }
             }
 
@@ -14187,9 +14170,7 @@ mod root {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                     let mut f = f.debug_struct("ParameterRef");
                     f.field("name", &self.name());
-                    if let ::core::option::Option::Some(field_value) = self.value().transpose() {
-                        f.field("value", &field_value);
-                    }
+                    f.field("value", &self.value());
                     f.finish()
                 }
             }
@@ -14201,11 +14182,7 @@ mod root {
                 fn try_from(value: ParameterRef<'a>) -> ::planus::Result<Self> {
                     ::core::result::Result::Ok(Self {
                         name: ::core::convert::TryInto::try_into(value.name()?)?,
-                        value: if let ::core::option::Option::Some(value) = value.value()? {
-                            ::core::option::Option::Some(::core::convert::TryInto::try_into(value)?)
-                        } else {
-                            ::core::option::Option::None
-                        },
+                        value: ::core::convert::TryInto::try_into(value.value()?)?,
                     })
                 }
             }

--- a/rust/src/fbs.rs
+++ b/rust/src/fbs.rs
@@ -13389,16 +13389,7 @@ mod root {
             )]
             pub struct String {
                 /// The field `value` in the table `String`
-                pub value: ::core::option::Option<::planus::alloc::string::String>,
-            }
-
-            #[allow(clippy::derivable_impls)]
-            impl ::core::default::Default for String {
-                fn default() -> Self {
-                    Self {
-                        value: ::core::default::Default::default(),
-                    }
-                }
+                pub value: ::planus::alloc::string::String,
             }
 
             impl String {
@@ -13411,23 +13402,17 @@ mod root {
                 #[allow(clippy::too_many_arguments)]
                 pub fn create(
                     builder: &mut ::planus::Builder,
-                    field_value: impl ::planus::WriteAsOptional<
-                        ::planus::Offset<::core::primitive::str>,
-                    >,
+                    field_value: impl ::planus::WriteAs<::planus::Offset<str>>,
                 ) -> ::planus::Offset<Self> {
                     let prepared_value = field_value.prepare(builder);
 
                     let mut table_writer: ::planus::table_writer::TableWriter<6> =
                         ::core::default::Default::default();
-                    if prepared_value.is_some() {
-                        table_writer.write_entry::<::planus::Offset<str>>(0);
-                    }
+                    table_writer.write_entry::<::planus::Offset<str>>(0);
 
                     unsafe {
                         table_writer.finish(builder, |object_writer| {
-                            if let ::core::option::Option::Some(prepared_value) = prepared_value {
-                                object_writer.write::<_, _, 4>(&prepared_value);
-                            }
+                            object_writer.write::<_, _, 4>(&prepared_value);
                         });
                     }
                     builder.current_offset()
@@ -13475,16 +13460,9 @@ mod root {
                 #[allow(clippy::type_complexity)]
                 pub fn value<T0>(self, value: T0) -> StringBuilder<(T0,)>
                 where
-                    T0: ::planus::WriteAsOptional<::planus::Offset<::core::primitive::str>>,
+                    T0: ::planus::WriteAs<::planus::Offset<str>>,
                 {
                     StringBuilder((value,))
-                }
-
-                /// Sets the [`value` field](String#structfield.value) to null.
-                #[inline]
-                #[allow(clippy::type_complexity)]
-                pub fn value_as_null(self) -> StringBuilder<((),)> {
-                    self.value(())
                 }
             }
 
@@ -13499,7 +13477,7 @@ mod root {
                 }
             }
 
-            impl<T0: ::planus::WriteAsOptional<::planus::Offset<::core::primitive::str>>>
+            impl<T0: ::planus::WriteAs<::planus::Offset<str>>>
                 ::planus::WriteAs<::planus::Offset<String>> for StringBuilder<(T0,)>
             {
                 type Prepared = ::planus::Offset<String>;
@@ -13510,7 +13488,7 @@ mod root {
                 }
             }
 
-            impl<T0: ::planus::WriteAsOptional<::planus::Offset<::core::primitive::str>>>
+            impl<T0: ::planus::WriteAs<::planus::Offset<str>>>
                 ::planus::WriteAsOptional<::planus::Offset<String>> for StringBuilder<(T0,)>
             {
                 type Prepared = ::planus::Offset<String>;
@@ -13524,8 +13502,8 @@ mod root {
                 }
             }
 
-            impl<T0: ::planus::WriteAsOptional<::planus::Offset<::core::primitive::str>>>
-                ::planus::WriteAsOffset<String> for StringBuilder<(T0,)>
+            impl<T0: ::planus::WriteAs<::planus::Offset<str>>> ::planus::WriteAsOffset<String>
+                for StringBuilder<(T0,)>
             {
                 #[inline]
                 fn prepare(&self, builder: &mut ::planus::Builder) -> ::planus::Offset<String> {
@@ -13541,20 +13519,15 @@ mod root {
             impl<'a> StringRef<'a> {
                 /// Getter for the [`value` field](String#structfield.value).
                 #[inline]
-                pub fn value(
-                    &self,
-                ) -> ::planus::Result<::core::option::Option<&'a ::core::primitive::str>>
-                {
-                    self.0.access(0, "String", "value")
+                pub fn value(&self) -> ::planus::Result<&'a ::core::primitive::str> {
+                    self.0.access_required(0, "String", "value")
                 }
             }
 
             impl<'a> ::core::fmt::Debug for StringRef<'a> {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                     let mut f = f.debug_struct("StringRef");
-                    if let ::core::option::Option::Some(field_value) = self.value().transpose() {
-                        f.field("value", &field_value);
-                    }
+                    f.field("value", &self.value());
                     f.finish()
                 }
             }
@@ -13565,11 +13538,7 @@ mod root {
                 #[allow(unreachable_code)]
                 fn try_from(value: StringRef<'a>) -> ::planus::Result<Self> {
                     ::core::result::Result::Ok(Self {
-                        value: if let ::core::option::Option::Some(value) = value.value()? {
-                            ::core::option::Option::Some(::core::convert::TryInto::try_into(value)?)
-                        } else {
-                            ::core::option::Option::None
-                        },
+                        value: ::core::convert::TryInto::try_into(value.value()?)?,
                     })
                 }
             }

--- a/rust/src/fbs.rs
+++ b/rust/src/fbs.rs
@@ -16795,8 +16795,7 @@ mod root {
                     ::planus::alloc::vec::Vec<self::RtpHeaderExtensionParameters>,
                 >,
                 /// The field `encodings` in the table `RtpParameters`
-                pub encodings:
-                    ::core::option::Option<::planus::alloc::vec::Vec<self::RtpEncodingParameters>>,
+                pub encodings: ::planus::alloc::vec::Vec<self::RtpEncodingParameters>,
                 /// The field `rtcp` in the table `RtpParameters`
                 pub rtcp: ::core::option::Option<::planus::alloc::boxed::Box<self::RtcpParameters>>,
             }
@@ -16818,7 +16817,7 @@ mod root {
                     field_header_extensions: impl ::planus::WriteAsOptional<
                         ::planus::Offset<[::planus::Offset<self::RtpHeaderExtensionParameters>]>,
                     >,
-                    field_encodings: impl ::planus::WriteAsOptional<
+                    field_encodings: impl ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpEncodingParameters>]>,
                     >,
                     field_rtcp: impl ::planus::WriteAsOptional<::planus::Offset<self::RtcpParameters>>,
@@ -16840,11 +16839,7 @@ mod root {
                             [::planus::Offset<self::RtpHeaderExtensionParameters>],
                         >>(2);
                     }
-                    if prepared_encodings.is_some() {
-                        table_writer.write_entry::<::planus::Offset<
-                            [::planus::Offset<self::RtpEncodingParameters>],
-                        >>(3);
-                    }
+                    table_writer.write_entry::<::planus::Offset<[::planus::Offset<self::RtpEncodingParameters>]>>(3);
                     if prepared_rtcp.is_some() {
                         table_writer.write_entry::<::planus::Offset<self::RtcpParameters>>(4);
                     }
@@ -16860,11 +16855,7 @@ mod root {
                             {
                                 object_writer.write::<_, _, 4>(&prepared_header_extensions);
                             }
-                            if let ::core::option::Option::Some(prepared_encodings) =
-                                prepared_encodings
-                            {
-                                object_writer.write::<_, _, 4>(&prepared_encodings);
-                            }
+                            object_writer.write::<_, _, 4>(&prepared_encodings);
                             if let ::core::option::Option::Some(prepared_rtcp) = prepared_rtcp {
                                 object_writer.write::<_, _, 4>(&prepared_rtcp);
                             }
@@ -16984,19 +16975,12 @@ mod root {
                 #[allow(clippy::type_complexity)]
                 pub fn encodings<T3>(self, value: T3) -> RtpParametersBuilder<(T0, T1, T2, T3)>
                 where
-                    T3: ::planus::WriteAsOptional<
+                    T3: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpEncodingParameters>]>,
                     >,
                 {
                     let (v0, v1, v2) = self.0;
                     RtpParametersBuilder((v0, v1, v2, value))
-                }
-
-                /// Sets the [`encodings` field](RtpParameters#structfield.encodings) to null.
-                #[inline]
-                #[allow(clippy::type_complexity)]
-                pub fn encodings_as_null(self) -> RtpParametersBuilder<(T0, T1, T2, ())> {
-                    self.encodings(())
                 }
             }
 
@@ -17042,7 +17026,7 @@ mod root {
                     T2: ::planus::WriteAsOptional<
                         ::planus::Offset<[::planus::Offset<self::RtpHeaderExtensionParameters>]>,
                     >,
-                    T3: ::planus::WriteAsOptional<
+                    T3: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpEncodingParameters>]>,
                     >,
                     T4: ::planus::WriteAsOptional<::planus::Offset<self::RtcpParameters>>,
@@ -17068,7 +17052,7 @@ mod root {
                     T2: ::planus::WriteAsOptional<
                         ::planus::Offset<[::planus::Offset<self::RtpHeaderExtensionParameters>]>,
                     >,
-                    T3: ::planus::WriteAsOptional<
+                    T3: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpEncodingParameters>]>,
                     >,
                     T4: ::planus::WriteAsOptional<::planus::Offset<self::RtcpParameters>>,
@@ -17094,7 +17078,7 @@ mod root {
                     T2: ::planus::WriteAsOptional<
                         ::planus::Offset<[::planus::Offset<self::RtpHeaderExtensionParameters>]>,
                     >,
-                    T3: ::planus::WriteAsOptional<
+                    T3: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpEncodingParameters>]>,
                     >,
                     T4: ::planus::WriteAsOptional<::planus::Offset<self::RtcpParameters>>,
@@ -17155,11 +17139,9 @@ mod root {
                 pub fn encodings(
                     &self,
                 ) -> ::planus::Result<
-                    ::core::option::Option<
-                        ::planus::Vector<'a, ::planus::Result<self::RtpEncodingParametersRef<'a>>>,
-                    >,
+                    ::planus::Vector<'a, ::planus::Result<self::RtpEncodingParametersRef<'a>>>,
                 > {
-                    self.0.access(3, "RtpParameters", "encodings")
+                    self.0.access_required(3, "RtpParameters", "encodings")
                 }
 
                 /// Getter for the [`rtcp` field](RtpParameters#structfield.rtcp).
@@ -17184,11 +17166,7 @@ mod root {
                     {
                         f.field("header_extensions", &field_header_extensions);
                     }
-                    if let ::core::option::Option::Some(field_encodings) =
-                        self.encodings().transpose()
-                    {
-                        f.field("encodings", &field_encodings);
-                    }
+                    f.field("encodings", &self.encodings());
                     if let ::core::option::Option::Some(field_rtcp) = self.rtcp().transpose() {
                         f.field("rtcp", &field_rtcp);
                     }
@@ -17215,13 +17193,7 @@ mod root {
                         } else {
                             ::core::option::Option::None
                         },
-                        encodings: if let ::core::option::Option::Some(encodings) =
-                            value.encodings()?
-                        {
-                            ::core::option::Option::Some(encodings.to_vec_result()?)
-                        } else {
-                            ::core::option::Option::None
-                        },
+                        encodings: value.encodings()?.to_vec_result()?,
                         rtcp: if let ::core::option::Option::Some(rtcp) = value.rtcp()? {
                             ::core::option::Option::Some(::planus::alloc::boxed::Box::new(
                                 ::core::convert::TryInto::try_into(rtcp)?,

--- a/rust/src/fbs.rs
+++ b/rust/src/fbs.rs
@@ -14245,7 +14245,7 @@ mod root {
                 /// The field `type` in the table `RtcpFeedback`
                 pub type_: ::planus::alloc::string::String,
                 /// The field `parameter` in the table `RtcpFeedback`
-                pub parameter: ::core::option::Option<::planus::alloc::string::String>,
+                pub parameter: ::planus::alloc::string::String,
             }
 
             impl RtcpFeedback {
@@ -14259,9 +14259,7 @@ mod root {
                 pub fn create(
                     builder: &mut ::planus::Builder,
                     field_type_: impl ::planus::WriteAs<::planus::Offset<str>>,
-                    field_parameter: impl ::planus::WriteAsOptional<
-                        ::planus::Offset<::core::primitive::str>,
-                    >,
+                    field_parameter: impl ::planus::WriteAs<::planus::Offset<str>>,
                 ) -> ::planus::Offset<Self> {
                     let prepared_type_ = field_type_.prepare(builder);
                     let prepared_parameter = field_parameter.prepare(builder);
@@ -14269,18 +14267,12 @@ mod root {
                     let mut table_writer: ::planus::table_writer::TableWriter<8> =
                         ::core::default::Default::default();
                     table_writer.write_entry::<::planus::Offset<str>>(0);
-                    if prepared_parameter.is_some() {
-                        table_writer.write_entry::<::planus::Offset<str>>(1);
-                    }
+                    table_writer.write_entry::<::planus::Offset<str>>(1);
 
                     unsafe {
                         table_writer.finish(builder, |object_writer| {
                             object_writer.write::<_, _, 4>(&prepared_type_);
-                            if let ::core::option::Option::Some(prepared_parameter) =
-                                prepared_parameter
-                            {
-                                object_writer.write::<_, _, 4>(&prepared_parameter);
-                            }
+                            object_writer.write::<_, _, 4>(&prepared_parameter);
                         });
                     }
                     builder.current_offset()
@@ -14346,17 +14338,10 @@ mod root {
                 #[allow(clippy::type_complexity)]
                 pub fn parameter<T1>(self, value: T1) -> RtcpFeedbackBuilder<(T0, T1)>
                 where
-                    T1: ::planus::WriteAsOptional<::planus::Offset<::core::primitive::str>>,
+                    T1: ::planus::WriteAs<::planus::Offset<str>>,
                 {
                     let (v0,) = self.0;
                     RtcpFeedbackBuilder((v0, value))
-                }
-
-                /// Sets the [`parameter` field](RtcpFeedback#structfield.parameter) to null.
-                #[inline]
-                #[allow(clippy::type_complexity)]
-                pub fn parameter_as_null(self) -> RtcpFeedbackBuilder<(T0, ())> {
-                    self.parameter(())
                 }
             }
 
@@ -14376,7 +14361,7 @@ mod root {
 
             impl<
                     T0: ::planus::WriteAs<::planus::Offset<str>>,
-                    T1: ::planus::WriteAsOptional<::planus::Offset<::core::primitive::str>>,
+                    T1: ::planus::WriteAs<::planus::Offset<str>>,
                 > ::planus::WriteAs<::planus::Offset<RtcpFeedback>>
                 for RtcpFeedbackBuilder<(T0, T1)>
             {
@@ -14393,7 +14378,7 @@ mod root {
 
             impl<
                     T0: ::planus::WriteAs<::planus::Offset<str>>,
-                    T1: ::planus::WriteAsOptional<::planus::Offset<::core::primitive::str>>,
+                    T1: ::planus::WriteAs<::planus::Offset<str>>,
                 > ::planus::WriteAsOptional<::planus::Offset<RtcpFeedback>>
                 for RtcpFeedbackBuilder<(T0, T1)>
             {
@@ -14410,7 +14395,7 @@ mod root {
 
             impl<
                     T0: ::planus::WriteAs<::planus::Offset<str>>,
-                    T1: ::planus::WriteAsOptional<::planus::Offset<::core::primitive::str>>,
+                    T1: ::planus::WriteAs<::planus::Offset<str>>,
                 > ::planus::WriteAsOffset<RtcpFeedback> for RtcpFeedbackBuilder<(T0, T1)>
             {
                 #[inline]
@@ -14436,11 +14421,8 @@ mod root {
 
                 /// Getter for the [`parameter` field](RtcpFeedback#structfield.parameter).
                 #[inline]
-                pub fn parameter(
-                    &self,
-                ) -> ::planus::Result<::core::option::Option<&'a ::core::primitive::str>>
-                {
-                    self.0.access(1, "RtcpFeedback", "parameter")
+                pub fn parameter(&self) -> ::planus::Result<&'a ::core::primitive::str> {
+                    self.0.access_required(1, "RtcpFeedback", "parameter")
                 }
             }
 
@@ -14448,11 +14430,7 @@ mod root {
                 fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
                     let mut f = f.debug_struct("RtcpFeedbackRef");
                     f.field("type_", &self.type_());
-                    if let ::core::option::Option::Some(field_parameter) =
-                        self.parameter().transpose()
-                    {
-                        f.field("parameter", &field_parameter);
-                    }
+                    f.field("parameter", &self.parameter());
                     f.finish()
                 }
             }
@@ -14464,15 +14442,7 @@ mod root {
                 fn try_from(value: RtcpFeedbackRef<'a>) -> ::planus::Result<Self> {
                     ::core::result::Result::Ok(Self {
                         type_: ::core::convert::TryInto::try_into(value.type_()?)?,
-                        parameter: if let ::core::option::Option::Some(parameter) =
-                            value.parameter()?
-                        {
-                            ::core::option::Option::Some(::core::convert::TryInto::try_into(
-                                parameter,
-                            )?)
-                        } else {
-                            ::core::option::Option::None
-                        },
+                        parameter: ::core::convert::TryInto::try_into(value.parameter()?)?,
                     })
                 }
             }

--- a/rust/src/fbs.rs
+++ b/rust/src/fbs.rs
@@ -16791,9 +16791,8 @@ mod root {
                 /// The field `codecs` in the table `RtpParameters`
                 pub codecs: ::planus::alloc::vec::Vec<self::RtpCodecParameters>,
                 /// The field `header_extensions` in the table `RtpParameters`
-                pub header_extensions: ::core::option::Option<
+                pub header_extensions:
                     ::planus::alloc::vec::Vec<self::RtpHeaderExtensionParameters>,
-                >,
                 /// The field `encodings` in the table `RtpParameters`
                 pub encodings: ::planus::alloc::vec::Vec<self::RtpEncodingParameters>,
                 /// The field `rtcp` in the table `RtpParameters`
@@ -16814,7 +16813,7 @@ mod root {
                     field_codecs: impl ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpCodecParameters>]>,
                     >,
-                    field_header_extensions: impl ::planus::WriteAsOptional<
+                    field_header_extensions: impl ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpHeaderExtensionParameters>]>,
                     >,
                     field_encodings: impl ::planus::WriteAs<
@@ -16834,11 +16833,9 @@ mod root {
                         table_writer.write_entry::<::planus::Offset<str>>(0);
                     }
                     table_writer.write_entry::<::planus::Offset<[::planus::Offset<self::RtpCodecParameters>]>>(1);
-                    if prepared_header_extensions.is_some() {
-                        table_writer.write_entry::<::planus::Offset<
-                            [::planus::Offset<self::RtpHeaderExtensionParameters>],
-                        >>(2);
-                    }
+                    table_writer.write_entry::<::planus::Offset<
+                        [::planus::Offset<self::RtpHeaderExtensionParameters>],
+                    >>(2);
                     table_writer.write_entry::<::planus::Offset<[::planus::Offset<self::RtpEncodingParameters>]>>(3);
                     table_writer.write_entry::<::planus::Offset<self::RtcpParameters>>(4);
 
@@ -16848,11 +16845,7 @@ mod root {
                                 object_writer.write::<_, _, 4>(&prepared_mid);
                             }
                             object_writer.write::<_, _, 4>(&prepared_codecs);
-                            if let ::core::option::Option::Some(prepared_header_extensions) =
-                                prepared_header_extensions
-                            {
-                                object_writer.write::<_, _, 4>(&prepared_header_extensions);
-                            }
+                            object_writer.write::<_, _, 4>(&prepared_header_extensions);
                             object_writer.write::<_, _, 4>(&prepared_encodings);
                             object_writer.write::<_, _, 4>(&prepared_rtcp);
                         });
@@ -16949,19 +16942,12 @@ mod root {
                 #[allow(clippy::type_complexity)]
                 pub fn header_extensions<T2>(self, value: T2) -> RtpParametersBuilder<(T0, T1, T2)>
                 where
-                    T2: ::planus::WriteAsOptional<
+                    T2: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpHeaderExtensionParameters>]>,
                     >,
                 {
                     let (v0, v1) = self.0;
                     RtpParametersBuilder((v0, v1, value))
-                }
-
-                /// Sets the [`header_extensions` field](RtpParameters#structfield.header_extensions) to null.
-                #[inline]
-                #[allow(clippy::type_complexity)]
-                pub fn header_extensions_as_null(self) -> RtpParametersBuilder<(T0, T1, ())> {
-                    self.header_extensions(())
                 }
             }
 
@@ -17012,7 +16998,7 @@ mod root {
                     T1: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpCodecParameters>]>,
                     >,
-                    T2: ::planus::WriteAsOptional<
+                    T2: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpHeaderExtensionParameters>]>,
                     >,
                     T3: ::planus::WriteAs<
@@ -17038,7 +17024,7 @@ mod root {
                     T1: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpCodecParameters>]>,
                     >,
-                    T2: ::planus::WriteAsOptional<
+                    T2: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpHeaderExtensionParameters>]>,
                     >,
                     T3: ::planus::WriteAs<
@@ -17064,7 +17050,7 @@ mod root {
                     T1: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpCodecParameters>]>,
                     >,
-                    T2: ::planus::WriteAsOptional<
+                    T2: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpHeaderExtensionParameters>]>,
                     >,
                     T3: ::planus::WriteAs<
@@ -17113,14 +17099,13 @@ mod root {
                 pub fn header_extensions(
                     &self,
                 ) -> ::planus::Result<
-                    ::core::option::Option<
-                        ::planus::Vector<
-                            'a,
-                            ::planus::Result<self::RtpHeaderExtensionParametersRef<'a>>,
-                        >,
+                    ::planus::Vector<
+                        'a,
+                        ::planus::Result<self::RtpHeaderExtensionParametersRef<'a>>,
                     >,
                 > {
-                    self.0.access(2, "RtpParameters", "header_extensions")
+                    self.0
+                        .access_required(2, "RtpParameters", "header_extensions")
                 }
 
                 /// Getter for the [`encodings` field](RtpParameters#structfield.encodings).
@@ -17147,11 +17132,7 @@ mod root {
                         f.field("mid", &field_mid);
                     }
                     f.field("codecs", &self.codecs());
-                    if let ::core::option::Option::Some(field_header_extensions) =
-                        self.header_extensions().transpose()
-                    {
-                        f.field("header_extensions", &field_header_extensions);
-                    }
+                    f.field("header_extensions", &self.header_extensions());
                     f.field("encodings", &self.encodings());
                     f.field("rtcp", &self.rtcp());
                     f.finish()
@@ -17170,13 +17151,7 @@ mod root {
                             ::core::option::Option::None
                         },
                         codecs: value.codecs()?.to_vec_result()?,
-                        header_extensions: if let ::core::option::Option::Some(header_extensions) =
-                            value.header_extensions()?
-                        {
-                            ::core::option::Option::Some(header_extensions.to_vec_result()?)
-                        } else {
-                            ::core::option::Option::None
-                        },
+                        header_extensions: value.header_extensions()?.to_vec_result()?,
                         encodings: value.encodings()?.to_vec_result()?,
                         rtcp: ::planus::alloc::boxed::Box::new(::core::convert::TryInto::try_into(
                             value.rtcp()?,

--- a/rust/src/fbs.rs
+++ b/rust/src/fbs.rs
@@ -16797,7 +16797,7 @@ mod root {
                 /// The field `encodings` in the table `RtpParameters`
                 pub encodings: ::planus::alloc::vec::Vec<self::RtpEncodingParameters>,
                 /// The field `rtcp` in the table `RtpParameters`
-                pub rtcp: ::core::option::Option<::planus::alloc::boxed::Box<self::RtcpParameters>>,
+                pub rtcp: ::planus::alloc::boxed::Box<self::RtcpParameters>,
             }
 
             impl RtpParameters {
@@ -16820,7 +16820,7 @@ mod root {
                     field_encodings: impl ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpEncodingParameters>]>,
                     >,
-                    field_rtcp: impl ::planus::WriteAsOptional<::planus::Offset<self::RtcpParameters>>,
+                    field_rtcp: impl ::planus::WriteAs<::planus::Offset<self::RtcpParameters>>,
                 ) -> ::planus::Offset<Self> {
                     let prepared_mid = field_mid.prepare(builder);
                     let prepared_codecs = field_codecs.prepare(builder);
@@ -16840,9 +16840,7 @@ mod root {
                         >>(2);
                     }
                     table_writer.write_entry::<::planus::Offset<[::planus::Offset<self::RtpEncodingParameters>]>>(3);
-                    if prepared_rtcp.is_some() {
-                        table_writer.write_entry::<::planus::Offset<self::RtcpParameters>>(4);
-                    }
+                    table_writer.write_entry::<::planus::Offset<self::RtcpParameters>>(4);
 
                     unsafe {
                         table_writer.finish(builder, |object_writer| {
@@ -16856,9 +16854,7 @@ mod root {
                                 object_writer.write::<_, _, 4>(&prepared_header_extensions);
                             }
                             object_writer.write::<_, _, 4>(&prepared_encodings);
-                            if let ::core::option::Option::Some(prepared_rtcp) = prepared_rtcp {
-                                object_writer.write::<_, _, 4>(&prepared_rtcp);
-                            }
+                            object_writer.write::<_, _, 4>(&prepared_rtcp);
                         });
                     }
                     builder.current_offset()
@@ -16990,17 +16986,10 @@ mod root {
                 #[allow(clippy::type_complexity)]
                 pub fn rtcp<T4>(self, value: T4) -> RtpParametersBuilder<(T0, T1, T2, T3, T4)>
                 where
-                    T4: ::planus::WriteAsOptional<::planus::Offset<self::RtcpParameters>>,
+                    T4: ::planus::WriteAs<::planus::Offset<self::RtcpParameters>>,
                 {
                     let (v0, v1, v2, v3) = self.0;
                     RtpParametersBuilder((v0, v1, v2, v3, value))
-                }
-
-                /// Sets the [`rtcp` field](RtpParameters#structfield.rtcp) to null.
-                #[inline]
-                #[allow(clippy::type_complexity)]
-                pub fn rtcp_as_null(self) -> RtpParametersBuilder<(T0, T1, T2, T3, ())> {
-                    self.rtcp(())
                 }
             }
 
@@ -17029,7 +17018,7 @@ mod root {
                     T3: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpEncodingParameters>]>,
                     >,
-                    T4: ::planus::WriteAsOptional<::planus::Offset<self::RtcpParameters>>,
+                    T4: ::planus::WriteAs<::planus::Offset<self::RtcpParameters>>,
                 > ::planus::WriteAs<::planus::Offset<RtpParameters>>
                 for RtpParametersBuilder<(T0, T1, T2, T3, T4)>
             {
@@ -17055,7 +17044,7 @@ mod root {
                     T3: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpEncodingParameters>]>,
                     >,
-                    T4: ::planus::WriteAsOptional<::planus::Offset<self::RtcpParameters>>,
+                    T4: ::planus::WriteAs<::planus::Offset<self::RtcpParameters>>,
                 > ::planus::WriteAsOptional<::planus::Offset<RtpParameters>>
                 for RtpParametersBuilder<(T0, T1, T2, T3, T4)>
             {
@@ -17081,7 +17070,7 @@ mod root {
                     T3: ::planus::WriteAs<
                         ::planus::Offset<[::planus::Offset<self::RtpEncodingParameters>]>,
                     >,
-                    T4: ::planus::WriteAsOptional<::planus::Offset<self::RtcpParameters>>,
+                    T4: ::planus::WriteAs<::planus::Offset<self::RtcpParameters>>,
                 > ::planus::WriteAsOffset<RtpParameters>
                 for RtpParametersBuilder<(T0, T1, T2, T3, T4)>
             {
@@ -17146,11 +17135,8 @@ mod root {
 
                 /// Getter for the [`rtcp` field](RtpParameters#structfield.rtcp).
                 #[inline]
-                pub fn rtcp(
-                    &self,
-                ) -> ::planus::Result<::core::option::Option<self::RtcpParametersRef<'a>>>
-                {
-                    self.0.access(4, "RtpParameters", "rtcp")
+                pub fn rtcp(&self) -> ::planus::Result<self::RtcpParametersRef<'a>> {
+                    self.0.access_required(4, "RtpParameters", "rtcp")
                 }
             }
 
@@ -17167,9 +17153,7 @@ mod root {
                         f.field("header_extensions", &field_header_extensions);
                     }
                     f.field("encodings", &self.encodings());
-                    if let ::core::option::Option::Some(field_rtcp) = self.rtcp().transpose() {
-                        f.field("rtcp", &field_rtcp);
-                    }
+                    f.field("rtcp", &self.rtcp());
                     f.finish()
                 }
             }
@@ -17194,13 +17178,9 @@ mod root {
                             ::core::option::Option::None
                         },
                         encodings: value.encodings()?.to_vec_result()?,
-                        rtcp: if let ::core::option::Option::Some(rtcp) = value.rtcp()? {
-                            ::core::option::Option::Some(::planus::alloc::boxed::Box::new(
-                                ::core::convert::TryInto::try_into(rtcp)?,
-                            ))
-                        } else {
-                            ::core::option::Option::None
-                        },
+                        rtcp: ::planus::alloc::boxed::Box::new(::core::convert::TryInto::try_into(
+                            value.rtcp()?,
+                        )?),
                     })
                 }
             }

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -603,7 +603,6 @@ pub(crate) fn get_consumable_rtp_parameters(
     consumable_params.rtcp = RtcpParameters {
         cname: params.rtcp.cname.clone(),
         reduced_size: true,
-        mux: Some(true),
     };
 
     consumable_params

--- a/rust/src/ortc/tests.rs
+++ b/rust/src/ortc/tests.rs
@@ -368,7 +368,6 @@ fn get_producer_rtp_parameters_mapping_get_consumable_rtp_parameters_get_consume
         RtcpParameters {
             cname: rtp_parameters.rtcp.cname.clone(),
             reduced_size: true,
-            mux: Some(true),
         }
     );
 
@@ -543,7 +542,6 @@ fn get_producer_rtp_parameters_mapping_get_consumable_rtp_parameters_get_consume
         RtcpParameters {
             cname: rtp_parameters.rtcp.cname.clone(),
             reduced_size: true,
-            mux: Some(true),
         },
     );
 
@@ -650,7 +648,6 @@ fn get_producer_rtp_parameters_mapping_get_consumable_rtp_parameters_get_consume
         RtcpParameters {
             cname: rtp_parameters.rtcp.cname,
             reduced_size: true,
-            mux: Some(true),
         },
     );
 }

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -799,7 +799,6 @@ impl RtpParameters {
                             .map(|rtx| RtpEncodingParametersRtx { ssrc: rtx.ssrc }),
                         dtx: Some(encoding.dtx),
                         scalability_mode: encoding.scalability_mode.unwrap_or_default().parse()?,
-                        scale_resolution_down_by: None,
                         max_bitrate: encoding.max_bitrate,
                     })
                 })
@@ -1190,9 +1189,6 @@ pub struct RtpEncodingParameters {
     /// Number of spatial and temporal layers in the RTP stream.
     #[serde(default, skip_serializing_if = "ScalabilityMode::is_none")]
     pub scalability_mode: ScalabilityMode,
-    /// Factor by which to reduce the size of a video track during encoding.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub scale_resolution_down_by: Option<f64>,
     /// Maximum number of bits per second to allow a track encoded with this encoding to use.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub max_bitrate: Option<u32>,

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -788,7 +788,6 @@ impl RtpParameters {
                 .collect::<Result<_, Box<dyn Error>>>()?,
             encodings: rtp_parameters
                 .encodings
-                .unwrap_or_default()
                 .into_iter()
                 .map(|encoding| {
                     Ok(RtpEncodingParameters {
@@ -883,26 +882,25 @@ impl RtpParameters {
                     })
                     .collect(),
             ),
-            encodings: Some(
-                self.encodings
-                    .into_iter()
-                    .map(|encoding| rtp_parameters::RtpEncodingParameters {
-                        ssrc: encoding.ssrc,
-                        rid: encoding.rid,
-                        codec_payload_type: encoding.codec_payload_type,
-                        rtx: encoding
-                            .rtx
-                            .map(|rtx| Box::new(rtp_parameters::Rtx { ssrc: rtx.ssrc })),
-                        dtx: encoding.dtx.unwrap_or_default(),
-                        scalability_mode: if encoding.scalability_mode.is_none() {
-                            None
-                        } else {
-                            Some(encoding.scalability_mode.as_str().to_string())
-                        },
-                        max_bitrate: encoding.max_bitrate,
-                    })
-                    .collect(),
-            ),
+            encodings: self
+                .encodings
+                .into_iter()
+                .map(|encoding| rtp_parameters::RtpEncodingParameters {
+                    ssrc: encoding.ssrc,
+                    rid: encoding.rid,
+                    codec_payload_type: encoding.codec_payload_type,
+                    rtx: encoding
+                        .rtx
+                        .map(|rtx| Box::new(rtp_parameters::Rtx { ssrc: rtx.ssrc })),
+                    dtx: encoding.dtx.unwrap_or_default(),
+                    scalability_mode: if encoding.scalability_mode.is_none() {
+                        None
+                    } else {
+                        Some(encoding.scalability_mode.as_str().to_string())
+                    },
+                    max_bitrate: encoding.max_bitrate,
+                })
+                .collect(),
             rtcp: Some(Box::new(rtp_parameters::RtcpParameters {
                 cname: self.rtcp.cname,
                 reduced_size: self.rtcp.reduced_size,

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -804,14 +804,10 @@ impl RtpParameters {
                     })
                 })
                 .collect::<Result<_, Box<dyn Error>>>()?,
-            rtcp: rtp_parameters
-                .rtcp
-                .map(|rtcp| RtcpParameters {
-                    cname: rtcp.cname,
-                    reduced_size: rtcp.reduced_size,
-                    mux: None,
-                })
-                .unwrap_or_default(),
+            rtcp: RtcpParameters {
+                cname: rtp_parameters.rtcp.cname,
+                reduced_size: rtp_parameters.rtcp.reduced_size,
+            },
         })
     }
 
@@ -901,10 +897,10 @@ impl RtpParameters {
                     max_bitrate: encoding.max_bitrate,
                 })
                 .collect(),
-            rtcp: Some(Box::new(rtp_parameters::RtcpParameters {
+            rtcp: Box::new(rtp_parameters::RtcpParameters {
                 cname: self.rtcp.cname,
                 reduced_size: self.rtcp.reduced_size,
-            })),
+            }),
         }
     }
 }
@@ -1236,9 +1232,6 @@ pub struct RtcpParameters {
     /// Whether reduced size RTCP RFC 5506 is configured (if true) or compound RTCP
     /// as specified in RFC 3550 (if false). Default true.
     pub reduced_size: bool,
-    /// Whether RTCP-mux is used. Default true.
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub mux: Option<bool>,
 }
 
 impl Default for RtcpParameters {
@@ -1246,7 +1239,6 @@ impl Default for RtcpParameters {
         Self {
             cname: None,
             reduced_size: true,
-            mux: None,
         }
     }
 }

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -776,7 +776,6 @@ impl RtpParameters {
                 .collect::<Result<_, Box<dyn Error>>>()?,
             header_extensions: rtp_parameters
                 .header_extensions
-                .unwrap_or_default()
                 .into_iter()
                 .map(|header_extension_parameters| {
                     Ok(RtpHeaderExtensionParameters {
@@ -864,19 +863,18 @@ impl RtpParameters {
                     },
                 })
                 .collect(),
-            header_extensions: Some(
-                self.header_extensions
-                    .into_iter()
-                    .map(|header_extension_parameters| {
-                        rtp_parameters::RtpHeaderExtensionParameters {
-                            uri: header_extension_parameters.uri.as_str().to_string(),
-                            id: header_extension_parameters.id as u8,
-                            encrypt: header_extension_parameters.encrypt,
-                            parameters: None,
-                        }
-                    })
-                    .collect(),
-            ),
+            header_extensions: self
+                .header_extensions
+                .into_iter()
+                .map(
+                    |header_extension_parameters| rtp_parameters::RtpHeaderExtensionParameters {
+                        uri: header_extension_parameters.uri.as_str().to_string(),
+                        id: header_extension_parameters.id as u8,
+                        encrypt: header_extension_parameters.encrypt,
+                        parameters: None,
+                    },
+                )
+                .collect(),
             encodings: self
                 .encodings
                 .into_iter()

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -747,7 +747,7 @@ impl RtpParameters {
                         .map(|rtcp_feedback| {
                             RtcpFeedback::from_type_parameter(
                                 &rtcp_feedback.type_,
-                                &rtcp_feedback.parameter.unwrap_or_default(),
+                                &rtcp_feedback.parameter,
                             )
                         })
                         .collect::<Result<_, _>>()?;
@@ -862,7 +862,7 @@ impl RtpParameters {
                                     let (r#type, parameter) = rtcp_feedback.as_type_parameter();
                                     rtp_parameters::RtcpFeedback {
                                         type_: r#type.to_string(),
-                                        parameter: Some(parameter.to_string()),
+                                        parameter: parameter.to_string(),
                                     }
                                 })
                                 .collect(),

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -720,7 +720,7 @@ impl RtpParameters {
                         .map(|parameters| {
                             Ok((
                                 Cow::Owned(parameters.name),
-                                match parameters.value.ok_or("Value must always be specified")? {
+                                match parameters.value {
                                     rtp_parameters::Value::Boolean(_)
                                     | rtp_parameters::Value::Double(_)
                                     | rtp_parameters::Value::IntegerArray(_) => {
@@ -838,7 +838,7 @@ impl RtpParameters {
                             .iter()
                             .map(|(name, value)| rtp_parameters::Parameter {
                                 name: name.to_string(),
-                                value: Some(match value {
+                                value: match value {
                                     RtpCodecParametersParametersValue::String(s) => {
                                         rtp_parameters::Value::String(Box::new(
                                             rtp_parameters::String {
@@ -851,7 +851,7 @@ impl RtpParameters {
                                             rtp_parameters::Integer { value: *n as i32 },
                                         ))
                                     }
-                                }),
+                                },
                             })
                             .collect(),
                     ),

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -734,9 +734,7 @@ impl RtpParameters {
                                         )
                                     }
                                     rtp_parameters::Value::String(s) => {
-                                        RtpCodecParametersParametersValue::String(
-                                            s.value.unwrap_or_default().into(),
-                                        )
+                                        RtpCodecParametersParametersValue::String(s.value.into())
                                     }
                                 },
                             ))
@@ -842,7 +840,7 @@ impl RtpParameters {
                                     RtpCodecParametersParametersValue::String(s) => {
                                         rtp_parameters::Value::String(Box::new(
                                             rtp_parameters::String {
-                                                value: Some(s.to_string()),
+                                                value: s.to_string(),
                                             },
                                         ))
                                     }

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -976,7 +976,6 @@ fn dump_succeeds() {
                     rtx: None,
                     dtx: None,
                     scalability_mode: ScalabilityMode::None,
-                    scale_resolution_down_by: None,
                     ssrc: audio_consumer
                         .rtp_parameters()
                         .encodings
@@ -1104,7 +1103,6 @@ fn dump_succeeds() {
                         .rtx,
                     dtx: None,
                     scalability_mode: "L4T1".parse().unwrap(),
-                    scale_resolution_down_by: None,
                     rid: None,
                     max_bitrate: None,
                 }],

--- a/rust/tests/integration/producer.rs
+++ b/rust/tests/integration/producer.rs
@@ -714,7 +714,6 @@ fn dump_succeeds() {
                     rtx: None,
                     dtx: None,
                     scalability_mode: ScalabilityMode::None,
-                    scale_resolution_down_by: None,
                     max_bitrate: None
                 }],
             );
@@ -752,7 +751,6 @@ fn dump_succeeds() {
                         rtx: Some(RtpEncodingParametersRtx { ssrc: 22222223 }),
                         dtx: None,
                         scalability_mode: "L1T3".parse().unwrap(),
-                        scale_resolution_down_by: None,
                         max_bitrate: None
                     },
                     RtpEncodingParameters {
@@ -762,7 +760,6 @@ fn dump_succeeds() {
                         rtx: Some(RtpEncodingParametersRtx { ssrc: 22222225 }),
                         dtx: None,
                         scalability_mode: ScalabilityMode::None,
-                        scale_resolution_down_by: None,
                         max_bitrate: None
                     },
                     RtpEncodingParameters {
@@ -772,7 +769,6 @@ fn dump_succeeds() {
                         rtx: Some(RtpEncodingParametersRtx { ssrc: 22222227 }),
                         dtx: None,
                         scalability_mode: ScalabilityMode::None,
-                        scale_resolution_down_by: None,
                         max_bitrate: None
                     },
                     RtpEncodingParameters {
@@ -782,7 +778,6 @@ fn dump_succeeds() {
                         rtx: Some(RtpEncodingParametersRtx { ssrc: 22222229 }),
                         dtx: None,
                         scalability_mode: ScalabilityMode::None,
-                        scale_resolution_down_by: None,
                         max_bitrate: None
                     },
                 ],

--- a/worker/fbs/rtpParameters.fbs
+++ b/worker/fbs/rtpParameters.fbs
@@ -82,7 +82,7 @@ table RtpParameters {
   mid:string;
   codecs:[RtpCodecParameters] (required);
   header_extensions:[RtpHeaderExtensionParameters];
-  encodings:[RtpEncodingParameters];
+  encodings:[RtpEncodingParameters] (required);
   rtcp:RtcpParameters;
 }
 

--- a/worker/fbs/rtpParameters.fbs
+++ b/worker/fbs/rtpParameters.fbs
@@ -81,7 +81,7 @@ table RtcpParameters {
 table RtpParameters {
   mid:string;
   codecs:[RtpCodecParameters] (required);
-  header_extensions:[RtpHeaderExtensionParameters];
+  header_extensions:[RtpHeaderExtensionParameters] (required);
   encodings:[RtpEncodingParameters] (required);
   rtcp:RtcpParameters (required);
 }

--- a/worker/fbs/rtpParameters.fbs
+++ b/worker/fbs/rtpParameters.fbs
@@ -35,7 +35,7 @@ union Value {
 
 table Parameter {
   name: string (required);
-  value: Value;
+  value: Value (required);
 }
 
 table RtcpFeedback {

--- a/worker/fbs/rtpParameters.fbs
+++ b/worker/fbs/rtpParameters.fbs
@@ -22,7 +22,7 @@ table Double {
 }
 
 table String {
-  value:string;
+  value:string (required);
 }
 
 union Value {

--- a/worker/fbs/rtpParameters.fbs
+++ b/worker/fbs/rtpParameters.fbs
@@ -83,7 +83,7 @@ table RtpParameters {
   codecs:[RtpCodecParameters] (required);
   header_extensions:[RtpHeaderExtensionParameters];
   encodings:[RtpEncodingParameters] (required);
-  rtcp:RtcpParameters;
+  rtcp:RtcpParameters (required);
 }
 
 table CodecMapping {

--- a/worker/fbs/rtpParameters.fbs
+++ b/worker/fbs/rtpParameters.fbs
@@ -40,7 +40,7 @@ table Parameter {
 
 table RtcpFeedback {
   type:string (required);
-  parameter:string;
+  parameter:string (required);
 }
 
 table RtpCodecParameters {

--- a/worker/include/RTC/RtpDictionaries.hpp
+++ b/worker/include/RTC/RtpDictionaries.hpp
@@ -295,7 +295,6 @@ namespace RTC
 		std::vector<RtpEncodingParameters> encodings;
 		std::vector<RtpHeaderExtensionParameters> headerExtensions;
 		RtcpParameters rtcp;
-		bool hasRtcp{ false };
 	};
 } // namespace RTC
 

--- a/worker/src/RTC/RtpDictionaries/RtcpFeedback.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtcpFeedback.cpp
@@ -13,11 +13,8 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		this->type = data->type()->str();
-
-		// parameter is optional.
-		if (flatbuffers::IsFieldPresent(data, FBS::RtpParameters::RtcpFeedback::VT_PARAMETER))
-			this->parameter = data->parameter()->str();
+		this->type      = data->type()->str();
+		this->parameter = data->parameter()->str();
 	}
 
 	flatbuffers::Offset<FBS::RtpParameters::RtcpFeedback> RtcpFeedback::FillBuffer(

--- a/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
@@ -128,10 +128,6 @@ namespace RTC
 		if (this->codecs.empty())
 			MS_THROW_TYPE_ERROR("empty codecs");
 
-		// encodings is mandatory.
-		if (!flatbuffers::IsFieldPresent(data, FBS::RtpParameters::RtpParameters::VT_ENCODINGS))
-			MS_THROW_TYPE_ERROR("missing encodings");
-
 		this->encodings.reserve(data->encodings()->size());
 
 		for (const auto* entry : *data->encodings())
@@ -143,25 +139,16 @@ namespace RTC
 		if (this->encodings.empty())
 			MS_THROW_TYPE_ERROR("empty encodings");
 
-		// headerExtensions is optional.
-		if (flatbuffers::IsFieldPresent(data, FBS::RtpParameters::RtpParameters::VT_HEADEREXTENSIONS))
-		{
-			this->headerExtensions.reserve(data->headerExtensions()->size());
+		this->headerExtensions.reserve(data->headerExtensions()->size());
 
-			for (const auto* entry : *data->headerExtensions())
-			{
-				// This may throw due the constructor of RTC::RtpHeaderExtensionParameters.
-				this->headerExtensions.emplace_back(entry);
-			}
+		for (const auto* entry : *data->headerExtensions())
+		{
+			// This may throw due the constructor of RTC::RtpHeaderExtensionParameters.
+			this->headerExtensions.emplace_back(entry);
 		}
 
-		// rtcp is optional.
-		if (flatbuffers::IsFieldPresent(data, FBS::RtpParameters::RtpParameters::VT_RTCP))
-		{
-			// This may throw.
-			this->rtcp    = RTC::RtcpParameters(data->rtcp());
-			this->hasRtcp = true;
-		}
+		// This may throw.
+		this->rtcp = RTC::RtcpParameters(data->rtcp());
 
 		// Validate RTP parameters.
 		ValidateCodecs();
@@ -203,8 +190,7 @@ namespace RTC
 		// Add rtcp.
 		flatbuffers::Offset<FBS::RtpParameters::RtcpParameters> rtcp;
 
-		if (this->hasRtcp)
-			rtcp = this->rtcp.FillBuffer(builder);
+		rtcp = this->rtcp.FillBuffer(builder);
 
 		return FBS::RtpParameters::CreateRtpParametersDirect(
 		  builder, mid.c_str(), &codecs, &headerExtensions, &encodings, rtcp);


### PR DESCRIPTION
* Make many RtpEncodings parameters required.
* remove scale_resolution_by in Rust, not used anywhere.
* remove rtcpParameters.mux, not used anywhere.
