### PR TITLE
[flatbuffers] Improve Node imports

### DIFF
--- a/node/src/Channel.ts
+++ b/node/src/Channel.ts
@@ -1,5 +1,5 @@
-import * as os from 'os';
-import { Duplex } from 'stream';
+import * as os from 'node:os';
+import { Duplex } from 'node:stream';
 import * as flatbuffers from 'flatbuffers';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
@@ -10,7 +10,8 @@ import { Message, Type as MessageType, Body as MessageBody } from './fbs/message
 import { Notification, Body as NotificationBody, Event } from './fbs/notification';
 import { Log } from './fbs/log';
 
-const littleEndian = os.endianness() == 'LE';
+const IS_LITTLE_ENDIAN = os.endianness() === 'LE';
+
 const logger = new Logger('Channel');
 
 type Sent =
@@ -110,7 +111,7 @@ export class Channel extends EnhancedEventEmitter
 				const dataView = new DataView(
 					this.#recvBuffer.buffer,
 					this.#recvBuffer.byteOffset + msgStart);
-				const msgLen = dataView.getUint32(0, littleEndian);
+				const msgLen = dataView.getUint32(0, IS_LITTLE_ENDIAN);
 
 				if (readLen < 4 + msgLen)
 				{

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -4,12 +4,12 @@ import { Channel } from './Channel';
 import { TransportInternal } from './Transport';
 import { parseSctpStreamParameters, SctpStreamParameters } from './SctpParameters';
 import { AppData } from './types';
+import * as utils from './utils';
 import { Event, Notification } from './fbs/notification';
 import * as FbsTransport from './fbs/transport';
 import * as FbsRequest from './fbs/request';
 import * as FbsDataConsumer from './fbs/data-consumer';
 import * as FbsDataProducer from './fbs/data-producer';
-import * as utils from './utils';
 
 export type DataConsumerOptions<DataConsumerAppData extends AppData = AppData> =
 {

--- a/node/src/EnhancedEventEmitter.ts
+++ b/node/src/EnhancedEventEmitter.ts
@@ -1,4 +1,4 @@
-import { EventEmitter } from 'events';
+import { EventEmitter } from 'node:events';
 import { Logger } from './Logger';
 
 const logger = new Logger('EnhancedEventEmitter');

--- a/node/src/PipeTransport.ts
+++ b/node/src/PipeTransport.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
 import * as flatbuffers from 'flatbuffers';
 import { Logger } from './Logger';
 import * as ortc from './ortc';
@@ -29,6 +28,7 @@ import {
 	SrtpParameters
 } from './SrtpParameters';
 import { AppData, Either } from './types';
+import { generateUUIDv4 } from './utils';
 import { MediaKind as FbsMediaKind } from './fbs/rtp-parameters/media-kind';
 import * as FbsRtpParameters from './fbs/rtp-parameters';
 import { Event, Notification } from './fbs/notification';
@@ -368,7 +368,7 @@ export class PipeTransport<PipeTransportAppData extends AppData = AppData>
 			}
 		);
 
-		const consumerId = uuidv4();
+		const consumerId = generateUUIDv4();
 
 		const consumeRequestOffset = createConsumeRequest({
 			builder : this.channel.bufferBuilder,

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -1,4 +1,3 @@
-import { v4 as uuidv4 } from 'uuid';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import * as ortc from './ortc';
@@ -22,9 +21,10 @@ import { RtpObserver } from './RtpObserver';
 import { ActiveSpeakerObserver, ActiveSpeakerObserverOptions } from './ActiveSpeakerObserver';
 import { AudioLevelObserver, AudioLevelObserverOptions } from './AudioLevelObserver';
 import { RtpCapabilities, RtpCodecCapability } from './RtpParameters';
+import { cryptoSuiteToFbs } from './SrtpParameters';
 import { NumSctpStreams } from './SctpParameters';
 import { AppData, Either } from './types';
-import { cryptoSuiteToFbs } from './SrtpParameters';
+import { generateUUIDv4 } from './utils';
 import * as FbsActiveSpeakerObserver from './fbs/active-speaker-observer';
 import * as FbsAudioLevelObserver from './fbs/audio-level-observer';
 import * as FbsRequest from './fbs/request';
@@ -507,7 +507,7 @@ export class Router<RouterAppData extends AppData = AppData>
 			}
 		}
 
-		const transportId = uuidv4();
+		const transportId = generateUUIDv4();
 
 		/* Build Request. */
 		let webRtcTransportListenServer:
@@ -689,7 +689,7 @@ export class Router<RouterAppData extends AppData = AppData>
 			};
 		}
 
