### PR TITLE
FBS: Remove unneeded message type member

### DIFF
--- a/node/src/Channel.ts
+++ b/node/src/Channel.ts
@@ -6,7 +6,7 @@ import { EnhancedEventEmitter } from './EnhancedEventEmitter';
 import { InvalidStateError } from './errors';
 import { Body as RequestBody, Method, Request } from './fbs/request';
 import { Response } from './fbs/response';
-import { Message, Type as MessageType, Body as MessageBody } from './fbs/message';
+import { Message, Body as MessageBody } from './fbs/message';
 import { Notification, Body as NotificationBody, Event } from './fbs/notification';
 import { Log } from './fbs/log';
 

--- a/node/src/Channel.ts
+++ b/node/src/Channel.ts
@@ -128,9 +128,9 @@ export class Channel extends EnhancedEventEmitter
 
 				try
 				{
-					switch (message.type())
+					switch (message.dataType())
 					{
-						case MessageType.RESPONSE:
+						case MessageBody.Response:
 						{
 							const response = new Response();
 
@@ -141,7 +141,7 @@ export class Channel extends EnhancedEventEmitter
 							break;
 						}
 
-						case MessageType.NOTIFICATION:
+						case MessageBody.Notification:
 						{
 							const notification = new Notification();
 
@@ -152,7 +152,7 @@ export class Channel extends EnhancedEventEmitter
 							break;
 						}
 
-						case MessageType.LOG:
+						case MessageBody.Log:
 						{
 							const log = new Log();
 
@@ -283,7 +283,6 @@ export class Channel extends EnhancedEventEmitter
 
 		const messageOffset = Message.createMessage(
 			this.#bufferBuilder,
-			MessageType.NOTIFICATION,
 			MessageBody.Notification,
 			notificationOffset
 		);
@@ -348,7 +347,6 @@ export class Channel extends EnhancedEventEmitter
 
 		const messageOffset = Message.createMessage(
 			this.#bufferBuilder,
-			MessageType.REQUEST,
 			MessageBody.Request,
 			requestOffset
 		);

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -95,7 +95,7 @@ impl Request for WorkerCloseRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -126,7 +126,7 @@ impl Request for WorkerDumpRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -203,7 +203,7 @@ impl Request for WorkerUpdateSettingsRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -243,7 +243,7 @@ impl Request for WorkerCreateWebRtcServerRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -282,7 +282,7 @@ impl Request for WebRtcServerCloseRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -313,7 +313,7 @@ impl Request for WebRtcServerDumpRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -395,7 +395,7 @@ impl Request for WorkerCreateRouterRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -430,7 +430,7 @@ impl Request for RouterCloseRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -461,7 +461,7 @@ impl Request for RouterDumpRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -606,7 +606,7 @@ impl Request for RouterCreateDirectTransportRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -772,7 +772,7 @@ impl Request for RouterCreateWebRtcTransportRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -849,7 +849,7 @@ impl Request for RouterCreateWebRtcTransportWithServerRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -981,7 +981,7 @@ impl Request for RouterCreatePlainTransportRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1107,7 +1107,7 @@ impl Request for RouterCreatePipeTransportRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1208,7 +1208,7 @@ impl Request for RouterCreateAudioLevelObserverRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1273,7 +1273,7 @@ impl Request for RouterCreateActiveSpeakerObserverRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1304,7 +1304,7 @@ impl Request for TransportDumpRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1339,7 +1339,7 @@ impl Request for TransportGetStatsRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1380,7 +1380,7 @@ impl Request for TransportCloseRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1421,7 +1421,7 @@ impl Request for WebRtcTransportConnectRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1475,7 +1475,7 @@ impl Request for PipeTransportConnectRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1534,7 +1534,7 @@ impl Request for TransportConnectPlainRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1584,7 +1584,7 @@ impl Request for TransportSetMaxIncomingBitrateRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1620,7 +1620,7 @@ impl Request for TransportSetMaxOutgoingBitrateRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1656,7 +1656,7 @@ impl Request for TransportSetMinOutgoingBitrateRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1686,7 +1686,7 @@ impl Request for TransportRestartIceRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1748,7 +1748,7 @@ impl Request for TransportProduceRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1820,7 +1820,7 @@ impl Request for TransportConsumeRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1902,7 +1902,7 @@ impl Request for TransportProduceDataRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -1993,7 +1993,7 @@ impl Request for TransportConsumeDataRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2054,7 +2054,7 @@ impl Request for TransportEnableTraceEventRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2094,7 +2094,7 @@ impl Notification for TransportSendRtcpNotification {
             Some(notification_body),
         );
         let message_body = message::Body::create_notification(&mut builder, notification);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2125,7 +2125,7 @@ impl Request for ProducerCloseRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2156,7 +2156,7 @@ impl Request for ProducerDumpRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2191,7 +2191,7 @@ impl Request for ProducerGetStatsRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2227,7 +2227,7 @@ impl Request for ProducerPauseRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2258,7 +2258,7 @@ impl Request for ProducerResumeRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2300,7 +2300,7 @@ impl Request for ProducerEnableTraceEventRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2340,7 +2340,7 @@ impl Notification for ProducerSendNotification {
             Some(notification_body),
         );
         let message_body = message::Body::create_notification(&mut builder, notification);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2371,7 +2371,7 @@ impl Request for ConsumerCloseRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2402,7 +2402,7 @@ impl Request for ConsumerDumpRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2437,7 +2437,7 @@ impl Request for ConsumerGetStatsRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2473,7 +2473,7 @@ impl Request for ConsumerPauseRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2504,7 +2504,7 @@ impl Request for ConsumerResumeRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2544,7 +2544,7 @@ impl Request for ConsumerSetPreferredLayersRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2594,7 +2594,7 @@ impl Request for ConsumerSetPriorityRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2632,7 +2632,7 @@ impl Request for ConsumerRequestKeyFrameRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2674,7 +2674,7 @@ impl Request for ConsumerEnableTraceEventRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2717,7 +2717,7 @@ impl Request for DataProducerCloseRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2748,7 +2748,7 @@ impl Request for DataProducerDumpRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2784,7 +2784,7 @@ impl Request for DataProducerGetStatsRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2820,7 +2820,7 @@ impl Request for DataProducerPauseRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2851,7 +2851,7 @@ impl Request for DataProducerResumeRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2895,8 +2895,7 @@ impl Notification for DataProducerSendNotification {
             Some(notification_body),
         );
         let message_body = message::Body::create_notification(&mut builder, notification);
-        let message =
-            message::Message::create(&mut builder, message::Type::Notification, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2929,7 +2928,7 @@ impl Request for DataConsumerCloseRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2960,7 +2959,7 @@ impl Request for DataConsumerDumpRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -2996,7 +2995,7 @@ impl Request for DataConsumerGetStatsRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -3032,7 +3031,7 @@ impl Request for DataConsumerPauseRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -3063,7 +3062,7 @@ impl Request for DataConsumerResumeRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -3099,7 +3098,7 @@ impl Request for DataConsumerGetBufferedAmountRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -3150,7 +3149,7 @@ impl Request for DataConsumerSetBufferedAmountLowThresholdRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -3188,7 +3187,7 @@ impl Request for DataConsumerSendRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -3236,7 +3235,7 @@ impl Request for DataConsumerSetSubchannelsRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -3281,7 +3280,7 @@ impl Request for RtpObserverCloseRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -3311,7 +3310,7 @@ impl Request for RtpObserverPauseRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -3341,7 +3340,7 @@ impl Request for RtpObserverResumeRequest {
             None::<request::Body>,
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -3380,7 +3379,7 @@ impl Request for RtpObserverAddProducerRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }
@@ -3419,7 +3418,7 @@ impl Request for RtpObserverRemoveProducerRequest {
             Some(request_body),
         );
         let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message::Type::Request, message_body);
+        let message = message::Message::create(&mut builder, message_body);
 
         builder.finish(message, None).to_vec()
     }

--- a/worker/fbs/message.fbs
+++ b/worker/fbs/message.fbs
@@ -5,13 +5,6 @@ include "response.fbs";
 
 namespace FBS.Message;
 
-enum Type: uint8 {
-    REQUEST = 0,
-    RESPONSE,
-    NOTIFICATION,
-    LOG,
-}
-
 union Body {
     Request: FBS.Request.Request,
     Response: FBS.Response.Response,
@@ -20,7 +13,6 @@ union Body {
 }
 
 table Message {
-    type: Type;
     data: Body (required);
 }
 

--- a/worker/include/Channel/ChannelNotifier.hpp
+++ b/worker/include/Channel/ChannelNotifier.hpp
@@ -29,11 +29,8 @@ namespace Channel
 			auto notification = FBS::Notification::CreateNotificationDirect(
 			  builder, targetId.c_str(), event, type, body.Union());
 
-			auto message = FBS::Message::CreateMessage(
-			  builder,
-			  FBS::Message::Type::NOTIFICATION,
-			  FBS::Message::Body::Notification,
-			  notification.Union());
+			auto message =
+			  FBS::Message::CreateMessage(builder, FBS::Message::Body::Notification, notification.Union());
 
 			builder.FinishSizePrefixed(message);
 			this->channel->Send(builder.GetBufferPointer(), builder.GetSize());
@@ -46,11 +43,8 @@ namespace Channel
 			auto notification =
 			  FBS::Notification::CreateNotificationDirect(builder, targetId.c_str(), event);
 
-			auto message = FBS::Message::CreateMessage(
-			  builder,
-			  FBS::Message::Type::NOTIFICATION,
-			  FBS::Message::Body::Notification,
-			  notification.Union());
+			auto message =
+			  FBS::Message::CreateMessage(builder, FBS::Message::Body::Notification, notification.Union());
 
 			builder.FinishSizePrefixed(message);
 			this->channel->Send(builder.GetBufferPointer(), builder.GetSize());

--- a/worker/include/Channel/ChannelRequest.hpp
+++ b/worker/include/Channel/ChannelRequest.hpp
@@ -42,8 +42,8 @@ namespace Channel
 			auto& builder = this->bufferBuilder;
 			auto response = FBS::Response::CreateResponse(builder, this->id, true, type, body.Union());
 
-			auto message = FBS::Message::CreateMessage(
-			  builder, FBS::Message::Type::RESPONSE, FBS::Message::Body::Response, response.Union());
+			auto message =
+			  FBS::Message::CreateMessage(builder, FBS::Message::Body::Response, response.Union());
 
 			builder.FinishSizePrefixed(message);
 			this->Send(builder.GetBufferPointer(), builder.GetSize());

--- a/worker/src/Channel/ChannelRequest.cpp
+++ b/worker/src/Channel/ChannelRequest.cpp
@@ -165,8 +165,8 @@ namespace Channel
 	void ChannelRequest::SendResponse(const flatbuffers::Offset<FBS::Response::Response>& response)
 	{
 		auto& builder = this->bufferBuilder;
-		auto message  = FBS::Message::CreateMessage(
-      builder, FBS::Message::Type::RESPONSE, FBS::Message::Body::Response, response.Union());
+		auto message =
+		  FBS::Message::CreateMessage(builder, FBS::Message::Body::Response, response.Union());
 
 		builder.FinishSizePrefixed(message);
 		this->Send(builder.GetBufferPointer(), builder.GetSize());

--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -149,9 +149,9 @@ namespace Channel
 			return;
 		}
 
-		auto log     = FBS::Log::CreateLogDirect(this->bufferBuilder, msg);
-		auto message = FBS::Message::CreateMessage(
-		  this->bufferBuilder, FBS::Message::Type::LOG, FBS::Message::Body::Log, log.Union());
+		auto log = FBS::Log::CreateLogDirect(this->bufferBuilder, msg);
+		auto message =
+		  FBS::Message::CreateMessage(this->bufferBuilder, FBS::Message::Body::Log, log.Union());
 
 		this->bufferBuilder.FinishSizePrefixed(message);
 		this->Send(this->bufferBuilder.GetBufferPointer(), this->bufferBuilder.GetSize());
@@ -185,7 +185,7 @@ namespace Channel
 			MS_DUMP("%s", s.c_str());
 #endif
 
-			if (message->type() == FBS::Message::Type::REQUEST)
+			if (message->data_type() == FBS::Message::Body::Request)
 			{
 				ChannelRequest* request;
 
@@ -207,7 +207,7 @@ namespace Channel
 
 				delete request;
 			}
-			else if (message->type() == FBS::Message::Type::NOTIFICATION)
+			else if (message->data_type() == FBS::Message::Body::Notification)
 			{
 				ChannelNotification* notification;
 
@@ -265,7 +265,7 @@ namespace Channel
 		MS_DUMP("%s", s.c_str());
 #endif
 
-		if (message->type() == FBS::Message::Type::REQUEST)
+		if (message->data_type() == FBS::Message::Body::Request)
 		{
 			ChannelRequest* request;
 
@@ -287,7 +287,7 @@ namespace Channel
 
 			delete request;
 		}
-		else if (message->type() == FBS::Message::Type::NOTIFICATION)
+		else if (message->data_type() == FBS::Message::Body::Notification)
 		{
 			ChannelNotification* notification;
 


### PR DESCRIPTION
It's not needed since the body contained in the message is already typed.

The very same way, we could get rid of `method` member in `request` and `event` member in `notification`.