### PR TITLE
Fix NPM 'postinstall' task in Windows

### DIFF
--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -445,7 +445,9 @@ function installMsysMake()
 		pythonPath = String(res.stdout).trim();
 	}
 
-	executeCmd(`${pythonPath} worker\\scripts\\getmake.py`);
+	const dir = path.resolve('worker/out/msys');
+
+	executeCmd(`${pythonPath} worker\\scripts\\getmake.py --dir="${dir}"`);
 }
 
 function ensureDir(dir)

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -1,4 +1,5 @@
 use std::env;
+#[cfg(target_os = "windows")]
 use std::path::Path;
 use std::process::Command;
 

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -19,8 +19,10 @@ fn main() {
     // Force forward slashes on Windows too so that is plays well with our dumb `Makefile`.
     let mediasoup_out_dir = format!("{}/out", out_dir.replace('\\', "/"));
 
-    // Store original PATH so we make `make clean-all` use it, otherwise
-    // our modified PATH may include rm.exe in Windows and delete itself.
+    // Store original PATH so we make `make clean-all` use it. This is because, in Windows,
+    // we may need to fetch `make` and we store it in out/msys and then we add out/msys/bin
+    // to the PATH, and that folder may contain rm.exe, so `make clean-all` would use
+    // that rm.exe and delete itself and make the task fail.
     let original_path = env::var("PATH").unwrap();
 
     // Add C++ std lib

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -1,6 +1,4 @@
 use std::env;
-#[cfg(target_os = "windows")]
-use std::path::Path;
 use std::process::Command;
 
 fn main() {
@@ -94,7 +92,7 @@ fn main() {
             };
 
             let worker_abs_path = env::current_dir().unwrap();
-            let dir = Path::new(&worker_abs_path).join("out/msys");
+            let dir = worker_abs_path.join("out/msys");
 
             if !Command::new(python)
                 .arg("scripts\\getmake.py")

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -16,7 +16,7 @@ fn main() {
     };
 
     let out_dir = env::var("OUT_DIR").unwrap();
-    // Force forward slashes on Windows too so that is plays well with our dumb `Makefile`
+    // Force forward slashes on Windows too so that is plays well with our dumb `Makefile`.
     let mediasoup_out_dir = format!("{}/out", out_dir.replace('\\', "/"));
 
     // Add C++ std lib
@@ -91,8 +91,7 @@ fn main() {
                 "python".to_string()
             };
 
-            let worker_abs_path = env::current_dir().unwrap();
-            let dir = worker_abs_path.join("out/msys");
+            let dir = format!("{}/msys", mediasoup_out_dir.replace('\\', "/"));
 
             if !Command::new(python)
                 .arg("scripts\\getmake.py")
@@ -104,6 +103,11 @@ fn main() {
             {
                 panic!("Failed to install MSYS/make")
             }
+
+            env::set_var(
+                "PATH",
+                format!("{}\\bin;{}", dir, env::var("PATH").unwrap()),
+            );
         }
 
         env::set_var(

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -19,6 +19,10 @@ fn main() {
     // Force forward slashes on Windows too so that is plays well with our dumb `Makefile`.
     let mediasoup_out_dir = format!("{}/out", out_dir.replace('\\', "/"));
 
+    // Store original PATH so we make `make clean-all` use it, otherwise
+    // our modified PATH may include rm.exe in Windows and delete itself.
+    let original_path = env::var("PATH").unwrap();
+
     // Add C++ std lib
     #[cfg(target_os = "linux")]
     {
@@ -172,6 +176,7 @@ fn main() {
         // Clean
         if !Command::new("make")
             .arg("clean-all")
+            .env("PATH", original_path)
             .env("MEDIASOUP_OUT_DIR", &mediasoup_out_dir)
             .spawn()
             .expect("Failed to start")

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -79,7 +79,7 @@ fn main() {
     {
         if !std::path::Path::new("worker/out/msys/bin/make.exe").exists() {
             let python = if env::var("PYTHON").is_ok() {
-                env::var("PYTHON").unwrap().to_string()
+                env::var("PYTHON").unwrap()
             } else if Command::new("where")
                 .arg("python3")
                 .status()
@@ -92,10 +92,10 @@ fn main() {
             };
 
             let worker_abs_path = env::current_dir().unwrap();
-            let dir = format!("{}\\out\\msys", worker_abs_path.display());
+            let dir = Path::new(&worker_abs_path).join("out/msys");
 
             if !Command::new(python)
-                .arg("scripts\\getmake.py --dir {}", dir)
+                .arg("scripts\\getmake.py --dir {}", dir.display())
                 .status()
                 .expect("Failed to start")
                 .success()

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -1,4 +1,5 @@
 use std::env;
+use std::path::Path;
 use std::process::Command;
 
 fn main() {
@@ -95,7 +96,9 @@ fn main() {
             let dir = Path::new(&worker_abs_path).join("out/msys");
 
             if !Command::new(python)
-                .arg("scripts\\getmake.py --dir {}", dir.display())
+                .arg("scripts\\getmake.py")
+                .arg("--dir")
+                .arg(dir)
                 .status()
                 .expect("Failed to start")
                 .success()

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -96,7 +96,7 @@ fn main() {
             if !Command::new(python)
                 .arg("scripts\\getmake.py")
                 .arg("--dir")
-                .arg(dir)
+                .arg(dir.clone())
                 .status()
                 .expect("Failed to start")
                 .success()

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -78,19 +78,24 @@ fn main() {
     #[cfg(target_os = "windows")]
     {
         if !std::path::Path::new("worker/out/msys/bin/make.exe").exists() {
-            let python = if Command::new("where")
-                .arg("python3.exe")
+            let python = if env::var("PYTHON").is_ok() {
+                env::var("PYTHON").unwrap().to_string()
+            } else if Command::new("where")
+                .arg("python3")
                 .status()
                 .expect("Failed to start")
                 .success()
             {
-                "python3"
+                "python3".to_string()
             } else {
-                "python"
+                "python".to_string()
             };
 
+            let worker_abs_path = env::current_dir().unwrap();
+            let dir = format!("{}\\out\\msys", worker_abs_path.display());
+
             if !Command::new(python)
-                .arg("scripts\\getmake.py")
+                .arg("scripts\\getmake.py --dir {}", dir)
                 .status()
                 .expect("Failed to start")
                 .success()

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -80,8 +80,8 @@ fn main() {
     #[cfg(target_os = "windows")]
     {
         if !std::path::Path::new("worker/out/msys/bin/make.exe").exists() {
-            let python = if env::var("PYTHON").is_ok() {
-                env::var("PYTHON").unwrap()
+            let python = if let Ok(python) = env::var("PYTHON") {
+                python
             } else if Command::new("where")
                 .arg("python3")
                 .status()

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -97,7 +97,7 @@ fn main() {
                 "python".to_string()
             };
 
-            let dir = format!("{}/msys", mediasoup_out_dir.replace("\\", "/"));
+            let dir = format!("{}/msys", mediasoup_out_dir.replace('\\', "/"));
 
             if !Command::new(python)
                 .arg("scripts\\getmake.py")

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -97,7 +97,7 @@ fn main() {
                 "python".to_string()
             };
 
-            let dir = format!("{}/msys", mediasoup_out_dir.replace('\\', "/"));
+            let dir = format!("{}/msys", mediasoup_out_dir.replace("\\", "/"));
 
             if !Command::new(python)
                 .arg("scripts\\getmake.py")

--- a/worker/scripts/getmake.py
+++ b/worker/scripts/getmake.py
@@ -1,10 +1,21 @@
-import io, hashlib, tarfile, urllib.request
+import argparse, io, hashlib, tarfile, urllib.request
+
+argParser = argparse.ArgumentParser()
+
+argParser.add_argument(
+  '--dir',
+  type=str,
+  required=True,
+  help='absolute path of the directoy in which fetched content will be placed'
+)
+
+args = argParser.parse_args()
 
 def get(url, digest):
   data = urllib.request.urlopen(url).read()
   assert hashlib.sha256(data).hexdigest() == digest
   tar = tarfile.open(fileobj=io.BytesIO(data))
-  tar.extractall('worker/out/msys')
+  tar.extractall(args.dir)
   tar.close()
 
 get('https://sourceforge.net/projects/mingw/files/MSYS/Base/msys-core/msys-1.0.19-1/msysCORE-1.0.19-1-msys-1.0.19-bin.tar.xz/download', '8c4157d739a460f85563bc4451e9f1bbd42b13c4f63770d43b9f45a781f07858')


### PR DESCRIPTION
Fixes #1179

Provide `getmake.py` with the absolute path in which it must place fetched stuff.