-		const transportId = uuidv4();
+		const transportId = generateUUIDv4();
 
 		/* Build Request. */
 		const baseTransportOptions = new FbsTransport.OptionsT(
@@ -837,7 +837,7 @@ export class Router<RouterAppData extends AppData = AppData>
 			};
 		}
 
-		const transportId = uuidv4();
+		const transportId = generateUUIDv4();
 
 		/* Build Request. */
 		const baseTransportOptions = new FbsTransport.OptionsT(
@@ -946,7 +946,7 @@ export class Router<RouterAppData extends AppData = AppData>
 			throw new TypeError('if given, appData must be an object');
 		}
 
-		const transportId = uuidv4();
+		const transportId = generateUUIDv4();
 
 		/* Build Request. */
 		const baseTransportOptions = new FbsTransport.OptionsT(
@@ -1404,7 +1404,7 @@ export class Router<RouterAppData extends AppData = AppData>
 			throw new TypeError('if given, appData must be an object');
 		}
 
-		const rtpObserverId = uuidv4();
+		const rtpObserverId = generateUUIDv4();
 
 		/* Build Request. */
 		const activeRtpObserverOptions =
@@ -1482,7 +1482,7 @@ export class Router<RouterAppData extends AppData = AppData>
 			throw new TypeError('if given, appData must be an object');
 		}
 
-		const rtpObserverId = uuidv4();
+		const rtpObserverId = generateUUIDv4();
 
 		/* Build Request. */
 		const audioLevelObserverOptions =

--- a/node/src/RtpStream.ts
+++ b/node/src/RtpStream.ts
@@ -1,7 +1,8 @@
 import * as FbsRtpStream from './fbs/rtp-stream';
 import * as FbsRtpParameters from './fbs/rtp-parameters';
 
