### PR TITLE
Rust: FBS do not use heap to process responses

### DIFF
--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -19,6 +19,7 @@ use crate::ortc::RtpMapping;
 use crate::pipe_transport::PipeTransportOptions;
 use crate::plain_transport::PlainTransportOptions;
 use crate::producer::{ProducerId, ProducerTraceEventType, ProducerType};
+use crate::router::consumer::ConsumerDump;
 use crate::router::producer::ProducerDump;
 use crate::router::{RouterDump, RouterId};
 use crate::rtp_observer::RtpObserverId;
@@ -2388,7 +2389,7 @@ pub(crate) struct ConsumerDumpRequest {}
 impl Request for ConsumerDumpRequest {
     const METHOD: request::Method = request::Method::ConsumerDump;
     type HandlerId = ConsumerId;
-    type Response = response::Body;
+    type Response = ConsumerDump;
 
     fn into_bytes(self, id: u32, handler_id: Self::HandlerId) -> Vec<u8> {
         let mut builder = Builder::new();
@@ -2409,12 +2410,11 @@ impl Request for ConsumerDumpRequest {
     fn convert_response(
         response: Option<response::BodyRef<'_>>,
     ) -> Result<Self::Response, Box<dyn Error>> {
-        match response {
-            Some(data) => Ok(data.try_into().unwrap()),
-            _ => {
-                panic!("Wrong message from worker: {response:?}");
-            }
-        }
+        let Some(response::BodyRef::ConsumerDumpResponse(data)) = response else {
+            panic!("Wrong message from worker: {response:?}");
+        };
+
+        ConsumerDump::from_fbs_ref(data)
     }
 }
 

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -101,8 +101,9 @@ impl RtpMapping {
                         ssrc: mapping?.ssrc()?,
                         scalability_mode: mapping?
                             .scalability_mode()?
-                            .unwrap_or(String::from("S1T1").as_str())
-                            .parse()?,
+                            .map(|maybe_scalability_mode| maybe_scalability_mode.parse())
+                            .transpose()?
+                            .unwrap_or_default(),
                         mapped_ssrc: mapping?.mapped_ssrc()?,
                     })
                 })

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::convert::TryFrom;
+use std::error::Error;
 use std::mem;
 use std::num::{NonZeroU32, NonZeroU8};
 use std::ops::Deref;
@@ -77,32 +78,36 @@ impl RtpMapping {
         }
     }
 
