### PR TITLE
Renamed WebRtcTransport `webRtcServerClosed()` to `listenServerClosed()`

### DIFF
--- a/node/src/WebRtcTransport.ts
+++ b/node/src/WebRtcTransport.ts
@@ -374,11 +374,11 @@ export class WebRtcTransport<WebRtcTransportAppData extends AppData = AppData>
 	}
 
 	/**
-	 * Called when closing the associated WebRtcServer.
+	 * Called when closing the associated listenServer (WebRtcServer).
 	 *
 	 * @private
 	 */
-	webRtcServerClosed(): void
+	listenServerClosed(): void
 	{
 		if (this.closed)
 		{


### PR DESCRIPTION
I've found a typo where the `WebRtcTransport.webRtcServerClosed()` was never called. Instead, the `Transport.listenServerClosed()` method is being directly called by WebRtcServer, so the clean-ups done at `webRtcServerClosed()` are never done. Since `listenServerClose` event is at Transport level with the idea maybe of have other listener servers in the future (raw TCP? RTP?), I've renamed `webRtcServerClosed()` to the more generic one `listenServerClosed()`, calling to the parent class.