### PR TITLE
Fix RTCP SDES

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+### Next
+
+* Fix RTCP SDES ([PR #1139](https://github.com/versatica/mediasoup/pull/1139)).
+
+
 ### 3.12.8
 
 * Export `workerBin` absolute path ([PR #1123](https://github.com/versatica/mediasoup/pull/1123)).

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -12,7 +12,7 @@ RUN \
 	   clang
 
 # Install node 16.
-RUN curl -sL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash -
 RUN apt-get install -y nodejs
 
 # Make CC and CXX point to clang/clang++ installed above.

--- a/worker/include/RTC/RTCP/Sdes.hpp
+++ b/worker/include/RTC/RTCP/Sdes.hpp
@@ -121,6 +121,9 @@ namespace RTC
 					size += item->GetSize();
 				}
 
+				// Add the mandatory null octet.
+				++size;
+
 				// Consider pading to 32 bits (4 bytes) boundary.
 				// http://stackoverflow.com/questions/11642210/computing-padding-required-for-n-byte-alignment
 				return (size + 3) & ~3;

--- a/worker/src/RTC/RTCP/Sdes.cpp
+++ b/worker/src/RTC/RTCP/Sdes.cpp
@@ -61,7 +61,9 @@ namespace RTC
 			auto it = SdesItem::type2String.find(type);
 
 			if (it == SdesItem::type2String.end())
+			{
 				return Unknown;
+			}
 
 			return it->second;
 		}
@@ -127,17 +129,64 @@ namespace RTC
 
 			std::unique_ptr<SdesChunk> chunk(new SdesChunk(ssrc));
 
-			size_t offset = 4u /* ssrc */;
+			size_t offset{ 4u }; /* ssrc */
+			size_t chunkLength{ 4u };
 
 			while (len > offset)
 			{
-				SdesItem* item = SdesItem::Parse(data + offset, len - offset);
+				auto* item = SdesItem::Parse(data + offset, len - offset);
 
 				if (!item)
+				{
 					break;
+				}
 
 				chunk->AddItem(item);
+				chunkLength += item->GetSize();
 				offset += item->GetSize();
+			}
+
+			// Once all items have been parsed, there must be 1, 2, 3 or 4 null octets
+			// (this is mandatory). The first one (AKA item type 0) means "end of
+			// items", and the others maybe needed for padding the chunk to 4 bytes.
+
+			// First ensure that there is at least one null octet.
+			if (offset == len || (offset < len && Utils::Byte::Get1Byte(data, offset) != 0u))
+			{
+				MS_WARN_TAG(rtcp, "invalid SDES chunk (missing mandatory null octet), discarded");
+
+				return nullptr;
+			}
+
+			// So we have the mandatory null octet.
+			++chunkLength;
+			++offset;
+
+			// Then check that there are 0, 1, 2 or 3 (no more) null octets that pad
+			// the chunk to 4 bytes.
+			auto neededAdditionalNullOctets = Utils::Byte::PadTo4Bytes(static_cast<uint16_t>(chunkLength)) -
+			                                  static_cast<uint16_t>(chunkLength);
+			uint16_t foundAdditionalNullOctets{ 0u };
+
+			for (uint16_t i{ 0u }; len > offset && i < neededAdditionalNullOctets; ++i)
+			{
+				if (Utils::Byte::Get1Byte(data, offset + i) != 0u)
+				{
+					MS_WARN_TAG(rtcp, "invalid SDES chunk (missing additional null octets), discarded");
+
+					return nullptr;
+				}
+
+				++foundAdditionalNullOctets;
+				++chunkLength;
+				++offset;
+			}
+
+			if (foundAdditionalNullOctets != neededAdditionalNullOctets)
+			{
+				MS_WARN_TAG(rtcp, "invalid SDES chunk (missing additional null octets), discarded");
+
+				return nullptr;
 			}
 
 			return chunk.release();
@@ -159,10 +208,15 @@ namespace RTC
 				offset += item->Serialize(buffer + offset);
 			}
 
+			// Add the mandatory null octet.
+			buffer[offset] = 0;
+
+			++offset;
+
 			// 32 bits padding.
 			const size_t padding = (-offset) & 3;
 
-			for (size_t i{ 0 }; i < padding; ++i)
+			for (size_t i{ 0u }; i < padding; ++i)
 			{
 				buffer[offset + i] = 0;
 			}
@@ -199,9 +253,9 @@ namespace RTC
 			size_t offset = Packet::CommonHeaderSize;
 			uint8_t count = header->count;
 
-			while ((count-- != 0u) && (len > offset))
+			while (count-- && (len > offset))
 			{
-				SdesChunk* chunk = SdesChunk::Parse(data + offset, len - offset);
+				auto* chunk = SdesChunk::Parse(data + offset, len - offset);
 
 				if (chunk != nullptr)
 				{
@@ -210,8 +264,15 @@ namespace RTC
 				}
 				else
 				{
-					return packet.release();
+					break;
 				}
+			}
+
+			if (packet->GetCount() != header->count)
+			{
+				MS_WARN_TAG(rtcp, "RTCP count value doesn't match found number of chunks, discarded");
+
+				return nullptr;
 			}
 
 			return packet.release();
@@ -227,7 +288,7 @@ namespace RTC
 			size_t length   = 0;
 			uint8_t* header = { nullptr };
 
-			for (size_t i = 0; i < this->GetCount(); i++)
+			for (size_t i{ 0u }; i < this->GetCount(); ++i)
 			{
 				// Create a new SDES packet header for each 31 chunks.
 				if (i % MaxChunksPerPacket == 0)

--- a/worker/src/RTC/RTCP/Sdes.cpp
+++ b/worker/src/RTC/RTCP/Sdes.cpp
@@ -164,8 +164,9 @@ namespace RTC
 
 			// Then check that there are 0, 1, 2 or 3 (no more) null octets that pad
 			// the chunk to 4 bytes.
-			uint16_t neededAdditionalNullOctets = Utils::Byte::PadTo4Bytes(static_cast<uint16_t>(chunkLength)) -
-			                                  static_cast<uint16_t>(chunkLength);
+			uint16_t neededAdditionalNullOctets =
+			  Utils::Byte::PadTo4Bytes(static_cast<uint16_t>(chunkLength)) -
+			  static_cast<uint16_t>(chunkLength);
 			uint16_t foundAdditionalNullOctets{ 0u };
 
 			for (uint16_t i{ 0u }; len > offset && i < neededAdditionalNullOctets; ++i)

--- a/worker/src/RTC/RTCP/Sdes.cpp
+++ b/worker/src/RTC/RTCP/Sdes.cpp
@@ -164,15 +164,20 @@ namespace RTC
 
 			// Then check that there are 0, 1, 2 or 3 (no more) null octets that pad
 			// the chunk to 4 bytes.
-			auto neededAdditionalNullOctets = Utils::Byte::PadTo4Bytes(static_cast<uint16_t>(chunkLength)) -
+			uint16_t neededAdditionalNullOctets = Utils::Byte::PadTo4Bytes(static_cast<uint16_t>(chunkLength)) -
 			                                  static_cast<uint16_t>(chunkLength);
 			uint16_t foundAdditionalNullOctets{ 0u };
 
 			for (uint16_t i{ 0u }; len > offset && i < neededAdditionalNullOctets; ++i)
 			{
-				if (Utils::Byte::Get1Byte(data, offset + i) != 0u)
+				if (Utils::Byte::Get1Byte(data, offset) != 0u)
 				{
-					MS_WARN_TAG(rtcp, "invalid SDES chunk (missing additional null octets), discarded");
+					MS_WARN_TAG(
+					  rtcp,
+					  "invalid SDES chunk (missing additional null octets [needed:%" PRIu16 ", found:%" PRIu16
+					  "]), discarded",
+					  neededAdditionalNullOctets,
+					  foundAdditionalNullOctets);
 
 					return nullptr;
 				}
@@ -184,7 +189,12 @@ namespace RTC
 
 			if (foundAdditionalNullOctets != neededAdditionalNullOctets)
 			{
-				MS_WARN_TAG(rtcp, "invalid SDES chunk (missing additional null octets), discarded");
+				MS_WARN_TAG(
+				  rtcp,
+				  "invalid SDES chunk (missing additional null octets [needed:%" PRIu16 ", found:%" PRIu16
+				  "]), discarded",
+				  neededAdditionalNullOctets,
+				  foundAdditionalNullOctets);
 
 				return nullptr;
 			}

--- a/worker/src/RTC/RTCP/Sdes.cpp
+++ b/worker/src/RTC/RTCP/Sdes.cpp
@@ -36,16 +36,20 @@ namespace RTC
 			// Get the header.
 			auto* header = const_cast<Header*>(reinterpret_cast<const Header*>(data));
 
+			// If item type is 0, there is no need for length field (unless padding
+			// is needed).
+			if (len > 0 && header->type == SdesItem::Type::END)
+			{
+				return nullptr;
+			}
+
 			// data size must be >= header + length value.
-			if (len < HeaderSize || len < (1u * 2) + header->length)
+			if (len < HeaderSize || len < HeaderSize + header->length)
 			{
 				MS_WARN_TAG(rtcp, "not enough space for SDES item, discarded");
 
 				return nullptr;
 			}
-
-			if (header->type == SdesItem::Type::END)
-				return nullptr;
 
 			return new SdesItem(header);
 		}

--- a/worker/test/src/RTC/RTCP/TestSdes.cpp
+++ b/worker/test/src/RTC/RTCP/TestSdes.cpp
@@ -4,6 +4,10 @@
 #include <cstring> // std::memcmp()
 #include <string>
 
+// TODO: Remove
+#define MS_CLASS "RTC::RTCP::TestSdes"
+#include "Logger.hpp"
+
 using namespace RTC::RTCP;
 
 namespace TestSdes
@@ -11,65 +15,261 @@ namespace TestSdes
 	// RTCP Sdes Packet.
 
 	// clang-format off
-	uint8_t buffer[] =
+	uint8_t buffer1[] =
 	{
 		0x81, 0xca, 0x00, 0x06, // Type: 202 (SDES), Count: 1, Length: 6
 		0x9f, 0x65, 0xe7, 0x42, // SSRC: 0x9f65e742
+		// Chunk 1
 		0x01, 0x10, 0x74, 0x37, // Item Type: 1 (CNAME), Length: 16, Value: t7mkYnCm46OcINy/
 		0x6d, 0x6b, 0x59, 0x6e,
 		0x43, 0x6d, 0x34, 0x36,
 		0x4f, 0x63, 0x49, 0x4e,
-		0x79, 0x2f, 0x00, 0x00
+		0x79, 0x2f, 0x00, 0x00  // 2 null octects
 	};
 	// clang-format on
 
-	uint8_t* chunkBuffer = buffer + Packet::CommonHeaderSize;
+	uint8_t* chunkBuffer1 = buffer1 + Packet::CommonHeaderSize;
 
-	// SDES values.
-	uint32_t ssrc{ 0x9f65e742 };
-	SdesItem::Type type{ SdesItem::Type::CNAME };
-	std::string value{ "t7mkYnCm46OcINy/" };
-	size_t length = 16;
+	// First chunk (chunk 1).
+	uint32_t ssrc1{ 0x9f65e742 };
+	// First item (item 1).
+	SdesItem::Type item1Type{ SdesItem::Type::CNAME };
+	std::string item1Value{ "t7mkYnCm46OcINy/" };
+	size_t item1Length{ 16u };
 
-	void verify(SdesChunk* chunk)
+	// clang-format off
+	uint8_t buffer2[] =
 	{
-		REQUIRE(chunk->GetSsrc() == ssrc);
+		0x82, 0xca, 0x00, 0x0c, // Type: 202 (SDES), Count: 2, Length: 12
+		// Chunk 2
+		0x00, 0x00, 0x04, 0xd2, // SSRC: 1234
+		0x01, 0x06, 0x71, 0x77, // Item Type: 1 (CNAME), Length: 6, Text: "qwerty"
+		0x65, 0x72, 0x74, 0x79,
+		0x06, 0x06, 0x69, 0xc3, // Item Type: 6 (TOOL), Length: 6, Text: "iñaki"
+		0xb1, 0x61, 0x6b, 0x69,
+		0x00, 0x00, 0x00, 0x00, // 4 null octects
+		// Chunk 3
+		0x00, 0x00, 0x16, 0x2e, // SSRC: 5678
+		0x05, 0x11, 0x73, 0x6f, // Item Type: 5 (LOC), Length: 17, Text: "somewhere œæ€"
+		0x6d, 0x65, 0x77, 0x68,
+		0x65, 0x72, 0x65, 0x20,
+		0xc5, 0x93, 0xc3, 0xa6,
+		0xe2, 0x82, 0xac, 0x00  // 1 null octect
+	};
+	// clang-format on
 
-		SdesItem* item = *(chunk->Begin());
+	uint8_t* chunkBuffer2 = buffer2 + Packet::CommonHeaderSize;
 
-		REQUIRE(item->GetType() == type);
-		REQUIRE(item->GetLength() == length);
-		REQUIRE(std::string(item->GetValue(), length) == value);
-	}
+	// First chunk (chunk 2).
+	uint32_t ssrc2{ 1234 };
+	// First item (item 2).
+	SdesItem::Type item2Type{ SdesItem::Type::CNAME };
+	std::string item2Value{ "qwerty" };
+	size_t item2Length{ 6u };
+	// First item (item 3).
+	SdesItem::Type item3Type{ SdesItem::Type::TOOL };
+	std::string item3Value{ "iñaki" };
+	size_t item3Length{ 6u };
+
+	// Second chunk (chunk 3).
+	uint32_t ssrc3{ 5678 };
+	// First item (item 4).
+	SdesItem::Type item4Type{ SdesItem::Type::LOC };
+	std::string item4Value{ "somewhere œæ€" };
+	size_t item4Length{ 17u };
 } // namespace TestSdes
 
 using namespace TestSdes;
 
 SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 {
-	SECTION("parse packet")
+	SECTION("parse packet 1")
 	{
-		SdesPacket* packet = SdesPacket::Parse(buffer, sizeof(buffer));
-		SdesChunk* chunk   = *(packet->Begin());
-
-		auto* header = reinterpret_cast<RTC::RTCP::Packet::CommonHeader*>(buffer);
+		SdesPacket* packet = SdesPacket::Parse(buffer1, sizeof(buffer1));
+		auto* header       = reinterpret_cast<RTC::RTCP::Packet::CommonHeader*>(buffer1);
+		size_t chunkIdx{ 0u };
+		size_t itemIdx{ 0u };
 
 		REQUIRE(ntohs(header->length) == 6);
-		REQUIRE(chunk);
+		REQUIRE(packet->GetSize() == 28);
+		REQUIRE(packet->GetCount() == 1);
 
-		verify(chunk);
-
-		SECTION("serialize SdesChunk instance")
+		// TODO: We never exit this loop!!!
+		for (auto* chunk = *(packet->Begin()); chunk != *(packet->End()); ++chunk, ++chunkIdx)
 		{
-			uint8_t serialized[sizeof(buffer) - Packet::CommonHeaderSize] = { 0 };
+			MS_DUMP("---- parse packet 1 | chunkIdx:%zu, chunk address:%llu", chunkIdx, chunk);
 
-			chunk->Serialize(serialized);
-
-			SECTION("compare serialized SdesChunk with original buffer")
+			switch (chunkIdx)
 			{
-				REQUIRE(std::memcmp(chunkBuffer, serialized, sizeof(buffer) - Packet::CommonHeaderSize) == 0);
+				/* First chunk (chunk 1). */
+				case 0:
+				{
+					// Chunk size must be 24 bytes (including 4 null octects).
+					REQUIRE(chunk->GetSize() == 24);
+					REQUIRE(chunk->GetSsrc() == ssrc1);
+
+					// TODO: We never exit this loop!!!
+					for (auto* item = *(chunk->Begin()); item != *(chunk->End()); ++item, ++itemIdx)
+					{
+						MS_DUMP("---- parse packet 1 | itemIdx:%zu, item address:%llu", itemIdx, item);
+
+						switch (itemIdx)
+						{
+							/* First item (item 1). */
+							case 0:
+							{
+								REQUIRE(item->GetType() == item1Type);
+								REQUIRE(item->GetLength() == item1Length);
+								REQUIRE(std::string(item->GetValue(), item1Length) == item1Value);
+
+								break;
+							}
+						}
+					}
+
+					// There is 1 item.
+					REQUIRE(itemIdx == 0);
+
+					SECTION("serialize SdesChunk instance")
+					{
+						// NOTE: Length of first chunk (including null octects) is 24.
+						uint8_t serialized[24] = { 0 };
+
+						chunk->Serialize(serialized);
+
+						SECTION("compare serialized SdesChunk with original buffer")
+						{
+							REQUIRE(std::memcmp(chunkBuffer1, serialized, 24) == 0);
+						}
+					}
+
+					break;
+				}
 			}
 		}
+
+		// There is 1 chunk.
+		REQUIRE(chunkIdx == 0);
+
+		delete packet;
+	}
+
+	SECTION("parse packet 2")
+	{
+		SdesPacket* packet = SdesPacket::Parse(buffer2, sizeof(buffer2));
+		auto* header       = reinterpret_cast<RTC::RTCP::Packet::CommonHeader*>(buffer2);
+		size_t chunkIdx{ 0u };
+		size_t itemIdx{ 0u };
+
+		REQUIRE(ntohs(header->length) == 12);
+		// TODO: Test fails, packet->GetSize() returns 28 which is the byte length
+		// of the header plus only first chunk (but there are 2 chunks).
+		// REQUIRE(packet->GetSize() == 52);
+		REQUIRE(packet->GetCount() == 2);
+
+		for (auto* chunk = *(packet->Begin()); chunk != *(packet->End()); ++chunk, ++chunkIdx)
+		{
+			switch (chunkIdx)
+			{
+				/* First chunk (chunk 2). */
+				case 0:
+				{
+					// Chunk size must be 24 bytes (including 4 null octects).
+					REQUIRE(chunk->GetSize() == 24);
+					REQUIRE(chunk->GetSsrc() == ssrc2);
+
+					for (auto* item = *(chunk->Begin()); item != *(chunk->End()); ++item, ++itemIdx)
+					{
+						switch (itemIdx)
+						{
+							/* First item (item 2). */
+							case 0:
+							{
+								REQUIRE(item->GetType() == item2Type);
+								REQUIRE(item->GetLength() == item2Length);
+								REQUIRE(std::string(item->GetValue(), item2Length) == item2Value);
+
+								break;
+							}
+
+							/* Second item (item 3). */
+							case 1:
+							{
+								REQUIRE(item->GetType() == item3Type);
+								REQUIRE(item->GetLength() == item3Length);
+								REQUIRE(std::string(item->GetValue(), item3Length) == item3Value);
+
+								break;
+							}
+						}
+					}
+
+					// There are 2 items.
+					REQUIRE(itemIdx == 1);
+
+					SECTION("serialize SdesChunk instance")
+					{
+						// NOTE: Length of first chunk (including null octects) is 24.
+						uint8_t serialized[24] = { 0 };
+
+						chunk->Serialize(serialized);
+
+						SECTION("compare serialized SdesChunk with original buffer")
+						{
+							REQUIRE(std::memcmp(chunkBuffer2, serialized, 24) == 0);
+						}
+					}
+
+					break;
+				}
+
+				/* Second chunk (chunk 3). */
+				case 1:
+				{
+					// Chunk size must be 24 bytes (including 1 null octect).
+					REQUIRE(chunk->GetSize() == 24);
+					REQUIRE(chunk->GetSsrc() == ssrc3);
+
+					for (auto* item = *(chunk->Begin()); item != *(chunk->End()); ++item, ++itemIdx)
+					{
+						switch (itemIdx)
+						{
+							/* First item (item 4). */
+							case 0:
+							{
+								REQUIRE(item->GetType() == item4Type);
+								REQUIRE(item->GetLength() == item4Length);
+								REQUIRE(std::string(item->GetValue(), item4Length) == item4Value);
+
+								break;
+							}
+						}
+					}
+
+					// There is 1 item.
+					REQUIRE(itemIdx == 0);
+
+					SECTION("serialize SdesChunk instance")
+					{
+						// NOTE: Length of second chunk (including null octects) is 24.
+						uint8_t serialized[24] = { 0 };
+
+						chunk->Serialize(serialized);
+
+						SECTION("compare serialized SdesChunk with original buffer")
+						{
+							REQUIRE(std::memcmp(chunkBuffer2 + 4 + 24, serialized, 24) == 0);
+						}
+					}
+
+					break;
+				}
+			}
+		}
+
+		// There are 2 chunks.
+		REQUIRE(chunkIdx == 1);
+
 		delete packet;
 	}
 
@@ -82,23 +282,24 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 		for (auto i = 1; i <= count; i++)
 		{
 			// Create chunk and add to packet.
-			SdesChunk* chunk = new SdesChunk(i /*ssrc*/);
+			SdesChunk* chunk1 = new SdesChunk(i /*ssrc*/);
 
-			auto* item = new RTC::RTCP::SdesItem(SdesItem::Type::CNAME, value.size(), value.c_str());
+			auto* item1 =
+			  new RTC::RTCP::SdesItem(SdesItem::Type::CNAME, item1Value.size(), item1Value.c_str());
 
-			chunk->AddItem(item);
+			chunk1->AddItem(item1);
 
-			packet.AddChunk(chunk);
+			packet.AddChunk(chunk1);
 		}
 
 		REQUIRE(packet.GetCount() == count);
 
-		uint8_t buffer[1500] = { 0 };
+		uint8_t buffer1[1500] = { 0 };
 
 		// Serialization must contain 2 RR packets since report count exceeds 31.
-		packet.Serialize(buffer);
+		packet.Serialize(buffer1);
 
-		auto* packet2 = static_cast<SdesPacket*>(Packet::Parse(buffer, sizeof(buffer)));
+		auto* packet2 = static_cast<SdesPacket*>(Packet::Parse(buffer1, sizeof(buffer1)));
 
 		REQUIRE(packet2 != nullptr);
 		REQUIRE(packet2->GetCount() == 31);
@@ -114,8 +315,8 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 			auto* item = *(chunk->Begin());
 
 			REQUIRE(item->GetType() == SdesItem::Type::CNAME);
-			REQUIRE(item->GetSize() == 2 + value.size());
-			REQUIRE(std::string(item->GetValue()) == value);
+			REQUIRE(item->GetSize() == 2 + item1Value.size());
+			REQUIRE(std::string(item->GetValue()) == item1Value);
 		}
 
 		SdesPacket* packet3 = static_cast<SdesPacket*>(packet2->GetNext());
