### PR TITLE
Fix IceServer crash when client uses ICE renomination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### NEXT
 
 * CI: Use Node.js version 20 ([PR #1177](https://github.com/versatica/mediasoup/pull/1177)).
+* Fix `IceServer` crash when client uses ICE nomination ([PR #1182](https://github.com/versatica/mediasoup/pull/1182)).
 
 
 ### 3.12.13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 ### NEXT
 
 * CI: Use Node.js version 20 ([PR #1177](https://github.com/versatica/mediasoup/pull/1177)).
-* Fix `IceServer` crash when client uses ICE nomination ([PR #1182](https://github.com/versatica/mediasoup/pull/1182)).
+* Fix `IceServer` crash when client uses ICE renomination ([PR #1182](https://github.com/versatica/mediasoup/pull/1182)).
 
 
 ### 3.12.13

--- a/worker/include/RTC/IceServer.hpp
+++ b/worker/include/RTC/IceServer.hpp
@@ -122,8 +122,8 @@ namespace RTC
 		std::string password;
 		std::string oldUsernameFragment;
 		std::string oldPassword;
-		uint32_t remoteNomination{ 0u };
 		IceState state{ IceState::NEW };
+		uint32_t remoteNomination{ 0u };
 		std::list<RTC::TransportTuple> tuples;
 		RTC::TransportTuple* selectedTuple{ nullptr };
 	};

--- a/worker/include/RTC/IceServer.hpp
+++ b/worker/include/RTC/IceServer.hpp
@@ -94,7 +94,7 @@ namespace RTC
 		bool IsValidTuple(const RTC::TransportTuple* tuple) const;
 		void RemoveTuple(RTC::TransportTuple* tuple);
 		/**
-		 * This should be just called in 'connected' or completed' state and the
+		 * This should be just called in 'connected' or 'completed' state and the
 		 * given tuple must be an already valid tuple.
 		 */
 		void MayForceSelectedTuple(const RTC::TransportTuple* tuple);

--- a/worker/include/RTC/IceServer.hpp
+++ b/worker/include/RTC/IceServer.hpp
@@ -93,9 +93,11 @@ namespace RTC
 		}
 		bool IsValidTuple(const RTC::TransportTuple* tuple) const;
 		void RemoveTuple(RTC::TransportTuple* tuple);
-		// This should be just called in 'connected' or completed' state
-		// and the given tuple must be an already valid tuple.
-		void ForceSelectedTuple(const RTC::TransportTuple* tuple);
+		/**
+		 * This should be just called in 'connected' or completed' state and the
+		 * given tuple must be an already valid tuple.
+		 */
+		void MayForceSelectedTuple(const RTC::TransportTuple* tuple);
 
 	private:
 		void HandleTuple(

--- a/worker/src/RTC/IceServer.cpp
+++ b/worker/src/RTC/IceServer.cpp
@@ -220,9 +220,13 @@ namespace RTC
 
 				// Authenticate the response.
 				if (this->oldPassword.empty())
+				{
 					response->Authenticate(this->password);
+				}
 				else
+				{
 					response->Authenticate(this->oldPassword);
+				}
 
 				// Send back.
 				response->Serialize(StunSerializeBuffer);
@@ -233,7 +237,9 @@ namespace RTC
 				uint32_t nomination{ 0u };
 
 				if (packet->HasNomination())
+				{
 					nomination = packet->GetNomination();
+				}
 
 				// Handle the tuple.
 				HandleTuple(tuple, packet->HasUseCandidate(), packet->HasNomination(), nomination);
@@ -294,7 +300,9 @@ namespace RTC
 
 		// If not found, ignore.
 		if (!removedTuple)
+		{
 			return;
+		}
 
 		// Notify the listener.
 		this->listener->OnIceServerTupleRemoved(this, removedTuple);
@@ -319,6 +327,10 @@ namespace RTC
 			{
 				// Update state.
 				this->state = IceState::DISCONNECTED;
+
+				// Reset remote nomination.
+				this->remoteNomination = 0u;
+
 				// Notify the listener.
 				this->listener->OnIceServerDisconnected(this);
 			}
@@ -351,10 +363,6 @@ namespace RTC
 		{
 			case IceState::NEW:
 			{
-				// There should be no tuples.
-				MS_ASSERT(
-				  this->tuples.empty(), "state is 'new' but there are %zu tuples", this->tuples.size());
-
 				// There shouldn't be a selected tuple.
 				MS_ASSERT(!this->selectedTuple, "state is 'new' but there is selected tuple");
 
@@ -373,15 +381,22 @@ namespace RTC
 
 					// Mark it as selected tuple.
 					SetSelectedTuple(storedTuple);
+
 					// Update state.
 					this->state = IceState::CONNECTED;
+
 					// Notify the listener.
 					this->listener->OnIceServerConnected(this);
 				}
 				else
 				{
-					// Store the tuple.
-					auto* storedTuple = AddTuple(tuple);
+					auto* storedTuple = HasTuple(tuple);
+
+					// If a new tuple store it.
+					if (!storedTuple)
+					{
+						storedTuple = AddTuple(tuple);
+					}
 
 					if ((hasNomination && nomination > this->remoteNomination) || !hasNomination)
 					{
@@ -395,11 +410,16 @@ namespace RTC
 
 						// Mark it as selected tuple.
 						SetSelectedTuple(storedTuple);
+
 						// Update state.
 						this->state = IceState::COMPLETED;
+
 						// Update nomination.
 						if (hasNomination && nomination > this->remoteNomination)
+						{
 							this->remoteNomination = nomination;
+						}
+
 						// Notify the listener.
 						this->listener->OnIceServerCompleted(this);
 					}
@@ -410,12 +430,6 @@ namespace RTC
 
 			case IceState::DISCONNECTED:
 			{
-				// There should be no tuples.
-				MS_ASSERT(
-				  this->tuples.empty(),
-				  "state is 'disconnected' but there are %zu tuples",
-				  this->tuples.size());
-
 				// There shouldn't be a selected tuple.
 				MS_ASSERT(!this->selectedTuple, "state is 'disconnected' but there is selected tuple");
 
@@ -434,15 +448,22 @@ namespace RTC
 
 					// Mark it as selected tuple.
 					SetSelectedTuple(storedTuple);
+
 					// Update state.
 					this->state = IceState::CONNECTED;
+
 					// Notify the listener.
 					this->listener->OnIceServerConnected(this);
 				}
 				else
 				{
-					// Store the tuple.
-					auto* storedTuple = AddTuple(tuple);
+					auto* storedTuple = HasTuple(tuple);
+
+					// If a new tuple store it.
+					if (!storedTuple)
+					{
+						storedTuple = AddTuple(tuple);
+					}
 
 					if ((hasNomination && nomination > this->remoteNomination) || !hasNomination)
 					{
@@ -456,11 +477,16 @@ namespace RTC
 
 						// Mark it as selected tuple.
 						SetSelectedTuple(storedTuple);
+
 						// Update state.
 						this->state = IceState::COMPLETED;
+
 						// Update nomination.
 						if (hasNomination && nomination > this->remoteNomination)
+						{
 							this->remoteNomination = nomination;
+						}
+
 						// Notify the listener.
 						this->listener->OnIceServerCompleted(this);
 					}
@@ -481,7 +507,9 @@ namespace RTC
 				{
 					// If a new tuple store it.
 					if (!HasTuple(tuple))
+					{
 						AddTuple(tuple);
+					}
 				}
 				else
 				{
@@ -497,17 +525,24 @@ namespace RTC
 
 					// If a new tuple store it.
 					if (!storedTuple)
+					{
 						storedTuple = AddTuple(tuple);
+					}
 
 					if ((hasNomination && nomination > this->remoteNomination) || !hasNomination)
 					{
 						// Mark it as selected tuple.
 						SetSelectedTuple(storedTuple);
+
 						// Update state.
 						this->state = IceState::COMPLETED;
+
 						// Update nomination.
 						if (hasNomination && nomination > this->remoteNomination)
+						{
 							this->remoteNomination = nomination;
+						}
+
 						// Notify the listener.
 						this->listener->OnIceServerCompleted(this);
 					}
@@ -528,7 +563,9 @@ namespace RTC
 				{
 					// If a new tuple store it.
 					if (!HasTuple(tuple))
+					{
 						AddTuple(tuple);
+					}
 				}
 				else
 				{
@@ -536,15 +573,20 @@ namespace RTC
 
 					// If a new tuple store it.
 					if (!storedTuple)
+					{
 						storedTuple = AddTuple(tuple);
+					}
 
 					if ((hasNomination && nomination > this->remoteNomination) || !hasNomination)
 					{
 						// Mark it as selected tuple.
 						SetSelectedTuple(storedTuple);
+
 						// Update nomination.
 						if (hasNomination && nomination > this->remoteNomination)
+						{
 							this->remoteNomination = nomination;
+						}
 					}
 				}
 
@@ -565,7 +607,9 @@ namespace RTC
 		// If it is UDP then we must store the remote address (until now it is
 		// just a pointer that will be freed soon).
 		if (storedTuple->GetProtocol() == TransportTuple::Protocol::UDP)
+		{
 			storedTuple->StoreUdpRemoteAddress();
+		}
 
 		// Notify the listener.
 		this->listener->OnIceServerTupleAdded(this, storedTuple);
@@ -614,14 +658,11 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// If there is no selected tuple yet then we know that the tuples list
-		// is empty.
-		if (!this->selectedTuple)
-			return nullptr;
-
-		// Check the current selected tuple.
-		if (this->selectedTuple->Compare(tuple))
+		// Check the current selected tuple (if any).
+		if (this->selectedTuple && this->selectedTuple->Compare(tuple))
+		{
 			return this->selectedTuple;
+		}
 
 		// Otherwise check other stored tuples.
 		for (const auto& it : this->tuples)
@@ -629,7 +670,9 @@ namespace RTC
 			auto* storedTuple = const_cast<RTC::TransportTuple*>(std::addressof(it));
 
 			if (storedTuple->Compare(tuple))
+			{
 				return storedTuple;
+			}
 		}
 
 		return nullptr;
@@ -641,7 +684,9 @@ namespace RTC
 
 		// If already the selected tuple do nothing.
 		if (storedTuple == this->selectedTuple)
+		{
 			return;
+		}
 
 		this->selectedTuple = storedTuple;
 

--- a/worker/src/RTC/IceServer.cpp
+++ b/worker/src/RTC/IceServer.cpp
@@ -397,13 +397,8 @@ namespace RTC
 				}
 				else
 				{
-					auto* storedTuple = HasTuple(tuple);
-
-					// If a new tuple store it.
-					if (!storedTuple)
-					{
-						storedTuple = AddTuple(tuple);
-					}
+					// Store the tuple.
+					auto* storedTuple = AddTuple(tuple);
 
 					if ((hasNomination && nomination > this->remoteNomination) || !hasNomination)
 					{
@@ -464,13 +459,8 @@ namespace RTC
 				}
 				else
 				{
-					auto* storedTuple = HasTuple(tuple);
-
-					// If a new tuple store it.
-					if (!storedTuple)
-					{
-						storedTuple = AddTuple(tuple);
-					}
+					// Store the tuple.
+					auto* storedTuple = AddTuple(tuple);
 
 					if ((hasNomination && nomination > this->remoteNomination) || !hasNomination)
 					{
@@ -512,11 +502,8 @@ namespace RTC
 
 				if (!hasUseCandidate && !hasNomination)
 				{
-					// If a new tuple store it.
-					if (!HasTuple(tuple))
-					{
-						AddTuple(tuple);
-					}
+					// Store the tuple.
+					AddTuple(tuple);
 				}
 				else
 				{
@@ -528,13 +515,8 @@ namespace RTC
 					  hasNomination ? "true" : "false",
 					  nomination);
 
-					auto* storedTuple = HasTuple(tuple);
-
-					// If a new tuple store it.
-					if (!storedTuple)
-					{
-						storedTuple = AddTuple(tuple);
-					}
+					// Store the tuple.
+					auto* storedTuple = AddTuple(tuple);
 
 					if ((hasNomination && nomination > this->remoteNomination) || !hasNomination)
 					{
@@ -568,21 +550,13 @@ namespace RTC
 
 				if (!hasUseCandidate && !hasNomination)
 				{
-					// If a new tuple store it.
-					if (!HasTuple(tuple))
-					{
-						AddTuple(tuple);
-					}
+					// Store the tuple.
+					AddTuple(tuple);
 				}
 				else
 				{
-					auto* storedTuple = HasTuple(tuple);
-
-					// If a new tuple store it.
-					if (!storedTuple)
-					{
-						storedTuple = AddTuple(tuple);
-					}
+					// Store the tuple.
+					auto* storedTuple = AddTuple(tuple);
 
 					if ((hasNomination && nomination > this->remoteNomination) || !hasNomination)
 					{
@@ -606,10 +580,19 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		auto* storedTuple = HasTuple(tuple);
+
+		if (storedTuple)
+		{
+			MS_DEBUG_DEV('tuple already exists');
+
+			return storedTuple;
+		}
+
 		// Add the new tuple at the beginning of the list.
 		this->tuples.push_front(*tuple);
 
-		auto* storedTuple = std::addressof(*this->tuples.begin());
+		storedTuple = std::addressof(*this->tuples.begin());
 
 		// If it is UDP then we must store the remote address (until now it is
 		// just a pointer that will be freed soon).

--- a/worker/src/RTC/IceServer.cpp
+++ b/worker/src/RTC/IceServer.cpp
@@ -337,18 +337,25 @@ namespace RTC
 		}
 	}
 
-	void IceServer::ForceSelectedTuple(const RTC::TransportTuple* tuple)
+	void IceServer::MayForceSelectedTuple(const RTC::TransportTuple* tuple)
 	{
 		MS_TRACE();
 
-		MS_ASSERT(
-		  this->selectedTuple, "cannot force the selected tuple if there was not a selected tuple");
+		if (this->state != IceState::CONNECTED && this->state != IceState::COMPLETED)
+		{
+			MS_WARN_TAG(ice, "cannot force selected tuple if not in state 'connected' or 'completed'");
+
+			return;
+		}
 
 		auto* storedTuple = HasTuple(tuple);
 
-		MS_ASSERT(
-		  storedTuple,
-		  "cannot force the selected tuple if the given tuple was not already a valid tuple");
+		if (!storedTuple)
+		{
+			MS_WARN_TAG(ice, "cannot force selected tuple if the given tuple was not already a valid one");
+
+			return;
+		}
 
 		// Mark it as selected tuple.
 		SetSelectedTuple(storedTuple);

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -1058,10 +1058,11 @@ namespace RTC
 		}
 
 		// Trick for clients performing aggressive ICE regardless we are ICE-Lite.
-		// NOTE: Only do it if we already have a selected ICE candidate tuple.
-		if (this->iceServer->GetSelectedTuple())
+		if (
+		  this->iceServer->GetState() == RTC::IceServer::IceState::CONNECTED ||
+		  this->iceServer->GetState() == RTC::IceServer::IceState::COMPLETED)
 		{
-			this->iceServer->ForceSelectedTuple(tuple);
+			this->iceServer->MayForceSelectedTuple(tuple);
 		}
 
 		// Check that DTLS status is 'connecting' or 'connected'.
@@ -1146,10 +1147,11 @@ namespace RTC
 		}
 
 		// Trick for clients performing aggressive ICE regardless we are ICE-Lite.
-		// NOTE: Only do it if we already have a selected ICE candidate tuple.
-		if (this->iceServer->GetSelectedTuple())
+		if (
+		  this->iceServer->GetState() == RTC::IceServer::IceState::CONNECTED ||
+		  this->iceServer->GetState() == RTC::IceServer::IceState::COMPLETED)
 		{
-			this->iceServer->ForceSelectedTuple(tuple);
+			this->iceServer->MayForceSelectedTuple(tuple);
 		}
 
 		// Pass the packet to the parent transport.

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -1058,12 +1058,7 @@ namespace RTC
 		}
 
 		// Trick for clients performing aggressive ICE regardless we are ICE-Lite.
-		if (
-		  this->iceServer->GetState() == RTC::IceServer::IceState::CONNECTED ||
-		  this->iceServer->GetState() == RTC::IceServer::IceState::COMPLETED)
-		{
-			this->iceServer->MayForceSelectedTuple(tuple);
-		}
+		this->iceServer->MayForceSelectedTuple(tuple);
 
 		// Check that DTLS status is 'connecting' or 'connected'.
 		if (
@@ -1147,12 +1142,7 @@ namespace RTC
 		}
 
 		// Trick for clients performing aggressive ICE regardless we are ICE-Lite.
-		if (
-		  this->iceServer->GetState() == RTC::IceServer::IceState::CONNECTED ||
-		  this->iceServer->GetState() == RTC::IceServer::IceState::COMPLETED)
-		{
-			this->iceServer->MayForceSelectedTuple(tuple);
-		}
+		this->iceServer->MayForceSelectedTuple(tuple);
 
 		// Pass the packet to the parent transport.
 		RTC::Transport::ReceiveRtpPacket(packet);

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -1058,7 +1058,11 @@ namespace RTC
 		}
 
 		// Trick for clients performing aggressive ICE regardless we are ICE-Lite.
-		this->iceServer->ForceSelectedTuple(tuple);
+		// NOTE: Only do it if we already have a selected ICE candidate tuple.
+		if (this->iceServer->GetSelectedTuple())
+		{
+			this->iceServer->ForceSelectedTuple(tuple);
+		}
 
 		// Check that DTLS status is 'connecting' or 'connected'.
 		if (
@@ -1142,7 +1146,11 @@ namespace RTC
 		}
 
 		// Trick for clients performing aggressive ICE regardless we are ICE-Lite.
-		this->iceServer->ForceSelectedTuple(tuple);
+		// NOTE: Only do it if we already have a selected ICE candidate tuple.
+		if (this->iceServer->GetSelectedTuple())
+		{
+			this->iceServer->ForceSelectedTuple(tuple);
+		}
 
 		// Pass the packet to the parent transport.
 		RTC::Transport::ReceiveRtpPacket(packet);


### PR DESCRIPTION
Fixes #1176

### Details

- Problem was in this PR 756 that added support for ICE renomination: https://datatracker.ietf.org/doc/html/draft-thatcher-ice-renomination
- Before that PR, we always assumed that if there is a tuple then we are in 'connected' or 'completed' state, so there is a selected ICE tuple.
- That's no longer true when client uses ICE nomination stuff.