### PR TITLE
[flatbuffers] Fix missing options in router.createWebRtcTransport()

### DIFF
--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -405,8 +405,8 @@ export class Router<RouterAppData extends AppData = AppData>
 			listenInfos,
 			listenIps,
 			port,
-			enableUdp = true,
-			enableTcp = false,
+			enableUdp,
+			enableTcp,
 			preferUdp = false,
 			preferTcp = false,
 			initialAvailableOutgoingBitrate = 600000,
@@ -438,6 +438,19 @@ export class Router<RouterAppData extends AppData = AppData>
 		else if (appData && typeof appData !== 'object')
 		{
 			throw new TypeError('if given, appData must be an object');
+		}
+
+		// If webRtcServer is given, then do not force default values for enableUdp
+		// and enableTcp. Otherwise set them if unset.
+		if (webRtcServer)
+		{
+			enableUdp ??= true;
+			enableTcp ??= true;
+		}
+		else
+		{
+			enableUdp ??= true;
+			enableTcp ??= false;
 		}
 
 		// Convert deprecated TransportListenIps to TransportListenInfos.
@@ -545,7 +558,11 @@ export class Router<RouterAppData extends AppData = AppData>
 			webRtcServer ?
 				FbsWebRtcTransport.Listen.ListenServer :
 				FbsWebRtcTransport.Listen.ListenIndividual,
