### PR TITLE
bump up meson from 1.1.0 to 1.2.1 (Fixes Xcode 15 build issues)

### DIFF
--- a/worker/Makefile
+++ b/worker/Makefile
@@ -20,7 +20,7 @@ PIP_DIR = $(MEDIASOUP_OUT_DIR)/pip
 INSTALL_DIR ?= $(MEDIASOUP_OUT_DIR)/$(MEDIASOUP_BUILDTYPE)
 BUILD_DIR ?= $(INSTALL_DIR)/build
 MESON ?= $(PIP_DIR)/bin/meson
-MESON_VERSION ?= 1.1.0
+MESON_VERSION ?= 1.2.1
 # `MESON_ARGS` can be used to provide extra configuration parameters to Meson,
 # such as adding defines or changing optimization options. For instance, use
 # `MESON_ARGS="-Dms_log_trace=true -Dms_log_file_line=true" npm i` to compile


### PR DESCRIPTION
issue : meson build fails on xcode 15 which uses clang 15 where the command 
cc --version fails
<img width="1096" alt="image" src="https://github.com/versatica/mediasoup/assets/69193694/b3540a0d-f92c-44f1-a55a-5da24fecfb77">

this issue seems to have been resolved in meson 1.2.1 (latest version currently)
<img width="1206" alt="image" src="https://github.com/versatica/mediasoup/assets/69193694/9c0d06db-a79a-4447-98e9-b9ad885a0ab5">

