### PR TITLE
DataChannel subchannels

### DIFF
--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -571,29 +571,25 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 	{
 		logger.debug('setSubchannels()');
 
-		console.log('TODO');
+		/* Build Request. */
+		const requestOffset = new FbsDataConsumer.SetSubchannelsRequestT(
+			subchannels
+		).pack(this.#channel.bufferBuilder);
 
-		const subchannelsSet = new Set(subchannels);
+		const response = await this.#channel.request(
+			FbsRequest.Method.DATACONSUMER_SET_SUBCHANNELS,
+			FbsRequest.Body.FBS_DataConsumer_SetSubchannelsRequest,
+			requestOffset,
+			this.#internal.dataConsumerId
+		);
 
-		// /* Build Request. */
-		// const requestOffset = new FbsTransport.SetSubchannelsRequestT(
-		// 	this.#internal.dataConsumerId,
-		// 	subchannels
-		// ).pack(this.#channel.bufferBuilder);
+		/* Decode Response. */
+		const data = new FbsDataConsumer.SetSubchannelsResponse();
 
-		// const response = await this.#channel.request(
-		// 	FbsRequest.Method.DATACONSUMER_SET_SUBCHANNELS,
-		// 	FbsRequest.Body.FBS_DATA_CONSUMER_SetSubchannelsRequest,,
-		// 	requestOffset,
-		// 	this.#internal.dataConsumerId
-		// );
+		response.body(data);
 
-		// /* Decode Response. */
-		// const data = new FbsDataConsumer.SetSubchannelsResponse();
-
-		// response.body(data);
-
-		// return parseSubchannels(data);
+		// Update subchannels.
+		this.#subchannels = utils.parseVector(data, 'subchannels');
 	}
 
 	private handleWorkerNotifications(): void

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -46,6 +46,13 @@ export type DataConsumerOptions<DataConsumerAppData extends AppData = AppData> =
 	paused?: boolean;
 
 	/**
+	 * Subchannels this data consumer initially subscribes to.
+	 * Only used in case this data consumer receives messages from a local data
+	 * producer that specifies subchannel(s) when calling send().
+	 */
+	subchannels?: number[];
+
+	/**
 	 * Custom application data.
 	 */
 	appData?: DataConsumerAppData;
@@ -93,6 +100,7 @@ type DataConsumerDump = DataConsumerData &
 	id: string;
 	paused: boolean;
 	dataProducerPaused: boolean;
+	subchannels: number[];
 };
 
 type DataConsumerInternal = TransportInternal &
@@ -132,6 +140,9 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 	// Associated DataProducer paused flag.
 	#dataProducerPaused = false;
 
+	// Subchannels subscribed to.
+	#subchannels: number[];
+
 	// Custom app data.
 	#appData: DataConsumerAppData;
 
@@ -148,6 +159,7 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 			channel,
 			paused,
 			dataProducerPaused,
+			subchannels,
 			appData
 		}:
 		{
@@ -156,6 +168,7 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 			channel: Channel;
 			paused: boolean;
 			dataProducerPaused: boolean;
+			subchannels: number[];
 			appData?: DataConsumerAppData;
 		}
 	)
@@ -169,6 +182,7 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 		this.#channel = channel;
 		this.#paused = paused;
 		this.#dataProducerPaused = dataProducerPaused;
+		this.#subchannels = subchannels;
 		this.#appData = appData || {} as DataConsumerAppData;
 
 		this.handleWorkerNotifications();
