### PR TITLE
[flatbuffers] Remove '__MEDIASOUP_VERSION__' replacement in JS transpiled files

### DIFF
--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -1,6 +1,7 @@
 import * as process from 'node:process';
 import * as path from 'node:path';
 import { spawn, ChildProcess } from 'node:child_process';
+import { version } from './';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import * as ortc from './ortc';
@@ -334,7 +335,7 @@ export class Worker<WorkerAppData extends AppData = AppData>
 			{
 				env :
 				{
-					MEDIASOUP_VERSION : '__MEDIASOUP_VERSION__',
+					MEDIASOUP_VERSION : version,
 					// Let the worker process inherit all environment variables, useful
 					// if a custom and not in the path GCC is used so the user can set
 					// LD_LIBRARY_PATH environment variable for runtime.

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -1,3 +1,5 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import { workerBin, Worker, WorkerSettings } from './Worker';
@@ -14,14 +16,14 @@ export { types };
 /**
  * Expose mediasoup version.
  */
-export const version = '__MEDIASOUP_VERSION__';
+export const { version } = JSON.parse(fs.readFileSync(
+	path.join(__dirname, '..', '..', 'package.json'), { encoding: 'utf-8' }
+));
 
 /**
  * Expose parseScalabilityMode() function.
  */
 export { parse as parseScalabilityMode } from './scalabilityModes';
-
-const logger = new Logger();
 
 export type ObserverEvents =
 {
@@ -39,6 +41,8 @@ export { observer };
  * Full path of the mediasoup-worker binary.
  */
 export { workerBin };
+
+const logger = new Logger();
 
 /**
  * Create a Worker.

--- a/node/src/tests/test-mediasoup.ts
+++ b/node/src/tests/test-mediasoup.ts
@@ -1,9 +1,21 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import * as mediasoup from '../';
 
+const PKG = JSON.parse(fs.readFileSync(
+	path.join(__dirname, '..', '..', '..', 'package.json'), { encoding: 'utf-8' })
+);
+
 const {
+	version,
 	getSupportedRtpCapabilities,
 	parseScalabilityMode
 } = mediasoup;
+
+test('mediasoup.version matches version field in package.json', () =>
+{
+	expect(version).toBe(PKG.version);
+});
 
 test('mediasoup.getSupportedRtpCapabilities() returns the mediasoup RTP capabilities', () =>
 {

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -96,7 +96,6 @@ async function run()
 		{
 			installNodeDeps();
 			buildTypescript(/* force */ true);
-			replaceVersion();
 
 			break;
 		}
@@ -161,7 +160,6 @@ async function run()
 		case 'test:node':
 		{
 			buildTypescript(/* force */ false);
-			replaceVersion();
 			testNode();
 
 			break;
@@ -177,7 +175,6 @@ async function run()
 		case 'coverage:node':
 		{
 			buildTypescript(/* force */ false);
-			replaceVersion();
 			executeCmd('jest --coverage');
 			executeCmd('open-cli coverage/lcov-report/index.html');
 
@@ -269,32 +266,6 @@ async function run()
 
 			exitWithError();
 		}
-	}
-}
-
-function replaceVersion()
-{
-	logInfo('replaceVersion()');
-
-	const files = fs.readdirSync('node/lib',
-		{
-			withFileTypes : true,
-			recursive     : true
-		});
-
-	for (const file of files)
-	{
-		if (!file.isFile())
-		{
-			continue;
-		}
-
-		// NOTE: dirent.path is only available in Node >= 20.
-		const filePath = path.join(file.path ?? 'node/lib', file.name);
-		const text = fs.readFileSync(filePath, { encoding: 'utf8' });
-		const result = text.replace(/__MEDIASOUP_VERSION__/g, PKG.version);
-
-		fs.writeFileSync(filePath, result, { encoding: 'utf8' });
 	}
 }
 
@@ -463,7 +434,6 @@ function checkRelease()
 	installNodeDeps();
 	flatcNode();
 	buildTypescript(/* force */ true);
-	replaceVersion();
 	buildWorker();
 	lintNode();
 	lintWorker();


### PR DESCRIPTION
- Instead of writing into all transpiled JS files in `node/lib/`, read `package.json` just once in launch time and read "version" from it.
- I'm not happy with this, not sure if better than before. But clearly we are gonna remove this useless `mediasoup.version` public getter in v4.