### PR TITLE
Rust remove FBS suffixes

### DIFF
--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -403,7 +403,7 @@ impl Inner {
                 let request = RouterCloseRequest { router_id: self.id };
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request_fbs("", request).await {
+                        if let Err(error) = channel.request("", request).await {
                             error!("router closing failed on drop: {}", error);
                         }
                     })
@@ -534,7 +534,7 @@ impl Router {
 
         self.inner
             .channel
-            .request_fbs(self.inner.id, RouterDumpRequest {})
+            .request(self.inner.id, RouterDumpRequest {})
             .await
     }
 
@@ -563,7 +563,7 @@ impl Router {
 
         self.inner
             .channel
-            .request_fbs(
+            .request(
                 self.inner.id,
                 RouterCreateDirectTransportRequest {
                     data: RouterCreateDirectTransportData::from_options(
@@ -629,7 +629,7 @@ impl Router {
         let data = self
             .inner
             .channel
-            .request_fbs(
+            .request(
                 self.inner.id,
                 RouterCreateWebRtcTransportRequest {
                     data: RouterCreateWebrtcTransportData::from_options(
@@ -698,7 +698,7 @@ impl Router {
         let data = self
             .inner
             .channel
-            .request_fbs(
+            .request(
                 self.inner.id,
                 RouterCreatePipeTransportRequest {
                     data: RouterCreatePipeTransportData::from_options(
@@ -763,7 +763,7 @@ impl Router {
         let data = self
             .inner
             .channel
-            .request_fbs(
+            .request(
                 self.inner.id,
                 RouterCreatePlainTransportRequest {
                     data: RouterCreatePlainTransportData::from_options(
@@ -829,7 +829,7 @@ impl Router {
 
         self.inner
             .channel
-            .request_fbs(
+            .request(
                 self.inner.id,
                 RouterCreateAudioLevelObserverRequest {
                     data: RouterCreateAudioLevelObserverData::from_options(
@@ -889,7 +889,7 @@ impl Router {
 
         self.inner
             .channel
-            .request_fbs(
+            .request(
                 self.inner.id,
                 RouterCreateActiveSpeakerObserverRequest {
                     data: RouterCreateActiveSpeakerObserverData::from_options(

--- a/rust/src/router/active_speaker_observer.rs
+++ b/rust/src/router/active_speaker_observer.rs
@@ -138,7 +138,7 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request_fbs(router_id, request).await {
+                        if let Err(error) = channel.request(router_id, request).await {
                             error!("active speaker observer closing failed on drop: {}", error);
                         }
                     })
@@ -199,7 +199,7 @@ impl RtpObserver for ActiveSpeakerObserver {
 
         self.inner
             .channel
-            .request_fbs(self.id(), RtpObserverPauseRequest {})
+            .request(self.id(), RtpObserverPauseRequest {})
             .await?;
 
         let was_paused = self.inner.paused.swap(true, Ordering::SeqCst);
@@ -216,7 +216,7 @@ impl RtpObserver for ActiveSpeakerObserver {
 
         self.inner
             .channel
-            .request_fbs(self.id(), RtpObserverResumeRequest {})
+            .request(self.id(), RtpObserverResumeRequest {})
             .await?;
 
         let was_paused = self.inner.paused.swap(false, Ordering::SeqCst);
@@ -240,7 +240,7 @@ impl RtpObserver for ActiveSpeakerObserver {
         };
         self.inner
             .channel
-            .request_fbs(self.id(), RtpObserverAddProducerRequest { producer_id })
+            .request(self.id(), RtpObserverAddProducerRequest { producer_id })
             .await?;
 
         self.inner.handlers.add_producer.call_simple(&producer);
@@ -257,7 +257,7 @@ impl RtpObserver for ActiveSpeakerObserver {
         };
         self.inner
             .channel
-            .request_fbs(self.id(), RtpObserverRemoveProducerRequest { producer_id })
+            .request(self.id(), RtpObserverRemoveProducerRequest { producer_id })
             .await?;
 
         self.inner.handlers.remove_producer.call_simple(&producer);
@@ -317,7 +317,7 @@ impl ActiveSpeakerObserver {
             let router = router.clone();
             let handlers = Arc::clone(&handlers);
 
-            channel.subscribe_to_fbs_notifications(id.into(), move |notification| {
+            channel.subscribe_to_notifications(id.into(), move |notification| {
                 match Notification::from_fbs(notification) {
                     Ok(notification) => match notification {
                         Notification::DominantSpeaker(dominant_speaker) => {

--- a/rust/src/router/audio_level_observer.rs
+++ b/rust/src/router/audio_level_observer.rs
@@ -160,7 +160,7 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request_fbs(router_id, request).await {
+                        if let Err(error) = channel.request(router_id, request).await {
                             error!("audio level observer closing failed on drop: {}", error);
                         }
                     })
@@ -221,7 +221,7 @@ impl RtpObserver for AudioLevelObserver {
 
         self.inner
             .channel
-            .request_fbs(self.id(), RtpObserverPauseRequest {})
+            .request(self.id(), RtpObserverPauseRequest {})
             .await?;
 
         let was_paused = self.inner.paused.swap(true, Ordering::SeqCst);
@@ -238,7 +238,7 @@ impl RtpObserver for AudioLevelObserver {
 
         self.inner
             .channel
-            .request_fbs(self.id(), RtpObserverResumeRequest {})
+            .request(self.id(), RtpObserverResumeRequest {})
             .await?;
 
         let was_paused = self.inner.paused.swap(false, Ordering::SeqCst);
@@ -262,7 +262,7 @@ impl RtpObserver for AudioLevelObserver {
         };
         self.inner
             .channel
-            .request_fbs(self.id(), RtpObserverAddProducerRequest { producer_id })
+            .request(self.id(), RtpObserverAddProducerRequest { producer_id })
             .await?;
 
         self.inner.handlers.add_producer.call_simple(&producer);
@@ -279,7 +279,7 @@ impl RtpObserver for AudioLevelObserver {
         };
         self.inner
             .channel
-            .request_fbs(self.id(), RtpObserverRemoveProducerRequest { producer_id })
+            .request(self.id(), RtpObserverRemoveProducerRequest { producer_id })
             .await?;
 
         self.inner.handlers.remove_producer.call_simple(&producer);
@@ -339,7 +339,7 @@ impl AudioLevelObserver {
             let router = router.clone();
             let handlers = Arc::clone(&handlers);
 
-            channel.subscribe_to_fbs_notifications(id.into(), move |notification| {
+            channel.subscribe_to_notifications(id.into(), move |notification| {
                 match Notification::from_fbs(notification) {
                     Ok(notification) => match notification {
                         Notification::Volumes(volumes) => {

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -707,7 +707,7 @@ impl Inner {
                 self.executor
                     .spawn(async move {
                         if weak_producer.upgrade().is_some() {
-                            if let Err(error) = channel.request_fbs(transport_id, request).await {
+                            if let Err(error) = channel.request(transport_id, request).await {
                                 error!("consumer closing failed on drop: {}", error);
                             }
                         }
@@ -783,7 +783,7 @@ impl Consumer {
             let current_layers = Arc::clone(&current_layers);
             let inner_weak = Arc::clone(&inner_weak);
 
-            channel.subscribe_to_fbs_notifications(id.into(), move |notification| {
+            channel.subscribe_to_notifications(id.into(), move |notification| {
                 match Notification::from_fbs(notification) {
                     Ok(notification) => match notification {
                         Notification::ProducerClose => {
@@ -993,7 +993,7 @@ impl Consumer {
         let response = self
             .inner
             .channel
-            .request_fbs(self.id(), ConsumerDumpRequest {})
+            .request(self.id(), ConsumerDumpRequest {})
             .await?;
 
         if let response::Body::ConsumerDumpResponse(data) = response {
@@ -1013,7 +1013,7 @@ impl Consumer {
         let response = self
             .inner
             .channel
-            .request_fbs(self.id(), ConsumerGetStatsRequest {})
+            .request(self.id(), ConsumerGetStatsRequest {})
             .await;
 
         if let Ok(response::Body::ConsumerGetStatsResponse(data)) = response {
@@ -1042,7 +1042,7 @@ impl Consumer {
 
         self.inner
             .channel
-            .request_fbs(self.id(), ConsumerPauseRequest {})
+            .request(self.id(), ConsumerPauseRequest {})
             .await?;
 
         let mut paused = self.inner.paused.lock();
@@ -1062,7 +1062,7 @@ impl Consumer {
 
         self.inner
             .channel
-            .request_fbs(self.id(), ConsumerResumeRequest {})
+            .request(self.id(), ConsumerResumeRequest {})
             .await?;
 
         let mut paused = self.inner.paused.lock();
@@ -1087,7 +1087,7 @@ impl Consumer {
         let consumer_layers = self
             .inner
             .channel
-            .request_fbs(
+            .request(
                 self.id(),
                 ConsumerSetPreferredLayersRequest {
                     data: consumer_layers,
@@ -1109,7 +1109,7 @@ impl Consumer {
         let result = self
             .inner
             .channel
-            .request_fbs(self.id(), ConsumerSetPriorityRequest { priority })
+            .request(self.id(), ConsumerSetPriorityRequest { priority })
             .await?;
 
         *self.inner.priority.lock() = result.priority;
@@ -1126,7 +1126,7 @@ impl Consumer {
         let result = self
             .inner
             .channel
-            .request_fbs(self.id(), ConsumerSetPriorityRequest { priority })
+            .request(self.id(), ConsumerSetPriorityRequest { priority })
             .await?;
 
         *self.inner.priority.lock() = result.priority;
@@ -1140,7 +1140,7 @@ impl Consumer {
 
         self.inner
             .channel
-            .request_fbs(self.id(), ConsumerRequestKeyFrameRequest {})
+            .request(self.id(), ConsumerRequestKeyFrameRequest {})
             .await
     }
 
@@ -1153,7 +1153,7 @@ impl Consumer {
 
         self.inner
             .channel
-            .request_fbs(self.id(), ConsumerEnableTraceEventRequest { types })
+            .request(self.id(), ConsumerEnableTraceEventRequest { types })
             .await
     }
 

--- a/rust/src/router/data_consumer.rs
+++ b/rust/src/router/data_consumer.rs
@@ -338,7 +338,7 @@ impl Inner {
                 self.executor
                     .spawn(async move {
                         if weak_data_producer.upgrade().is_some() {
-                            if let Err(error) = channel.request_fbs(transport_id, request).await {
+                            if let Err(error) = channel.request(transport_id, request).await {
                                 error!("consumer closing failed on drop: {}", error);
                             }
                         }
@@ -470,7 +470,7 @@ impl DataConsumer {
             let data_producer_paused = Arc::clone(&data_producer_paused);
             let inner_weak = Arc::clone(&inner_weak);
 
-            channel.subscribe_to_fbs_notifications(id.into(), move |notification| {
+            channel.subscribe_to_notifications(id.into(), move |notification| {
                 match Notification::from_fbs(notification) {
                     Ok(notification) => match notification {
                         Notification::DataProducerClose => {
@@ -658,7 +658,7 @@ impl DataConsumer {
         let response = self
             .inner()
             .channel
-            .request_fbs(self.id(), DataConsumerDumpRequest {})
+            .request(self.id(), DataConsumerDumpRequest {})
             .await?;
 
         if let response::Body::DataConsumerDumpResponse(data) = response {
@@ -678,7 +678,7 @@ impl DataConsumer {
         let response = self
             .inner()
             .channel
-            .request_fbs(self.id(), DataConsumerGetStatsRequest {})
+            .request(self.id(), DataConsumerGetStatsRequest {})
             .await?;
 
         if let response::Body::DataConsumerGetStatsResponse(data) = response {
@@ -694,7 +694,7 @@ impl DataConsumer {
 
         self.inner()
             .channel
-            .request_fbs(self.id(), DataConsumerPauseRequest {})
+            .request(self.id(), DataConsumerPauseRequest {})
             .await?;
 
         let mut paused = self.inner().paused.lock();
@@ -714,7 +714,7 @@ impl DataConsumer {
 
         self.inner()
             .channel
-            .request_fbs(self.id(), DataConsumerResumeRequest {})
+            .request(self.id(), DataConsumerResumeRequest {})
             .await?;
 
         let mut paused = self.inner().paused.lock();
@@ -741,7 +741,7 @@ impl DataConsumer {
         let response = self
             .inner()
             .channel
-            .request_fbs(self.id(), DataConsumerGetBufferedAmountRequest {})
+            .request(self.id(), DataConsumerGetBufferedAmountRequest {})
             .await?;
 
         Ok(response.buffered_amount)
@@ -760,7 +760,7 @@ impl DataConsumer {
 
         self.inner()
             .channel
-            .request_fbs(
+            .request(
                 self.id(),
                 DataConsumerSetBufferedAmountLowThresholdRequest { threshold },
             )
@@ -888,7 +888,7 @@ impl DirectDataConsumer {
 
         self.inner
             .channel
-            .request_fbs(
+            .request(
                 self.inner.id,
                 DataConsumerSendRequest {
                     ppid,

--- a/rust/src/router/data_producer.rs
+++ b/rust/src/router/data_producer.rs
@@ -209,7 +209,7 @@ impl Inner {
                 };
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request_fbs(transport_id, request).await {
+                        if let Err(error) = channel.request(transport_id, request).await {
                             error!("data producer closing failed on drop: {}", error);
                         }
                     })
@@ -420,7 +420,7 @@ impl DataProducer {
         let response = self
             .inner()
             .channel
-            .request_fbs(self.id(), DataProducerDumpRequest {})
+            .request(self.id(), DataProducerDumpRequest {})
             .await?;
 
         if let response::Body::DataProducerDumpResponse(data) = response {
@@ -440,7 +440,7 @@ impl DataProducer {
         let response = self
             .inner()
             .channel
-            .request_fbs(self.id(), DataProducerGetStatsRequest {})
+            .request(self.id(), DataProducerGetStatsRequest {})
             .await?;
 
         if let response::Body::DataProducerGetStatsResponse(data) = response {
@@ -458,7 +458,7 @@ impl DataProducer {
 
         self.inner()
             .channel
-            .request_fbs(self.id(), DataProducerPauseRequest {})
+            .request(self.id(), DataProducerPauseRequest {})
             .await?;
 
         let was_paused = self.inner().paused.swap(true, Ordering::SeqCst);
@@ -478,7 +478,7 @@ impl DataProducer {
 
         self.inner()
             .channel
-            .request_fbs(self.id(), DataProducerResumeRequest {})
+            .request(self.id(), DataProducerResumeRequest {})
             .await?;
 
         let was_paused = self.inner().paused.swap(false, Ordering::SeqCst);
@@ -546,7 +546,7 @@ impl DirectDataProducer {
     pub fn send(&self, message: WebRtcMessage<'_>) -> Result<(), NotificationError> {
         let (ppid, _payload) = message.into_ppid_and_payload();
 
-        self.inner.channel.notify_fbs(
+        self.inner.channel.notify(
             self.inner.id,
             DataProducerSendNotification {
                 ppid,

--- a/rust/src/router/direct_transport.rs
+++ b/rust/src/router/direct_transport.rs
@@ -307,7 +307,7 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request_fbs(router_id, request).await {
+                        if let Err(error) = channel.request(router_id, request).await {
                             error!("transport closing failed on drop: {}", error);
                         }
                     })
@@ -567,7 +567,7 @@ impl DirectTransport {
         let subscription_handler = {
             let handlers = Arc::clone(&handlers);
 
-            channel.subscribe_to_fbs_notifications(id.into(), move |notification| {
+            channel.subscribe_to_notifications(id.into(), move |notification| {
                 match Notification::from_fbs(notification) {
                     Ok(notification) => match notification {
                         Notification::Trace(trace_event_data) => {
@@ -629,7 +629,7 @@ impl DirectTransport {
     pub fn send_rtcp(&self, rtcp_packet: Vec<u8>) -> Result<(), NotificationError> {
         self.inner
             .channel
-            .notify_fbs(self.id(), TransportSendRtcpNotification { rtcp_packet })
+            .notify(self.id(), TransportSendRtcpNotification { rtcp_packet })
     }
 
     /// Callback is called when the direct transport receives a RTCP packet from its router.

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -366,7 +366,7 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request_fbs(router_id, request).await {
+                        if let Err(error) = channel.request(router_id, request).await {
                             error!("transport closing failed on drop: {}", error);
                         }
                     })
@@ -616,7 +616,7 @@ impl PipeTransport {
             let handlers = Arc::clone(&handlers);
             let data = Arc::clone(&data);
 
-            channel.subscribe_to_fbs_notifications(id.into(), move |notification| {
+            channel.subscribe_to_notifications(id.into(), move |notification| {
                 match Notification::from_fbs(notification) {
                     Ok(notification) => match notification {
                         Notification::SctpStateChange { sctp_state } => {
@@ -691,7 +691,7 @@ impl PipeTransport {
         let response = self
             .inner
             .channel
-            .request_fbs(
+            .request(
                 self.id(),
                 PipeTransportConnectRequest {
                     ip: remote_parameters.ip,

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -439,7 +439,7 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request_fbs(router_id, request).await {
+                        if let Err(error) = channel.request(router_id, request).await {
                             error!("transport closing failed on drop: {}", error);
                         }
                     })
@@ -682,7 +682,7 @@ impl PlainTransport {
             let handlers = Arc::clone(&handlers);
             let data = Arc::clone(&data);
 
-            channel.subscribe_to_fbs_notifications(id.into(), move |notification| {
+            channel.subscribe_to_notifications(id.into(), move |notification| {
                 match Notification::from_fbs(notification) {
                     Ok(notification) => match notification {
                         Notification::Tuple { tuple } => {
@@ -862,7 +862,7 @@ impl PlainTransport {
         let response = self
             .inner
             .channel
-            .request_fbs(
+            .request(
                 self.inner.id,
                 TransportConnectPlainRequest {
                     ip: remote_parameters.ip,

--- a/rust/src/router/producer.rs
+++ b/rust/src/router/producer.rs
@@ -601,7 +601,7 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request_fbs(transport_id, request).await {
+                        if let Err(error) = channel.request(transport_id, request).await {
                             error!("producer closing failed on drop: {}", error);
                         }
                     })
@@ -722,7 +722,7 @@ impl Producer {
             let handlers = Arc::clone(&handlers);
             let score = Arc::clone(&score);
 
-            channel.subscribe_to_fbs_notifications(id.into(), move |notification| {
+            channel.subscribe_to_notifications(id.into(), move |notification| {
                 match Notification::from_fbs(notification) {
                     Ok(notification) => match notification {
                         Notification::Score(scores) => {
@@ -852,7 +852,7 @@ impl Producer {
         let response = self
             .inner()
             .channel
-            .request_fbs(self.id(), ProducerDumpRequest {})
+            .request(self.id(), ProducerDumpRequest {})
             .await?;
 
         if let response::Body::ProducerDumpResponse(data) = response {
@@ -872,7 +872,7 @@ impl Producer {
         let response = self
             .inner()
             .channel
-            .request_fbs(self.id(), ProducerGetStatsRequest {})
+            .request(self.id(), ProducerGetStatsRequest {})
             .await;
 
         if let Ok(response::Body::ProducerGetStatsResponse(data)) = response {
@@ -890,7 +890,7 @@ impl Producer {
 
         self.inner()
             .channel
-            .request_fbs(self.id(), ProducerPauseRequest {})
+            .request(self.id(), ProducerPauseRequest {})
             .await?;
 
         let was_paused = self.inner().paused.swap(true, Ordering::SeqCst);
@@ -910,7 +910,7 @@ impl Producer {
 
         self.inner()
             .channel
-            .request_fbs(self.id(), ProducerResumeRequest {})
+            .request(self.id(), ProducerResumeRequest {})
             .await?;
 
         let was_paused = self.inner().paused.swap(false, Ordering::SeqCst);
@@ -931,7 +931,7 @@ impl Producer {
 
         self.inner()
             .channel
-            .request_fbs(self.id(), ProducerEnableTraceEventRequest { types })
+            .request(self.id(), ProducerEnableTraceEventRequest { types })
             .await
     }
 
@@ -1028,7 +1028,7 @@ impl DirectProducer {
     pub fn send(&self, rtp_packet: Vec<u8>) -> Result<(), NotificationError> {
         self.inner
             .channel
-            .notify_fbs(self.inner.id, ProducerSendNotification { rtp_packet })
+            .notify(self.inner.id, ProducerSendNotification { rtp_packet })
     }
 }
 

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -443,25 +443,25 @@ pub(super) trait TransportImpl: TransportGeneric {
 
     async fn dump_impl(&self) -> Result<response::Body, RequestError> {
         self.channel()
-            .request_fbs(self.id(), TransportDumpRequest {})
+            .request(self.id(), TransportDumpRequest {})
             .await
     }
 
     async fn get_stats_impl(&self) -> Result<response::Body, RequestError> {
         self.channel()
-            .request_fbs(self.id(), TransportGetStatsRequest {})
+            .request(self.id(), TransportGetStatsRequest {})
             .await
     }
 
     async fn set_max_incoming_bitrate_impl(&self, bitrate: u32) -> Result<(), RequestError> {
         self.channel()
-            .request_fbs(self.id(), TransportSetMaxIncomingBitrateRequest { bitrate })
+            .request(self.id(), TransportSetMaxIncomingBitrateRequest { bitrate })
             .await
     }
 
     async fn set_max_outgoing_bitrate_impl(&self, bitrate: u32) -> Result<(), RequestError> {
         self.channel()
-            .request_fbs(self.id(), TransportSetMaxOutgoingBitrateRequest { bitrate })
+            .request(self.id(), TransportSetMaxOutgoingBitrateRequest { bitrate })
             .await
     }
 
@@ -470,13 +470,13 @@ pub(super) trait TransportImpl: TransportGeneric {
         types: Vec<TransportTraceEventType>,
     ) -> Result<(), RequestError> {
         self.channel()
-            .request_fbs(self.id(), TransportEnableTraceEventRequest { types })
+            .request(self.id(), TransportEnableTraceEventRequest { types })
             .await
     }
 
     async fn set_min_outgoing_bitrate_impl(&self, bitrate: u32) -> Result<(), RequestError> {
         self.channel()
-            .request_fbs(self.id(), TransportSetMinOutgoingBitrateRequest { bitrate })
+            .request(self.id(), TransportSetMinOutgoingBitrateRequest { bitrate })
             .await
     }
 
@@ -548,7 +548,7 @@ pub(super) trait TransportImpl: TransportGeneric {
 
         let response = self
             .channel()
-            .request_fbs(
+            .request(
                 self.id(),
                 TransportProduceRequest {
                     producer_id,
@@ -646,7 +646,7 @@ pub(super) trait TransportImpl: TransportGeneric {
 
         let response = self
             .channel()
-            .request_fbs(
+            .request(
                 self.id(),
                 TransportConsumeRequest {
                     consumer_id,
@@ -724,7 +724,7 @@ pub(super) trait TransportImpl: TransportGeneric {
 
         let response = self
             .channel()
-            .request_fbs(
+            .request(
                 self.id(),
                 TransportProduceDataRequest {
                     data_producer_id,
@@ -820,7 +820,7 @@ pub(super) trait TransportImpl: TransportGeneric {
 
         let response = self
             .channel()
-            .request_fbs(
+            .request(
                 self.id(),
                 TransportConsumeDataRequest {
                     data_consumer_id,

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -525,7 +525,7 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request_fbs(router_id, request).await {
+                        if let Err(error) = channel.request(router_id, request).await {
                             error!("transport closing failed on drop: {}", error);
                         }
                     })
@@ -779,7 +779,7 @@ impl WebRtcTransport {
             let handlers = Arc::clone(&handlers);
             let data = Arc::clone(&data);
 
-            channel.subscribe_to_fbs_notifications(id.into(), move |notification| {
+            channel.subscribe_to_notifications(id.into(), move |notification| {
                 match Notification::from_fbs(notification) {
                     Ok(notification) => match notification {
                         Notification::IceStateChange { ice_state } => {
@@ -931,7 +931,7 @@ impl WebRtcTransport {
         let response = self
             .inner
             .channel
-            .request_fbs(
+            .request(
                 self.id(),
                 WebRtcTransportConnectRequest {
                     dtls_parameters: remote_parameters.dtls_parameters,
@@ -1045,7 +1045,7 @@ impl WebRtcTransport {
 
         self.inner
             .channel
-            .request_fbs(self.id(), TransportRestartIceRequest {})
+            .request(self.id(), TransportRestartIceRequest {})
             .await
     }
 

--- a/rust/src/webrtc_server.rs
+++ b/rust/src/webrtc_server.rs
@@ -184,7 +184,7 @@ impl Inner {
                 };
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request_fbs("", request).await {
+                        if let Err(error) = channel.request("", request).await {
                             error!("WebRTC server closing failed on drop: {}", error);
                         }
                     })
@@ -286,7 +286,7 @@ impl WebRtcServer {
 
         self.inner
             .channel
-            .request_fbs(self.id(), WebRtcServerDumpRequest {})
+            .request(self.id(), WebRtcServerDumpRequest {})
             .await
     }
 

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -488,7 +488,7 @@ impl Inner {
         let (sender, receiver) = async_oneshot::oneshot();
         let id = self.id;
         let sender = Mutex::new(Some(sender));
-        let _handler = self.channel.subscribe_to_fbs_notifications(
+        let _handler = self.channel.subscribe_to_notifications(
             SubscriptionTarget::String(std::process::id().to_string()),
             move |notification| {
                 let result = match notification.event().unwrap() {
@@ -553,7 +553,7 @@ impl Inner {
 
             self.executor
                 .spawn(async move {
-                    let _ = channel.request_fbs("", WorkerCloseRequest {}).await;
+                    let _ = channel.request("", WorkerCloseRequest {}).await;
 
                     // Drop channels in here after response from worker
                     drop(channel);
@@ -622,10 +622,7 @@ impl Worker {
     pub async fn dump(&self) -> Result<WorkerDump, RequestError> {
         debug!("dump()");
 
-        self.inner
-            .channel
-            .request_fbs("", WorkerDumpRequest {})
-            .await
+        self.inner.channel.request("", WorkerDumpRequest {}).await
     }
 
     /// Updates the worker settings in runtime. Just a subset of the worker settings can be updated.
@@ -635,7 +632,7 @@ impl Worker {
         match self
             .inner
             .channel
-            .request_fbs("", WorkerUpdateSettingsRequest { data })
+            .request("", WorkerUpdateSettingsRequest { data })
             .await
         {
             Ok(_) => Ok(()),
@@ -666,7 +663,7 @@ impl Worker {
 
         self.inner
             .channel
-            .request_fbs(
+            .request(
                 "",
                 WorkerCreateWebRtcServerRequest {
                     webrtc_server_id,
@@ -715,7 +712,7 @@ impl Worker {
 
         self.inner
             .channel
-            .request_fbs("", WorkerCreateRouterRequest { router_id })
+            .request("", WorkerCreateRouterRequest { router_id })
             .await
             .map_err(CreateRouterError::Request)?;
 

--- a/rust/src/worker/common.rs
+++ b/rust/src/worker/common.rs
@@ -21,11 +21,11 @@ impl<F> Default for EventHandlersList<F> {
 }
 
 #[derive(Clone)]
-pub(super) struct FBSEventHandlers<F> {
+pub(super) struct EventHandlers<F> {
     handlers: Arc<Mutex<HashedMap<SubscriptionTarget, EventHandlersList<F>>>>,
 }
 
-impl<F: Sized + Send + Sync + 'static> FBSEventHandlers<F> {
+impl<F: Sized + Send + Sync + 'static> EventHandlers<F> {
     pub(super) fn new() -> Self {
         let handlers = Arc::<Mutex<HashedMap<SubscriptionTarget, EventHandlersList<F>>>>::default();
         Self { handlers }
@@ -73,14 +73,14 @@ impl<F: Sized + Send + Sync + 'static> FBSEventHandlers<F> {
         })
     }
 
-    pub(super) fn downgrade(&self) -> FBSWeakEventHandlers<F> {
-        FBSWeakEventHandlers {
+    pub(super) fn downgrade(&self) -> WeakEventHandlers<F> {
+        WeakEventHandlers {
             handlers: Arc::downgrade(&self.handlers),
         }
     }
 }
 
-impl FBSEventHandlers<Arc<dyn Fn(notification::NotificationRef<'_>) + Send + Sync + 'static>> {
+impl EventHandlers<Arc<dyn Fn(notification::NotificationRef<'_>) + Send + Sync + 'static>> {
     pub(super) fn call_callbacks_with_single_value(
         &self,
         target_id: &SubscriptionTarget,
@@ -96,15 +96,15 @@ impl FBSEventHandlers<Arc<dyn Fn(notification::NotificationRef<'_>) + Send + Syn
 }
 
 #[derive(Clone)]
-pub(super) struct FBSWeakEventHandlers<F> {
+pub(super) struct WeakEventHandlers<F> {
     handlers: Weak<Mutex<HashedMap<SubscriptionTarget, EventHandlersList<F>>>>,
 }
 
-impl<F> FBSWeakEventHandlers<F> {
-    pub(super) fn upgrade(&self) -> Option<FBSEventHandlers<F>> {
+impl<F> WeakEventHandlers<F> {
+    pub(super) fn upgrade(&self) -> Option<EventHandlers<F>> {
         self.handlers
             .upgrade()
-            .map(|handlers| FBSEventHandlers { handlers })
+            .map(|handlers| EventHandlers { handlers })
     }
 }
 


### PR DESCRIPTION
They were temporal until every message was ported to flatbuffers.