### PR TITLE
Rust: properly store incoming notifications

### DIFF
--- a/rust/src/router/consumer/tests.rs
+++ b/rust/src/router/consumer/tests.rs
@@ -105,7 +105,6 @@ async fn init() -> (Router, WebRtcTransport, WebRtcTransport) {
 }
 
 #[test]
-#[ignore]
 fn producer_close_event() {
     future::block_on(async move {
         let (_router, transport_1, transport_2) = init().await;

--- a/rust/src/router/data_consumer/tests.rs
+++ b/rust/src/router/data_consumer/tests.rs
@@ -63,7 +63,6 @@ async fn init() -> (Router, DataProducer) {
 }
 
 #[test]
-#[ignore]
 fn data_producer_close_event() {
     future::block_on(async move {
         let (router, data_producer) = init().await;

--- a/rust/src/router/pipe_transport/tests.rs
+++ b/rust/src/router/pipe_transport/tests.rs
@@ -122,7 +122,6 @@ async fn init() -> (Router, Router, WebRtcTransport, WebRtcTransport) {
 }
 
 #[test]
-#[ignore]
 fn producer_close_is_transmitted_to_pipe_consumer() {
     future::block_on(async move {
         let (router1, router2, transport1, transport2) = init().await;
@@ -162,7 +161,6 @@ fn producer_close_is_transmitted_to_pipe_consumer() {
 }
 
 #[test]
-#[ignore]
 fn data_producer_close_is_transmitted_to_pipe_data_consumer() {
     future::block_on(async move {
         let (router1, router2, transport1, transport2) = init().await;

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -1371,7 +1371,6 @@ fn set_unset_priority_succeeds() {
 }
 
 #[test]
-#[ignore]
 fn producer_pause_resume_events() {
     future::block_on(async move {
         let (_executor_guard, _worker, _router, transport_1, transport_2) = init().await;


### PR DESCRIPTION
Store the whole binary message and retrieve the notification reference before calling the handler.