### PR TITLE
Replace `uuid` package with built-in `crypto.randomUUID()`

### DIFF
--- a/node/src/PipeTransport.ts
+++ b/node/src/PipeTransport.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { Logger } from './Logger';
 import * as ortc from './ortc';
 import {
@@ -322,7 +322,7 @@ export class PipeTransport<PipeTransportAppData extends AppData = AppData>
 
 		const reqData =
 		{
-			consumerId             : uuidv4(),
+			consumerId             : randomUUID(),
 			producerId,
 			kind                   : producer.kind,
 			rtpParameters,

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import * as ortc from './ortc';
@@ -413,7 +413,7 @@ export class Router<RouterAppData extends AppData = AppData>
 
 		const reqData =
 		{
-			transportId    : uuidv4(),
+			transportId    : randomUUID(),
 			webRtcServerId : webRtcServer ? webRtcServer.id : undefined,
 			listenIps,
 			port,
@@ -525,7 +525,7 @@ export class Router<RouterAppData extends AppData = AppData>
 
 		const reqData =
 		{
-			transportId   : uuidv4(),
+			transportId   : randomUUID(),
 			listenIp,
 			port,
 			rtcpMux,
@@ -627,7 +627,7 @@ export class Router<RouterAppData extends AppData = AppData>
 
 		const reqData =
 		{
-			transportId   : uuidv4(),
+			transportId   : randomUUID(),
 			listenIp,
 			port,
 			enableSctp,
@@ -697,7 +697,7 @@ export class Router<RouterAppData extends AppData = AppData>
 
 		const reqData =
 		{
-			transportId : uuidv4(),
+			transportId : randomUUID(),
 			direct      : true,
 			maxMessageSize
 		};
@@ -1083,7 +1083,7 @@ export class Router<RouterAppData extends AppData = AppData>
 
 		const reqData =
 		{
-			rtpObserverId : uuidv4(),
+			rtpObserverId : randomUUID(),
 			interval
 		};
 
@@ -1137,7 +1137,7 @@ export class Router<RouterAppData extends AppData = AppData>
 
 		const reqData =
 		{
-			rtpObserverId : uuidv4(),
+			rtpObserverId : randomUUID(),
 			maxEntries,
 			threshold,
 			interval

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -1,4 +1,4 @@
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import * as utils from './utils';
@@ -595,7 +595,7 @@ export class Transport
 			// do not include CNAME, create a random one.
 			else if (!this.#cnameForProducers)
 			{
-				this.#cnameForProducers = uuidv4().substr(0, 8);
+				this.#cnameForProducers = randomUUID().substring(0, 8);
 			}
 
 			// Override Producer's CNAME.
@@ -615,7 +615,7 @@ export class Transport
 
 		const reqData =
 		{
-			producerId : id || uuidv4(),
+			producerId : id ?? randomUUID(),
 			kind,
 			rtpParameters,
 			rtpMapping,
@@ -747,7 +747,7 @@ export class Transport
 
 		const reqData =
 		{
-			consumerId             : uuidv4(),
+			consumerId             : randomUUID(),
 			producerId,
 			kind                   : producer.kind,
 			rtpParameters,
@@ -844,7 +844,7 @@ export class Transport
 
 		const reqData =
 		{
-			dataProducerId : id || uuidv4(),
+			dataProducerId : id ?? randomUUID(),
 			type,
 			sctpStreamParameters,
 			label,
@@ -967,7 +967,7 @@ export class Transport
 
 		const reqData =
 		{
-			dataConsumerId : uuidv4(),
+			dataConsumerId : randomUUID(),
 			dataProducerId,
 			type,
 			sctpStreamParameters,

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -1,7 +1,7 @@
 import * as process from 'process';
 import * as path from 'path';
 import { spawn, ChildProcess } from 'child_process';
-import { v4 as uuidv4 } from 'uuid';
+import { randomUUID } from 'crypto';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import * as ortc from './ortc';
@@ -635,7 +635,7 @@ export class Worker<WorkerAppData extends AppData = AppData>
 
 		const reqData =
 		{
-			webRtcServerId : uuidv4(),
+			webRtcServerId : randomUUID(),
 			listenInfos
 		};
 
@@ -676,7 +676,7 @@ export class Worker<WorkerAppData extends AppData = AppData>
 		// This may throw.
 		const rtpCapabilities = ortc.generateRouterRtpCapabilities(mediaCodecs);
 
-		const reqData = { routerId: uuidv4() };
+		const reqData = { routerId: randomUUID() };
 
 		await this.#channel.request('worker.createRouter', undefined, reqData);
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,15 +14,13 @@
         "h264-profile-level-id": "^1.0.1",
         "node-fetch": "^3.3.2",
         "supports-color": "^9.4.0",
-        "tar": "^6.1.15",
-        "uuid": "^9.0.0"
+        "tar": "^6.1.15"
       },
       "devDependencies": {
         "@octokit/rest": "^20.0.1",
         "@types/debug": "^4.1.8",
         "@types/jest": "^29.5.3",
         "@types/node": "^20.4.9",
-        "@types/uuid": "^9.0.2",
         "@typescript-eslint/eslint-plugin": "^6.3.0",
         "@typescript-eslint/parser": "^6.3.0",
         "eslint": "^8.46.0",
@@ -1531,12 +1529,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
-      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -6410,14 +6402,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -7795,12 +7779,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.2.tgz",
-      "integrity": "sha512-kNnC1GFBLuhImSnV7w4njQkUiJi0ZXUycu1rUaouPqiKlXkh77JKgdRnTAp1x5eBwcIwbtI+3otwzuIDEuDoxQ==",
       "dev": true
     },
     "@types/yargs": {
@@ -11165,11 +11143,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "uuid": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.0.tgz",
-      "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -91,15 +91,13 @@
     "h264-profile-level-id": "^1.0.1",
     "node-fetch": "^3.3.2",
     "supports-color": "^9.4.0",
-    "tar": "^6.1.15",
-    "uuid": "^9.0.0"
+    "tar": "^6.1.15"
   },
   "devDependencies": {
     "@octokit/rest": "^20.0.1",
     "@types/debug": "^4.1.8",
     "@types/jest": "^29.5.3",
     "@types/node": "^20.4.9",
-    "@types/uuid": "^9.0.2",
     "@typescript-eslint/eslint-plugin": "^6.3.0",
     "@typescript-eslint/parser": "^6.3.0",
     "eslint": "^8.46.0",

--- a/worker/scripts/package-lock.json
+++ b/worker/scripts/package-lock.json
@@ -11,6 +11,9 @@
         "clang-tools-prebuilt": "^0.1.4",
         "gulp": "^4.0.2",
         "gulp-clang-format": "^1.0.27"
+      },
+      "peerDependencies": {
+        "uuid": "^3.3.2"
       }
     },
     "node_modules/ajv": {
@@ -5117,6 +5120,16 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
     },
+    "node_modules/uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+      "peer": true,
+      "bin": {
+        "uuid": "bin/uuid"
+      }
+    },
     "node_modules/v8flags": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.2.0.tgz",
@@ -9628,6 +9641,12 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
+    },
+    "uuid": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+      "peer": true
     },
     "v8flags": {
       "version": "3.2.0",

--- a/worker/scripts/package-lock.json
+++ b/worker/scripts/package-lock.json
@@ -4063,8 +4063,7 @@
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "tunnel-agent": "^0.6.0"
       },
       "engines": {
         "node": ">= 6"
@@ -5117,16 +5116,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
       "dev": true
-    },
-    "node_modules/uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "dev": true,
-      "bin": {
-        "uuid": "bin/uuid"
-      }
     },
     "node_modules/v8flags": {
       "version": "3.2.0",
@@ -8762,8 +8751,7 @@
         "qs": "~6.5.2",
         "safe-buffer": "^5.1.2",
         "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
+        "tunnel-agent": "^0.6.0"
       }
     },
     "require-directory": {
@@ -9639,12 +9627,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
-    },
-    "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "dev": true
     },
     "v8flags": {

--- a/worker/scripts/package.json
+++ b/worker/scripts/package.json
@@ -6,5 +6,8 @@
     "clang-tools-prebuilt": "^0.1.4",
     "gulp": "^4.0.2",
     "gulp-clang-format": "^1.0.27"
+  },
+  "peerDependencies": {
+    "uuid": "^3.3.2"
   }
 }


### PR DESCRIPTION
This PR replace `uuid` package with Node.js built-in `crypto.randomUUID()` function. Also, it fixes a couple of typos where the random UUID would be generated if an empty string would be provided as `id`, now only it's being generated if `undefined` is provided (note, we should validate the provided `id` is an UUID instead of a random string, though).

OTOH, I've found that the `id` field of `DataProducerOptions` is not documented. Not fully sure if it makes sense to provide it all, since bandwidth and CPU are low, or it's just there only to mimic `Producer` API...