@@ -134,8 +335,8 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 			auto* item = *(chunk->Begin());
 
 			REQUIRE(item->GetType() == SdesItem::Type::CNAME);
-			REQUIRE(item->GetSize() == 2 + value.size());
-			REQUIRE(std::string(item->GetValue()) == value);
+			REQUIRE(item->GetSize() == 2 + item1Value.size());
+			REQUIRE(std::string(item->GetValue()) == item1Value);
 		}
 
 		delete packet2;
@@ -144,13 +345,19 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 	SECTION("create SdesChunk")
 	{
-		auto* item = new SdesItem(type, length, value.c_str());
+		auto* item = new SdesItem(item1Type, item1Length, item1Value.c_str());
 
 		// Create sdes chunk.
-		SdesChunk chunk(ssrc);
+		SdesChunk chunk(ssrc1);
 
 		chunk.AddItem(item);
 
-		verify(&chunk);
+		REQUIRE(chunk.GetSsrc() == ssrc1);
+
+		SdesItem* item1 = *(chunk.Begin());
+
+		REQUIRE(item1->GetType() == item1Type);
+		REQUIRE(item1->GetLength() == item1Length);
+		REQUIRE(std::string(item1->GetValue(), item1Length) == item1Value);
 	}
 }

--- a/worker/test/src/RTC/RTCP/TestSdes.cpp
+++ b/worker/test/src/RTC/RTCP/TestSdes.cpp
@@ -24,7 +24,7 @@ namespace TestSdes
 		0x6d, 0x6b, 0x59, 0x6e,
 		0x43, 0x6d, 0x34, 0x36,
 		0x4f, 0x63, 0x49, 0x4e,
