### PR TITLE
rust: move PipeTransport to flatbuffers

### DIFF
--- a/node/src/PipeTransport.ts
+++ b/node/src/PipeTransport.ts
@@ -313,7 +313,7 @@ export class PipeTransport<PipeTransportAppData extends AppData = AppData>
 		// Wait for response.
 		const response = await this.channel.request(
 			FbsRequest.Method.PIPETRANSPORT_CONNECT,
-			FbsRequest.Body.FBS_PipeTransport_ConnectRequest,
+			FbsRequest.Body.PipeTransport_ConnectRequest,
 			requestOffset,
 			this.internal.transportId
 		);

--- a/rust/src/fbs.rs
+++ b/rust/src/fbs.rs
@@ -50465,6 +50465,11 @@ mod root {
                     ::planus::alloc::boxed::Box<super::plain_transport::ConnectRequest>,
                 ),
 
+                /// The variant `PipeTransport_ConnectRequest` in the union `Body`
+                PipeTransportConnectRequest(
+                    ::planus::alloc::boxed::Box<super::pipe_transport::ConnectRequest>,
+                ),
+
                 /// The variant of type `FBS.WebRtcTransport.ConnectRequest` in the union `Body`
                 ConnectRequest(
                     ::planus::alloc::boxed::Box<super::web_rtc_transport::ConnectRequest>,
@@ -50719,11 +50724,19 @@ mod root {
                 }
 
                 #[inline]
+                pub fn create_pipe_transport_connect_request(
+                    builder: &mut ::planus::Builder,
+                    value: impl ::planus::WriteAsOffset<super::pipe_transport::ConnectRequest>,
+                ) -> ::planus::UnionOffset<Self> {
+                    ::planus::UnionOffset::new(27, value.prepare(builder).downcast())
+                }
+
+                #[inline]
                 pub fn create_connect_request(
                     builder: &mut ::planus::Builder,
                     value: impl ::planus::WriteAsOffset<super::web_rtc_transport::ConnectRequest>,
                 ) -> ::planus::UnionOffset<Self> {
-                    ::planus::UnionOffset::new(27, value.prepare(builder).downcast())
+                    ::planus::UnionOffset::new(28, value.prepare(builder).downcast())
                 }
 
                 #[inline]
@@ -50731,7 +50744,7 @@ mod root {
                     builder: &mut ::planus::Builder,
                     value: impl ::planus::WriteAsOffset<super::consumer::SetPreferredLayersRequest>,
                 ) -> ::planus::UnionOffset<Self> {
-                    ::planus::UnionOffset::new(28, value.prepare(builder).downcast())
+                    ::planus::UnionOffset::new(29, value.prepare(builder).downcast())
                 }
 
                 #[inline]
@@ -50739,7 +50752,7 @@ mod root {
                     builder: &mut ::planus::Builder,
                     value: impl ::planus::WriteAsOffset<super::consumer::SetPriorityRequest>,
                 ) -> ::planus::UnionOffset<Self> {
-                    ::planus::UnionOffset::new(29, value.prepare(builder).downcast())
+                    ::planus::UnionOffset::new(30, value.prepare(builder).downcast())
                 }
 
                 #[inline]
@@ -50749,7 +50762,7 @@ mod root {
                         super::data_consumer::SetBufferedAmountLowThresholdRequest,
                     >,
                 ) -> ::planus::UnionOffset<Self> {
-                    ::planus::UnionOffset::new(30, value.prepare(builder).downcast())
+                    ::planus::UnionOffset::new(31, value.prepare(builder).downcast())
                 }
 
                 #[inline]
@@ -50757,7 +50770,7 @@ mod root {
                     builder: &mut ::planus::Builder,
                     value: impl ::planus::WriteAsOffset<super::data_consumer::SendRequest>,
                 ) -> ::planus::UnionOffset<Self> {
-                    ::planus::UnionOffset::new(31, value.prepare(builder).downcast())
+                    ::planus::UnionOffset::new(32, value.prepare(builder).downcast())
                 }
 
                 #[inline]
@@ -50765,7 +50778,7 @@ mod root {
                     builder: &mut ::planus::Builder,
                     value: impl ::planus::WriteAsOffset<super::rtp_observer::AddProducerRequest>,
                 ) -> ::planus::UnionOffset<Self> {
-                    ::planus::UnionOffset::new(32, value.prepare(builder).downcast())
+                    ::planus::UnionOffset::new(33, value.prepare(builder).downcast())
                 }
 
                 #[inline]
@@ -50773,7 +50786,7 @@ mod root {
                     builder: &mut ::planus::Builder,
                     value: impl ::planus::WriteAsOffset<super::rtp_observer::RemoveProducerRequest>,
                 ) -> ::planus::UnionOffset<Self> {
-                    ::planus::UnionOffset::new(33, value.prepare(builder).downcast())
+                    ::planus::UnionOffset::new(34, value.prepare(builder).downcast())
                 }
             }
 
