### PR TITLE
DepOpenSSL, initialize

### DIFF
--- a/worker/src/DepOpenSSL.cpp
+++ b/worker/src/DepOpenSSL.cpp
@@ -22,6 +22,7 @@ void DepOpenSSL::ClassInit()
 	  []
 	  {
 		  MS_DEBUG_TAG(info, "openssl version: \"%s\"", OpenSSL_version(OPENSSL_VERSION));
+		  MS_DEBUG_TAG(info, "openssl CPU info: \"%s\"", OpenSSL_version(OPENSSL_CPU_INFO));
 
 		  // Initialize some crypto stuff.
 		  RAND_poll();


### PR DESCRIPTION
It's difficult to know if we are using HW acceleration for encrypting SRTP.

In theory we are. We are compiling `libsrtp` with `openssl` so the first makes use of HW capabilities of the second. I've realised that it is by calling `OPENSSL_init_ssl()` that the corresponding capability bits are filled, which are used for hardware encryption.

I've added two logs, before and after `openssl` initialization which show the CPU info. In my case `arm64` I have the same values:

```txt
DepOpenSSL::operator()() | openssl CPU info before init: "CPUINFO: OPENSSL_armcap=0x7d" +0ms
DepOpenSSL::operator()() | openssl CPU info after init : "CPUINFO: OPENSSL_armcap=0x7d" +1ms
```

Which shows like the CPU capability bits are already filled even before calling `OPENSSL_init_ssl()`. So perhaps calling this method is not needed.

@vpalmisano, I know you played with `openssl` in the past. Do you have any opinion about this? Anyone?

I'd like to know if we are using HW capabilities in `libsrtp`.

NOTE: I've made a local performance tests. Using HW capabilities makes a great difference:

**With** HW capabilities:

```txt
 _OPENSSL_armcap="~0x200000200000000" openssl speed -elapsed -evp aes-128-cbc
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
AES-128-CBC     498907.71k  1280811.39k  1356705.88k  1450232.35k  1462927.36k  1400826.54k
````
**Without** HW capabilities:

```txt
OPENSSL_armcap="~0x200000200000000" openssl speed -elapsed -evp aes-128-cbc
The 'numbers' are in 1000s of bytes per second processed.
type             16 bytes     64 bytes    256 bytes   1024 bytes   8192 bytes  16384 bytes
AES-128-CBC     287775.07k   292925.91k   272145.52k   286081.37k   300997.49k   296943.62k
```

**EDIT**:

In order to know if `libsrtp` is making use of HW encryption start the media server with the corresponding ENV variable and without it, and start a router with many video consumers. Ie:

This will disable the capabilities for arm64, change the name to `OPENSSL_ia32cap` for an intel CPU.
```txt
OPENSSL_armcap="~0x200000200000000" npm run start
```

In my case, disabling the HW capabilities takes twice as much CPU on a arm64 (Mac M1)