-		0x79, 0x2f, 0x00, 0x00  // 2 null octects
+		0x79, 0x2f, 0x00, 0x00  // 2 null octets
 	};
 	// clang-format on
 
@@ -47,14 +47,14 @@ namespace TestSdes
 		0x65, 0x72, 0x74, 0x79,
 		0x06, 0x06, 0x69, 0xc3, // Item Type: 6 (TOOL), Length: 6, Text: "iñaki"
 		0xb1, 0x61, 0x6b, 0x69,
-		0x00, 0x00, 0x00, 0x00, // 4 null octects
+		0x00, 0x00, 0x00, 0x00, // 4 null octets
 		// Chunk 3
 		0x00, 0x00, 0x16, 0x2e, // SSRC: 5678
 		0x05, 0x11, 0x73, 0x6f, // Item Type: 5 (LOC), Length: 17, Text: "somewhere œæ€"
 		0x6d, 0x65, 0x77, 0x68,
 		0x65, 0x72, 0x65, 0x20,
 		0xc5, 0x93, 0xc3, 0xa6,
-		0xe2, 0x82, 0xac, 0x00  // 1 null octect
+		0xe2, 0x82, 0xac, 0x00  // 1 null octet
 	};
 	// clang-format on
 
@@ -104,7 +104,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 				/* First chunk (chunk 1). */
 				case 0:
 				{
-					// Chunk size must be 24 bytes (including 4 null octects).
+					// Chunk size must be 24 bytes (including 4 null octets).
 					REQUIRE(chunk->GetSize() == 24);
 					REQUIRE(chunk->GetSsrc() == ssrc1);
 
@@ -132,7 +132,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 					SECTION("serialize SdesChunk instance")
 					{
-						// NOTE: Length of first chunk (including null octects) is 24.
+						// NOTE: Length of first chunk (including null octets) is 24.
 						uint8_t serialized[24] = { 0 };
 
 						chunk->Serialize(serialized);
@@ -174,7 +174,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 				/* First chunk (chunk 2). */
 				case 0:
 				{
-					// Chunk size must be 24 bytes (including 4 null octects).
+					// Chunk size must be 24 bytes (including 4 null octets).
 					REQUIRE(chunk->GetSize() == 24);
 					REQUIRE(chunk->GetSsrc() == ssrc2);
 
@@ -209,7 +209,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 					SECTION("serialize SdesChunk instance")
 					{
-						// NOTE: Length of first chunk (including null octects) is 24.
+						// NOTE: Length of first chunk (including null octets) is 24.
 						uint8_t serialized[24] = { 0 };
 
 						chunk->Serialize(serialized);
@@ -226,7 +226,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 				/* Second chunk (chunk 3). */
 				case 1:
 				{
-					// Chunk size must be 24 bytes (including 1 null octect).
+					// Chunk size must be 24 bytes (including 1 null octet).
 					REQUIRE(chunk->GetSize() == 24);
 					REQUIRE(chunk->GetSsrc() == ssrc3);
 
@@ -251,7 +251,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 					SECTION("serialize SdesChunk instance")
 					{
-						// NOTE: Length of second chunk (including null octects) is 24.
+						// NOTE: Length of second chunk (including null octets) is 24.
 						uint8_t serialized[24] = { 0 };
 
 						chunk->Serialize(serialized);

--- a/worker/test/src/RTC/RTCP/TestSdes.cpp
+++ b/worker/test/src/RTC/RTCP/TestSdes.cpp
@@ -99,6 +99,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 		SdesPacket* packet = SdesPacket::Parse(buffer1, sizeof(buffer1));
 		auto* header       = reinterpret_cast<RTC::RTCP::Packet::CommonHeader*>(buffer1);
 
+		REQUIRE(packet);
 		REQUIRE(ntohs(header->length) == 6);
 		REQUIRE(packet->GetSize() == 28);
 		REQUIRE(packet->GetCount() == 1);
@@ -171,6 +172,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 		SdesPacket* packet = SdesPacket::Parse(buffer2, sizeof(buffer2));
 		auto* header       = reinterpret_cast<RTC::RTCP::Packet::CommonHeader*>(buffer2);
 
+		REQUIRE(packet);
 		REQUIRE(ntohs(header->length) == 13);
 		// Despite total buffer size is 56 bytes, our GetSize() method doesn't not
 		// consider RTCP padding (4 bytes in this case).
@@ -298,6 +300,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 		SdesPacket* packet = SdesPacket::Parse(buffer3, sizeof(buffer3));
 		auto* header       = reinterpret_cast<RTC::RTCP::Packet::CommonHeader*>(buffer3);
 
+		REQUIRE(packet);
 		REQUIRE(ntohs(header->length) == 3);
 		REQUIRE(packet->GetSize() == 16);
 		REQUIRE(packet->GetCount() == 1);
@@ -353,7 +356,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 			auto* chunk1          = *it;
 			uint8_t* chunk1Buffer = buffer3 + Packet::CommonHeaderSize;
 
-			// NOTE: Length of first chunk (including null octets) is 24.
+			// NOTE: Length of first chunk (including null octets) is 12.
 			uint8_t serialized1[12] = { 0 };
 
 			chunk1->Serialize(serialized1);

--- a/worker/test/src/RTC/RTCP/TestSdes.cpp
+++ b/worker/test/src/RTC/RTCP/TestSdes.cpp
@@ -95,61 +95,61 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 		REQUIRE(packet->GetCount() == 1);
 
 		// TODO: We never exit this loop!!!
-		for (auto* chunk = *(packet->Begin()); chunk != *(packet->End()); ++chunk, ++chunkIdx)
-		{
-			MS_DUMP("---- parse packet 1 | chunkIdx:%zu, chunk address:%llu", chunkIdx, chunk);
+		// for (auto* chunk = *(packet->Begin()); chunk != *(packet->End()); ++chunk, ++chunkIdx)
+		// {
+		// 	MS_DUMP("---- parse packet 1 | chunkIdx:%zu, chunk address:%llu", chunkIdx, chunk);
 
-			switch (chunkIdx)
-			{
-				/* First chunk (chunk 1). */
-				case 0:
-				{
-					// Chunk size must be 24 bytes (including 4 null octets).
-					REQUIRE(chunk->GetSize() == 24);
-					REQUIRE(chunk->GetSsrc() == ssrc1);
+		// 	switch (chunkIdx)
+		// 	{
+		// 		/* First chunk (chunk 1). */
+		// 		case 0:
+		// 		{
+		// 			// Chunk size must be 24 bytes (including 4 null octets).
+		// 			REQUIRE(chunk->GetSize() == 24);
+		// 			REQUIRE(chunk->GetSsrc() == ssrc1);
 
-					// TODO: We never exit this loop!!!
-					for (auto* item = *(chunk->Begin()); item != *(chunk->End()); ++item, ++itemIdx)
-					{
-						MS_DUMP("---- parse packet 1 | itemIdx:%zu, item address:%llu", itemIdx, item);
+		// 			// TODO: We never exit this loop!!!
+		// 			for (auto* item = *(chunk->Begin()); item != *(chunk->End()); ++item, ++itemIdx)
+		// 			{
+		// 				MS_DUMP("---- parse packet 1 | itemIdx:%zu, item address:%llu", itemIdx, item);
 
-						switch (itemIdx)
-						{
-							/* First item (item 1). */
-							case 0:
-							{
-								REQUIRE(item->GetType() == item1Type);
-								REQUIRE(item->GetLength() == item1Length);
-								REQUIRE(std::string(item->GetValue(), item1Length) == item1Value);
+		// 				switch (itemIdx)
+		// 				{
+		// 					/* First item (item 1). */
+		// 					case 0:
+		// 					{
+		// 						REQUIRE(item->GetType() == item1Type);
+		// 						REQUIRE(item->GetLength() == item1Length);
+		// 						REQUIRE(std::string(item->GetValue(), item1Length) == item1Value);
 
-								break;
-							}
-						}
-					}
+		// 						break;
+		// 					}
+		// 				}
+		// 			}
 
-					// There is 1 item.
-					REQUIRE(itemIdx == 0);
+		// 			// There is 1 item.
+		// 			REQUIRE(itemIdx == 0);
 
-					SECTION("serialize SdesChunk instance")
-					{
-						// NOTE: Length of first chunk (including null octets) is 24.
-						uint8_t serialized[24] = { 0 };
+		// 			SECTION("serialize SdesChunk instance")
+		// 			{
+		// 				// NOTE: Length of first chunk (including null octets) is 24.
+		// 				uint8_t serialized[24] = { 0 };
 
-						chunk->Serialize(serialized);
+		// 				chunk->Serialize(serialized);
 
-						SECTION("compare serialized SdesChunk with original buffer")
-						{
-							REQUIRE(std::memcmp(chunkBuffer1, serialized, 24) == 0);
-						}
-					}
+		// 				SECTION("compare serialized SdesChunk with original buffer")
+		// 				{
+		// 					REQUIRE(std::memcmp(chunkBuffer1, serialized, 24) == 0);
+		// 				}
+		// 			}
 
-					break;
-				}
-			}
-		}
+		// 			break;
+		// 		}
+		// 	}
+		// }
 
-		// There is 1 chunk.
-		REQUIRE(chunkIdx == 0);
+		// // There is 1 chunk.
+		// REQUIRE(chunkIdx == 0);
 
 		delete packet;
 	}
@@ -162,113 +162,111 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 		size_t itemIdx{ 0u };
 
 		REQUIRE(ntohs(header->length) == 12);
-		// TODO: Test fails, packet->GetSize() returns 28 which is the byte length
-		// of the header plus only first chunk (but there are 2 chunks).
-		// REQUIRE(packet->GetSize() == 52);
+		REQUIRE(packet->GetSize() == 52);
 		REQUIRE(packet->GetCount() == 2);
 
-		for (auto* chunk = *(packet->Begin()); chunk != *(packet->End()); ++chunk, ++chunkIdx)
-		{
-			switch (chunkIdx)
-			{
-				/* First chunk (chunk 2). */
-				case 0:
-				{
-					// Chunk size must be 24 bytes (including 4 null octets).
-					REQUIRE(chunk->GetSize() == 24);
-					REQUIRE(chunk->GetSsrc() == ssrc2);
+		// for (auto* chunk = *(packet->Begin()); chunk != *(packet->End()); ++chunk, ++chunkIdx)
+		// {
+		// 	switch (chunkIdx)
+		// 	{
+		// 		/* First chunk (chunk 2). */
+		// 		case 0:
+		// 		{
+		// 			// Chunk size must be 24 bytes (including 4 null octets).
+		// 			REQUIRE(chunk->GetSize() == 24);
+		// 			REQUIRE(chunk->GetSsrc() == ssrc2);
 
-					for (auto* item = *(chunk->Begin()); item != *(chunk->End()); ++item, ++itemIdx)
-					{
-						switch (itemIdx)
-						{
-							/* First item (item 2). */
-							case 0:
-							{
-								REQUIRE(item->GetType() == item2Type);
-								REQUIRE(item->GetLength() == item2Length);
-								REQUIRE(std::string(item->GetValue(), item2Length) == item2Value);
+		// 			for (auto* item = *(chunk->Begin()); item != *(chunk->End()); ++item, ++itemIdx)
+		// 			{
+		// 				switch (itemIdx)
+		// 				{
+		// 					/* First item (item 2). */
+		// 					case 0:
+		// 					{
+		// 						REQUIRE(item->GetType() == item2Type);
+		// 						REQUIRE(item->GetLength() == item2Length);
+		// 						REQUIRE(std::string(item->GetValue(), item2Length) == item2Value);
 
-								break;
-							}
+		// 						break;
+		// 					}
 
-							/* Second item (item 3). */
-							case 1:
-							{
-								REQUIRE(item->GetType() == item3Type);
-								REQUIRE(item->GetLength() == item3Length);
-								REQUIRE(std::string(item->GetValue(), item3Length) == item3Value);
+		// 					/* Second item (item 3). */
+		// 					case 1:
+		// 					{
+		// 						REQUIRE(item->GetType() == item3Type);
+		// 						REQUIRE(item->GetLength() == item3Length);
+		// 						REQUIRE(std::string(item->GetValue(), item3Length) == item3Value);
 
-								break;
-							}
-						}
-					}
+		// 						break;
+		// 					}
+		// 				}
+		// 			}
 
-					// There are 2 items.
-					REQUIRE(itemIdx == 1);
+		// 			// There are 2 items.
+		// 			REQUIRE(itemIdx == 1);
 
-					SECTION("serialize SdesChunk instance")
-					{
-						// NOTE: Length of first chunk (including null octets) is 24.
-						uint8_t serialized[24] = { 0 };
+		// 			SECTION("serialize SdesChunk instance")
+		// 			{
+		// 				// NOTE: Length of first chunk (including null octets) is 24.
+		// 				uint8_t serialized[24] = { 0 };
 
-						chunk->Serialize(serialized);
+		// 				chunk->Serialize(serialized);
 
-						SECTION("compare serialized SdesChunk with original buffer")
-						{
-							REQUIRE(std::memcmp(chunkBuffer2, serialized, 24) == 0);
-						}
-					}
+		// 				SECTION("compare serialized SdesChunk with original buffer")
+		// 				{
+		// 					REQUIRE(std::memcmp(chunkBuffer2, serialized, 24) == 0);
+		// 				}
+		// 			}
 
-					break;
-				}
+		// 			break;
+		// 		}
 
-				/* Second chunk (chunk 3). */
-				case 1:
-				{
-					// Chunk size must be 24 bytes (including 1 null octet).
-					REQUIRE(chunk->GetSize() == 24);
-					REQUIRE(chunk->GetSsrc() == ssrc3);
+		// 		/* Second chunk (chunk 3). */
+		// 		case 1:
+		// 		{
+		// 			// Chunk size must be 24 bytes (including 1 null octet).
+		// 			REQUIRE(chunk->GetSize() == 24);
+		// 			REQUIRE(chunk->GetSsrc() == ssrc3);
 
-					for (auto* item = *(chunk->Begin()); item != *(chunk->End()); ++item, ++itemIdx)
-					{
-						switch (itemIdx)
-						{
-							/* First item (item 4). */
-							case 0:
-							{
-								REQUIRE(item->GetType() == item4Type);
-								REQUIRE(item->GetLength() == item4Length);
-								REQUIRE(std::string(item->GetValue(), item4Length) == item4Value);
+		// 			for (auto* item = *(chunk->Begin()); item != *(chunk->End()); ++item, ++itemIdx)
+		// 			{
+		// 				switch (itemIdx)
+		// 				{
+		// 					/* First item (item 4). */
+		// 					case 0:
+		// 					{
+		// 						REQUIRE(item->GetType() == item4Type);
+		// 						REQUIRE(item->GetLength() == item4Length);
+		// 						REQUIRE(std::string(item->GetValue(), item4Length) == item4Value);
 
-								break;
-							}
-						}
-					}
+		// 						break;
+		// 					}
+		// 				}
+		// 			}
 
-					// There is 1 item.
-					REQUIRE(itemIdx == 0);
+		// 			// There is 1 item.
+		// 			REQUIRE(itemIdx == 0);
 
-					SECTION("serialize SdesChunk instance")
-					{
-						// NOTE: Length of second chunk (including null octets) is 24.
-						uint8_t serialized[24] = { 0 };
+		// 			SECTION("serialize SdesChunk instance")
+		// 			{
+		// 				// NOTE: Length of second chunk (including null octets) is 24.
+		// 				uint8_t serialized[24] = { 0 };
 
-						chunk->Serialize(serialized);
+		// 				chunk->Serialize(serialized);
 
-						SECTION("compare serialized SdesChunk with original buffer")
-						{
-							REQUIRE(std::memcmp(chunkBuffer2 + 4 + 24, serialized, 24) == 0);
-						}
-					}
+		// 				SECTION("compare serialized SdesChunk with original buffer")
+		// 				{
+		// 					REQUIRE(std::memcmp(chunkBuffer2 + 4 + 24, serialized, 24) == 0);
+		// 				}
+		// 			}
 
-					break;
-				}
-			}
-		}
+		// 			break;
+		// 		}
+		// 	}
+		// }
 
-		// There are 2 chunks.
-		REQUIRE(chunkIdx == 1);
+		// // There are 2 chunks.
+		// REQUIRE(chunkIdx == 1);
 
 		delete packet;
 	}

--- a/worker/test/src/tests.cpp
+++ b/worker/test/src/tests.cpp
@@ -40,6 +40,10 @@ int main(int argc, char* argv[])
 	{
 		Settings::configuration.logTags.rtp = true;
 	}
+	if (std::getenv("MS_TEST_LOG_TAG_RTCP"))
+	{
+		Settings::configuration.logTags.rtcp = true;
+	}
 
 	// Initialize static stuff.
 	DepLibUV::ClassInit();


### PR DESCRIPTION
### Details

- Initially this PR was intended to remove a non legit warning log. A SDES chunk may perfecly terminate with a single null octet (AKA item type === 0) and, if so, we MUST NOT check the next byte (item length) because it may not exist (if chunk is padded to 4 bytes) and, if it exists, it should be one or more zeroes (up to 3) to pad the chunk to 4 bytes.
- However then I've added more tests and replicated this one I've written in rtp.js library: https://github.com/versatica/rtp.js/blob/master/src/tests/rtcp/SdesPacket.test.ts#L195 and I also refactored the existing SDES test to test more things. And LOT of problems show up.

### Bonus Tracks

- Use Node 18 in `Dockerfile`.

### Issue 2

*UPDATE:* Fixed in this commit: https://github.com/versatica/mediasoup/pull/1139/commits/1d107e0188f3729ca2404a1ec89f63a8d7646520


Parsing of this SDES proper packet fails miserably ("parse packet 2" section in `TestSdes.cpp` in this branch):

```
0x82, 0xca, 0x00, 0x0c, // Type: 202 (SDES), Count: 2, Length: 12
// Chunk 2
0x00, 0x00, 0x04, 0xd2, // SSRC: 1234
0x01, 0x06, 0x71, 0x77, // Item Type: 1 (CNAME), Length: 6, Text: "qwerty"
0x65, 0x72, 0x74, 0x79,
0x06, 0x06, 0x69, 0xc3, // Item Type: 6 (TOOL), Length: 6, Text: "iñaki"
0xb1, 0x61, 0x6b, 0x69,
0x00, 0x00, 0x00, 0x00, // 4 null octets
// Chunk 3
0x00, 0x00, 0x16, 0x2e, // SSRC: 5678
0x05, 0x11, 0x73, 0x6f, // Item Type: 5 (LOC), Length: 17, Text: "somewhere œæ€"
0x6d, 0x65, 0x77, 0x68,
0x65, 0x72, 0x65, 0x20,
0xc5, 0x93, 0xc3, 0xa6,
0xe2, 0x82, 0xac, 0x00  // 1 null octet
```

1. `packet->GetSize()` should return 52 bytes however it returns 28 which is the byte length of the SDES header (4 bytes) plus only the first chunk (24 bytes), but there are 2 chunks!
2. However `packet->GetCount()` returns 2 as expected, and given that the code it runs is `return this->chunks.size();` it clearly means that it's parsing the second chunk with length 0 (wrong, it's 24).

I'm pretty sure that the SDES parsing in rtp.js is way better than here. For instance, by checking `Sdes.cpp` code I don't see any evidence that it's properly processing chunk null octets.
* As per spec, each SDES chunk MUST be padded to 4 bytes with null octets at the end.
* In addition, each chunk MUST end with 1, 2, 3 or 4 mandatory null octets. Why? Because "item type === 0" is the only way to say "this is the end of this chunk", and the remaining 1, 2 or 3 null octets are needed in case of padding.

So in packet above, chunk 1 ends with 4 null octets (which are part of the chunk) because the 2 items it contains are already padded to 4 bytes, so we need to add a "item type 0" null octet to define "end of items in this chunk", so we also need to add another 3 null octets for padding.

**To make it clear:** DO NOT try to parse as many null octets as possible. We must only parse from 1 to 4 null octet and stop once the chunk is padded to 4 bytes. So for example, in the packet above, look at the second/last item item in the first chunk:
```
0x06, 0x06, 0x69, 0xc3, // Item Type: 6 (TOOL), Length: 6, Text: "iñaki"
0xb1, 0x61, 0x6b, 0x69,
0x00, 0x00, 0x00, 0x00, // 4 null octets
```

And then look at the SSRC line of the second chunk:
```
0x00, 0x00, 0x16, 0x2e, // SSRC: 5678
```

**Yes!** it starts with 2 zeroes, but this is because SSRC is 5678 so `0x00, 0x00, 0x16, 0x2e`!

I'm pretty sure that parsing in mediasoup `Sdes.cpp` is not considering this at all.

- Check the SDES parser of **rtp.js** to see how it does it properly: https://github.com/versatica/rtp.js/blob/master/src/rtcp/SdesPacket.ts?ts=2#L111
- And also the constructor of `SdesChunk`: https://github.com/versatica/rtp.js/blob/master/src/rtcp/SdesPacket.ts#L336

### Issue 3

*UPDATE:* Fixed in this commit: https://github.com/versatica/mediasoup/pull/1139/commits/1114f978612d8bc85d17b96e971b763ff5286055

I've added "parse packet 3" https://github.com/versatica/mediasoup/pull/1139/commits/e303b74c6040e9da0f96bcdeba2b3743595eee14 and the test fails since it cannot parse packet 3.