### PR TITLE
Update mediasoup-rust versions

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,12 +1,16 @@
 # Changelog
 
+# 0.11.5
+
+* Updates from mediasoup TypeScript `3.11.9..=3.12.16`.
+
 # 0.11.4
 
 * Fix consuming data producer from direct transport by data consumer on non-direct transport.
 
 # 0.11.3
 
-* Updates from mediasoup TypeScript `3.10.13..=3.11.8`.
+* Updates from mediasoup TypeScript `3.11.1..=3.11.8`.
 
 # 0.11.2
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 # 0.11.3
 
-* Updates from mediasoup TypeScript `3.11.1..=3.11.8`.
+* Updates from mediasoup TypeScript `3.11.3..=3.11.8`.
 
 # 0.11.2
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-# 0.11.5
+# 0.12.0
 
 * Updates from mediasoup TypeScript `3.11.9..=3.12.16`.
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup"
-version = "0.11.4"
+version = "0.11.5"
 description = "Cutting Edge WebRTC Video Conferencing in Rust"
 categories = ["api-bindings", "multimedia", "network-programming"]
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
@@ -45,7 +45,7 @@ version = "0.8.1"
 
 [dependencies.mediasoup-sys]
 path = "../worker"
-version = "0.5.4"
+version = "0.5.5"
 
 [dependencies.parking_lot]
 version = "0.12.1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup"
-version = "0.11.5"
+version = "0.12.0"
 description = "Cutting Edge WebRTC Video Conferencing in Rust"
 categories = ["api-bindings", "multimedia", "network-programming"]
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
@@ -45,7 +45,7 @@ version = "0.8.1"
 
 [dependencies.mediasoup-sys]
 path = "../worker"
-version = "0.5.5"
+version = "0.6.0"
 
 [dependencies.parking_lot]
 version = "0.12.1"

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup-sys"
-version = "0.5.4"
+version = "0.6.0"
 description = "FFI bindings to C++ libmediasoup-worker"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition = "2021"


### PR DESCRIPTION
After merged I think I must only run `cargo publish` as documented in my notes.