@@ -50854,6 +50867,9 @@ mod root {
                         }
                         Self::PlainTransportConnectRequest(value) => {
                             Self::create_plain_transport_connect_request(builder, value)
+                        }
+                        Self::PipeTransportConnectRequest(value) => {
+                            Self::create_pipe_transport_connect_request(builder, value)
                         }
                         Self::ConnectRequest(value) => Self::create_connect_request(builder, value),
                         Self::SetPreferredLayersRequest(value) => {
@@ -51206,12 +51222,24 @@ mod root {
                     BodyBuilder(::planus::Initialized(value))
                 }
 
+                /// Creates an instance of the [`PipeTransport_ConnectRequest` variant](Body#variant.PipeTransportConnectRequest).
+                #[inline]
+                pub fn pipe_transport_connect_request<T>(
+                    self,
+                    value: T,
+                ) -> BodyBuilder<::planus::Initialized<27, T>>
+                where
+                    T: ::planus::WriteAsOffset<super::pipe_transport::ConnectRequest>,
+                {
+                    BodyBuilder(::planus::Initialized(value))
+                }
+
                 /// Creates an instance of the [`ConnectRequest` variant](Body#variant.ConnectRequest).
                 #[inline]
                 pub fn connect_request<T>(
                     self,
                     value: T,
-                ) -> BodyBuilder<::planus::Initialized<27, T>>
+                ) -> BodyBuilder<::planus::Initialized<28, T>>
                 where
                     T: ::planus::WriteAsOffset<super::web_rtc_transport::ConnectRequest>,
                 {
@@ -51223,7 +51251,7 @@ mod root {
                 pub fn set_preferred_layers_request<T>(
                     self,
                     value: T,
-                ) -> BodyBuilder<::planus::Initialized<28, T>>
+                ) -> BodyBuilder<::planus::Initialized<29, T>>
                 where
                     T: ::planus::WriteAsOffset<super::consumer::SetPreferredLayersRequest>,
                 {
@@ -51235,7 +51263,7 @@ mod root {
                 pub fn set_priority_request<T>(
                     self,
                     value: T,
-                ) -> BodyBuilder<::planus::Initialized<29, T>>
+                ) -> BodyBuilder<::planus::Initialized<30, T>>
                 where
                     T: ::planus::WriteAsOffset<super::consumer::SetPriorityRequest>,
                 {
@@ -51247,7 +51275,7 @@ mod root {
                 pub fn set_buffered_amount_low_threshold_request<T>(
                     self,
                     value: T,
-                ) -> BodyBuilder<::planus::Initialized<30, T>>
+                ) -> BodyBuilder<::planus::Initialized<31, T>>
                 where
                     T: ::planus::WriteAsOffset<
                         super::data_consumer::SetBufferedAmountLowThresholdRequest,
@@ -51258,7 +51286,7 @@ mod root {
 
                 /// Creates an instance of the [`SendRequest` variant](Body#variant.SendRequest).
                 #[inline]
-                pub fn send_request<T>(self, value: T) -> BodyBuilder<::planus::Initialized<31, T>>
+                pub fn send_request<T>(self, value: T) -> BodyBuilder<::planus::Initialized<32, T>>
                 where
                     T: ::planus::WriteAsOffset<super::data_consumer::SendRequest>,
                 {
@@ -51270,7 +51298,7 @@ mod root {
                 pub fn add_producer_request<T>(
                     self,
                     value: T,
-                ) -> BodyBuilder<::planus::Initialized<32, T>>
+                ) -> BodyBuilder<::planus::Initialized<33, T>>
                 where
                     T: ::planus::WriteAsOffset<super::rtp_observer::AddProducerRequest>,
                 {
@@ -51282,7 +51310,7 @@ mod root {
                 pub fn remove_producer_request<T>(
                     self,
                     value: T,
-                ) -> BodyBuilder<::planus::Initialized<33, T>>
+                ) -> BodyBuilder<::planus::Initialized<34, T>>
                 where
                     T: ::planus::WriteAsOffset<super::rtp_observer::RemoveProducerRequest>,
                 {
@@ -51875,7 +51903,7 @@ mod root {
             }
             impl<T> ::planus::WriteAsUnion<Body> for BodyBuilder<::planus::Initialized<27, T>>
             where
-                T: ::planus::WriteAsOffset<super::web_rtc_transport::ConnectRequest>,
+                T: ::planus::WriteAsOffset<super::pipe_transport::ConnectRequest>,
             {
                 #[inline]
                 fn prepare(&self, builder: &mut ::planus::Builder) -> ::planus::UnionOffset<Body> {
@@ -51885,7 +51913,7 @@ mod root {
 
             impl<T> ::planus::WriteAsOptionalUnion<Body> for BodyBuilder<::planus::Initialized<27, T>>
             where
-                T: ::planus::WriteAsOffset<super::web_rtc_transport::ConnectRequest>,
+                T: ::planus::WriteAsOffset<super::pipe_transport::ConnectRequest>,
             {
                 #[inline]
                 fn prepare(
@@ -51897,7 +51925,7 @@ mod root {
             }
             impl<T> ::planus::WriteAsUnion<Body> for BodyBuilder<::planus::Initialized<28, T>>
             where
-                T: ::planus::WriteAsOffset<super::consumer::SetPreferredLayersRequest>,
+                T: ::planus::WriteAsOffset<super::web_rtc_transport::ConnectRequest>,
             {
                 #[inline]
                 fn prepare(&self, builder: &mut ::planus::Builder) -> ::planus::UnionOffset<Body> {
@@ -51907,7 +51935,7 @@ mod root {
 
             impl<T> ::planus::WriteAsOptionalUnion<Body> for BodyBuilder<::planus::Initialized<28, T>>
             where
-                T: ::planus::WriteAsOffset<super::consumer::SetPreferredLayersRequest>,
+                T: ::planus::WriteAsOffset<super::web_rtc_transport::ConnectRequest>,
             {
                 #[inline]
                 fn prepare(
@@ -51919,7 +51947,7 @@ mod root {
             }
             impl<T> ::planus::WriteAsUnion<Body> for BodyBuilder<::planus::Initialized<29, T>>
             where
-                T: ::planus::WriteAsOffset<super::consumer::SetPriorityRequest>,
+                T: ::planus::WriteAsOffset<super::consumer::SetPreferredLayersRequest>,
             {
                 #[inline]
                 fn prepare(&self, builder: &mut ::planus::Builder) -> ::planus::UnionOffset<Body> {
@@ -51929,7 +51957,7 @@ mod root {
 
             impl<T> ::planus::WriteAsOptionalUnion<Body> for BodyBuilder<::planus::Initialized<29, T>>
             where
-                T: ::planus::WriteAsOffset<super::consumer::SetPriorityRequest>,
+                T: ::planus::WriteAsOffset<super::consumer::SetPreferredLayersRequest>,
             {
                 #[inline]
                 fn prepare(
@@ -51941,9 +51969,7 @@ mod root {
             }
             impl<T> ::planus::WriteAsUnion<Body> for BodyBuilder<::planus::Initialized<30, T>>
             where
-                T: ::planus::WriteAsOffset<
-                    super::data_consumer::SetBufferedAmountLowThresholdRequest,
-                >,
+                T: ::planus::WriteAsOffset<super::consumer::SetPriorityRequest>,
             {
                 #[inline]
                 fn prepare(&self, builder: &mut ::planus::Builder) -> ::planus::UnionOffset<Body> {
@@ -51953,9 +51979,7 @@ mod root {
 
             impl<T> ::planus::WriteAsOptionalUnion<Body> for BodyBuilder<::planus::Initialized<30, T>>
             where
-                T: ::planus::WriteAsOffset<
-                    super::data_consumer::SetBufferedAmountLowThresholdRequest,
-                >,
+                T: ::planus::WriteAsOffset<super::consumer::SetPriorityRequest>,
             {
                 #[inline]
                 fn prepare(
@@ -51967,7 +51991,9 @@ mod root {
             }
             impl<T> ::planus::WriteAsUnion<Body> for BodyBuilder<::planus::Initialized<31, T>>
             where
-                T: ::planus::WriteAsOffset<super::data_consumer::SendRequest>,
+                T: ::planus::WriteAsOffset<
+                    super::data_consumer::SetBufferedAmountLowThresholdRequest,
+                >,
             {
                 #[inline]
                 fn prepare(&self, builder: &mut ::planus::Builder) -> ::planus::UnionOffset<Body> {
@@ -51977,7 +52003,9 @@ mod root {
 
             impl<T> ::planus::WriteAsOptionalUnion<Body> for BodyBuilder<::planus::Initialized<31, T>>
             where
-                T: ::planus::WriteAsOffset<super::data_consumer::SendRequest>,
+                T: ::planus::WriteAsOffset<
+                    super::data_consumer::SetBufferedAmountLowThresholdRequest,
+                >,
             {
                 #[inline]
                 fn prepare(
@@ -51989,7 +52017,7 @@ mod root {
             }
             impl<T> ::planus::WriteAsUnion<Body> for BodyBuilder<::planus::Initialized<32, T>>
             where
-                T: ::planus::WriteAsOffset<super::rtp_observer::AddProducerRequest>,
+                T: ::planus::WriteAsOffset<super::data_consumer::SendRequest>,
             {
                 #[inline]
                 fn prepare(&self, builder: &mut ::planus::Builder) -> ::planus::UnionOffset<Body> {
@@ -51999,7 +52027,7 @@ mod root {
 
             impl<T> ::planus::WriteAsOptionalUnion<Body> for BodyBuilder<::planus::Initialized<32, T>>
             where
-                T: ::planus::WriteAsOffset<super::rtp_observer::AddProducerRequest>,
+                T: ::planus::WriteAsOffset<super::data_consumer::SendRequest>,
             {
                 #[inline]
                 fn prepare(
@@ -52011,7 +52039,7 @@ mod root {
             }
             impl<T> ::planus::WriteAsUnion<Body> for BodyBuilder<::planus::Initialized<33, T>>
             where
-                T: ::planus::WriteAsOffset<super::rtp_observer::RemoveProducerRequest>,
+                T: ::planus::WriteAsOffset<super::rtp_observer::AddProducerRequest>,
             {
                 #[inline]
                 fn prepare(&self, builder: &mut ::planus::Builder) -> ::planus::UnionOffset<Body> {
@@ -52020,6 +52048,28 @@ mod root {
             }
 
             impl<T> ::planus::WriteAsOptionalUnion<Body> for BodyBuilder<::planus::Initialized<33, T>>
+            where
+                T: ::planus::WriteAsOffset<super::rtp_observer::AddProducerRequest>,
+            {
+                #[inline]
+                fn prepare(
+                    &self,
+                    builder: &mut ::planus::Builder,
+                ) -> ::core::option::Option<::planus::UnionOffset<Body>> {
+                    ::core::option::Option::Some(::planus::WriteAsUnion::prepare(self, builder))
+                }
+            }
+            impl<T> ::planus::WriteAsUnion<Body> for BodyBuilder<::planus::Initialized<34, T>>
+            where
+                T: ::planus::WriteAsOffset<super::rtp_observer::RemoveProducerRequest>,
+            {
+                #[inline]
+                fn prepare(&self, builder: &mut ::planus::Builder) -> ::planus::UnionOffset<Body> {
+                    ::planus::UnionOffset::new(34, (self.0).0.prepare(builder).downcast())
+                }
+            }
+
+            impl<T> ::planus::WriteAsOptionalUnion<Body> for BodyBuilder<::planus::Initialized<34, T>>
             where
                 T: ::planus::WriteAsOffset<super::rtp_observer::RemoveProducerRequest>,
             {
@@ -52065,6 +52115,7 @@ mod root {
                 CloseDataProducerRequest(super::transport::CloseDataProducerRequestRef<'a>),
                 CloseDataConsumerRequest(super::transport::CloseDataConsumerRequestRef<'a>),
                 PlainTransportConnectRequest(super::plain_transport::ConnectRequestRef<'a>),
+                PipeTransportConnectRequest(super::pipe_transport::ConnectRequestRef<'a>),
                 ConnectRequest(super::web_rtc_transport::ConnectRequestRef<'a>),
                 SetPreferredLayersRequest(super::consumer::SetPreferredLayersRequestRef<'a>),
                 SetPriorityRequest(super::consumer::SetPriorityRequestRef<'a>),
@@ -52239,6 +52290,12 @@ mod root {
                             ))
                         }
 
+                        BodyRef::PipeTransportConnectRequest(value) => {
+                            Self::PipeTransportConnectRequest(::planus::alloc::boxed::Box::new(
+                                ::core::convert::TryFrom::try_from(value)?,
+                            ))
+                        }
+
                         BodyRef::ConnectRequest(value) => {
                             Self::ConnectRequest(::planus::alloc::boxed::Box::new(
                                 ::core::convert::TryFrom::try_from(value)?,
@@ -52371,27 +52428,30 @@ mod root {
                         26 => ::core::result::Result::Ok(Self::PlainTransportConnectRequest(
                             ::planus::TableRead::from_buffer(buffer, field_offset)?,
                         )),
-                        27 => ::core::result::Result::Ok(Self::ConnectRequest(
+                        27 => ::core::result::Result::Ok(Self::PipeTransportConnectRequest(
                             ::planus::TableRead::from_buffer(buffer, field_offset)?,
                         )),
-                        28 => ::core::result::Result::Ok(Self::SetPreferredLayersRequest(
+                        28 => ::core::result::Result::Ok(Self::ConnectRequest(
                             ::planus::TableRead::from_buffer(buffer, field_offset)?,
                         )),
-                        29 => ::core::result::Result::Ok(Self::SetPriorityRequest(
+                        29 => ::core::result::Result::Ok(Self::SetPreferredLayersRequest(
                             ::planus::TableRead::from_buffer(buffer, field_offset)?,
                         )),
-                        30 => {
+                        30 => ::core::result::Result::Ok(Self::SetPriorityRequest(
+                            ::planus::TableRead::from_buffer(buffer, field_offset)?,
+                        )),
+                        31 => {
                             ::core::result::Result::Ok(Self::SetBufferedAmountLowThresholdRequest(
                                 ::planus::TableRead::from_buffer(buffer, field_offset)?,
                             ))
                         }
-                        31 => ::core::result::Result::Ok(Self::SendRequest(
+                        32 => ::core::result::Result::Ok(Self::SendRequest(
                             ::planus::TableRead::from_buffer(buffer, field_offset)?,
                         )),
-                        32 => ::core::result::Result::Ok(Self::AddProducerRequest(
+                        33 => ::core::result::Result::Ok(Self::AddProducerRequest(
                             ::planus::TableRead::from_buffer(buffer, field_offset)?,
                         )),
-                        33 => ::core::result::Result::Ok(Self::RemoveProducerRequest(
+                        34 => ::core::result::Result::Ok(Self::RemoveProducerRequest(
                             ::planus::TableRead::from_buffer(buffer, field_offset)?,
                         )),
                         _ => ::core::result::Result::Err(

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -5,7 +5,8 @@ use crate::consumer::{Consumer, ConsumerId, ConsumerOptions};
 use crate::data_consumer::{DataConsumer, DataConsumerId, DataConsumerOptions, DataConsumerType};
 use crate::data_producer::{DataProducer, DataProducerId, DataProducerOptions, DataProducerType};
 use crate::data_structures::{AppData, ListenInfo, SctpState, TransportTuple};
-use crate::messages::{PipeTransportData, TransportCloseRequest, TransportConnectPipeRequest};
+use crate::fbs::{pipe_transport, response};
+use crate::messages::{PipeTransportConnectRequest, PipeTransportData, TransportCloseRequestFbs};
 use crate::producer::{Producer, ProducerId, ProducerOptions};
 use crate::router::transport::{TransportImpl, TransportType};
 use crate::router::Router;
@@ -24,6 +25,7 @@ use log::{debug, error};
 use nohash_hasher::IntMap;
 use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
+use std::error::Error;
 use std::fmt;
 use std::net::IpAddr;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
@@ -92,15 +94,90 @@ pub struct PipeTransportDump {
     pub data_consumer_ids: Vec<DataConsumerId>,
     pub recv_rtp_header_extensions: RecvRtpHeaderExtensions,
     pub rtp_listener: RtpListener,
-    pub max_message_size: usize,
+    pub max_message_size: u32,
     pub sctp_parameters: Option<SctpParameters>,
     pub sctp_state: Option<SctpState>,
     pub sctp_listener: Option<SctpListener>,
     pub trace_event_types: String,
     // PipeTransport specific.
-    pub tuple: Option<TransportTuple>,
+    pub tuple: TransportTuple,
     pub rtx: bool,
     pub srtp_parameters: Option<SrtpParameters>,
+}
+
+impl PipeTransportDump {
+    pub(crate) fn from_fbs(dump: pipe_transport::DumpResponse) -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
+            // Common to all Transports.
+            id: dump.base.id.parse()?,
+            direct: false,
+            producer_ids: dump
+                .base
+                .producer_ids
+                .iter()
+                .map(|producer_id| Ok(producer_id.parse()?))
+                .collect::<Result<_, Box<dyn Error>>>()?,
+            consumer_ids: dump
+                .base
+                .consumer_ids
+                .iter()
+                .map(|consumer_id| Ok(consumer_id.parse()?))
+                .collect::<Result<_, Box<dyn Error>>>()?,
+            map_ssrc_consumer_id: dump
+                .base
+                .map_ssrc_consumer_id
+                .iter()
+                .map(|key_value| Ok((key_value.key, key_value.value.parse()?)))
+                .collect::<Result<_, Box<dyn Error>>>()?,
+            map_rtx_ssrc_consumer_id: dump
+                .base
+                .map_rtx_ssrc_consumer_id
+                .iter()
+                .map(|key_value| Ok((key_value.key, key_value.value.parse()?)))
+                .collect::<Result<_, Box<dyn Error>>>()?,
+            data_producer_ids: dump
+                .base
+                .data_producer_ids
+                .iter()
+                .map(|data_producer_id| Ok(data_producer_id.parse()?))
+                .collect::<Result<_, Box<dyn Error>>>()?,
+            data_consumer_ids: dump
+                .base
+                .data_consumer_ids
+                .iter()
+                .map(|data_consumer_id| Ok(data_consumer_id.parse()?))
+                .collect::<Result<_, Box<dyn Error>>>()?,
+            recv_rtp_header_extensions: RecvRtpHeaderExtensions::from_fbs(
+                dump.base.recv_rtp_header_extensions.as_ref(),
+            ),
+            rtp_listener: RtpListener::from_fbs(dump.base.rtp_listener.as_ref())?,
+            max_message_size: dump.base.max_message_size,
+            sctp_parameters: dump
+                .base
+                .sctp_parameters
+                .as_ref()
+                .map(|parameters| SctpParameters::from_fbs(parameters.as_ref())),
+            sctp_state: dump
+                .base
+                .sctp_state
+                .map(|state| SctpState::from_fbs(&state)),
+            sctp_listener: dump.base.sctp_listener.as_ref().map(|listener| {
+                SctpListener::from_fbs(listener.as_ref()).expect("Error parsing SctpListner")
+            }),
+            trace_event_types: dump
+                .base
+                .trace_event_types
+                .iter()
+                .map(|event| event.to_string())
+                .collect(),
+            // PlainTransport specific.
+            tuple: TransportTuple::from_fbs(dump.tuple.as_ref()),
+            rtx: dump.rtx,
+            srtp_parameters: dump
+                .srtp_parameters
+                .map(|parameters| SrtpParameters::from_fbs(parameters.as_ref())),
+        })
+    }
 }
 
 /// RTC statistics of the pipe transport.
@@ -114,32 +191,68 @@ pub struct PipeTransportStat {
     pub transport_id: TransportId,
     pub timestamp: u64,
     pub sctp_state: Option<SctpState>,
-    pub bytes_received: usize,
+    pub bytes_received: u64,
     pub recv_bitrate: u32,
-    pub bytes_sent: usize,
+    pub bytes_sent: u64,
     pub send_bitrate: u32,
-    pub rtp_bytes_received: usize,
+    pub rtp_bytes_received: u64,
     pub rtp_recv_bitrate: u32,
-    pub rtp_bytes_sent: usize,
+    pub rtp_bytes_sent: u64,
     pub rtp_send_bitrate: u32,
-    pub rtx_bytes_received: usize,
+    pub rtx_bytes_received: u64,
     pub rtx_recv_bitrate: u32,
-    pub rtx_bytes_sent: usize,
+    pub rtx_bytes_sent: u64,
     pub rtx_send_bitrate: u32,
-    pub probation_bytes_sent: usize,
+    pub probation_bytes_sent: u64,
     pub probation_send_bitrate: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub available_outgoing_bitrate: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub available_incoming_bitrate: Option<u32>,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub max_incoming_bitrate: Option<u32>,
+    pub max_incoming_bitrate: u32,
+    pub max_outgoing_bitrate: u32,
+    pub min_outgoing_bitrate: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rtp_packet_loss_received: Option<f64>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rtp_packet_loss_sent: Option<f64>,
     // PipeTransport specific.
-    pub tuple: Option<TransportTuple>,
+    pub tuple: TransportTuple,
+}
+
+impl PipeTransportStat {
+    pub(crate) fn from_fbs(
+        stats: pipe_transport::GetStatsResponse,
+    ) -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
+            transport_id: stats.base.transport_id.parse()?,
+            timestamp: stats.base.timestamp,
+            sctp_state: stats.base.sctp_state.as_ref().map(SctpState::from_fbs),
+            bytes_received: stats.base.bytes_received,
+            recv_bitrate: stats.base.recv_bitrate,
+            bytes_sent: stats.base.bytes_sent,
+            send_bitrate: stats.base.send_bitrate,
+            rtp_bytes_received: stats.base.rtp_bytes_received,
+            rtp_recv_bitrate: stats.base.rtp_recv_bitrate,
+            rtp_bytes_sent: stats.base.rtp_bytes_sent,
+            rtp_send_bitrate: stats.base.rtp_send_bitrate,
+            rtx_bytes_received: stats.base.rtx_bytes_received,
+            rtx_recv_bitrate: stats.base.rtx_recv_bitrate,
+            rtx_bytes_sent: stats.base.rtx_bytes_sent,
+            rtx_send_bitrate: stats.base.rtx_send_bitrate,
+            probation_bytes_sent: stats.base.probation_bytes_sent,
+            probation_send_bitrate: stats.base.probation_send_bitrate,
+            available_outgoing_bitrate: stats.base.available_outgoing_bitrate,
+            available_incoming_bitrate: stats.base.available_incoming_bitrate,
+            max_incoming_bitrate: stats.base.max_incoming_bitrate,
+            max_outgoing_bitrate: stats.base.max_outgoing_bitrate,
+            min_outgoing_bitrate: stats.base.min_outgoing_bitrate,
+            rtp_packet_loss_received: stats.base.rtp_packet_loss_received,
+            rtp_packet_loss_sent: stats.base.rtp_packet_loss_sent,
+            // PlainTransport specific.
+            tuple: TransportTuple::from_fbs(stats.tuple.as_ref()),
+        })
+    }
 }
 
 /// Remote parameters for pipe transport.
@@ -214,13 +327,13 @@ impl Inner {
             if close_request {
                 let channel = self.channel.clone();
                 let router_id = self.router.id();
-                let request = TransportCloseRequest {
+                let request = TransportCloseRequestFbs {
                     transport_id: self.id,
                 };
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(router_id, request).await {
+                        if let Err(error) = channel.request_fbs(router_id, request).await {
                             error!("transport closing failed on drop: {}", error);
                         }
                     })
@@ -410,28 +523,25 @@ impl TransportGeneric for PipeTransport {
     async fn dump(&self) -> Result<Self::Dump, RequestError> {
         debug!("dump()");
 
-        todo!();
-        /*
-        serde_json::from_value(self.dump_impl().await?).map_err(|error| {
-            RequestError::FailedToParse {
-                error: error.to_string(),
-            }
-        })
-        */
+        if let response::Body::FbsPipeTransportDumpResponse(data) = self.dump_impl().await? {
+            Ok(PipeTransportDump::from_fbs(*data).expect("Error parsing dump response"))
+        } else {
+            panic!("Wrong message from worker");
+        }
     }
 
     async fn get_stats(&self) -> Result<Vec<Self::Stat>, RequestError> {
         debug!("get_stats()");
 
-        todo!();
-
-        /*
-        serde_json::from_value(self.get_stats_impl().await?).map_err(|error| {
-            RequestError::FailedToParse {
-                error: error.to_string(),
-            }
-        })
-        */
+        if let response::Body::FbsPipeTransportGetStatsResponse(data) =
+            self.get_stats_impl().await?
+        {
+            Ok(vec![
+                PipeTransportStat::from_fbs(*data).expect("Error parsing dump response")
+            ])
+        } else {
+            panic!("Wrong message from worker");
+        }
     }
 }
 
@@ -550,9 +660,9 @@ impl PipeTransport {
         let response = self
             .inner
             .channel
-            .request(
+            .request_fbs(
                 self.id(),
-                TransportConnectPipeRequest {
+                PipeTransportConnectRequest {
                     ip: remote_parameters.ip,
                     port: remote_parameters.port,
                     srtp_parameters: remote_parameters.srtp_parameters,

--- a/worker/fbs/request.fbs
+++ b/worker/fbs/request.fbs
@@ -104,7 +104,7 @@ union Body {
   FBS.Transport.CloseDataProducerRequest,
   FBS.Transport.CloseDataConsumerRequest,
   PlainTransport_ConnectRequest: FBS.PlainTransport.ConnectRequest,
-  FBS.PipeTransport.ConnectRequest,
+  PipeTransport_ConnectRequest: FBS.PipeTransport.ConnectRequest,
   FBS.WebRtcTransport.ConnectRequest,
   FBS.Producer.EnableTraceEventRequest,
   FBS.Consumer.SetPreferredLayersRequest,


### PR DESCRIPTION
PipeTransport tests are not disabled because they depend on WebRtcTransport, which will be done next.