-    pub(crate) fn from_fbs(mapping: rtp_parameters::RtpMapping) -> Self {
-        Self {
+    pub(crate) fn from_fbs_ref(
+        mapping: rtp_parameters::RtpMappingRef<'_>,
+    ) -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
             codecs: mapping
-                .codecs
+                .codecs()?
                 .iter()
-                .map(|mapping| RtpMappingCodec {
-                    payload_type: mapping.payload_type,
-                    mapped_payload_type: mapping.mapped_payload_type,
+                .map(|mapping| {
+                    Ok(RtpMappingCodec {
+                        payload_type: mapping?.payload_type()?,
+                        mapped_payload_type: mapping?.mapped_payload_type()?,
+                    })
                 })
-                .collect(),
+                .collect::<Result<Vec<_>, Box<dyn Error>>>()?,
             encodings: mapping
-                .encodings
+                .encodings()?
                 .iter()
-                .map(|mapping| RtpMappingEncoding {
-                    rid: mapping.rid.clone().map(|rid| rid.to_string()),
-                    ssrc: mapping.ssrc,
-                    scalability_mode: mapping
-                        .scalability_mode
-                        .clone()
-                        .unwrap_or(String::from("S1T1"))
-                        .parse()
-                        .unwrap(),
-                    mapped_ssrc: mapping.mapped_ssrc,
+                .map(|mapping| {
+                    Ok(RtpMappingEncoding {
+                        rid: mapping?.rid()?.map(|rid| rid.to_string()),
+                        ssrc: mapping?.ssrc()?,
+                        scalability_mode: mapping?
+                            .scalability_mode()?
+                            .unwrap_or(String::from("S1T1").as_str())
+                            .parse()?,
+                        mapped_ssrc: mapping?.mapped_ssrc()?,
+                    })
                 })
-                .collect(),
-        }
+                .collect::<Result<Vec<_>, Box<dyn Error>>>()?,
+        })
     }
 }
 

--- a/rust/src/prelude.rs
+++ b/rust/src/prelude.rs
@@ -65,7 +65,8 @@ pub use crate::data_structures::{
 pub use crate::rtp_parameters::{
     MediaKind, MimeTypeAudio, MimeTypeVideo, RtcpFeedback, RtcpParameters, RtpCapabilities,
     RtpCapabilitiesFinalized, RtpCodecCapability, RtpCodecParameters, RtpCodecParametersParameters,
-    RtpHeaderExtensionParameters, RtpHeaderExtensionUri, RtpParameters,
+    RtpEncodingParameters, RtpEncodingParametersRtx, RtpHeaderExtensionParameters,
+    RtpHeaderExtensionUri, RtpParameters,
 };
 pub use crate::sctp_parameters::SctpStreamParameters;
 pub use crate::srtp_parameters::SrtpCryptoSuite;

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -180,6 +180,26 @@ impl RtpStreamParams {
             rtx_payload_type: params.rtx_payload_type,
         }
     }
+
+    pub(crate) fn from_fbs_ref(params: rtp_stream::ParamsRef<'_>) -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
+            clock_rate: params.clock_rate()?,
+            cname: params.cname()?.to_string(),
+            encoding_idx: params.encoding_idx()?,
+            mime_type: params.mime_type()?.parse()?,
+            payload_type: params.payload_type()?,
+            spatial_layers: params.spatial_layers()?,
+            ssrc: params.ssrc()?,
+            temporal_layers: params.temporal_layers()?,
+            use_dtx: params.use_dtx()?,
+            use_in_band_fec: params.use_in_band_fec()?,
+            use_nack: params.use_nack()?,
+            use_pli: params.use_pli()?,
+            rid: params.rid()?.map(|rid| rid.to_string()),
+            rtx_ssrc: params.rtx_ssrc()?,
+            rtx_payload_type: params.rtx_payload_type()?,
+        })
+    }
 }
 
 #[derive(Debug, Clone, PartialOrd, Eq, PartialEq, Deserialize, Serialize)]