@@ -675,14 +689,15 @@ export function parseDataConsumerDumpResponse(
 		label              : data.label()!,
 		protocol           : data.protocol()!,
 		paused             : data.paused(),
-		dataProducerPaused : data.dataProducerPaused()
+		dataProducerPaused : data.dataProducerPaused(),
+		subchannels        : data.subchannels()
 
 	};
 }
 
 function parseDataConsumerStats(
 	binary: FbsDataConsumer.GetStatsResponse
-):DataConsumerStat
+): DataConsumerStat
 {
 	return {
 		type           : 'data-consumer',

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -8,6 +8,7 @@ import { Event, Notification } from './fbs/notification';
 import * as FbsTransport from './fbs/transport';
 import * as FbsRequest from './fbs/request';
 import * as FbsDataConsumer from './fbs/data-consumer';
+import * as utils from './utils';
 
 export type DataConsumerOptions<DataConsumerAppData extends AppData = AppData> =
 {
@@ -258,6 +259,14 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 	get dataProducerPaused(): boolean
 	{
 		return this.#dataProducerPaused;
+	}
+
+	/**
+	 * Get current subchannels this data consumer is subscribed to.
+	 */
+	get subchannels(): number[]
+	{
+		return Array.from(this.#subchannels);
 	}
 
 	/**
@@ -555,6 +564,38 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 		return data.bufferedAmount();
 	}
 
+	/**
+	 * Set subchannels.
+	 */
+	async setSubchannels(subchannels: number[]): Promise<void>
+	{
+		logger.debug('setSubchannels()');
+
+		console.log('TODO');
+
+		subchannels = [...new Set(subchannels)];
+
+		// /* Build Request. */
+		// const requestOffset = new FbsTransport.SetSubchannelsRequestT(
+		// 	this.#internal.dataConsumerId,
+		// 	subchannels
+		// ).pack(this.#channel.bufferBuilder);
+
+		// const response = await this.#channel.request(
+		// 	FbsRequest.Method.DATACONSUMER_SET_SUBCHANNELS,
+		// 	FbsRequest.Body.FBS_DATA_CONSUMER_SetSubchannelsRequest,,
+		// 	requestOffset,
+		// 	this.#internal.dataConsumerId
+		// );
+
+		// /* Decode Response. */
+		// const data = new FbsDataConsumer.SetSubchannelsResponse();
+
+		// response.body(data);
+
+		// return parseSubchannels(data);
+	}
+
 	private handleWorkerNotifications(): void
 	{
 		this.#channel.on(this.#internal.dataConsumerId, (event: Event, data?: Notification) =>
@@ -690,8 +731,7 @@ export function parseDataConsumerDumpResponse(
 		protocol           : data.protocol()!,
 		paused             : data.paused(),
 		dataProducerPaused : data.dataProducerPaused(),
-		subchannels        : data.subchannels()
-
+		subchannels        : utils.parseVector(data, 'subchannels')
 	};
 }
 

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -573,7 +573,7 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 
 		console.log('TODO');
 
-		subchannels = [...new Set(subchannels)];
+		const subchannelsSet = new Set(subchannels);
 
 		// /* Build Request. */
 		// const requestOffset = new FbsTransport.SetSubchannelsRequestT(

--- a/node/src/DataProducer.ts
+++ b/node/src/DataProducer.ts
@@ -387,7 +387,12 @@ export class DataProducer<DataProducerAppData extends AppData = AppData>
 	/**
 	 * Send data (just valid for DataProducers created on a DirectTransport).
 	 */
-	send(message: string | Buffer, ppid?: number): void
+	send(
+		message: string | Buffer,
+		ppid?: number,
+		subchannels?: number[],
+		requiredSubchannel?: number
+	): void
 	{
 		if (typeof message !== 'string' && !Buffer.isBuffer(message))
 		{
@@ -431,6 +436,10 @@ export class DataProducer<DataProducerAppData extends AppData = AppData>
 
 		let dataOffset = 0;
 
+		const subchannelsOffset = FbsDataProducer.SendNotification.createSubchannelsVector(
+			builder, subchannels ?? []
+		);
+
 		if (typeof message === 'string')
 		{
 			const messageOffset = builder.createString(message);
@@ -450,7 +459,9 @@ export class DataProducer<DataProducerAppData extends AppData = AppData>
 			typeof message === 'string' ?
 				FbsDataProducer.Data.String :
 				FbsDataProducer.Data.Binary,
-			dataOffset
+			dataOffset,
+			subchannelsOffset,
+			requiredSubchannel ?? null
 		);
 
 		this.#channel.notify(

--- a/node/src/RtpParameters.ts
+++ b/node/src/RtpParameters.ts
@@ -2,8 +2,8 @@ import * as flatbuffers from 'flatbuffers';
 import {
 	Boolean as FbsBoolean,
 	Double as FbsDouble,
-	Integer as FbsInteger,
-	IntegerArray as FbsIntegerArray,
+	Integer32 as FbsInteger32,
+	Integer32Array as FbsInteger32Array,
 	String as FbsString,
 	Parameter as FbsParameter,
 	RtcpFeedback as FbsRtcpFeedback,
@@ -564,16 +564,15 @@ export function serializeParameters(
 				builder, keyOffset, FbsValue.Boolean, value === true ? 1:0
 			);
 		}
-
 		else if (typeof value === 'number')
 		{
 			// Integer.
 			if (value % 1 === 0)
 			{
-				const valueOffset = FbsInteger.createInteger(builder, value);
+				const valueOffset = FbsInteger32.createInteger32(builder, value);
 
 				parameterOffset = FbsParameter.createParameter(
-					builder, keyOffset, FbsValue.Integer, valueOffset
+					builder, keyOffset, FbsValue.Integer32, valueOffset
 				);
 			}
 			// Float.
@@ -586,7 +585,6 @@ export function serializeParameters(
 				);
 			}
 		}
-
 		else if (typeof value === 'string')
 		{
 			const valueOffset = FbsString.createString(builder, builder.createString(value));
@@ -595,16 +593,14 @@ export function serializeParameters(
 				builder, keyOffset, FbsValue.String, valueOffset
 			);
 		}
-
 		else if (Array.isArray(value))
 		{
-			const valueOffset = FbsIntegerArray.createValueVector(builder, value);
+			const valueOffset = FbsInteger32Array.createValueVector(builder, value);
 
 			parameterOffset = FbsParameter.createParameter(
-				builder, keyOffset, FbsValue.IntegerArray, valueOffset
+				builder, keyOffset, FbsValue.Integer32Array, valueOffset
 			);
 		}
-
 		else
 		{
 			throw new Error(`invalid parameter type [key:'${key}', value:${value}]`);
@@ -645,9 +641,9 @@ export function parseParameters(data: any): any
 				break;
 			}
 
-			case FbsValue.Integer:
+			case FbsValue.Integer32:
 			{
-				const value = new FbsInteger();
+				const value = new FbsInteger32();
 
 				fbsParameter.value(value);
 
@@ -678,9 +674,9 @@ export function parseParameters(data: any): any
 				break;
 			}
 
-			case FbsValue.IntegerArray:
+			case FbsValue.Integer32Array:
 			{
-				const value = new FbsIntegerArray();
+				const value = new FbsInteger32Array();
 
 				fbsParameter.value(value);
 

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -1684,7 +1684,7 @@ function createConsumeDataRequest({
 	label,
 	protocol,
 	paused,
-	subchannels
+	subchannels = []
 } : {
 	builder: flatbuffers.Builder;
 	dataConsumerId: string;
@@ -1712,6 +1712,10 @@ function createConsumeDataRequest({
 		);
 	}
 
+	const subchannelsOffset = FbsTransport.ConsumeDataRequest.createSubchannelsVector(
+		builder, subchannels
+	);
+
 	FbsTransport.ConsumeDataRequest.startConsumeDataRequest(builder);
 	FbsTransport.ConsumeDataRequest.addDataConsumerId(builder, dataConsumerIdOffset);
 	FbsTransport.ConsumeDataRequest.addDataProducerId(builder, dataProducerIdOffset);
@@ -1727,15 +1731,7 @@ function createConsumeDataRequest({
 	FbsTransport.ConsumeDataRequest.addLabel(builder, labelOffset);
 	FbsTransport.ConsumeDataRequest.addProtocol(builder, protocolOffset);
 	FbsTransport.ConsumeDataRequest.addPaused(builder, paused);
-
-	if (subchannels)
-	{
-		const subchannelsOffset = FbsTransport.ConsumeDataRequest.createSubchannelsVector(
-			builder, subchannels
-		);
-
-		FbsTransport.ConsumeDataRequest.addSubchannels(builder, subchannelsOffset);
-	}
+	FbsTransport.ConsumeDataRequest.addSubchannels(builder, subchannelsOffset);
 
 	return FbsTransport.ConsumeDataRequest.endConsumeDataRequest(builder);
 }

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -1080,6 +1080,7 @@ export class Transport
 			maxPacketLifeTime,
 			maxRetransmits,
 			paused = false,
+			subchannels,
 			appData
 		}: DataConsumerOptions<ConsumerAppData>
 	): Promise<DataConsumer<ConsumerAppData>>
@@ -1163,7 +1164,8 @@ export class Transport
 			sctpStreamParameters,
 			label,
 			protocol,
-			paused
+			paused,
+			subchannels
 		});
 
 		const response = await this.channel.request(
@@ -1197,6 +1199,7 @@ export class Transport
 				},
 				channel            : this.channel,
 				paused             : dump.paused,
+				subchannels        : dump.subchannels,
 				dataProducerPaused : dump.dataProducerPaused,
 				appData
 			});
@@ -1680,9 +1683,10 @@ function createConsumeDataRequest({
 	sctpStreamParameters,
 	label,
 	protocol,
-	paused
+	paused,
+	subchannels
 } : {
-	builder : flatbuffers.Builder;
+	builder: flatbuffers.Builder;
 	dataConsumerId: string;
 	dataProducerId: string;
 	type: DataConsumerType;
@@ -1690,6 +1694,7 @@ function createConsumeDataRequest({
 	label: string;
 	protocol: string;
 	paused: boolean;
+	subchannels?: number[];
 }): number
 {
 	const dataConsumerIdOffset = builder.createString(dataConsumerId);
@@ -1722,6 +1727,13 @@ function createConsumeDataRequest({
 	FbsTransport.ConsumeDataRequest.addLabel(builder, labelOffset);
 	FbsTransport.ConsumeDataRequest.addProtocol(builder, protocolOffset);
 	FbsTransport.ConsumeDataRequest.addPaused(builder, paused);
+
+	if (subchannels)
+	{
+		// TODO: Obviously this is wrong since I have to serialize the array into FBS
+		// format.
+		FbsTransport.ConsumeDataRequest.addSubchannels(builder, subchannels);
+	}
 
 	return FbsTransport.ConsumeDataRequest.endConsumeDataRequest(builder);
 }

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -1730,9 +1730,11 @@ function createConsumeDataRequest({
 
 	if (subchannels)
 	{
-		// TODO: Obviously this is wrong since I have to serialize the array into FBS
-		// format.
-		FbsTransport.ConsumeDataRequest.addSubchannels(builder, subchannels);
+		const subchannelsOffset = FbsTransport.ConsumeDataRequest.createSubchannelsVector(
+			builder, subchannels
+		);
+
+		FbsTransport.ConsumeDataRequest.addSubchannels(builder, subchannelsOffset);
 	}
 
 	return FbsTransport.ConsumeDataRequest.endConsumeDataRequest(builder);

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -53,10 +53,10 @@ test('transport.consumeData() succeeds', async () =>
 		{
 			dataProducerId    : dataProducer.id,
 			maxPacketLifeTime : 4000,
-			appData           : { baz: 'LOL' },
 			// Valid values are 0...65535 so others and duplicated ones will be
 			// discarded.
-			subchannels       : [ 0, 1, 1, 1, 2, 65535, 65536, 65537, 100 ]
+			subchannels       : [ 0, 1, 1, 1, 2, 65535, 65536, 65537, 100 ],
+			appData           : { baz: 'LOL' }
 		});
 
 	expect(onObserverNewDataConsumer).toHaveBeenCalledTimes(1);
@@ -130,6 +130,13 @@ test('dataConsumer.getStats() succeeds', async () =>
 					bytesSent    : 0
 				}
 			]);
+}, 2000);
+
+test('dataConsumer.setSubchannels() succeeds', async () =>
+{
+	await dataConsumer1.setSubchannels([ 999, 999, 998, 65536 ]);
+
+	expect(dataConsumer1.subchannels.sort((a, b) => a - b)).toEqual([ 0, 998, 999 ]);
 }, 2000);
 
 test('transport.consumeData() on a DirectTransport succeeds', async () =>

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -53,7 +53,10 @@ test('transport.consumeData() succeeds', async () =>
 		{
 			dataProducerId    : dataProducer.id,
 			maxPacketLifeTime : 4000,
-			appData           : { baz: 'LOL' }
+			appData           : { baz: 'LOL' },
+			// Valid values are 0...65535 so others and duplicated ones will be
+			// discarded.
+			subchannels       : [ 0, 1, 1, 1, 2, 65535, 65536, 65537, 100 ]
 		});
 
 	expect(onObserverNewDataConsumer).toHaveBeenCalledTimes(1);
@@ -70,6 +73,7 @@ test('transport.consumeData() succeeds', async () =>
 	expect(dataConsumer1.label).toBe('foo');
 	expect(dataConsumer1.protocol).toBe('bar');
 	expect(dataConsumer1.paused).toBe(false);
+	expect(dataConsumer1.subchannels.sort((a, b) => a - b)).toEqual([ 0, 1, 2, 100, 65535 ]);
 	expect(dataConsumer1.appData).toEqual({ baz: 'LOL' });
 
 	const dump = await router.dump();

--- a/node/src/tests/test-DirectTransport.ts
+++ b/node/src/tests/test-DirectTransport.ts
@@ -249,12 +249,7 @@ test('dataProducer.send() succeeds', async () =>
 test('dataProducer.send() with subchannels succeeds', async () =>
 {
 	const transport2 = await router.createDirectTransport();
-	const dataProducer = await transport2.produceData(
-		{
-			label    : 'foo',
-			protocol : 'bar',
-			appData  : { foo: 'bar' }
-		});
+	const dataProducer = await transport2.produceData();
 	const dataConsumer1 = await transport2.consumeData(
 		{
 			dataProducerId : dataProducer.id,

--- a/node/src/utils.ts
+++ b/node/src/utils.ts
@@ -3,16 +3,27 @@ import { ProducerType } from './Producer';
 import { Type as FbsRtpParametersType } from './fbs/rtp-parameters';
 
 /**
- * Clones the given object/array.
+ * Clones the given value.
  */
-export function clone(data: any): any
+export function clone<T>(value: T): T
 {
-	if (typeof data !== 'object')
+	if (value === undefined)
 	{
-		return {};
+		return undefined as unknown as T;
 	}
-
-	return JSON.parse(JSON.stringify(data));
+	else if (Number.isNaN(value))
+	{
+		return NaN as unknown as T;
+	}
+	else if (typeof structuredClone === 'function')
+	{
+		// Available in Node >= 18.
+		return structuredClone(value);
+	}
+	else
+	{
+		return JSON.parse(JSON.stringify(value));
+	}
 }
 
 /**

--- a/worker/fbs/dataConsumer.fbs
+++ b/worker/fbs/dataConsumer.fbs
@@ -20,6 +20,7 @@ table DumpResponse {
   protocol:string (required);
   paused:bool;
   data_producer_paused:bool;
+  subchannels:[uint16] (required);
 }
 
 table GetStatsResponse {

--- a/worker/fbs/dataConsumer.fbs
+++ b/worker/fbs/dataConsumer.fbs
@@ -50,6 +50,14 @@ table SendRequest {
   data:Data (required);
 }
 
+table SetSubchannelsRequest {
+  subchannels:[uint16];
+}
+
+table SetSubchannelsResponse {
+  subchannels:[uint16];
+}
+
 // Notifications from Worker.
 
 table BufferedAmountLowNotification {

--- a/worker/fbs/dataConsumer.fbs
+++ b/worker/fbs/dataConsumer.fbs
@@ -20,7 +20,7 @@ table DumpResponse {
   protocol:string (required);
   paused:bool;
   data_producer_paused:bool;
-  subchannels:[uint16] (required);
+  subchannels:[uint16];
 }
 
 table GetStatsResponse {

--- a/worker/fbs/dataProducer.fbs
+++ b/worker/fbs/dataProducer.fbs
@@ -37,5 +37,5 @@ table SendNotification {
   ppid:uint8;
   data:Data (required);
   subchannels:[uint16];
-  requiredSubchannel:uint16 = null;
+  required_subchannel:uint16 = null;
 }

--- a/worker/fbs/dataProducer.fbs
+++ b/worker/fbs/dataProducer.fbs
@@ -36,4 +36,6 @@ union Data {
 table SendNotification {
   ppid:uint8;
   data:Data (required);
+  subchannels:[uint16];
+  requiredSubchannel:uint16 = null;
 }

--- a/worker/fbs/request.fbs
+++ b/worker/fbs/request.fbs
@@ -71,6 +71,7 @@ enum Method: uint8 {
   DATACONSUMER_GET_BUFFERED_AMOUNT,
   DATACONSUMER_SET_BUFFERED_AMOUNT_LOW_THRESHOLD,
   DATACONSUMER_SEND,
+  DATACONSUMER_SET_SUBCHANNELS,
   RTPOBSERVER_PAUSE,
   RTPOBSERVER_RESUME,
   RTPOBSERVER_ADD_PRODUCER,
@@ -112,6 +113,7 @@ union Body {
   FBS.Consumer.EnableTraceEventRequest,
   FBS.DataConsumer.SetBufferedAmountLowThresholdRequest,
   FBS.DataConsumer.SendRequest,
+  FBS.DataConsumer.SetSubchannelsRequest,
   FBS.RtpObserver.AddProducerRequest,
   FBS.RtpObserver.RemoveProducerRequest,
 }

--- a/worker/fbs/response.fbs
+++ b/worker/fbs/response.fbs
@@ -39,6 +39,7 @@ union Body {
   FBS_DataConsumer_GetBufferedAmountResponse: FBS.DataConsumer.GetBufferedAmountResponse,
   FBS_DataConsumer_DumpResponse: FBS.DataConsumer.DumpResponse,
   FBS_DataConsumer_GetStatsResponse: FBS.DataConsumer.GetStatsResponse,
+  FBS_DataConsumer_SetSubchannelsResponse: FBS.DataConsumer.SetSubchannelsResponse,
 }
 
 table Response {

--- a/worker/fbs/rtpParameters.fbs
+++ b/worker/fbs/rtpParameters.fbs
@@ -9,11 +9,11 @@ table Boolean {
   value:uint8;
 }
 
-table Integer {
+table Integer32 {
   value:int32;
 }
 
-table IntegerArray {
+table Integer32Array {
   value:[int32];
 }
 
@@ -27,10 +27,10 @@ table String {
 
 union Value {
   Boolean,
-  Integer,
+  Integer32,
   Double,
   String,
-  IntegerArray,
+  Integer32Array,
 }
 
 table Parameter {

--- a/worker/fbs/transport.fbs
+++ b/worker/fbs/transport.fbs
@@ -72,6 +72,7 @@ table ConsumeDataRequest {
   label:string;
   protocol:string;
   paused:bool = false;
+  subchannels:[uint16];
 }
 
 table Tuple {

--- a/worker/include/RTC/DataConsumer.hpp
+++ b/worker/include/RTC/DataConsumer.hpp
@@ -29,9 +29,9 @@ namespace RTC
 		public:
 			virtual void OnDataConsumerSendMessage(
 			  RTC::DataConsumer* dataConsumer,
-			  uint32_t ppid,
 			  const uint8_t* msg,
 			  size_t len,
+			  uint32_t ppid,
 			  onQueuedCallback* cb)                                                        = 0;
 			virtual void OnDataConsumerDataProducerClosed(RTC::DataConsumer* dataConsumer) = 0;
 		};
@@ -98,7 +98,13 @@ namespace RTC
 		void SctpAssociationBufferedAmount(uint32_t bufferedAmount);
 		void SctpAssociationSendBufferFull();
 		void DataProducerClosed();
-		void SendMessage(uint32_t ppid, const uint8_t* msg, size_t len, onQueuedCallback* = nullptr);
+		void SendMessage(
+		  const uint8_t* msg,
+		  size_t len,
+		  uint32_t ppid,
+		  std::vector<uint16_t>& subchannels,
+		  std::optional<uint16_t> requiredSubchannel,
+		  onQueuedCallback* = nullptr);
 
 		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
 	public:

--- a/worker/include/RTC/DataConsumer.hpp
+++ b/worker/include/RTC/DataConsumer.hpp
@@ -6,6 +6,7 @@
 #include "Channel/ChannelSocket.hpp"
 #include "RTC/SctpDictionaries.hpp"
 #include "RTC/Shared.hpp"
+#include <absl/container/flat_hash_set.h>
 #include <string>
 
 namespace RTC
@@ -120,6 +121,7 @@ namespace RTC
 		RTC::SctpStreamParameters sctpStreamParameters;
 		std::string label;
 		std::string protocol;
+		absl::flat_hash_set<uint16_t> subchannels;
 		bool transportConnected{ false };
 		bool sctpAssociationConnected{ false };
 		bool paused{ false };

--- a/worker/include/RTC/DataProducer.hpp
+++ b/worker/include/RTC/DataProducer.hpp
@@ -8,6 +8,7 @@
 #include "RTC/SctpDictionaries.hpp"
 #include "RTC/Shared.hpp"
 #include <string>
+#include <vector>
 
 namespace RTC
 {
@@ -23,9 +24,14 @@ namespace RTC
 		public:
 			virtual void OnDataProducerReceiveData(RTC::DataProducer* producer, size_t len) = 0;
 			virtual void OnDataProducerMessageReceived(
-			  RTC::DataProducer* dataProducer, uint32_t ppid, const uint8_t* msg, size_t len) = 0;
-			virtual void OnDataProducerPaused(RTC::DataProducer* dataProducer)                = 0;
-			virtual void OnDataProducerResumed(RTC::DataProducer* dataProducer)               = 0;
+			  RTC::DataProducer* dataProducer,
+			  const uint8_t* msg,
+			  size_t len,
+			  uint32_t ppid,
+			  std::vector<uint16_t>& subchannels,
+			  std::optional<uint16_t> requiredSubchannel)                       = 0;
+			virtual void OnDataProducerPaused(RTC::DataProducer* dataProducer)  = 0;
+			virtual void OnDataProducerResumed(RTC::DataProducer* dataProducer) = 0;
 		};
 
 	public:
@@ -61,7 +67,12 @@ namespace RTC
 		{
 			return this->paused;
 		}
-		void ReceiveMessage(uint32_t ppid, const uint8_t* msg, size_t len);
+		void ReceiveMessage(
+		  const uint8_t* msg,
+		  size_t len,
+		  uint32_t ppid,
+		  std::vector<uint16_t>& subchannels,
+		  std::optional<uint16_t> requiredSubchannel);
 
 		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
 	public:

--- a/worker/include/RTC/DirectTransport.hpp
+++ b/worker/include/RTC/DirectTransport.hpp
@@ -32,9 +32,9 @@ namespace RTC
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendMessage(
 		  RTC::DataConsumer* dataConsumer,
-		  uint32_t ppid,
 		  const uint8_t* msg,
 		  size_t len,
+		  uint32_t ppid,
 		  onQueuedCallback* cb = nullptr) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;
 		void RecvStreamClosed(uint32_t ssrc) override;

--- a/worker/include/RTC/PipeTransport.hpp
+++ b/worker/include/RTC/PipeTransport.hpp
@@ -50,9 +50,9 @@ namespace RTC
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendMessage(
 		  RTC::DataConsumer* dataConsumer,
-		  uint32_t ppid,
 		  const uint8_t* msg,
 		  size_t len,
+		  uint32_t ppid,
 		  onQueuedCallback* cb = nullptr) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;
 		void RecvStreamClosed(uint32_t ssrc) override;

--- a/worker/include/RTC/PlainTransport.hpp
+++ b/worker/include/RTC/PlainTransport.hpp
@@ -48,9 +48,9 @@ namespace RTC
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendMessage(
 		  RTC::DataConsumer* dataConsumer,
-		  uint32_t ppid,
 		  const uint8_t* msg,
 		  size_t len,
+		  uint32_t ppid,
 		  onQueuedCallback* cb = nullptr) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;
 		void RecvStreamClosed(uint32_t ssrc) override;

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -17,6 +17,7 @@
 #include <absl/container/flat_hash_map.h>
 #include <absl/container/flat_hash_set.h>
 #include <string>
+#include <vector>
 
 namespace RTC
 {
@@ -96,9 +97,11 @@ namespace RTC
 		void OnTransportDataProducerMessageReceived(
 		  RTC::Transport* transport,
 		  RTC::DataProducer* dataProducer,
-		  uint32_t ppid,
 		  const uint8_t* msg,
-		  size_t len) override;
+		  size_t len,
+		  uint32_t ppid,
+		  std::vector<uint16_t>& subchannels,
+		  std::optional<uint16_t> requiredSubchannel) override;
 		void OnTransportNewDataConsumer(
 		  RTC::Transport* transport, RTC::DataConsumer* dataConsumer, std::string& dataProducerId) override;
 		void OnTransportDataConsumerClosed(RTC::Transport* transport, RTC::DataConsumer* dataConsumer) override;

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -15,8 +15,8 @@
 #include "RTC/Transport.hpp"
 #include "RTC/WebRtcServer.hpp"
 #include <absl/container/flat_hash_map.h>
+#include <absl/container/flat_hash_set.h>
 #include <string>
-#include <unordered_set>
 
 namespace RTC
 {

--- a/worker/include/RTC/SctpAssociation.hpp
+++ b/worker/include/RTC/SctpAssociation.hpp
@@ -47,9 +47,9 @@ namespace RTC
 			virtual void OnSctpAssociationMessageReceived(
 			  RTC::SctpAssociation* sctpAssociation,
 			  uint16_t streamId,
-			  uint32_t ppid,
 			  const uint8_t* msg,
-			  size_t len) = 0;
+			  size_t len,
+			  uint32_t ppid) = 0;
 			virtual void OnSctpAssociationBufferedAmount(
 			  RTC::SctpAssociation* sctpAssociation, uint32_t len) = 0;
 		};
@@ -92,9 +92,9 @@ namespace RTC
 		void ProcessSctpData(const uint8_t* data, size_t len);
 		void SendSctpMessage(
 		  RTC::DataConsumer* dataConsumer,
-		  uint32_t ppid,
 		  const uint8_t* msg,
 		  size_t len,
+		  uint32_t ppid,
 		  onQueuedCallback* cb = nullptr);
 		void HandleDataConsumer(RTC::DataConsumer* dataConsumer);
 		void DataProducerClosed(RTC::DataProducer* dataProducer);

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -30,6 +30,7 @@
 #include "handles/TimerHandle.hpp"
 #include <absl/container/flat_hash_map.h>
 #include <string>
+#include <vector>
 
 namespace RTC
 {
@@ -103,9 +104,11 @@ namespace RTC
 			virtual void OnTransportDataProducerMessageReceived(
 			  RTC::Transport* transport,
 			  RTC::DataProducer* dataProducer,
-			  uint32_t ppid,
 			  const uint8_t* msg,
-			  size_t len) = 0;
+			  size_t len,
+			  uint32_t ppid,
+			  std::vector<uint16_t>& subchannels,
+			  std::optional<uint16_t> requiredSubchannel) = 0;
 			virtual void OnTransportNewDataConsumer(
 			  RTC::Transport* transport, RTC::DataConsumer* dataConsumer, std::string& dataProducerId) = 0;
 			virtual void OnTransportDataConsumerClosed(
@@ -188,9 +191,9 @@ namespace RTC
 		virtual void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) = 0;
 		virtual void SendMessage(
 		  RTC::DataConsumer* dataConsumer,
-		  uint32_t ppid,
 		  const uint8_t* msg,
 		  size_t len,
+		  uint32_t ppid,
 		  onQueuedCallback* = nullptr)                             = 0;
 		virtual void SendSctpData(const uint8_t* data, size_t len) = 0;
 		virtual void RecvStreamClosed(uint32_t ssrc)               = 0;
@@ -245,7 +248,12 @@ namespace RTC
 			this->DataReceived(len);
 		}
 		void OnDataProducerMessageReceived(
-		  RTC::DataProducer* dataProducer, uint32_t ppid, const uint8_t* msg, size_t len) override;
+		  RTC::DataProducer* dataProducer,
+		  const uint8_t* msg,
+		  size_t len,
+		  uint32_t ppid,
+		  std::vector<uint16_t>& subchannels,
+		  std::optional<uint16_t> requiredSubchannel) override;
 		void OnDataProducerPaused(RTC::DataProducer* dataProducer) override;
 		void OnDataProducerResumed(RTC::DataProducer* dataProducer) override;
 
@@ -253,9 +261,9 @@ namespace RTC
 	public:
 		void OnDataConsumerSendMessage(
 		  RTC::DataConsumer* dataConsumer,
-		  uint32_t ppid,
 		  const uint8_t* msg,
 		  size_t len,
+		  uint32_t ppid,
 		  onQueuedCallback* = nullptr) override;
 		void OnDataConsumerDataProducerClosed(RTC::DataConsumer* dataConsumer) override;
 
@@ -270,9 +278,9 @@ namespace RTC
 		void OnSctpAssociationMessageReceived(
 		  RTC::SctpAssociation* sctpAssociation,
 		  uint16_t streamId,
-		  uint32_t ppid,
 		  const uint8_t* msg,
-		  size_t len) override;
+		  size_t len,
+		  uint32_t ppid) override;
 		void OnSctpAssociationBufferedAmount(
 		  RTC::SctpAssociation* sctpAssociation, uint32_t bufferedAmount) override;
 

--- a/worker/include/RTC/WebRtcTransport.hpp
+++ b/worker/include/RTC/WebRtcTransport.hpp
@@ -86,9 +86,9 @@ namespace RTC
 		void SendRtcpCompoundPacket(RTC::RTCP::CompoundPacket* packet) override;
 		void SendMessage(
 		  RTC::DataConsumer* dataConsumer,
-		  uint32_t ppid,
 		  const uint8_t* msg,
 		  size_t len,
+		  uint32_t ppid,
 		  onQueuedCallback* cb = nullptr) override;
 		void SendSctpData(const uint8_t* data, size_t len) override;
 		void RecvStreamClosed(uint32_t ssrc) override;

--- a/worker/include/common.hpp
+++ b/worker/include/common.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>    // uint8_t, etc
 #include <functional> // std::function
 #include <memory>     // std::addressof()
+#include <optional>
 #ifdef _WIN32
 #include <winsock2.h>
 // Avoid uv/win.h: error C2628 'intptr_t' followed by 'int' is illegal.

--- a/worker/src/Channel/ChannelRequest.cpp
+++ b/worker/src/Channel/ChannelRequest.cpp
@@ -74,6 +74,7 @@ namespace Channel
 		{ FBS::Request::Method::DATACONSUMER_GET_BUFFERED_AMOUNT,               "dataConsumer.getBufferedAmount"             },
 		{ FBS::Request::Method::DATACONSUMER_SET_BUFFERED_AMOUNT_LOW_THRESHOLD, "dataConsumer.setBufferedAmountLowThreshold" },
 		{ FBS::Request::Method::DATACONSUMER_SEND,                              "dataConsumer.send"                          },
+		{ FBS::Request::Method::DATACONSUMER_SET_SUBCHANNELS,                   "dataConsumer.setSubchannels"                },
 		{ FBS::Request::Method::RTPOBSERVER_PAUSE,                              "rtpObserver.pause"                          },
 		{ FBS::Request::Method::RTPOBSERVER_RESUME,                             "rtpObserver.resume"                         },
 		{ FBS::Request::Method::RTPOBSERVER_ADD_PRODUCER,                       "rtpObserver.addProducer"                    },

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -93,12 +93,21 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		flatbuffers::Offset<FBS::SctpParameters::SctpStreamParameters> sctpStreamParametersOffset;
+		flatbuffers::Offset<FBS::SctpParameters::SctpStreamParameters> sctpStreamParameters;
 
 		// Add sctpStreamParameters.
 		if (this->type == DataConsumer::Type::SCTP)
 		{
-			sctpStreamParametersOffset = this->sctpStreamParameters.FillBuffer(builder);
+			sctpStreamParameters = this->sctpStreamParameters.FillBuffer(builder);
+		}
+
+		std::vector<uint16_t> subchannelsArray;
+
+		subchannelsArray.reserve(this->subchannels.size());
+
+		for (auto subchannel : this->subchannels)
+		{
+			subchannelsArray.emplace_back(subchannel);
 		}
 
 		return FBS::DataConsumer::CreateDumpResponseDirect(
@@ -106,11 +115,12 @@ namespace RTC
 		  this->id.c_str(),
 		  this->dataProducerId.c_str(),
 		  this->typeString.c_str(),
-		  sctpStreamParametersOffset,
+		  sctpStreamParameters,
 		  this->label.c_str(),
 		  this->protocol.c_str(),
 		  this->paused,
-		  this->dataProducerPaused);
+		  this->dataProducerPaused,
+		  &subchannelsArray);
 	}
 
 	flatbuffers::Offset<FBS::DataConsumer::GetStatsResponse> DataConsumer::FillBufferStats(

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -66,12 +66,9 @@ namespace RTC
 		// paused is set to false by default.
 		this->paused = data->paused();
 
-		if (flatbuffers::IsFieldPresent(data, FBS::Transport::ConsumeDataRequest::VT_SUBCHANNELS))
+		for (const auto subchannel : *data->subchannels())
 		{
-			for (const auto subchannel : *data->subchannels())
-			{
-				this->subchannels.insert(subchannel);
-			}
+			this->subchannels.insert(subchannel);
 		}
 
 		// NOTE: This may throw.
@@ -101,13 +98,13 @@ namespace RTC
 			sctpStreamParameters = this->sctpStreamParameters.FillBuffer(builder);
 		}
 
-		std::vector<uint16_t> subchannelsArray;
+		std::vector<uint16_t> subchannels;
 
-		subchannelsArray.reserve(this->subchannels.size());
+		subchannels.reserve(this->subchannels.size());
 
 		for (auto subchannel : this->subchannels)
 		{
-			subchannelsArray.emplace_back(subchannel);
+			subchannels.emplace_back(subchannel);
 		}
 
 		return FBS::DataConsumer::CreateDumpResponseDirect(
@@ -120,7 +117,7 @@ namespace RTC
 		  this->protocol.c_str(),
 		  this->paused,
 		  this->dataProducerPaused,
-		  std::addressof(subchannelsArray));
+		  std::addressof(subchannels));
 	}
 
 	flatbuffers::Offset<FBS::DataConsumer::GetStatsResponse> DataConsumer::FillBufferStats(
@@ -314,7 +311,9 @@ namespace RTC
 					  }
 				  });
 
-				SendMessage(ppid, data, len, cb);
+				static std::vector<uint16_t> EmptySubchannels;
+
+				SendMessage(data, len, ppid, EmptySubchannels, std::nullopt, cb);
 
 				break;
 			}
@@ -330,18 +329,18 @@ namespace RTC
 					this->subchannels.insert(subchannel);
 				}
 
-				std::vector<uint16_t> subchannelsArray;
+				std::vector<uint16_t> subchannels;
 
-				subchannelsArray.reserve(this->subchannels.size());
+				subchannels.reserve(this->subchannels.size());
 
 				for (auto subchannel : this->subchannels)
 				{
-					subchannelsArray.emplace_back(subchannel);
+					subchannels.emplace_back(subchannel);
 				}
 
 				// Create response.
 				auto responseOffset = FBS::DataConsumer::CreateSetSubchannelsResponseDirect(
-				  request->GetBufferBuilder(), std::addressof(subchannelsArray));
+				  request->GetBufferBuilder(), std::addressof(subchannels));
 
 				request->Accept(FBS::Response::Body::FBS_DataConsumer_SetSubchannelsResponse, responseOffset);
 
@@ -478,13 +477,50 @@ namespace RTC
 		this->listener->OnDataConsumerDataProducerClosed(this);
 	}
 
-	void DataConsumer::SendMessage(uint32_t ppid, const uint8_t* msg, size_t len, onQueuedCallback* cb)
+	void DataConsumer::SendMessage(
+	  const uint8_t* msg,
+	  size_t len,
+	  uint32_t ppid,
+	  std::vector<uint16_t>& subchannels,
+	  std::optional<uint16_t> requiredSubchannel,
+	  onQueuedCallback* cb)
 	{
 		MS_TRACE();
 
 		if (!IsActive())
 		{
 			return;
+		}
+
+		// If a required subchannel is given, verify that this data consumer is
+		// subscribed to it.
+		if (
+		  requiredSubchannel.has_value() &&
+		  this->subchannels.find(requiredSubchannel.value()) == this->subchannels.end())
+		{
+			return;
+		}
+
+		// If subchannels are given, verify that this data consumer is subscribed
+		// to at least one of them.
+		if (subchannels.size() > 0)
+		{
+			bool subchannelMatched{ false };
+
+			for (const auto subchannel : subchannels)
+			{
+				if (this->subchannels.find(subchannel) != this->subchannels.end())
+				{
+					subchannelMatched = true;
+
+					break;
+				}
+			}
+
+			if (!subchannelMatched)
+			{
+				return;
+			}
 		}
 
 		if (len > this->maxMessageSize)
@@ -501,6 +537,6 @@ namespace RTC
 		this->messagesSent++;
 		this->bytesSent += len;
 
-		this->listener->OnDataConsumerSendMessage(this, ppid, msg, len, cb);
+		this->listener->OnDataConsumerSendMessage(this, msg, len, ppid, cb);
 	}
 } // namespace RTC

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -66,6 +66,14 @@ namespace RTC
 		// paused is set to false by default.
 		this->paused = data->paused();
 
+		if (flatbuffers::IsFieldPresent(data, FBS::Transport::ConsumeDataRequest::VT_SUBCHANNELS))
+		{
+			for (const auto subchannel : *data->subchannels())
+			{
+				this->subchannels.insert(subchannel);
+			}
+		}
+
 		// NOTE: This may throw.
 		this->shared->channelMessageRegistrator->RegisterHandler(
 		  this->id,

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -213,7 +213,7 @@ namespace RTC
 	}
 
 	void DirectTransport::SendMessage(
-	  RTC::DataConsumer* dataConsumer, uint32_t ppid, const uint8_t* msg, size_t len, onQueuedCallback* cb)
+	  RTC::DataConsumer* dataConsumer, const uint8_t* msg, size_t len, uint32_t ppid, onQueuedCallback* cb)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -541,11 +541,11 @@ namespace RTC
 	}
 
 	void PipeTransport::SendMessage(
-	  RTC::DataConsumer* dataConsumer, uint32_t ppid, const uint8_t* msg, size_t len, onQueuedCallback* cb)
+	  RTC::DataConsumer* dataConsumer, const uint8_t* msg, size_t len, uint32_t ppid, onQueuedCallback* cb)
 	{
 		MS_TRACE();
 
-		this->sctpAssociation->SendSctpMessage(dataConsumer, ppid, msg, len, cb);
+		this->sctpAssociation->SendSctpMessage(dataConsumer, msg, len, ppid, cb);
 	}
 
 	void PipeTransport::SendSctpData(const uint8_t* data, size_t len)

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -893,11 +893,11 @@ namespace RTC
 	}
 
 	void PlainTransport::SendMessage(
-	  RTC::DataConsumer* dataConsumer, uint32_t ppid, const uint8_t* msg, size_t len, onQueuedCallback* cb)
+	  RTC::DataConsumer* dataConsumer, const uint8_t* msg, size_t len, uint32_t ppid, onQueuedCallback* cb)
 	{
 		MS_TRACE();
 
-		this->sctpAssociation->SendSctpMessage(dataConsumer, ppid, msg, len, cb);
+		this->sctpAssociation->SendSctpMessage(dataConsumer, msg, len,ppid,  cb);
 	}
 
 	void PlainTransport::SendSctpData(const uint8_t* data, size_t len)

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -883,9 +883,11 @@ namespace RTC
 	inline void Router::OnTransportDataProducerMessageReceived(
 	  RTC::Transport* /*transport*/,
 	  RTC::DataProducer* dataProducer,
-	  uint32_t ppid,
 	  const uint8_t* msg,
-	  size_t len)
+	  size_t len,
+	  uint32_t ppid,
+	  std::vector<uint16_t>& subchannels,
+	  std::optional<uint16_t> requiredSubchannel)
 	{
 		MS_TRACE();
 
@@ -893,7 +895,7 @@ namespace RTC
 
 		for (auto* dataConsumer : dataConsumers)
 		{
-			dataConsumer->SendMessage(ppid, msg, len);
+			dataConsumer->SendMessage(msg, len, ppid, subchannels, requiredSubchannel);
 		}
 	}
 

--- a/worker/src/RTC/RtpDictionaries/Parameters.cpp
+++ b/worker/src/RTC/RtpDictionaries/Parameters.cpp
@@ -36,10 +36,10 @@ namespace RTC
 
 				case Value::Type::INTEGER:
 				{
-					auto valueOffset = FBS::RtpParameters::CreateInteger(builder, value.integerValue);
+					auto valueOffset = FBS::RtpParameters::CreateInteger32(builder, value.integerValue);
 
 					parameters.emplace_back(FBS::RtpParameters::CreateParameterDirect(
-					  builder, key.c_str(), FBS::RtpParameters::Value::Integer, valueOffset.Union()));
+					  builder, key.c_str(), FBS::RtpParameters::Value::Integer32, valueOffset.Union()));
 
 					break;
 				}
@@ -68,10 +68,10 @@ namespace RTC
 				case Value::Type::ARRAY_OF_INTEGERS:
 				{
 					auto valueOffset =
-					  FBS::RtpParameters::CreateIntegerArrayDirect(builder, &value.arrayOfIntegers);
+					  FBS::RtpParameters::CreateInteger32ArrayDirect(builder, &value.arrayOfIntegers);
 
 					parameters.emplace_back(FBS::RtpParameters::CreateParameterDirect(
-					  builder, key.c_str(), FBS::RtpParameters::Value::IntegerArray, valueOffset.Union()));
+					  builder, key.c_str(), FBS::RtpParameters::Value::Integer32Array, valueOffset.Union()));
 
 					break;
 				}
@@ -99,9 +99,9 @@ namespace RTC
 					break;
 				}
 
-				case FBS::RtpParameters::Value::Integer:
+				case FBS::RtpParameters::Value::Integer32:
 				{
-					this->mapKeyValues.emplace(key, Value(parameter->value_as_Integer()->value()));
+					this->mapKeyValues.emplace(key, Value(parameter->value_as_Integer32()->value()));
 
 					break;
 				}
@@ -120,9 +120,9 @@ namespace RTC
 					break;
 				}
 
-				case FBS::RtpParameters::Value::IntegerArray:
+				case FBS::RtpParameters::Value::Integer32Array:
 				{
-					this->mapKeyValues.emplace(key, Value(parameter->value_as_IntegerArray()->value()));
+					this->mapKeyValues.emplace(key, Value(parameter->value_as_Integer32Array()->value()));
 
 					break;
 				}

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -376,7 +376,7 @@ namespace RTC
 	}
 
 	void SctpAssociation::SendSctpMessage(
-	  RTC::DataConsumer* dataConsumer, uint32_t ppid, const uint8_t* msg, size_t len, onQueuedCallback* cb)
+	  RTC::DataConsumer* dataConsumer, const uint8_t* msg, size_t len, uint32_t ppid, onQueuedCallback* cb)
 	{
 		MS_TRACE();
 
@@ -688,7 +688,7 @@ namespace RTC
 		{
 			MS_DEBUG_DEV("directly notifying listener [eor:1, buffer len:0]");
 
-			this->listener->OnSctpAssociationMessageReceived(this, streamId, ppid, data, len);
+			this->listener->OnSctpAssociationMessageReceived(this, streamId, data, len, ppid);
 		}
 		// If end of message and there is buffered data, append data and notify buffer.
 		else if (eor && this->messageBufferLen != 0)
@@ -699,7 +699,7 @@ namespace RTC
 			MS_DEBUG_DEV("notifying listener [eor:1, buffer len:%zu]", this->messageBufferLen);
 
 			this->listener->OnSctpAssociationMessageReceived(
-			  this, streamId, ppid, this->messageBuffer, this->messageBufferLen);
+			  this, streamId, this->messageBuffer, this->messageBufferLen, ppid);
 
 			this->messageBufferLen = 0;
 		}

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2646,11 +2646,17 @@ namespace RTC
 	}
 
 	inline void Transport::OnDataProducerMessageReceived(
-	  RTC::DataProducer* dataProducer, uint32_t ppid, const uint8_t* msg, size_t len)
+	  RTC::DataProducer* dataProducer,
+	  const uint8_t* msg,
+	  size_t len,
+	  uint32_t ppid,
+	  std::vector<uint16_t>& subchannels,
+	  std::optional<uint16_t> requiredSubchannel)
 	{
 		MS_TRACE();
 
-		this->listener->OnTransportDataProducerMessageReceived(this, dataProducer, ppid, msg, len);
+		this->listener->OnTransportDataProducerMessageReceived(
+		  this, dataProducer, msg, len, ppid, subchannels, requiredSubchannel);
 	}
 
 	inline void Transport::OnDataProducerPaused(RTC::DataProducer* dataProducer)
