### PR TITLE
FBS: LayersChangeNotification body must be optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* FBS: Fix, LayersChangeNotification body must be optional ([1227](https://github.com/versatica/mediasoup/pull/1227))
+
+
 ### 3.13.1
 
 * Node: Extract version from `package.json` using `require()` ([PR #1217](https://github.com/versatica/mediasoup/pull/1217) by @arcinston).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### NEXT
 
-* FBS: Fix, LayersChangeNotification body must be optional ([1227](https://github.com/versatica/mediasoup/pull/1227))
+* FBS: `LayersChangeNotification` body must be optional ([PR #1227](https://github.com/versatica/mediasoup/pull/1227)).
 
 
 ### 3.13.1

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -621,11 +621,15 @@ impl Notification {
                     panic!("Wrong message from worker: {notification:?}");
                 };
 
-                let layers_fbs =
-                    consumer::ConsumerLayers::try_from(body.layers().unwrap()).unwrap();
-                let layers = ConsumerLayers::from_fbs(layers_fbs);
+                match body.layers().unwrap() {
+                    Some(layers) => {
+                        let layers_fbs = consumer::ConsumerLayers::try_from(layers).unwrap();
+                        let layers = ConsumerLayers::from_fbs(layers_fbs);
 
-                Ok(Notification::LayersChange(Some(layers)))
+                        Ok(Notification::LayersChange(Some(layers)))
+                    }
+                    None => Ok(Notification::LayersChange(None)),
+                }
             }
             notification::Event::ConsumerTrace => {
                 let Ok(Some(notification::BodyRef::ConsumerTraceNotification(body))) =

--- a/worker/fbs/consumer.fbs
+++ b/worker/fbs/consumer.fbs
@@ -80,7 +80,7 @@ table GetStatsResponse {
 // Notifications from Worker.
 
 table LayersChangeNotification {
-    layers: ConsumerLayers (required);
+    layers: ConsumerLayers;
 }
 
 table RtpNotification {


### PR DESCRIPTION
It's none when the spatial layer is -1 internally.

This was crashing the worker when trying to create an empty notification, since the schema was requiring the body.