-			webRtcServer ? webRtcTransportListenServer : webRtcTransportListenIndividual
+			webRtcServer ? webRtcTransportListenServer : webRtcTransportListenIndividual,
+			enableUdp,
+			enableTcp,
+			preferUdp,
+			preferTcp
 		);
 
 		const requestOffset = new FbsRouter.CreateWebRtcTransportRequestT(

--- a/node/src/WebRtcTransport.ts
+++ b/node/src/WebRtcTransport.ts
@@ -78,25 +78,21 @@ export type WebRtcTransportOptionsBase<WebRtcTransportAppData> =
 {
 	/**
 	 * Listen in UDP. Default true.
-	 * @deprecated
 	 */
 	enableUdp?: boolean;
 
 	/**
-	 * Listen in TCP. Default false.
-	 * @deprecated
+	 * Listen in TCP. Default true if webrtcServer is given, false otherwise.
 	 */
 	enableTcp?: boolean;
 
 	/**
 	 * Prefer UDP. Default false.
-	 * @deprecated
 	 */
 	preferUdp?: boolean;
 
 	/**
 	 * Prefer TCP. Default false.
-	 * @deprecated
 	 */
 	preferTcp?: boolean;
 

--- a/node/src/tests/test-WebRtcServer.ts
+++ b/node/src/tests/test-WebRtcServer.ts
@@ -356,7 +356,9 @@ test('router.createWebRtcTransport() with webRtcServer succeeds and transport is
 	const transport = await router.createWebRtcTransport(
 		{
 			webRtcServer,
-			appData : { foo: 'bar' }
+			// Let's disable UDP so resulting ICE candidates should only contain TCP.
+			enableUdp : false,
+			appData   : { foo: 'bar' }
 		});
 
 	await expect(router.dump())
@@ -373,17 +375,12 @@ test('router.createWebRtcTransport() with webRtcServer succeeds and transport is
 
 	const iceCandidates = transport.iceCandidates;
 
-	expect(iceCandidates.length).toBe(2);
+	expect(iceCandidates.length).toBe(1);
 	expect(iceCandidates[0].ip).toBe('127.0.0.1');
-	expect(iceCandidates[0].port).toBe(port1);
-	expect(iceCandidates[0].protocol).toBe('udp');
+	expect(iceCandidates[0].port).toBe(port2);
+	expect(iceCandidates[0].protocol).toBe('tcp');
 	expect(iceCandidates[0].type).toBe('host');
-	expect(iceCandidates[0].tcpType).toBeUndefined();
-	expect(iceCandidates[1].ip).toBe('127.0.0.1');
-	expect(iceCandidates[1].port).toBe(port2);
-	expect(iceCandidates[1].protocol).toBe('tcp');
-	expect(iceCandidates[1].type).toBe('host');
-	expect(iceCandidates[1].tcpType).toBe('passive');
+	expect(iceCandidates[0].tcpType).toBe('passive');
 
 	expect(transport.iceState).toBe('new');
 	expect(transport.iceSelectedTuple).toBeUndefined();

--- a/rust/src/fbs.rs
+++ b/rust/src/fbs.rs
@@ -1,4 +1,3 @@
-//! Flatbuffers data structures compiled from `.fbs` files
 pub use root::fbs::*;
 
 const _: () = ::planus::check_version_compatibility("planus-0.4.0");
@@ -37815,7 +37814,7 @@ mod root {
             /// The enum `TraceEventType` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Enum `TraceEventType` in the file `../worker/fbs/transport.fbs:122`
+            /// * Enum `TraceEventType` in the file `../worker/fbs/transport.fbs:121`
             #[derive(
                 Copy,
                 Clone,
@@ -37985,7 +37984,7 @@ mod root {
             /// The table `Dump` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `Dump` in the file `../worker/fbs/transport.fbs:127`
+            /// * Table `Dump` in the file `../worker/fbs/transport.fbs:126`
             #[derive(
                 Clone,
                 Debug,
@@ -39028,7 +39027,7 @@ mod root {
             /// The table `Stats` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `Stats` in the file `../worker/fbs/transport.fbs:145`
+            /// * Table `Stats` in the file `../worker/fbs/transport.fbs:144`
             #[derive(
                 Clone, Debug, PartialEq, PartialOrd, ::serde::Serialize, ::serde::Deserialize,
             )]
@@ -41689,7 +41688,7 @@ mod root {
             /// The table `SetMaxIncomingBitrateRequest` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `SetMaxIncomingBitrateRequest` in the file `../worker/fbs/transport.fbs:172`
+            /// * Table `SetMaxIncomingBitrateRequest` in the file `../worker/fbs/transport.fbs:171`
             #[derive(
                 Clone,
                 Debug,
@@ -41997,7 +41996,7 @@ mod root {
             /// The table `SetMaxOutgoingBitrateRequest` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `SetMaxOutgoingBitrateRequest` in the file `../worker/fbs/transport.fbs:176`
+            /// * Table `SetMaxOutgoingBitrateRequest` in the file `../worker/fbs/transport.fbs:175`
             #[derive(
                 Clone,
                 Debug,
@@ -42305,7 +42304,7 @@ mod root {
             /// The table `SetMinOutgoingBitrateRequest` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `SetMinOutgoingBitrateRequest` in the file `../worker/fbs/transport.fbs:180`
+            /// * Table `SetMinOutgoingBitrateRequest` in the file `../worker/fbs/transport.fbs:179`
             #[derive(
                 Clone,
                 Debug,
@@ -42613,7 +42612,7 @@ mod root {
             /// The table `EnableTraceEventRequest` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `EnableTraceEventRequest` in the file `../worker/fbs/transport.fbs:184`
+            /// * Table `EnableTraceEventRequest` in the file `../worker/fbs/transport.fbs:183`
             #[derive(
                 Clone,
                 Debug,
@@ -42891,7 +42890,7 @@ mod root {
             /// The table `CloseProducerRequest` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `CloseProducerRequest` in the file `../worker/fbs/transport.fbs:188`
+            /// * Table `CloseProducerRequest` in the file `../worker/fbs/transport.fbs:187`
             #[derive(
                 Clone,
                 Debug,
@@ -43157,7 +43156,7 @@ mod root {
             /// The table `CloseConsumerRequest` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `CloseConsumerRequest` in the file `../worker/fbs/transport.fbs:192`
+            /// * Table `CloseConsumerRequest` in the file `../worker/fbs/transport.fbs:191`
             #[derive(
                 Clone,
                 Debug,
@@ -43423,7 +43422,7 @@ mod root {
             /// The table `CloseDataProducerRequest` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `CloseDataProducerRequest` in the file `../worker/fbs/transport.fbs:196`
+            /// * Table `CloseDataProducerRequest` in the file `../worker/fbs/transport.fbs:195`
             #[derive(
                 Clone,
                 Debug,
@@ -43698,7 +43697,7 @@ mod root {
             /// The table `CloseDataConsumerRequest` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `CloseDataConsumerRequest` in the file `../worker/fbs/transport.fbs:200`
+            /// * Table `CloseDataConsumerRequest` in the file `../worker/fbs/transport.fbs:199`
             #[derive(
                 Clone,
                 Debug,
@@ -43973,7 +43972,7 @@ mod root {
             /// The table `SendRtcpNotification` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `SendRtcpNotification` in the file `../worker/fbs/transport.fbs:206`
+            /// * Table `SendRtcpNotification` in the file `../worker/fbs/transport.fbs:205`
             #[derive(
                 Clone,
                 Debug,
@@ -44238,7 +44237,7 @@ mod root {
             /// The table `SctpStateChangeNotification` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `SctpStateChangeNotification` in the file `../worker/fbs/transport.fbs:212`
+            /// * Table `SctpStateChangeNotification` in the file `../worker/fbs/transport.fbs:211`
             #[derive(
                 Clone,
                 Debug,
@@ -44559,7 +44558,7 @@ mod root {
             /// The union `TraceInfo` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Union `TraceInfo` in the file `../worker/fbs/transport.fbs:216`
+            /// * Union `TraceInfo` in the file `../worker/fbs/transport.fbs:215`
             #[derive(
                 Clone,
                 Debug,
@@ -44712,7 +44711,7 @@ mod root {
             /// The enum `BweType` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Enum `BweType` in the file `../worker/fbs/transport.fbs:220`
+            /// * Enum `BweType` in the file `../worker/fbs/transport.fbs:219`
             #[derive(
                 Copy,
                 Clone,
@@ -44882,7 +44881,7 @@ mod root {
             /// The table `BweTraceInfo` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `BweTraceInfo` in the file `../worker/fbs/transport.fbs:225`
+            /// * Table `BweTraceInfo` in the file `../worker/fbs/transport.fbs:224`
             #[derive(
                 Clone,
                 Debug,
@@ -45560,7 +45559,7 @@ mod root {
             /// The table `TraceNotification` in the namespace `FBS.Transport`
             ///
             /// Generated from these locations:
-            /// * Table `TraceNotification` in the file `../worker/fbs/transport.fbs:236`
+            /// * Table `TraceNotification` in the file `../worker/fbs/transport.fbs:235`
             #[derive(
                 Clone,
                 Debug,
@@ -73997,6 +73996,14 @@ mod root {
                 pub base: ::planus::alloc::boxed::Box<super::transport::Options>,
                 /// The field `listen` in the table `WebRtcTransportOptions`
                 pub listen: self::Listen,
+                /// The field `enable_udp` in the table `WebRtcTransportOptions`
+                pub enable_udp: bool,
+                /// The field `enable_tcp` in the table `WebRtcTransportOptions`
+                pub enable_tcp: bool,
+                /// The field `prefer_udp` in the table `WebRtcTransportOptions`
+                pub prefer_udp: bool,
+                /// The field `prefer_tcp` in the table `WebRtcTransportOptions`
+                pub prefer_tcp: bool,
             }
 
             impl WebRtcTransportOptions {
@@ -74011,21 +74018,61 @@ mod root {
                     builder: &mut ::planus::Builder,
                     field_base: impl ::planus::WriteAs<::planus::Offset<super::transport::Options>>,
                     field_listen: impl ::planus::WriteAsUnion<self::Listen>,
+                    field_enable_udp: impl ::planus::WriteAsDefault<bool, bool>,
+                    field_enable_tcp: impl ::planus::WriteAsDefault<bool, bool>,
+                    field_prefer_udp: impl ::planus::WriteAsDefault<bool, bool>,
+                    field_prefer_tcp: impl ::planus::WriteAsDefault<bool, bool>,
                 ) -> ::planus::Offset<Self> {
                     let prepared_base = field_base.prepare(builder);
                     let prepared_listen = field_listen.prepare(builder);
+                    let prepared_enable_udp = field_enable_udp.prepare(builder, &true);
+                    let prepared_enable_tcp = field_enable_tcp.prepare(builder, &true);
+                    let prepared_prefer_udp = field_prefer_udp.prepare(builder, &false);
+                    let prepared_prefer_tcp = field_prefer_tcp.prepare(builder, &false);
 
-                    let mut table_writer: ::planus::table_writer::TableWriter<10> =
+                    let mut table_writer: ::planus::table_writer::TableWriter<18> =
                         ::core::default::Default::default();
                     table_writer.write_entry::<::planus::Offset<super::transport::Options>>(0);
                     table_writer.write_entry::<::planus::Offset<self::Listen>>(2);
                     table_writer.write_entry::<u8>(1);
+                    if prepared_enable_udp.is_some() {
+                        table_writer.write_entry::<bool>(3);
+                    }
+                    if prepared_enable_tcp.is_some() {
+                        table_writer.write_entry::<bool>(4);
+                    }
+                    if prepared_prefer_udp.is_some() {
+                        table_writer.write_entry::<bool>(5);
+                    }
+                    if prepared_prefer_tcp.is_some() {
+                        table_writer.write_entry::<bool>(6);
+                    }
 
                     unsafe {
                         table_writer.finish(builder, |object_writer| {
                             object_writer.write::<_, _, 4>(&prepared_base);
                             object_writer.write::<_, _, 4>(&prepared_listen.offset());
                             object_writer.write::<_, _, 1>(&prepared_listen.tag());
+                            if let ::core::option::Option::Some(prepared_enable_udp) =
+                                prepared_enable_udp
+                            {
+                                object_writer.write::<_, _, 1>(&prepared_enable_udp);
+                            }
+                            if let ::core::option::Option::Some(prepared_enable_tcp) =
+                                prepared_enable_tcp
+                            {
+                                object_writer.write::<_, _, 1>(&prepared_enable_tcp);
+                            }
+                            if let ::core::option::Option::Some(prepared_prefer_udp) =
+                                prepared_prefer_udp
+                            {
+                                object_writer.write::<_, _, 1>(&prepared_prefer_udp);
+                            }
+                            if let ::core::option::Option::Some(prepared_prefer_tcp) =
+                                prepared_prefer_tcp
+                            {
+                                object_writer.write::<_, _, 1>(&prepared_prefer_tcp);
+                            }
                         });
                     }
                     builder.current_offset()
@@ -74065,7 +74112,15 @@ mod root {
                     &self,
                     builder: &mut ::planus::Builder,
                 ) -> ::planus::Offset<WebRtcTransportOptions> {
-                    WebRtcTransportOptions::create(builder, &self.base, &self.listen)
+                    WebRtcTransportOptions::create(
+                        builder,
+                        &self.base,
+                        &self.listen,
+                        self.enable_udp,
+                        self.enable_tcp,
+                        self.prefer_udp,
+                        self.prefer_tcp,
+                    )
                 }
             }
 
@@ -74102,6 +74157,110 @@ mod root {
             }
 
             impl<T0, T1> WebRtcTransportOptionsBuilder<(T0, T1)> {
+                /// Setter for the [`enable_udp` field](WebRtcTransportOptions#structfield.enable_udp).
+                #[inline]
+                #[allow(clippy::type_complexity)]
+                pub fn enable_udp<T2>(
+                    self,
+                    value: T2,
+                ) -> WebRtcTransportOptionsBuilder<(T0, T1, T2)>
+                where
+                    T2: ::planus::WriteAsDefault<bool, bool>,
+                {
+                    let (v0, v1) = self.0;
+                    WebRtcTransportOptionsBuilder((v0, v1, value))
+                }
+
+                /// Sets the [`enable_udp` field](WebRtcTransportOptions#structfield.enable_udp) to the default value.
+                #[inline]
+                #[allow(clippy::type_complexity)]
+                pub fn enable_udp_as_default(
+                    self,
+                ) -> WebRtcTransportOptionsBuilder<(T0, T1, ::planus::DefaultValue)>
+                {
+                    self.enable_udp(::planus::DefaultValue)
+                }
+            }
+
+            impl<T0, T1, T2> WebRtcTransportOptionsBuilder<(T0, T1, T2)> {
+                /// Setter for the [`enable_tcp` field](WebRtcTransportOptions#structfield.enable_tcp).
+                #[inline]
+                #[allow(clippy::type_complexity)]
+                pub fn enable_tcp<T3>(
+                    self,
+                    value: T3,
+                ) -> WebRtcTransportOptionsBuilder<(T0, T1, T2, T3)>
+                where
+                    T3: ::planus::WriteAsDefault<bool, bool>,
+                {
+                    let (v0, v1, v2) = self.0;
+                    WebRtcTransportOptionsBuilder((v0, v1, v2, value))
+                }
+
+                /// Sets the [`enable_tcp` field](WebRtcTransportOptions#structfield.enable_tcp) to the default value.
+                #[inline]
+                #[allow(clippy::type_complexity)]
+                pub fn enable_tcp_as_default(
+                    self,
+                ) -> WebRtcTransportOptionsBuilder<(T0, T1, T2, ::planus::DefaultValue)>
+                {
+                    self.enable_tcp(::planus::DefaultValue)
+                }
+            }
+
+            impl<T0, T1, T2, T3> WebRtcTransportOptionsBuilder<(T0, T1, T2, T3)> {
+                /// Setter for the [`prefer_udp` field](WebRtcTransportOptions#structfield.prefer_udp).
+                #[inline]
+                #[allow(clippy::type_complexity)]
+                pub fn prefer_udp<T4>(
+                    self,
+                    value: T4,
+                ) -> WebRtcTransportOptionsBuilder<(T0, T1, T2, T3, T4)>
+                where
+                    T4: ::planus::WriteAsDefault<bool, bool>,
+                {
+                    let (v0, v1, v2, v3) = self.0;
+                    WebRtcTransportOptionsBuilder((v0, v1, v2, v3, value))
+                }
+
+                /// Sets the [`prefer_udp` field](WebRtcTransportOptions#structfield.prefer_udp) to the default value.
+                #[inline]
+                #[allow(clippy::type_complexity)]
+                pub fn prefer_udp_as_default(
+                    self,
+                ) -> WebRtcTransportOptionsBuilder<(T0, T1, T2, T3, ::planus::DefaultValue)>
+                {
+                    self.prefer_udp(::planus::DefaultValue)
+                }
+            }
+
+            impl<T0, T1, T2, T3, T4> WebRtcTransportOptionsBuilder<(T0, T1, T2, T3, T4)> {
+                /// Setter for the [`prefer_tcp` field](WebRtcTransportOptions#structfield.prefer_tcp).
+                #[inline]
+                #[allow(clippy::type_complexity)]
+                pub fn prefer_tcp<T5>(
+                    self,
+                    value: T5,
+                ) -> WebRtcTransportOptionsBuilder<(T0, T1, T2, T3, T4, T5)>
+                where
+                    T5: ::planus::WriteAsDefault<bool, bool>,
+                {
+                    let (v0, v1, v2, v3, v4) = self.0;
+                    WebRtcTransportOptionsBuilder((v0, v1, v2, v3, v4, value))
+                }
+
+                /// Sets the [`prefer_tcp` field](WebRtcTransportOptions#structfield.prefer_tcp) to the default value.
+                #[inline]
+                #[allow(clippy::type_complexity)]
+                pub fn prefer_tcp_as_default(
+                    self,
+                ) -> WebRtcTransportOptionsBuilder<(T0, T1, T2, T3, T4, ::planus::DefaultValue)>
+                {
+                    self.prefer_tcp(::planus::DefaultValue)
+                }
+            }
+
+            impl<T0, T1, T2, T3, T4, T5> WebRtcTransportOptionsBuilder<(T0, T1, T2, T3, T4, T5)> {
                 /// Finish writing the builder to get an [Offset](::planus::Offset) to a serialized [WebRtcTransportOptions].
                 #[inline]
                 pub fn finish(
@@ -74118,8 +74277,12 @@ mod root {
             impl<
                     T0: ::planus::WriteAs<::planus::Offset<super::transport::Options>>,
                     T1: ::planus::WriteAsUnion<self::Listen>,
+                    T2: ::planus::WriteAsDefault<bool, bool>,
+                    T3: ::planus::WriteAsDefault<bool, bool>,
+                    T4: ::planus::WriteAsDefault<bool, bool>,
+                    T5: ::planus::WriteAsDefault<bool, bool>,
                 > ::planus::WriteAs<::planus::Offset<WebRtcTransportOptions>>
-                for WebRtcTransportOptionsBuilder<(T0, T1)>
+                for WebRtcTransportOptionsBuilder<(T0, T1, T2, T3, T4, T5)>
             {
                 type Prepared = ::planus::Offset<WebRtcTransportOptions>;
 
@@ -74135,8 +74298,12 @@ mod root {
             impl<
                     T0: ::planus::WriteAs<::planus::Offset<super::transport::Options>>,
                     T1: ::planus::WriteAsUnion<self::Listen>,
+                    T2: ::planus::WriteAsDefault<bool, bool>,
+                    T3: ::planus::WriteAsDefault<bool, bool>,
+                    T4: ::planus::WriteAsDefault<bool, bool>,
+                    T5: ::planus::WriteAsDefault<bool, bool>,
                 > ::planus::WriteAsOptional<::planus::Offset<WebRtcTransportOptions>>
-                for WebRtcTransportOptionsBuilder<(T0, T1)>
+                for WebRtcTransportOptionsBuilder<(T0, T1, T2, T3, T4, T5)>
             {
                 type Prepared = ::planus::Offset<WebRtcTransportOptions>;
 
@@ -74153,16 +74320,20 @@ mod root {
             impl<
                     T0: ::planus::WriteAs<::planus::Offset<super::transport::Options>>,
                     T1: ::planus::WriteAsUnion<self::Listen>,
+                    T2: ::planus::WriteAsDefault<bool, bool>,
+                    T3: ::planus::WriteAsDefault<bool, bool>,
+                    T4: ::planus::WriteAsDefault<bool, bool>,
+                    T5: ::planus::WriteAsDefault<bool, bool>,
                 > ::planus::WriteAsOffset<WebRtcTransportOptions>
-                for WebRtcTransportOptionsBuilder<(T0, T1)>
+                for WebRtcTransportOptionsBuilder<(T0, T1, T2, T3, T4, T5)>
             {
                 #[inline]
                 fn prepare(
                     &self,
                     builder: &mut ::planus::Builder,
                 ) -> ::planus::Offset<WebRtcTransportOptions> {
-                    let (v0, v1) = &self.0;
-                    WebRtcTransportOptions::create(builder, v0, v1)
+                    let (v0, v1, v2, v3, v4, v5) = &self.0;
+                    WebRtcTransportOptions::create(builder, v0, v1, v2, v3, v4, v5)
                 }
             }
 
@@ -74183,6 +74354,46 @@ mod root {
                     self.0
                         .access_union_required(1, "WebRtcTransportOptions", "listen")
                 }
+
+                /// Getter for the [`enable_udp` field](WebRtcTransportOptions#structfield.enable_udp).
+                #[inline]
+                pub fn enable_udp(&self) -> ::planus::Result<bool> {
+                    ::core::result::Result::Ok(
+                        self.0
+                            .access(3, "WebRtcTransportOptions", "enable_udp")?
+                            .unwrap_or(true),
+                    )
+                }
+
+                /// Getter for the [`enable_tcp` field](WebRtcTransportOptions#structfield.enable_tcp).
+                #[inline]
+                pub fn enable_tcp(&self) -> ::planus::Result<bool> {
+                    ::core::result::Result::Ok(
+                        self.0
+                            .access(4, "WebRtcTransportOptions", "enable_tcp")?
+                            .unwrap_or(true),
+                    )
+                }
+
+                /// Getter for the [`prefer_udp` field](WebRtcTransportOptions#structfield.prefer_udp).
+                #[inline]
+                pub fn prefer_udp(&self) -> ::planus::Result<bool> {
+                    ::core::result::Result::Ok(
+                        self.0
+                            .access(5, "WebRtcTransportOptions", "prefer_udp")?
+                            .unwrap_or(false),
+                    )
+                }
+
+                /// Getter for the [`prefer_tcp` field](WebRtcTransportOptions#structfield.prefer_tcp).
+                #[inline]
+                pub fn prefer_tcp(&self) -> ::planus::Result<bool> {
+                    ::core::result::Result::Ok(
+                        self.0
+                            .access(6, "WebRtcTransportOptions", "prefer_tcp")?
+                            .unwrap_or(false),
+                    )
+                }
             }
 
             impl<'a> ::core::fmt::Debug for WebRtcTransportOptionsRef<'a> {
@@ -74190,6 +74401,10 @@ mod root {
                     let mut f = f.debug_struct("WebRtcTransportOptionsRef");
                     f.field("base", &self.base());
                     f.field("listen", &self.listen());
+                    f.field("enable_udp", &self.enable_udp());
+                    f.field("enable_tcp", &self.enable_tcp());
+                    f.field("prefer_udp", &self.prefer_udp());
+                    f.field("prefer_tcp", &self.prefer_tcp());
                     f.finish()
                 }
             }
@@ -74204,6 +74419,10 @@ mod root {
                             value.base()?,
                         )?),
                         listen: ::core::convert::TryInto::try_into(value.listen()?)?,
+                        enable_udp: ::core::convert::TryInto::try_into(value.enable_udp()?)?,
+                        enable_tcp: ::core::convert::TryInto::try_into(value.enable_tcp()?)?,
+                        prefer_udp: ::core::convert::TryInto::try_into(value.prefer_udp()?)?,
+                        prefer_tcp: ::core::convert::TryInto::try_into(value.prefer_tcp()?)?,
                     })
                 }
             }
@@ -74285,7 +74504,7 @@ mod root {
             /// The enum `FingerprintAlgorithm` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Enum `FingerprintAlgorithm` in the file `../worker/fbs/webRtcTransport.fbs:24`
+            /// * Enum `FingerprintAlgorithm` in the file `../worker/fbs/webRtcTransport.fbs:28`
             #[derive(
                 Copy,
                 Clone,
@@ -74473,7 +74692,7 @@ mod root {
             /// The table `Fingerprint` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Table `Fingerprint` in the file `../worker/fbs/webRtcTransport.fbs:32`
+            /// * Table `Fingerprint` in the file `../worker/fbs/webRtcTransport.fbs:36`
             #[derive(
                 Clone,
                 Debug,
@@ -74797,7 +75016,7 @@ mod root {
             /// The enum `DtlsRole` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Enum `DtlsRole` in the file `../worker/fbs/webRtcTransport.fbs:37`
+            /// * Enum `DtlsRole` in the file `../worker/fbs/webRtcTransport.fbs:41`
             #[derive(
                 Copy,
                 Clone,
@@ -74971,7 +75190,7 @@ mod root {
             /// The enum `DtlsState` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Enum `DtlsState` in the file `../worker/fbs/webRtcTransport.fbs:43`
+            /// * Enum `DtlsState` in the file `../worker/fbs/webRtcTransport.fbs:47`
             #[derive(
                 Copy,
                 Clone,
@@ -75159,7 +75378,7 @@ mod root {
             /// The table `DtlsParameters` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Table `DtlsParameters` in the file `../worker/fbs/webRtcTransport.fbs:51`
+            /// * Table `DtlsParameters` in the file `../worker/fbs/webRtcTransport.fbs:55`
             #[derive(
                 Clone,
                 Debug,
@@ -75474,7 +75693,7 @@ mod root {
             /// The table `IceParameters` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Table `IceParameters` in the file `../worker/fbs/webRtcTransport.fbs:56`
+            /// * Table `IceParameters` in the file `../worker/fbs/webRtcTransport.fbs:60`
             #[derive(
                 Clone,
                 Debug,
@@ -75822,7 +76041,7 @@ mod root {
             /// The enum `IceCandidateType` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Enum `IceCandidateType` in the file `../worker/fbs/webRtcTransport.fbs:62`
+            /// * Enum `IceCandidateType` in the file `../worker/fbs/webRtcTransport.fbs:66`
             #[derive(
                 Copy,
                 Clone,
@@ -75988,7 +76207,7 @@ mod root {
             /// The enum `IceCandidateTcpType` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Enum `IceCandidateTcpType` in the file `../worker/fbs/webRtcTransport.fbs:66`
+            /// * Enum `IceCandidateTcpType` in the file `../worker/fbs/webRtcTransport.fbs:70`
             #[derive(
                 Copy,
                 Clone,
@@ -76154,7 +76373,7 @@ mod root {
             /// The enum `IceRole` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Enum `IceRole` in the file `../worker/fbs/webRtcTransport.fbs:70`
+            /// * Enum `IceRole` in the file `../worker/fbs/webRtcTransport.fbs:74`
             #[derive(
                 Copy,
                 Clone,
@@ -76324,7 +76543,7 @@ mod root {
             /// The enum `IceState` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Enum `IceState` in the file `../worker/fbs/webRtcTransport.fbs:75`
+            /// * Enum `IceState` in the file `../worker/fbs/webRtcTransport.fbs:79`
             #[derive(
                 Copy,
                 Clone,
@@ -76507,7 +76726,7 @@ mod root {
             /// The table `IceCandidate` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Table `IceCandidate` in the file `../worker/fbs/webRtcTransport.fbs:82`
+            /// * Table `IceCandidate` in the file `../worker/fbs/webRtcTransport.fbs:86`
             #[derive(
                 Clone,
                 Debug,
@@ -77078,7 +77297,7 @@ mod root {
             /// The table `ConnectRequest` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Table `ConnectRequest` in the file `../worker/fbs/webRtcTransport.fbs:92`
+            /// * Table `ConnectRequest` in the file `../worker/fbs/webRtcTransport.fbs:96`
             #[derive(
                 Clone,
                 Debug,
@@ -77341,7 +77560,7 @@ mod root {
             /// The table `ConnectResponse` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Table `ConnectResponse` in the file `../worker/fbs/webRtcTransport.fbs:96`
+            /// * Table `ConnectResponse` in the file `../worker/fbs/webRtcTransport.fbs:100`
             #[derive(
                 Clone,
                 Debug,
@@ -77630,7 +77849,7 @@ mod root {
             /// The table `DumpResponse` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Table `DumpResponse` in the file `../worker/fbs/webRtcTransport.fbs:100`
+            /// * Table `DumpResponse` in the file `../worker/fbs/webRtcTransport.fbs:104`
             #[derive(
                 Clone,
                 Debug,
@@ -78230,7 +78449,7 @@ mod root {
             /// The table `GetStatsResponse` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Table `GetStatsResponse` in the file `../worker/fbs/webRtcTransport.fbs:111`
+            /// * Table `GetStatsResponse` in the file `../worker/fbs/webRtcTransport.fbs:115`
             #[derive(
                 Clone, Debug, PartialEq, PartialOrd, ::serde::Serialize, ::serde::Deserialize,
             )]
@@ -78713,7 +78932,7 @@ mod root {
             /// The table `IceSelectedTupleChangeNotification` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Table `IceSelectedTupleChangeNotification` in the file `../worker/fbs/webRtcTransport.fbs:121`
+            /// * Table `IceSelectedTupleChangeNotification` in the file `../worker/fbs/webRtcTransport.fbs:125`
             #[derive(
                 Clone,
                 Debug,
@@ -78996,7 +79215,7 @@ mod root {
             /// The table `IceStateChangeNotification` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Table `IceStateChangeNotification` in the file `../worker/fbs/webRtcTransport.fbs:125`
+            /// * Table `IceStateChangeNotification` in the file `../worker/fbs/webRtcTransport.fbs:129`
             #[derive(
                 Clone,
                 Debug,
@@ -79297,7 +79516,7 @@ mod root {
             /// The table `DtlsStateChangeNotification` in the namespace `FBS.WebRtcTransport`
             ///
             /// Generated from these locations:
-            /// * Table `DtlsStateChangeNotification` in the file `../worker/fbs/webRtcTransport.fbs:129`
+            /// * Table `DtlsStateChangeNotification` in the file `../worker/fbs/webRtcTransport.fbs:133`
             #[derive(
                 Clone,
                 Debug,

--- a/rust/src/fbs.rs
+++ b/rust/src/fbs.rs
@@ -1,3 +1,4 @@
+//! Flatbuffers data structures compiled from `.fbs` files
 pub use root::fbs::*;
 
 const _: () = ::planus::check_version_compatibility("planus-0.4.0");

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -651,6 +651,10 @@ pub(crate) struct RouterCreateWebrtcTransportData {
     #[serde(flatten)]
     listen: RouterCreateWebrtcTransportListen,
     initial_available_outgoing_bitrate: u32,
+    enable_udp: bool,
+    enable_tcp: bool,
+    prefer_udp: bool,
+    prefer_tcp: bool,
     enable_sctp: bool,
     num_sctp_streams: NumSctpStreams,
     max_sctp_message_size: u32,
@@ -679,6 +683,10 @@ impl RouterCreateWebrtcTransportData {
             },
             initial_available_outgoing_bitrate: webrtc_transport_options
                 .initial_available_outgoing_bitrate,
+            enable_udp: webrtc_transport_options.enable_udp,
+            enable_tcp: webrtc_transport_options.enable_tcp,
+            prefer_udp: webrtc_transport_options.prefer_udp,
+            prefer_tcp: webrtc_transport_options.prefer_tcp,
             enable_sctp: webrtc_transport_options.enable_sctp,
             num_sctp_streams: webrtc_transport_options.num_sctp_streams,
             max_sctp_message_size: webrtc_transport_options.max_sctp_message_size,
@@ -700,6 +708,10 @@ impl RouterCreateWebrtcTransportData {
                 is_data_channel: true,
             }),
             listen: self.listen.to_fbs(),
+            enable_udp: self.enable_udp,
+            enable_tcp: self.enable_tcp,
+            prefer_udp: self.prefer_udp,
+            prefer_tcp: self.prefer_tcp,
         }
     }
 }

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -117,6 +117,18 @@ pub struct WebRtcTransportOptions {
     /// Initial available outgoing bitrate (in bps).
     /// Default 600000.
     pub initial_available_outgoing_bitrate: u32,
+    /// Enable UDP.
+    /// Default true.
+    pub enable_udp: bool,
+    /// Enable TCP.
+    /// Default true if webrtc_server is given, false otherwise.
+    pub enable_tcp: bool,
+    /// Prefer UDP.
+    /// Default false.
+    pub prefer_udp: bool,
+    /// Prefer TCP.
+    /// Default false.
+    pub prefer_tcp: bool,
     /// Create a SCTP association.
     /// Default false.
     pub enable_sctp: bool,
@@ -133,12 +145,16 @@ pub struct WebRtcTransportOptions {
 }
 
 impl WebRtcTransportOptions {
-    /// Create [`WebRtcTransport`] options with given listen IPs.
+    /// Create [`WebRtcTransport`] options with given listen infos.
     #[must_use]
     pub fn new(listen_infos: WebRtcTransportListenInfos) -> Self {
         Self {
             listen: WebRtcTransportListen::Individual { listen_infos },
             initial_available_outgoing_bitrate: 600_000,
+            enable_udp: true,
+            enable_tcp: false,
+            prefer_udp: false,
+            prefer_tcp: false,
             enable_sctp: false,
             num_sctp_streams: NumSctpStreams::default(),
             max_sctp_message_size: 262_144,
@@ -152,6 +168,10 @@ impl WebRtcTransportOptions {
         Self {
             listen: WebRtcTransportListen::Server { webrtc_server },
             initial_available_outgoing_bitrate: 600_000,
+            enable_udp: true,
+            enable_tcp: true,
+            prefer_udp: false,
+            prefer_tcp: false,
             enable_sctp: false,
             num_sctp_streams: NumSctpStreams::default(),
             max_sctp_message_size: 262_144,

--- a/rust/src/router/webrtc_transport/tests.rs
+++ b/rust/src/router/webrtc_transport/tests.rs
@@ -105,9 +105,8 @@ fn create_with_webrtc_server_succeeds() {
 
         let transport = router
             .create_webrtc_transport({
-                let mut webrtc_transport_options = WebRtcTransportOptions::new_with_server(
-                    webrtc_server.clone()
-                );
+                let mut webrtc_transport_options =
+                    WebRtcTransportOptions::new_with_server(webrtc_server.clone());
                 // Let's disable UDP so resulting ICE candidates should only contain TCP.
                 webrtc_transport_options.enable_udp = false;
 

--- a/rust/src/router/webrtc_transport/tests.rs
+++ b/rust/src/router/webrtc_transport/tests.rs
@@ -104,9 +104,15 @@ fn create_with_webrtc_server_succeeds() {
         });
 
         let transport = router
-            .create_webrtc_transport(WebRtcTransportOptions::new_with_server(
-                webrtc_server.clone(),
-            ))
+            .create_webrtc_transport({
+                let mut webrtc_transport_options = WebRtcTransportOptions::new_with_server(
+                    webrtc_server.clone()
+                );
+                // Let's disable UDP so resulting ICE candidates should only contain TCP.
+                webrtc_transport_options.enable_udp = false;
+
+                webrtc_transport_options
+            })
             .await
             .expect("Failed to create WebRTC transport");
 
@@ -124,18 +130,13 @@ fn create_with_webrtc_server_succeeds() {
 
         {
             let ice_candidates = transport.ice_candidates();
-            assert_eq!(ice_candidates.len(), 2);
+            assert_eq!(ice_candidates.len(), 1);
             assert_eq!(ice_candidates[0].ip, IpAddr::V4(Ipv4Addr::LOCALHOST));
-            assert_eq!(ice_candidates[0].protocol, Protocol::Udp);
-            assert_eq!(ice_candidates[0].port, port1);
+            assert_eq!(ice_candidates[0].protocol, Protocol::Tcp);
+            assert_eq!(ice_candidates[0].port, port2);
             assert_eq!(ice_candidates[0].r#type, IceCandidateType::Host);
-            assert_eq!(ice_candidates[0].tcp_type, None);
-            assert_eq!(ice_candidates[1].ip, IpAddr::V4(Ipv4Addr::LOCALHOST));
-            assert_eq!(ice_candidates[1].protocol, Protocol::Tcp);
-            assert_eq!(ice_candidates[1].port, port2);
-            assert_eq!(ice_candidates[1].r#type, IceCandidateType::Host);
             assert_eq!(
-                ice_candidates[1].tcp_type,
+                ice_candidates[0].tcp_type,
                 Some(IceCandidateTcpType::Passive)
             );
         }

--- a/rust/tests/integration/webrtc_transport.rs
+++ b/rust/tests/integration/webrtc_transport.rs
@@ -160,8 +160,8 @@ fn create_succeeds() {
                         .try_into()
                         .unwrap(),
                     );
-                    // TODO: I wonder how this was not needed before...
                     webrtc_transport_options.enable_sctp = true;
+                    webrtc_transport_options.enable_udp = false;
                     webrtc_transport_options.num_sctp_streams = NumSctpStreams {
                         os: 2048,
                         mis: 2048,

--- a/rust/tests/integration/webrtc_transport.rs
+++ b/rust/tests/integration/webrtc_transport.rs
@@ -161,7 +161,6 @@ fn create_succeeds() {
                         .unwrap(),
                     );
                     webrtc_transport_options.enable_sctp = true;
-                    webrtc_transport_options.enable_udp = false;
                     webrtc_transport_options.num_sctp_streams = NumSctpStreams {
                         os: 2048,
                         mis: 2048,

--- a/worker/fbs/transport.fbs
+++ b/worker/fbs/transport.fbs
@@ -108,7 +108,6 @@ table RecvRtpHeaderExtensions {
 
 table Options {
     direct: bool = false;
-
     /// Only needed for DirectTransport. This value is handled by base Transport.
     max_message_size: uint32 = null;
     initial_available_outgoing_bitrate: uint32 = null;

--- a/worker/fbs/webRtcTransport.fbs
+++ b/worker/fbs/webRtcTransport.fbs
@@ -19,6 +19,10 @@ union Listen {
 table WebRtcTransportOptions {
     base: FBS.Transport.Options (required);
     listen: Listen (required);
+    enable_udp: bool = true;
+    enable_tcp: bool = true;
+    prefer_udp: bool = false;
+    prefer_tcp: bool = false;
 }
 
 enum FingerprintAlgorithm: uint8 {

--- a/worker/include/RTC/WebRtcServer.hpp
+++ b/worker/include/RTC/WebRtcServer.hpp
@@ -48,7 +48,8 @@ namespace RTC
 	public:
 		flatbuffers::Offset<FBS::WebRtcServer::DumpResponse> FillBuffer(
 		  flatbuffers::FlatBufferBuilder& builder) const;
-		const std::vector<RTC::IceCandidate>& GetIceCandidates() const;
+		const std::vector<RTC::IceCandidate> GetIceCandidates(
+		  bool enableUdp, bool enableTcp, bool preferUdp, bool preferTcp) const;
 
 		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
 	public:
@@ -102,8 +103,6 @@ namespace RTC
 		absl::flat_hash_map<std::string, RTC::WebRtcTransport*> mapLocalIceUsernameFragmentWebRtcTransport;
 		// Map of WebRtcTransports indexed by TransportTuple.hash.
 		absl::flat_hash_map<uint64_t, RTC::WebRtcTransport*> mapTupleWebRtcTransport;
-		// ICE candidates.
-		std::vector<RTC::IceCandidate> iceCandidates;
 	};
 } // namespace RTC
 

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -248,7 +248,8 @@ namespace RTC
 				if (!webRtcServer)
 					MS_THROW_ERROR("wrong webRtcServerId (no associated WebRtcServer found)");
 
-				auto& iceCandidates = webRtcServer->GetIceCandidates();
+				auto iceCandidates = webRtcServer->GetIceCandidates(
+				  options->enableUdp(), options->enableTcp(), options->preferUdp(), options->preferTcp());
 
 				// This may throw.
 				auto* webRtcTransport = new RTC::WebRtcTransport(

--- a/worker/src/RTC/WebRtcServer.cpp
+++ b/worker/src/RTC/WebRtcServer.cpp
@@ -268,6 +268,11 @@ namespace RTC
 		std::vector<RTC::IceCandidate> iceCandidates;
 		uint16_t iceLocalPreferenceDecrement{ 0 };
 
+		if (!enableUdp)
+			MS_DUMP_STD("---------------------- no enableUdp");
+		else
+			MS_DUMP_STD("---------------------- YES enableUdp");
+
 		for (auto& item : this->udpSocketOrTcpServers)
 		{
 			if (item.udpSocket && enableUdp)

--- a/worker/src/RTC/WebRtcServer.cpp
+++ b/worker/src/RTC/WebRtcServer.cpp
@@ -268,11 +268,6 @@ namespace RTC
 		std::vector<RTC::IceCandidate> iceCandidates;
 		uint16_t iceLocalPreferenceDecrement{ 0 };
 
-		if (!enableUdp)
-			MS_DUMP_STD("---------------------- no enableUdp");
-		else
-			MS_DUMP_STD("---------------------- YES enableUdp");
-
 		for (auto& item : this->udpSocketOrTcpServers)
 		{
 			if (item.udpSocket && enableUdp)

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -28,6 +28,9 @@ namespace RTC
 
 	/* Instance methods. */
 
+	/**
+	 * This constructor is used when the WebRtcTransport doesn't use a WebRtcServer.
+	 */
 	WebRtcTransport::WebRtcTransport(
 	  RTC::Shared* shared,
 	  const std::string& id,


### PR DESCRIPTION
Fixes #1184

### Details

- No idea how, but flatbuffers branch misses `enableUdp`, `enableTcp`, and `preferUdp` and `preferTcp` options when creating a `WebRtcTransport` with a `WebRtcServer`. This was implemented in v3.