@@ -195,15 +215,15 @@ pub struct RtxStreamParams {
 }
 
 impl RtxStreamParams {
-    pub(crate) fn from_fbs(params: &rtx_stream::Params) -> Self {
-        Self {
-            clock_rate: params.clock_rate,
-            cname: params.cname.clone(),
-            mime_type: params.mime_type.clone().parse().unwrap(),
-            payload_type: params.payload_type,
-            ssrc: params.ssrc,
-            rrid: params.rrid.clone(),
-        }
+    pub(crate) fn from_fbs_ref(params: rtx_stream::ParamsRef<'_>) -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
+            clock_rate: params.clock_rate()?,
+            cname: params.cname()?.to_string(),
+            mime_type: params.mime_type()?.parse()?,
+            payload_type: params.payload_type()?,
+            ssrc: params.ssrc()?,
+            rrid: params.rrid()?.map(|rrid| rrid.to_string()),
+        })
     }
 }
 

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -291,13 +291,13 @@ impl ConsumerDump {
                 .consumable_rtp_encodings()?
                 .iter()
                 .map(|encoding_parameters| {
-                    Ok(RtpEncodingParameters::from_fbs_ref(encoding_parameters?)?)
+                    RtpEncodingParameters::from_fbs_ref(encoding_parameters?)
                 })
                 .collect::<Result<_, Box<dyn Error>>>()?,
             rtp_streams: dump?
                 .rtp_streams()?
                 .iter()
-                .map(|stream| Ok(RtpStream::from_fbs_ref(stream?)?))
+                .map(|stream| RtpStream::from_fbs_ref(stream?))
                 .collect::<Result<_, Box<dyn Error>>>()?,
             preferred_spatial_layer: dump?.preferred_spatial_layer()?,
             target_spatial_layer: dump?.target_spatial_layer()?,

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -161,26 +161,6 @@ pub struct RtpStreamParams {
 }
 
 impl RtpStreamParams {
-    pub(crate) fn from_fbs(params: &rtp_stream::Params) -> Self {
-        Self {
-            clock_rate: params.clock_rate,
-            cname: params.cname.clone(),
-            encoding_idx: params.encoding_idx,
-            mime_type: params.mime_type.clone().parse().unwrap(),
-            payload_type: params.payload_type,
-            spatial_layers: params.spatial_layers,
-            ssrc: params.ssrc,
-            temporal_layers: params.temporal_layers,
-            use_dtx: params.use_dtx,
-            use_in_band_fec: params.use_in_band_fec,
-            use_nack: params.use_nack,
-            use_pli: params.use_pli,
-            rid: params.rid.clone(),
-            rtx_ssrc: params.rtx_ssrc,
-            rtx_payload_type: params.rtx_payload_type,
-        }
-    }
-
     pub(crate) fn from_fbs_ref(params: rtp_stream::ParamsRef<'_>) -> Result<Self, Box<dyn Error>> {
         Ok(Self {
             clock_rate: params.clock_rate()?,
@@ -236,11 +216,11 @@ pub struct RtpStream {
 }
 
 impl RtpStream {
-    pub(crate) fn from_fbs(dump: rtp_stream::Dump) -> Self {
-        Self {
-            params: RtpStreamParams::from_fbs(&dump.params),
-            score: dump.score,
-        }
+    pub(crate) fn from_fbs_ref(dump: rtp_stream::DumpRef<'_>) -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
+            params: RtpStreamParams::from_fbs_ref(dump.params()?)?,
+            score: dump.score()?,
+        })
     }
 }
 
@@ -283,42 +263,48 @@ pub struct ConsumerDump {
 }
 
 impl ConsumerDump {
-    pub(crate) fn from_fbs(dump: consumer::DumpResponse) -> Result<Self, Box<dyn Error>> {
-        let dump = dump.data;
+    pub(crate) fn from_fbs_ref(
+        dump: consumer::DumpResponseRef<'_>,
+    ) -> Result<Self, Box<dyn Error>> {
+        let dump = dump.data();
 
         Ok(Self {
-            id: dump.base.id.parse()?,
-            kind: MediaKind::from_fbs(dump.base.kind),
-            paused: dump.base.paused,
-            priority: dump.base.priority,
-            producer_id: dump.base.producer_id.parse()?,
-            producer_paused: dump.base.producer_paused,
-            rtp_parameters: RtpParameters::from_fbs(*dump.base.rtp_parameters).unwrap(),
-            supported_codec_payload_types: dump.base.supported_codec_payload_types,
-            trace_event_types: dump
-                .base
-                .trace_event_types
+            id: dump?.base()?.id()?.parse()?,
+            kind: MediaKind::from_fbs(dump?.base()?.kind()?),
+            paused: dump?.base()?.paused()?,
+            priority: dump?.base()?.priority()?,
+            producer_id: dump?.base()?.producer_id()?.parse()?,
+            producer_paused: dump?.base()?.producer_paused()?,
+            rtp_parameters: RtpParameters::from_fbs_ref(dump?.base()?.rtp_parameters()?)?,
+            supported_codec_payload_types: Vec::from(
+                dump?.base()?.supported_codec_payload_types()?,
+            ),
+            trace_event_types: dump?
+                .base()?
+                .trace_event_types()?
                 .iter()
-                .map(ConsumerTraceEventType::from_fbs)
-                .collect(),
-            r#type: ConsumerType::from_fbs(dump.base.type_),
-            consumable_rtp_encodings: dump
-                .base
-                .consumable_rtp_encodings
-                .into_iter()
-                .map(RtpEncodingParameters::from_fbs)
-                .collect(),
-            rtp_streams: dump
-                .rtp_streams
-                .into_iter()
-                .map(RtpStream::from_fbs)
-                .collect(),
-            preferred_spatial_layer: dump.preferred_spatial_layer,
-            target_spatial_layer: dump.target_spatial_layer,
-            current_spatial_layer: dump.current_spatial_layer,
-            preferred_temporal_layer: dump.preferred_temporal_layer,
-            target_temporal_layer: dump.target_temporal_layer,
-            current_temporal_layer: dump.current_temporal_layer,
+                .map(|trace_event_type| Ok(ConsumerTraceEventType::from_fbs(trace_event_type?)))
+                .collect::<Result<_, Box<dyn Error>>>()?,
+            r#type: ConsumerType::from_fbs(dump?.base()?.type_()?),
+            consumable_rtp_encodings: dump?
+                .base()?
+                .consumable_rtp_encodings()?
+                .iter()
+                .map(|encoding_parameters| {
+                    Ok(RtpEncodingParameters::from_fbs_ref(encoding_parameters?)?)
+                })
+                .collect::<Result<_, Box<dyn Error>>>()?,
+            rtp_streams: dump?
+                .rtp_streams()?
+                .iter()
+                .map(|stream| Ok(RtpStream::from_fbs_ref(stream?)?))
+                .collect::<Result<_, Box<dyn Error>>>()?,
+            preferred_spatial_layer: dump?.preferred_spatial_layer()?,
+            target_spatial_layer: dump?.target_spatial_layer()?,
+            current_spatial_layer: dump?.current_spatial_layer()?,
+            preferred_temporal_layer: dump?.preferred_temporal_layer()?,
+            target_temporal_layer: dump?.target_temporal_layer()?,
+            current_temporal_layer: dump?.current_temporal_layer()?,
         })
     }
 }
@@ -583,7 +569,7 @@ impl ConsumerTraceEventType {
         }
     }
 
-    pub(crate) fn from_fbs(event_type: &consumer::TraceEventType) -> Self {
+    pub(crate) fn from_fbs(event_type: consumer::TraceEventType) -> Self {
         match event_type {
             consumer::TraceEventType::Rtp => ConsumerTraceEventType::Rtp,
             consumer::TraceEventType::Keyframe => ConsumerTraceEventType::KeyFrame,
@@ -1006,17 +992,10 @@ impl Consumer {
     pub async fn dump(&self) -> Result<ConsumerDump, RequestError> {
         debug!("dump()");
 
-        let response = self
-            .inner
+        self.inner
             .channel
             .request(self.id(), ConsumerDumpRequest {})
-            .await?;
-
-        if let response::Body::ConsumerDumpResponse(data) = response {
-            Ok(ConsumerDump::from_fbs(*data).expect("Error parsing dump response"))
-        } else {
-            panic!("Wrong message from worker");
-        }
+            .await
     }
 
     /// Returns current RTC statistics of the consumer.

--- a/rust/src/router/producer.rs
+++ b/rust/src/router/producer.rs
@@ -110,9 +110,13 @@ impl RtpStreamRecv {
         Ok(Self {
             params: RtpStreamParams::from_fbs_ref(dump.params()?)?,
             score: dump.score()?,
-            rtx_stream: dump.rtx_stream()?.map(|stream| RtxStream {
-                params: RtxStreamParams::from_fbs_ref(stream.params().unwrap()).unwrap(),
-            }),
+            rtx_stream: if let Some(rtx_stream) = dump.rtx_stream()? {
+                Some(RtxStream {
+                    params: RtxStreamParams::from_fbs_ref(rtx_stream.params()?)?,
+                })
+            } else {
+                None
+            },
         })
     }
 }

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -787,119 +787,6 @@ pub struct RtpParameters {
 }
 
 impl RtpParameters {
-    pub(crate) fn from_fbs(
-        rtp_parameters: rtp_parameters::RtpParameters,
-    ) -> Result<Self, Box<dyn Error>> {
-        Ok(Self {
-            mid: rtp_parameters.mid,
-            codecs: rtp_parameters
-                .codecs
-                .into_iter()
-                .map(|codec| {
-                    let parameters = codec
-                        .parameters
-                        .unwrap_or_default()
-                        .into_iter()
-                        .map(|parameters| {
-                            Ok((
-                                Cow::Owned(parameters.name),
-                                match parameters.value {
-                                    rtp_parameters::Value::Boolean(_)
-                                    | rtp_parameters::Value::Double(_)
-                                    | rtp_parameters::Value::Integer32Array(_) => {
-                                        // TODO: Above value variant should not exist in the
-                                        //  first place
-                                        panic!("Invalid parameter")
-                                    }
-                                    rtp_parameters::Value::Integer32(n) => {
-                                        RtpCodecParametersParametersValue::Number(
-                                            n.value.try_into()?,
-                                        )
-                                    }
-                                    rtp_parameters::Value::String(s) => {
-                                        RtpCodecParametersParametersValue::String(s.value.into())
-                                    }
-                                },
-                            ))
-                        })
-                        .collect::<Result<_, Box<dyn Error>>>()?;
-                    let rtcp_feedback = codec
-                        .rtcp_feedback
-                        .unwrap_or_default()
-                        .into_iter()
-                        .map(|rtcp_feedback| {
-                            RtcpFeedback::from_type_parameter(
-                                &rtcp_feedback.type_,
-                                &rtcp_feedback.parameter.unwrap_or_default(),
-                            )
-                        })
-                        .collect::<Result<_, _>>()?;
-
-                    Ok(match MimeType::from_str(&codec.mime_type)? {
-                        MimeType::Audio(mime_type) => RtpCodecParameters::Audio {
-                            mime_type,
-                            payload_type: codec.payload_type,
-                            clock_rate: codec.clock_rate.try_into()?,
-                            channels: codec
-                                .channels
-                                .ok_or("Audio must have channels specified")?
-                                .try_into()?,
-                            parameters,
-                            rtcp_feedback: vec![],
-                        },
-                        MimeType::Video(mime_type) => RtpCodecParameters::Video {
-                            mime_type,
-                            payload_type: codec.payload_type,
-                            clock_rate: codec.clock_rate.try_into()?,
-                            parameters,
-                            rtcp_feedback,
-                        },
-                    })
-                })
-                .collect::<Result<_, Box<dyn Error>>>()?,
-            header_extensions: rtp_parameters
-                .header_extensions
-                .into_iter()
-                .map(|header_extension_parameters| {
-                    Ok(RtpHeaderExtensionParameters {
-                        uri: RtpHeaderExtensionUri::from_fbs(header_extension_parameters.uri),
-                        id: u16::from(header_extension_parameters.id),
-                        encrypt: header_extension_parameters.encrypt,
-                    })
-                })
-                .collect::<Result<_, Box<dyn Error>>>()?,
-            encodings: rtp_parameters
-                .encodings
-                .into_iter()
-                .map(|encoding| {
-                    Ok(RtpEncodingParameters {
-                        ssrc: encoding.ssrc,
-                        rid: encoding.rid,
-                        codec_payload_type: encoding.codec_payload_type,
-                        rtx: encoding
-                            .rtx
-                            .map(|rtx| RtpEncodingParametersRtx { ssrc: rtx.ssrc }),
-                        dtx: {
-                            match encoding.dtx {
-                                true => Some(true),
-                                false => None,
-                            }
-                        },
-                        scalability_mode: encoding
-                            .scalability_mode
-                            .unwrap_or(String::from("S1T1"))
-                            .parse()?,
-                        max_bitrate: encoding.max_bitrate,
-                    })
-                })
-                .collect::<Result<_, Box<dyn Error>>>()?,
-            rtcp: RtcpParameters {
-                cname: rtp_parameters.rtcp.cname,
-                reduced_size: rtp_parameters.rtcp.reduced_size,
-            },
-        })
-    }
-
     pub(crate) fn from_fbs_ref(
         rtp_parameters: rtp_parameters::RtpParametersRef<'_>,
     ) -> Result<Self, Box<dyn Error>> {
@@ -1421,27 +1308,31 @@ impl RtpEncodingParameters {
         }
     }
 
-    pub(crate) fn from_fbs(encoding_parameters: rtp_parameters::RtpEncodingParameters) -> Self {
-        Self {
-            ssrc: encoding_parameters.ssrc,
-            rid: encoding_parameters.rid.clone(),
-            codec_payload_type: encoding_parameters.codec_payload_type,
-            rtx: encoding_parameters
-                .rtx
-                .map(|rtx| RtpEncodingParametersRtx { ssrc: rtx.ssrc }),
+    pub(crate) fn from_fbs_ref(
+        encoding_parameters: rtp_parameters::RtpEncodingParametersRef<'_>,
+    ) -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
+            ssrc: encoding_parameters.ssrc()?,
+            rid: encoding_parameters.rid()?.map(|rid| rid.to_string()),
+            codec_payload_type: encoding_parameters.codec_payload_type()?,
+            rtx: if let Some(rtx) = encoding_parameters.rtx()? {
+                Some(RtpEncodingParametersRtx { ssrc: rtx.ssrc()? })
+            } else {
+                None
+            },
             dtx: {
-                match encoding_parameters.dtx {
+                match encoding_parameters.dtx()? {
                     true => Some(true),
                     false => None,
                 }
             },
             scalability_mode: encoding_parameters
-                .scalability_mode
-                .unwrap_or(String::from("S1T1"))
-                .parse()
-                .unwrap(),
-            max_bitrate: encoding_parameters.max_bitrate,
-        }
+                .scalability_mode()?
+                .map(|maybe_scalability_mode| maybe_scalability_mode.parse())
+                .transpose()?
+                .unwrap_or_default(),
+            max_bitrate: encoding_parameters.max_bitrate()?,
+        })
     }
 }
 

--- a/rust/src/worker/channel.rs
+++ b/rust/src/worker/channel.rs
@@ -92,13 +92,13 @@ enum ChannelReceiveMessage<'a> {
 }
 
 // Remove the first 4 bytes which represent the buffer size.
-// NOTE: This is only needed for NodeJS.
+// NOTE: The prefix is only needed for NodeJS.
 fn unprefix_message(bytes: &[u8]) -> &[u8] {
     &bytes[4..]
 }
 
 fn deserialize_message(bytes: &[u8]) -> ChannelReceiveMessage<'_> {
-    let message_ref = message::MessageRef::read_as_root(&bytes).unwrap();
+    let message_ref = message::MessageRef::read_as_root(bytes).unwrap();
 
     match message_ref.data().unwrap() {
         message::BodyRef::Log(data) => match data.data().unwrap().chars().next() {


### PR DESCRIPTION
Avoid heap allocations on response processing. Provides 10% of performance improvement[*].

This is a test bed for rewriting the rest of `from_fbs` to `from_fbs_ref`.

NOTE: Once all `from_fbs` are moved to `from_fbs_ref`, rename the methods back to `from_fbs`

[*]: benched producer::dump()

NOTE: I'd like to merge this once approved. Let's have a TODO for making this improvement everywhere once flatbuffers branch is merged. This is totally a non blocker.

NOTE: I'm going to do some checks in Node too. But that's not a blocker for this PR.