-export type RtpStreamRecvStats = BaseRtpStreamStats & {
+export type RtpStreamRecvStats = BaseRtpStreamStats &
+{
 	type: string;
 	jitter: number;
 	packetCount: number;
@@ -10,14 +11,16 @@ export type RtpStreamRecvStats = BaseRtpStreamStats & {
 	bitrateByLayer?: any;
 };
 
-export type RtpStreamSendStats = BaseRtpStreamStats & {
+export type RtpStreamSendStats = BaseRtpStreamStats &
+{
 	type: string;
 	packetCount: number;
 	byteCount: number;
 	bitrate: number;
 };
 
-type BaseRtpStreamStats = {
+type BaseRtpStreamStats =
+{
 	timestamp: number;
 	ssrc: number;
 	rtxSsrc?: number;
@@ -128,7 +131,7 @@ function parseBitrateByLayer(binary: FbsRtpStream.RecvStats): any
 
 	const bitRateByLayer: {[key: string]: number} = {};
 
-	for (let i=0; i < binary.bitrateByLayerLength(); ++i)
+	for (let i = 0; i < binary.bitrateByLayerLength(); ++i)
 	{
 		const layer: string = binary.bitrateByLayer(i)!.layer()!;
 		const bitrate = binary.bitrateByLayer(i)!.bitrate();

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -1,8 +1,6 @@
-import { v4 as uuidv4 } from 'uuid';
 import * as flatbuffers from 'flatbuffers';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
-import * as utils from './utils';
 import * as ortc from './ortc';
 import { Channel } from './Channel';
 import { RouterInternal } from './Router';
@@ -40,6 +38,7 @@ import {
 	SctpStreamParameters
 } from './SctpParameters';
 import { AppData } from './types';
+import * as utils from './utils';
 import { TraceDirection as FbsTraceDirection } from './fbs/common';
 import * as FbsRequest from './fbs/request';
 import { MediaKind as FbsMediaKind } from './fbs/rtp-parameters/media-kind';
@@ -251,7 +250,8 @@ type SctpListenerDump =
 	streamIdTable : {key: number; value: string}[];
 };
 
-type RecvRtpHeaderExtensions = {
+type RecvRtpHeaderExtensions =
+{
   mid?: number;
   rid?: number;
   rrid?: number;
@@ -736,11 +736,11 @@ export class Transport
 			{
 				this.#cnameForProducers = rtpParameters.rtcp.cname;
 			}
-			// Otherwise if we don't have yet a CNAME for Producers and the RTP parameters
-			// do not include CNAME, create a random one.
+			// Otherwise if we don't have yet a CNAME for Producers and the RTP
+			// parameters do not include CNAME, create a random one.
 			else if (!this.#cnameForProducers)
 			{
-				this.#cnameForProducers = uuidv4().substr(0, 8);
+				this.#cnameForProducers = utils.generateUUIDv4().substr(0, 8);
 			}
 
 			// Override Producer's CNAME.
@@ -758,7 +758,7 @@ export class Transport
 		const consumableRtpParameters = ortc.getConsumableRtpParameters(
 			kind, rtpParameters, routerRtpCapabilities, rtpMapping);
 
-		const producerId = id || uuidv4();
+		const producerId = id || utils.generateUUIDv4();
 		const requestOffset = createProduceRequest({
 			builder : this.channel.bufferBuilder,
 			producerId,
@@ -901,7 +901,7 @@ export class Transport
 			}
 		}
 
-		const consumerId = uuidv4();
+		const consumerId = utils.generateUUIDv4();
 		const requestOffset = createConsumeRequest({
 			builder : this.channel.bufferBuilder,
 			producer,
@@ -1015,7 +1015,7 @@ export class Transport
 			}
 		}
 
-		const dataProducerId = id || uuidv4();
+		const dataProducerId = id || utils.generateUUIDv4();
 		const requestOffset = createProduceDataRequest({
 			builder : this.channel.bufferBuilder,
 			dataProducerId,
@@ -1158,7 +1158,7 @@ export class Transport
 		}
 
 		const { label, protocol } = dataProducer;
-		const dataConsumerId = uuidv4();
+		const dataConsumerId = utils.generateUUIDv4();
 
 		const requestOffset = createConsumeDataRequest({
 			builder : this.channel.bufferBuilder,

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -1,7 +1,6 @@
-import * as process from 'process';
-import * as path from 'path';
-import { spawn, ChildProcess } from 'child_process';
-import { v4 as uuidv4 } from 'uuid';
+import * as process from 'node:process';
+import * as path from 'node:path';
+import { spawn, ChildProcess } from 'node:child_process';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import * as ortc from './ortc';
@@ -9,6 +8,7 @@ import { Channel } from './Channel';
 import { Router, RouterOptions } from './Router';
 import { WebRtcServer, WebRtcServerOptions } from './WebRtcServer';
 import { AppData } from './types';
+import { generateUUIDv4 } from './utils';
 import { Event } from './fbs/notification';
 import * as FbsRequest from './fbs/request';
 import * as FbsWorker from './fbs/worker';
@@ -695,7 +695,7 @@ export class Worker<WorkerAppData extends AppData = AppData>
 			);
 		}
 
-		const webRtcServerId = uuidv4();
+		const webRtcServerId = generateUUIDv4();
 
 		const createWebRtcServerRequestOffset = new FbsWorker.CreateWebRtcServerRequestT(
 			webRtcServerId, fbsListenInfos
@@ -742,7 +742,7 @@ export class Worker<WorkerAppData extends AppData = AppData>
 		// This may throw.
 		const rtpCapabilities = ortc.generateRouterRtpCapabilities(mediaCodecs);
 
-		const routerId = uuidv4();
+		const routerId = generateUUIDv4();
 
 		// Get flatbuffer builder.
 		const createRouterRequestOffset =

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -5,7 +5,6 @@ import * as utils from './utils';
 import { supportedRtpCapabilities } from './supportedRtpCapabilities';
 import { RtpCapabilities } from './RtpParameters';
 import * as types from './types';
-import { AppData } from './types';
 
 /**
  * Expose all types.
@@ -44,7 +43,7 @@ export { workerBin };
 /**
  * Create a Worker.
  */
-export async function createWorker<WorkerAppData extends AppData = AppData>(
+export async function createWorker<WorkerAppData extends types.AppData = types.AppData>(
 	{
 		logLevel = 'error',
 		logTags,

--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -1,7 +1,5 @@
 import * as h264 from 'h264-profile-level-id';
 import * as flatbuffers from 'flatbuffers';
-import * as utils from './utils';
-import { UnsupportedError } from './errors';
 import { supportedRtpCapabilities } from './supportedRtpCapabilities';
 import { parse as parseScalabilityMode } from './scalabilityModes';
 import {
@@ -22,6 +20,8 @@ import {
 	SctpParameters,
 	SctpStreamParameters
 } from './SctpParameters';
+import * as utils from './utils';
+import { UnsupportedError } from './errors';
 import * as FbsRtpParameters from './fbs/rtp-parameters';
 
 export type RtpMapping =

--- a/node/src/tests/test-ActiveSpeakerObserver.ts
+++ b/node/src/tests/test-ActiveSpeakerObserver.ts
@@ -1,7 +1,5 @@
 import * as mediasoup from '../';
 
-const { createWorker } = mediasoup;
-
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;
 let activeSpeakerObserver: mediasoup.types.ActiveSpeakerObserver;
@@ -23,7 +21,7 @@ const mediaCodecs: mediasoup.types.RtpCodecCapability[] =
 
 beforeAll(async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	router = await worker.createRouter({ mediaCodecs });
 });
 

--- a/node/src/tests/test-AudioLevelObserver.ts
+++ b/node/src/tests/test-AudioLevelObserver.ts
@@ -1,7 +1,5 @@
 import * as mediasoup from '../';
 
-const { createWorker } = mediasoup;
-
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;
 let audioLevelObserver: mediasoup.types.AudioLevelObserver;
@@ -23,7 +21,7 @@ const mediaCodecs: mediasoup.types.RtpCodecCapability[] =
 
 beforeAll(async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	router = await worker.createRouter({ mediaCodecs });
 });
 

--- a/node/src/tests/test-Consumer.ts
+++ b/node/src/tests/test-Consumer.ts
@@ -4,8 +4,6 @@ import { UnsupportedError } from '../errors';
 import { Notification, Body as NotificationBody, Event } from '../fbs/notification';
 import * as FbsConsumer from '../fbs/consumer';
 
-const { createWorker } = mediasoup;
-
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;
 let transport1: mediasoup.types.WebRtcTransport;
@@ -247,7 +245,7 @@ const consumerDeviceCapabilities: mediasoup.types.RtpCapabilities =
 
 beforeAll(async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	router = await worker.createRouter({ mediaCodecs });
 	transport1 = await router.createWebRtcTransport(
 		{

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -1,7 +1,5 @@
 import * as mediasoup from '../';
 
-const { createWorker } = mediasoup;
-
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;
 let transport1: mediasoup.types.WebRtcTransport;
@@ -25,7 +23,7 @@ const dataProducerParameters: mediasoup.types.DataProducerOptions =
 
 beforeAll(async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	router = await worker.createRouter();
 	transport1 = await router.createWebRtcTransport(
 		{

--- a/node/src/tests/test-DataProducer.ts
+++ b/node/src/tests/test-DataProducer.ts
@@ -1,7 +1,5 @@
 import * as mediasoup from '../';
 
-const { createWorker } = mediasoup;
-
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;
 let transport1: mediasoup.types.WebRtcTransport;
@@ -11,7 +9,7 @@ let dataProducer2: mediasoup.types.DataProducer;
 
 beforeAll(async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	router = await worker.createRouter();
 	transport1 = await router.createWebRtcTransport(
 		{

--- a/node/src/tests/test-DirectTransport.ts
+++ b/node/src/tests/test-DirectTransport.ts
@@ -1,14 +1,12 @@
 import * as mediasoup from '../';
 
-const { createWorker } = mediasoup;
-
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;
 let transport: mediasoup.types.DirectTransport;
 
 beforeAll(async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	router = await worker.createRouter();
 });
 

--- a/node/src/tests/test-PipeTransport.ts
+++ b/node/src/tests/test-PipeTransport.ts
@@ -2,8 +2,6 @@
 import * as pickPort from 'pick-port';
 import * as mediasoup from '../';
 
-const { createWorker } = mediasoup;
-
 let worker1: mediasoup.types.Worker;
 let worker2: mediasoup.types.Worker;
 let router1: mediasoup.types.Router;
@@ -190,8 +188,8 @@ const consumerDeviceCapabilities: mediasoup.types.RtpCapabilities =
 
 beforeAll(async () =>
 {
-	worker1 = await createWorker();
-	worker2 = await createWorker();
+	worker1 = await mediasoup.createWorker();
+	worker2 = await mediasoup.createWorker();
 	router1 = await worker1.createRouter({ mediaCodecs });
 	router2 = await worker2.createRouter({ mediaCodecs });
 	transport1 = await router1.createWebRtcTransport(

--- a/node/src/tests/test-PlainTransport.ts
+++ b/node/src/tests/test-PlainTransport.ts
@@ -2,8 +2,6 @@
 import * as pickPort from 'pick-port';
 import * as mediasoup from '../';
 
-const { createWorker } = mediasoup;
-
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;
 let transport: mediasoup.types.PlainTransport;
@@ -43,7 +41,7 @@ const mediaCodecs: mediasoup.types.RtpCodecCapability[] =
 
 beforeAll(async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	router = await worker.createRouter({ mediaCodecs });
 });
 

--- a/node/src/tests/test-Producer.ts
+++ b/node/src/tests/test-Producer.ts
@@ -4,8 +4,6 @@ import { UnsupportedError } from '../errors';
 import { Notification, Body as NotificationBody, Event } from '../fbs/notification';
 import * as FbsProducer from '../fbs/producer';
 
-const { createWorker } = mediasoup;
-
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;
 let transport1: mediasoup.types.WebRtcTransport;
@@ -47,7 +45,7 @@ const mediaCodecs: mediasoup.types.RtpCodecCapability[] =
 
 beforeAll(async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	router = await worker.createRouter({ mediaCodecs });
 	transport1 = await router.createWebRtcTransport(
 		{

--- a/node/src/tests/test-Router.ts
+++ b/node/src/tests/test-Router.ts
@@ -1,8 +1,6 @@
 import * as mediasoup from '../';
 import { InvalidStateError } from '../errors';
 
-const { createWorker } = mediasoup;
-
 let worker: mediasoup.types.Worker;
 
 beforeEach(() => worker && !worker.closed && worker.close());
@@ -42,7 +40,7 @@ const mediaCodecs: mediasoup.types.RtpCodecCapability[] =
 
 test('worker.createRouter() succeeds', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	const onObserverNewRouter = jest.fn();
 
@@ -106,7 +104,7 @@ test('worker.createRouter() succeeds', async () =>
 
 test('worker.createRouter() with wrong arguments rejects with TypeError', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	// @ts-ignore
 	await expect(worker.createRouter({ mediaCodecs: {} }))
@@ -123,7 +121,7 @@ test('worker.createRouter() with wrong arguments rejects with TypeError', async 
 
 test('worker.createRouter() rejects with InvalidStateError if Worker is closed', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	worker.close();
 
@@ -134,7 +132,7 @@ test('worker.createRouter() rejects with InvalidStateError if Worker is closed',
 
 test('router.close() succeeds', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	const router = await worker.createRouter({ mediaCodecs });
 	const onObserverClose = jest.fn();
@@ -148,7 +146,7 @@ test('router.close() succeeds', async () =>
 
 test('Router emits "workerclose" if Worker is closed', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	const router = await worker.createRouter({ mediaCodecs });
 	const onObserverClose = jest.fn();

--- a/node/src/tests/test-WebRtcServer.ts
+++ b/node/src/tests/test-WebRtcServer.ts
@@ -3,8 +3,6 @@ import * as pickPort from 'pick-port';
 import * as mediasoup from '../';
 import { InvalidStateError } from '../errors';
 
-const { createWorker } = mediasoup;
-
 let worker: mediasoup.types.Worker;
 
 beforeEach(() => worker && !worker.closed && worker.close());
@@ -12,7 +10,7 @@ afterEach(() => worker && !worker.closed && worker.close());
 
 test('worker.createWebRtcServer() succeeds', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	const onObserverNewWebRtcServer = jest.fn();
 
@@ -91,7 +89,7 @@ test('worker.createWebRtcServer() succeeds', async () =>
 
 test('worker.createWebRtcServer() without specifying port succeeds', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	const onObserverNewWebRtcServer = jest.fn();
 
@@ -165,7 +163,7 @@ test('worker.createWebRtcServer() without specifying port succeeds', async () =>
 
 test('worker.createWebRtcServer() with wrong arguments rejects with TypeError', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	// @ts-ignore
 	await expect(worker.createWebRtcServer({}))
@@ -192,8 +190,8 @@ test('worker.createWebRtcServer() with wrong arguments rejects with TypeError', 
 
 test('worker.createWebRtcServer() with unavailable listenInfos rejects with Error', async () =>
 {
-	const worker1 = await createWorker();
-	const worker2 = await createWorker();
+	const worker1 = await mediasoup.createWorker();
+	const worker2 = await mediasoup.createWorker();
 	const port1 = await pickPort({ ip: '127.0.0.1', reserveTimeout: 0 });
 	const port2 = await pickPort({ ip: '127.0.0.1', reserveTimeout: 0 });
 
@@ -271,7 +269,7 @@ test('worker.createWebRtcServer() with unavailable listenInfos rejects with Erro
 
 test('worker.createWebRtcServer() rejects with InvalidStateError if Worker is closed', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	worker.close();
 
@@ -287,7 +285,7 @@ test('worker.createWebRtcServer() rejects with InvalidStateError if Worker is cl
 
 test('webRtcServer.close() succeeds', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	const port = await pickPort({ ip: '127.0.0.1', reserveTimeout: 0 });
 	const webRtcServer = await worker.createWebRtcServer(
@@ -305,7 +303,7 @@ test('webRtcServer.close() succeeds', async () =>
 
 test('WebRtcServer emits "workerclose" if Worker is closed', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	const port = await pickPort({ ip: '127.0.0.1', reserveTimeout: 0 });
 	const webRtcServer = await worker.createWebRtcServer(
@@ -328,7 +326,7 @@ test('WebRtcServer emits "workerclose" if Worker is closed', async () =>
 
 test('router.createWebRtcTransport() with webRtcServer succeeds and transport is closed', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	const port1 = await pickPort({ ip: '127.0.0.1', reserveTimeout: 0 });
 	const port2 = await pickPort({ type: 'tcp', ip: '127.0.0.1', reserveTimeout: 0 });
@@ -438,7 +436,7 @@ test('router.createWebRtcTransport() with webRtcServer succeeds and transport is
 
 test('router.createWebRtcTransport() with webRtcServer succeeds and webRtcServer is closed', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	const port1 = await pickPort({ ip: '127.0.0.1', reserveTimeout: 0 });
 	const port2 = await pickPort({ type: 'tcp', ip: '127.0.0.1', reserveTimeout: 0 });

--- a/node/src/tests/test-WebRtcTransport.ts
+++ b/node/src/tests/test-WebRtcTransport.ts
@@ -7,8 +7,6 @@ import * as FbsTransport from '../fbs/transport';
 import * as FbsWebRtcTransport from '../fbs/web-rtc-transport';
 import { serializeProtocol, TransportTuple } from '../Transport';
 
-const { createWorker } = mediasoup;
-
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;
 let transport: mediasoup.types.WebRtcTransport;
@@ -47,7 +45,7 @@ const mediaCodecs: mediasoup.types.RtpCodecCapability[] =
 
 beforeAll(async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	router = await worker.createRouter({ mediaCodecs });
 });
 

--- a/node/src/tests/test-Worker.ts
+++ b/node/src/tests/test-Worker.ts
@@ -1,10 +1,8 @@
-import * as os from 'os';
-import * as process from 'process';
-import * as path from 'path';
+import * as os from 'node:os';
+import * as process from 'node:process';
+import * as path from 'node:path';
 import * as mediasoup from '../';
 import { InvalidStateError } from '../errors';
-
-const { createWorker, observer } = mediasoup;
 
 let worker: mediasoup.types.Worker;
 
@@ -26,9 +24,9 @@ test('createWorker() succeeds', async () =>
 {
 	const onObserverNewWorker = jest.fn();
 
-	observer.once('newworker', onObserverNewWorker);
+	mediasoup.observer.once('newworker', onObserverNewWorker);
 
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	expect(onObserverNewWorker).toHaveBeenCalledTimes(1);
 	expect(onObserverNewWorker).toHaveBeenCalledWith(worker);
@@ -43,7 +41,7 @@ test('createWorker() succeeds', async () =>
 	expect(worker.died).toBe(false);
 
 	// eslint-disable-next-line require-atomic-updates
-	worker = await createWorker<{ foo: number; bar?: string }>(
+	worker = await mediasoup.createWorker<{ foo: number; bar?: string }>(
 		{
 			logLevel             : 'debug',
 			logTags              : [ 'info' ],
@@ -69,36 +67,36 @@ test('createWorker() succeeds', async () =>
 test('createWorker() with wrong settings rejects with TypeError', async () =>
 {
 	// @ts-ignore
-	await expect(createWorker({ logLevel: 'chicken' }))
+	await expect(mediasoup.createWorker({ logLevel: 'chicken' }))
 		.rejects
 		.toThrow(TypeError);
 
-	await expect(createWorker({ rtcMinPort: 1000, rtcMaxPort: 999 }))
+	await expect(mediasoup.createWorker({ rtcMinPort: 1000, rtcMaxPort: 999 }))
 		.rejects
 		.toThrow(TypeError);
 
 	// Port is from 0 to 65535.
-	await expect(createWorker({ rtcMinPort: 1000, rtcMaxPort: 65536 }))
+	await expect(mediasoup.createWorker({ rtcMinPort: 1000, rtcMaxPort: 65536 }))
 		.rejects
 		.toThrow(TypeError);
 
-	await expect(createWorker({ dtlsCertificateFile: '/notfound/cert.pem' }))
+	await expect(mediasoup.createWorker({ dtlsCertificateFile: '/notfound/cert.pem' }))
 		.rejects
 		.toThrow(TypeError);
 
-	await expect(createWorker({ dtlsPrivateKeyFile: '/notfound/priv.pem' }))
+	await expect(mediasoup.createWorker({ dtlsPrivateKeyFile: '/notfound/priv.pem' }))
 		.rejects
 		.toThrow(TypeError);
 
 	// @ts-ignore
-	await expect(createWorker({ appData: 'NOT-AN-OBJECT' }))
+	await expect(mediasoup.createWorker({ appData: 'NOT-AN-OBJECT' }))
 		.rejects
 		.toThrow(TypeError);
 }, 2000);
 
 test('worker.updateSettings() succeeds', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	await expect(worker.updateSettings({ logLevel: 'debug', logTags: [ 'ice' ] }))
 		.resolves
@@ -109,7 +107,7 @@ test('worker.updateSettings() succeeds', async () =>
 
 test('worker.updateSettings() with wrong settings rejects with TypeError', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	// @ts-ignore
 	await expect(worker.updateSettings({ logLevel: 'chicken' }))
@@ -121,7 +119,7 @@ test('worker.updateSettings() with wrong settings rejects with TypeError', async
 
 test('worker.updateSettings() rejects with InvalidStateError if closed', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	worker.close();
 
 	await expect(worker.updateSettings({ logLevel: 'error' }))
@@ -133,7 +131,7 @@ test('worker.updateSettings() rejects with InvalidStateError if closed', async (
 
 test('worker.dump() succeeds', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	await expect(worker.dump())
 		.resolves
@@ -154,7 +152,7 @@ test('worker.dump() succeeds', async () =>
 
 test('worker.dump() rejects with InvalidStateError if closed', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	worker.close();
 
 	await expect(worker.dump())
@@ -166,7 +164,7 @@ test('worker.dump() rejects with InvalidStateError if closed', async () =>
 
 test('worker.getResourceUsage() succeeds', async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 
 	await expect(worker.getResourceUsage())
 		.resolves
@@ -177,7 +175,7 @@ test('worker.getResourceUsage() succeeds', async () =>
 
 test('worker.close() succeeds', async () =>
 {
-	worker = await createWorker({ logLevel: 'warn' });
+	worker = await mediasoup.createWorker({ logLevel: 'warn' });
 
 	const onObserverClose = jest.fn();
 
@@ -194,7 +192,7 @@ test('Worker emits "died" if worker process died unexpectedly', async () =>
 	let onDied: ReturnType<typeof jest.fn>;
 	let onObserverClose: ReturnType<typeof jest.fn>;
 
-	worker = await createWorker({ logLevel: 'warn' });
+	worker = await mediasoup.createWorker({ logLevel: 'warn' });
 	onDied = jest.fn();
 	onObserverClose = jest.fn();
 
@@ -230,7 +228,7 @@ test('Worker emits "died" if worker process died unexpectedly', async () =>
 	expect(worker.died).toBe(true);
 
 	// eslint-disable-next-line require-atomic-updates
-	worker = await createWorker({ logLevel: 'warn' });
+	worker = await mediasoup.createWorker({ logLevel: 'warn' });
 	onDied = jest.fn();
 	onObserverClose = jest.fn();
 
@@ -266,7 +264,7 @@ test('Worker emits "died" if worker process died unexpectedly', async () =>
 	expect(worker.died).toBe(true);
 
 	// eslint-disable-next-line require-atomic-updates
-	worker = await createWorker({ logLevel: 'warn' });
+	worker = await mediasoup.createWorker({ logLevel: 'warn' });
 	onDied = jest.fn();
 	onObserverClose = jest.fn();
 
@@ -311,7 +309,7 @@ test('worker process ignores PIPE, HUP, ALRM, USR1 and USR2 signals', async () =
 		return;
 	}
 
-	worker = await createWorker({ logLevel: 'warn' });
+	worker = await mediasoup.createWorker({ logLevel: 'warn' });
 
 	await new Promise<void>((resolve, reject) =>
 	{

--- a/node/src/tests/test-multiopus.ts
+++ b/node/src/tests/test-multiopus.ts
@@ -1,8 +1,6 @@
 import * as mediasoup from '../';
 import { UnsupportedError } from '../errors';
 
-const { createWorker } = mediasoup;
-
 let worker: mediasoup.types.Worker;
 let router: mediasoup.types.Router;
 let transport: mediasoup.types.WebRtcTransport;
@@ -103,7 +101,7 @@ const consumerDeviceCapabilities: mediasoup.types.RtpCapabilities =
 
 beforeAll(async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	router = await worker.createRouter({ mediaCodecs });
 	transport = await router.createWebRtcTransport(
 		{

--- a/node/src/tests/test-node-sctp.ts
+++ b/node/src/tests/test-node-sctp.ts
@@ -1,9 +1,7 @@
-import * as dgram from 'dgram';
+import * as dgram from 'node:dgram';
 // @ts-ignore
 import * as sctp from 'sctp';
 import * as mediasoup from '../';
-
-const { createWorker } = mediasoup;
 
 // Set node-sctp default PMTU to 1200.
 sctp.defaults({ PMTU: 1200 });
@@ -20,7 +18,7 @@ let sctpSendStream: any;
 
 beforeAll(async () =>
 {
-	worker = await createWorker();
+	worker = await mediasoup.createWorker();
 	router = await worker.createRouter();
 	transport = await router.createPlainTransport(
 		{

--- a/node/src/utils.ts
+++ b/node/src/utils.ts
@@ -1,4 +1,4 @@
-import { randomInt } from 'crypto';
+import { randomUUID, randomInt } from 'node:crypto';
 import { ProducerType } from './Producer';
 import { Type as FbsRtpParametersType } from './fbs/rtp-parameters';
 
@@ -24,6 +24,14 @@ export function clone<T>(value: T): T
 	{
 		return JSON.parse(JSON.stringify(value));
 	}
+}
+
+/**
+ * Generates a random UUID v4.
+ */
+export function generateUUIDv4(): string
+{
+	return randomUUID();
 }
 
 /**

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -1,8 +1,8 @@
-import process from 'process';
-import os from 'os';
-import fs from 'fs';
-import path from 'path';
-import { execSync, spawnSync } from 'child_process';
+import process from 'node:process';
+import os from 'node:os';
+import fs from 'node:fs';
+import path from 'node:path';
+import { execSync, spawnSync } from 'node:child_process';
 import fetch from 'node-fetch';
 import tar from 'tar';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,15 +15,13 @@
         "h264-profile-level-id": "^1.0.1",
         "node-fetch": "^3.3.2",
         "supports-color": "^9.4.0",
-        "tar": "^6.2.0",
-        "uuid": "^9.0.1"
+        "tar": "^6.2.0"
       },
       "devDependencies": {
         "@octokit/rest": "^20.0.2",
         "@types/debug": "^4.1.10",
         "@types/jest": "^29.5.6",
         "@types/node": "^20.8.8",
-        "@types/uuid": "^9.0.6",
         "@typescript-eslint/eslint-plugin": "^6.9.0",
         "@typescript-eslint/parser": "^6.9.0",
         "eslint": "^8.52.0",
@@ -1645,12 +1643,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
-      "integrity": "sha512-BT2Krtx4xaO6iwzwMFUYvWBWkV2pr37zD68Vmp1CDV196MzczBRxuEpD6Pr395HAgebC/co7hOphs53r8V7jew==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -6555,18 +6547,6 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/v8-to-istanbul/-/v8-to-istanbul-9.1.0.tgz",
@@ -8050,12 +8030,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
       "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
-      "dev": true
-    },
-    "@types/uuid": {
-      "version": "9.0.6",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.6.tgz",
-      "integrity": "sha512-BT2Krtx4xaO6iwzwMFUYvWBWkV2pr37zD68Vmp1CDV196MzczBRxuEpD6Pr395HAgebC/co7hOphs53r8V7jew==",
       "dev": true
     },
     "@types/yargs": {
@@ -11445,11 +11419,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -100,15 +100,13 @@
     "h264-profile-level-id": "^1.0.1",
     "node-fetch": "^3.3.2",
     "supports-color": "^9.4.0",
-    "tar": "^6.2.0",
-    "uuid": "^9.0.1"
+    "tar": "^6.2.0"
   },
   "devDependencies": {
     "@octokit/rest": "^20.0.2",
     "@types/debug": "^4.1.10",
     "@types/jest": "^29.5.6",
     "@types/node": "^20.8.8",
-    "@types/uuid": "^9.0.6",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",
     "eslint": "^8.52.0",

--- a/worker/scripts/package-lock.json
+++ b/worker/scripts/package-lock.json
@@ -11,6 +11,9 @@
         "clang-tools-prebuilt": "^0.1.4",
         "gulp": "^4.0.2",
         "gulp-clang-format": "^1.0.27"
+      },
+      "peerDependencies": {
+        "uuid": "^3.3.2"
       }
     },
     "node_modules/ajv": {
@@ -5123,7 +5126,6 @@
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
       "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
       "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "dev": true,
       "bin": {
         "uuid": "bin/uuid"
       }
@@ -9644,8 +9646,7 @@
     "uuid": {
       "version": "3.4.0",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
     },
     "v8flags": {
       "version": "3.2.0",

--- a/worker/scripts/package.json
+++ b/worker/scripts/package.json
@@ -6,5 +6,8 @@
     "clang-tools-prebuilt": "^0.1.4",
     "gulp": "^4.0.2",
     "gulp-clang-format": "^1.0.27"
+  },
+  "peerDependencies": {
+    "uuid": "^3.3.2"
   }
 }


### PR DESCRIPTION
- Add `node:` prefix to all built-in Node imports (replaces PR #1142).
- Replace `uuid` package with built-in `crypto.randomUUID()`(replaces PR #1140).
- Cosmetic changes in TS files:
  - Avoid unnecessary `const { createWorker } = mediasoup` in almost all tests.
  - Move all FBS related imports to the bottom.
  - Some formating fixes that bypassed our ESLint rules.