### PR TITLE
C++: Fix DataProducer::Send invalid memory access

### DIFF
--- a/node/src/tests/test-DirectTransport.ts
+++ b/node/src/tests/test-DirectTransport.ts
@@ -211,7 +211,7 @@ test('dataProducer.send() succeeds', async () =>
 				expect(ppid).toBe(53); // PPID of WebRTC DataChannel binary.
 			}
 
-			expect(id).toBe(++lastRecvMessageId);
+			++lastRecvMessageId;
 		});
 	});
 

--- a/rust/tests/integration/direct_transport.rs
+++ b/rust/tests/integration/direct_transport.rs
@@ -157,7 +157,6 @@ fn get_stats_succeeds() {
 }
 
 #[test]
-#[ignore]
 fn send_succeeds() {
     future::block_on(async move {
         let (_worker, _router, transport) = init().await;
@@ -226,7 +225,6 @@ fn send_succeeds() {
                 }
 
                 last_recv_message_id.fetch_add(1, Ordering::SeqCst);
-                assert_eq!(id, last_recv_message_id.load(Ordering::SeqCst));
 
                 if id == num_messages {
                     let _ = received_messages_tx.lock().take().unwrap().send(());

--- a/worker/src/RTC/DataProducer.cpp
+++ b/worker/src/RTC/DataProducer.cpp
@@ -224,11 +224,14 @@ namespace RTC
 
 				std::vector<uint16_t> subchannels;
 
-				subchannels.reserve(body->subchannels()->size());
-
-				for (const auto subchannel : *body->subchannels())
+				if (flatbuffers::IsFieldPresent(body, FBS::DataProducer::SendNotification::VT_SUBCHANNELS))
 				{
-					subchannels.emplace_back(subchannel);
+					subchannels.reserve(body->subchannels()->size());
+
+					for (const auto subchannel : *body->subchannels())
+					{
+						subchannels.emplace_back(subchannel);
+					}
 				}
 
 				std::optional<uint16_t> requiredSubchannel{ std::nullopt };


### PR DESCRIPTION
'subchannels' are optional and hence they need to be checked before accessing them.

Remove test expectation that assumed we were receiving all messages in incremental mode. TS tests failure was being masked by [1], I don't know why Rust wasn't failing but definitely consumers are not receiving everything sent by the producer since in the tests both are paused at some time.

[1]: https://github.com/versatica/mediasoup/issues/1188