@@ -2668,11 +2674,11 @@ namespace RTC
 	}
 
 	inline void Transport::OnDataConsumerSendMessage(
-	  RTC::DataConsumer* dataConsumer, uint32_t ppid, const uint8_t* msg, size_t len, onQueuedCallback* cb)
+	  RTC::DataConsumer* dataConsumer, const uint8_t* msg, size_t len, uint32_t ppid, onQueuedCallback* cb)
 	{
 		MS_TRACE();
 
-		SendMessage(dataConsumer, ppid, msg, len, cb);
+		SendMessage(dataConsumer, msg, len, ppid, cb);
 	}
 
 	inline void Transport::OnDataConsumerDataProducerClosed(RTC::DataConsumer* dataConsumer)
@@ -2811,9 +2817,9 @@ namespace RTC
 	inline void Transport::OnSctpAssociationMessageReceived(
 	  RTC::SctpAssociation* /*sctpAssociation*/,
 	  uint16_t streamId,
-	  uint32_t ppid,
 	  const uint8_t* msg,
-	  size_t len)
+	  size_t len,
+	  uint32_t ppid)
 	{
 		MS_TRACE();
 
@@ -2830,7 +2836,10 @@ namespace RTC
 		// Pass the SCTP message to the corresponding DataProducer.
 		try
 		{
-			dataProducer->ReceiveMessage(ppid, msg, len);
+			static std::vector<uint16_t> EmptySubchannels;
+
+			dataProducer->ReceiveMessage(
+			  msg, len, ppid, EmptySubchannels, /*requiredSubchannel*/ std::nullopt);
 		}
 		catch (std::exception& error)
 		{

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -899,11 +899,11 @@ namespace RTC
 	}
 
 	void WebRtcTransport::SendMessage(
-	  RTC::DataConsumer* dataConsumer, uint32_t ppid, const uint8_t* msg, size_t len, onQueuedCallback* cb)
+	  RTC::DataConsumer* dataConsumer, const uint8_t* msg, size_t len, uint32_t ppid, onQueuedCallback* cb)
 	{
 		MS_TRACE();
 
-		this->sctpAssociation->SendSctpMessage(dataConsumer, ppid, msg, len, cb);
+		this->sctpAssociation->SendSctpMessage(dataConsumer, msg, len, ppid, cb);
 	}
 
 	void WebRtcTransport::SendSctpData(const uint8_t* data, size_t len)


### PR DESCRIPTION
Fixes #1151

- [x] Node: `transport.consumeData({ subchannels })`.
- [x] Node: `dataConsumer.subchannels` getter.
- [x] Node: `dataConsumer.setSubchannels()` method.
- [x] Node: Proper test in `test-DataConsumer.ts`.
- [x] Node: `dataProducer.send(message, ppid, subchannels, requiredSubchannel)` (new args).
- [x] Node: Proper test for `dataProducer.send()` with `DataConsumers` subscribed to specific subchannels.
- [x] Worker: Make subchannels work (hehe).
- [x] Rust: `transport.consumeData({ subchannels })`.
- [x] Rust: `dataConsumer.subchannels` getter.
- [x] Rust: `dataConsumer.setSubchannels()` method.
- [x] Rust: `dataProducer.send(message, ppid, subchannels, requiredSubchannel)` (new args).
- [x] Rust: Replicate Node tests.