### PR TITLE
Node: Add 'listenererror' in all entities

### DIFF
--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -173,6 +173,7 @@ export type ConsumerEvents =
 	layerschange: [ConsumerLayers?];
 	trace: [ConsumerTraceEventData];
 	rtp: [Buffer];
+	listenererror: [string, Error];
 	// Private events.
 	'@close': [];
 	'@producerclose': [];

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -85,6 +85,7 @@ export type DataConsumerEvents =
 	message: [Buffer, number];
 	sctpsendbufferfull: [];
 	bufferedamountlow: [number];
+	listenererror: [string, Error];
 	// Private events.
 	'@close': [];
 	'@dataproducerclose': [];

--- a/node/src/DataProducer.ts
+++ b/node/src/DataProducer.ts
@@ -61,6 +61,7 @@ export type DataProducerType = 'sctp' | 'direct';
 export type DataProducerEvents =
 {
 	transportclose: [];
+	listenererror: [string, Error];
 	// Private events.
 	'@close': [];
 };

--- a/node/src/EnhancedEventEmitter.ts
+++ b/node/src/EnhancedEventEmitter.ts
@@ -23,8 +23,6 @@ export class EnhancedEventEmitter<E extends Events = Events> extends EventEmitte
 	 */
 	safeEmit<K extends keyof E & string>(eventName: K, ...args: E[K]): boolean
 	{
-		const numListeners = super.listenerCount(eventName);
-
 		try
 		{
 			return super.emit(eventName, ...args);
@@ -33,9 +31,19 @@ export class EnhancedEventEmitter<E extends Events = Events> extends EventEmitte
 		{
 			logger.error(
 				'safeEmit() | event listener threw an error [eventName:%s]:%o',
-				eventName, error);
+				eventName, error
+			);
 
-			return Boolean(numListeners);
+			try
+			{
+				super.emit('listenererror', eventName, error);
+			}
+			catch (error2)
+			{
+				// Ignore it.
+			}
+
+			return Boolean(super.listenerCount(eventName));
 		}
 	}
 

--- a/node/src/Producer.ts
+++ b/node/src/Producer.ts
@@ -134,6 +134,7 @@ export type ProducerEvents =
 	score: [ProducerScore[]];
 	videoorientationchange: [ProducerVideoOrientation];
 	trace: [ProducerTraceEventData];
+	listenererror: [string, Error];
 	// Private events.
 	'@close': [];
 };

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -172,6 +172,7 @@ type PipeTransportPair =
 export type RouterEvents =
 {
 	workerclose: [];
+	listenererror: [string, Error];
 	// Private events.
 	'@close': [];
 };

--- a/node/src/RtpObserver.ts
+++ b/node/src/RtpObserver.ts
@@ -11,6 +11,7 @@ import * as FbsRtpObserver from './fbs/rtp-observer';
 export type RtpObserverEvents =
 {
 	routerclose: [];
+	listenererror: [string, Error];
 	// Private events.
 	'@close': [];
 };

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -154,6 +154,7 @@ export type TransportEvents =
 	routerclose: [];
 	listenserverclose: [];
 	trace: [TransportTraceEventData];
+	listenererror: [string, Error];
 	// Private events.
 	'@close': [];
 	'@newproducer': [Producer];

--- a/node/src/WebRtcServer.ts
+++ b/node/src/WebRtcServer.ts
@@ -31,6 +31,7 @@ export type WebRtcServerListenInfo = TransportListenInfo;
 export type WebRtcServerEvents =
 {
 	workerclose: [];
+	listenererror: [string, Error];
 	// Private events.
 	'@close': [];
 };

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -197,6 +197,7 @@ export type WorkerDump =
 export type WorkerEvents =
 {
 	died: [Error];
+	listenererror: [string, Error];
 	// Private events.
 	'@success': [];
 	'@failure': [Error];

--- a/node/src/tests/test-DirectTransport.ts
+++ b/node/src/tests/test-DirectTransport.ts
@@ -127,46 +127,38 @@ test('dataProducer.send() succeeds', async () =>
 	let sentMessageBytes = 0;
 	let effectivelySentMessageBytes = 0;
 	let recvMessageBytes = 0;
-	let lastSentMessageId = 0;
-	let lastRecvMessageId = 0;
-
-	// eslint-disable-next-line no-console
-	console.log('TODO: REMOVE');
-	transport2.on('listenererror', (eventName, error) =>
-	{
-		// eslint-disable-next-line no-console
-		console.error(`------ transport2 listener error [eventName:${eventName}]: ${error}`);
-		throw new Error(`------ transport2 listener error [eventName:${eventName}]: ${error}`);
-	});
-
-	// eslint-disable-next-line no-console
-	console.log('TODO: REMOVE');
-	dataProducer.on('listenererror', (eventName, error) =>
-	{
-		// eslint-disable-next-line no-console
-		console.log(`------ dataProducer listener error [eventName:${eventName}]: ${error}`);
-		throw new Error(`------ dataProducer listener error [eventName:${eventName}]: ${error}`);
-	});
-
-	// eslint-disable-next-line no-console
-	console.log('TODO: REMOVE');
-	dataConsumer.on('listenererror', (eventName, error) =>
-	{
-		// eslint-disable-next-line no-console
-		console.log(`------ dataConsumer listener error [eventName:${eventName}]: ${error}`);
-		throw new Error(`------ dataConsumer listener error [eventName:${eventName}]: ${error}`);
-	});
+	let numSentMessages = 0;
+	let numReceivedMessages = 0;
 
 	// eslint-disable-next-line no-async-promise-executor
-	await new Promise<void>(async (resolve) =>
+	await new Promise<void>(async (resolve, reject) =>
 	{
-		// Send messages over the sctpSendStream created above.
+		transport2.on('listenererror', (eventName, error) =>
+		{
+			reject(
+				new Error(`transport2 'listenererror' [eventName:${eventName}]: ${error}`)
+			);
+		});
+
+		dataProducer.on('listenererror', (eventName, error) =>
+		{
+			reject(
+				new Error(`dataProducer 'listenererror' [eventName:${eventName}]: ${error}`)
+			);
+		});
+
+		dataConsumer.on('listenererror', (eventName, error) =>
+		{
+			reject(
+				new Error(`dataConsumer 'listenererror' [eventName:${eventName}]: ${error}`)
+			);
+		});
 
 		sendNextMessage();
 
-		async function sendNextMessage()
+		async function sendNextMessage(): Promise<void>
 		{
-			const id = ++lastSentMessageId;
+			const id = ++numSentMessages;
 			let ppid;
 			let message;
 
@@ -217,6 +209,8 @@ test('dataProducer.send() succeeds', async () =>
 
 		dataConsumer.on('message', (message, ppid) =>
 		{
+			++numReceivedMessages;
+
 			// message is always a Buffer.
 			recvMessageBytes += message.byteLength;
 
@@ -226,22 +220,25 @@ test('dataProducer.send() succeeds', async () =>
 			{
 				resolve();
 			}
-
-			if (id < numMessages / 2)
+			// PPID of WebRTC DataChannel string.
+			else if (id < numMessages / 2 && ppid !== 51)
 			{
-				expect(ppid).toBe(51); // PPID of WebRTC DataChannel string.
+				reject(
+					new Error(`ppid in message with id ${id} should be 51 but it is ${ppid}`)
+				);
 			}
-			else
+			// PPID of WebRTC DataChannel binary.
+			else if (id > numMessages / 2 && ppid !== 53)
 			{
-				expect(ppid).toBe(53); // PPID of WebRTC DataChannel binary.
+				reject(
+					new Error(`ppid in message with id ${id} should be 53 but it is ${ppid}`)
+				);
 			}
-
-			++lastRecvMessageId;
 		});
 	});
 
-	expect(lastSentMessageId).toBe(numMessages);
-	expect(lastRecvMessageId).toBe(expectedReceivedNumMessages);
+	expect(numSentMessages).toBe(numMessages);
+	expect(numReceivedMessages).toBe(expectedReceivedNumMessages);
 	expect(recvMessageBytes).toBe(effectivelySentMessageBytes);
 
 	await expect(dataProducer.getStats())

--- a/node/src/tests/test-DirectTransport.ts
+++ b/node/src/tests/test-DirectTransport.ts
@@ -130,6 +130,24 @@ test('dataProducer.send() succeeds', async () =>
 	let lastSentMessageId = 0;
 	let lastRecvMessageId = 0;
 
+	console.log('TODO: REMOVE');
+	transport2.on('listenererror', (eventName, error) =>
+	{
+		throw new Error(`------ transport2 listener error [eventName:${eventName}]: ${error}`);
+	});
+
+	console.log('TODO: REMOVE');
+	dataProducer.on('listenererror', (eventName, error) =>
+	{
+		throw new Error(`------ dataProducer listener error [eventName:${eventName}]: ${error}`);
+	});
+
+	console.log('TODO: REMOVE');
+	dataConsumer.on('listenererror', (eventName, error) =>
+	{
+		throw new Error(`------ dataConsumer listener error [eventName:${eventName}]: ${error}`);
+	});
+
 	// eslint-disable-next-line no-async-promise-executor
 	await new Promise<void>(async (resolve) =>
 	{

--- a/node/src/tests/test-DirectTransport.ts
+++ b/node/src/tests/test-DirectTransport.ts
@@ -130,21 +130,30 @@ test('dataProducer.send() succeeds', async () =>
 	let lastSentMessageId = 0;
 	let lastRecvMessageId = 0;
 
+	// eslint-disable-next-line no-console
 	console.log('TODO: REMOVE');
 	transport2.on('listenererror', (eventName, error) =>
 	{
+		// eslint-disable-next-line no-console
+		console.error(`------ transport2 listener error [eventName:${eventName}]: ${error}`);
 		throw new Error(`------ transport2 listener error [eventName:${eventName}]: ${error}`);
 	});
 
+	// eslint-disable-next-line no-console
 	console.log('TODO: REMOVE');
 	dataProducer.on('listenererror', (eventName, error) =>
 	{
+		// eslint-disable-next-line no-console
+		console.log(`------ dataProducer listener error [eventName:${eventName}]: ${error}`);
 		throw new Error(`------ dataProducer listener error [eventName:${eventName}]: ${error}`);
 	});
 
+	// eslint-disable-next-line no-console
 	console.log('TODO: REMOVE');
 	dataConsumer.on('listenererror', (eventName, error) =>
 	{
+		// eslint-disable-next-line no-console
+		console.log(`------ dataConsumer listener error [eventName:${eventName}]: ${error}`);
 		throw new Error(`------ dataConsumer listener error [eventName:${eventName}]: ${error}`);
 	});
 

--- a/node/src/tests/test-Producer.ts
+++ b/node/src/tests/test-Producer.ts
@@ -235,18 +235,18 @@ test('transport2.produce() succeeds', async () =>
 			});
 }, 2000);
 
-test.only('transport1.produce() without header extensions and rtcp succeeds', async () =>
+test('transport1.produce() without header extensions and rtcp succeeds', async () =>
 {
 	const onObserverNewProducer = jest.fn();
 
 	transport1.observer.once('newproducer', onObserverNewProducer);
 
-	audioProducer = await transport1.produce(
+	const audioProducer2 = await transport1.produce(
 		{
 			kind          : 'audio',
 			rtpParameters :
 			{
-				mid    : 'AUDIO',
+				mid    : 'AUDIO2',
 				codecs :
 				[
 					{
@@ -268,34 +268,19 @@ test.only('transport1.produce() without header extensions and rtcp succeeds', as
 		});
 
 	expect(onObserverNewProducer).toHaveBeenCalledTimes(1);
-	expect(onObserverNewProducer).toHaveBeenCalledWith(audioProducer);
-	expect(typeof audioProducer.id).toBe('string');
-	expect(audioProducer.closed).toBe(false);
-	expect(audioProducer.kind).toBe('audio');
-	expect(typeof audioProducer.rtpParameters).toBe('object');
-	expect(audioProducer.type).toBe('simple');
+	expect(onObserverNewProducer).toHaveBeenCalledWith(audioProducer2);
+	expect(typeof audioProducer2.id).toBe('string');
+	expect(audioProducer2.closed).toBe(false);
+	expect(audioProducer2.kind).toBe('audio');
+	expect(typeof audioProducer2.rtpParameters).toBe('object');
+	expect(audioProducer2.type).toBe('simple');
 	// Private API.
-	expect(typeof audioProducer.consumableRtpParameters).toBe('object');
-	expect(audioProducer.paused).toBe(false);
-	expect(audioProducer.score).toEqual([]);
-	expect(audioProducer.appData).toEqual({ foo: 1, bar: '2' });
+	expect(typeof audioProducer2.consumableRtpParameters).toBe('object');
+	expect(audioProducer2.paused).toBe(false);
+	expect(audioProducer2.score).toEqual([]);
+	expect(audioProducer2.appData).toEqual({ foo: 1, bar: '2' });
 
-	await expect(router.dump())
-		.resolves
-		.toMatchObject(
-			{
-				mapProducerIdConsumerIds : [ { key: audioProducer.id, values: [] } ],
-				mapConsumerIdProducerId  : []
-			});
-
-	await expect(transport1.dump())
-		.resolves
-		.toMatchObject(
-			{
-				id          : transport1.id,
-				producerIds : [ audioProducer.id ],
-				consumerIds : []
-			});
+	audioProducer2.close();
 }, 2000);
 
 test('transport1.produce() with wrong arguments rejects with TypeError', async () =>
@@ -782,7 +767,10 @@ test('Producer emits "score"', async () =>
 
 	expect(onScore).toHaveBeenCalledTimes(3);
 	expect(videoProducer.score).toEqual(
-		[ { ssrc: 11, score: 10 }, { ssrc: 22, score: 9 } ]);
+		[
+			{ ssrc: 11, rid: undefined, score: 10, encodingIdx: 0 },
+			{ ssrc: 22, rid: undefined, score: 9, encodingIdx: 1 }
+		]);
 }, 2000);
 
 test('producer.close() succeeds', async () =>

--- a/node/src/tests/test-node-sctp.ts
+++ b/node/src/tests/test-node-sctp.ts
@@ -114,11 +114,16 @@ beforeAll(async () =>
 	dataConsumer = await transport.consumeData({ dataProducerId: dataProducer.id });
 });
 
-afterAll(() =>
+afterAll(async () =>
 {
 	udpSocket.close();
 	sctpSocket.end();
 	worker.close();
+
+	// NOTE: For some reason we have to wait a bit for the SCTP stuff to release
+	// internal things, otherwise Jest reports open handles. We don't care much
+	// honestly.
+	await new Promise((resolve) => setTimeout(resolve, 2000));
 });
 
 test('ordered DataProducer delivers all SCTP messages to the DataConsumer', async () =>
@@ -127,18 +132,20 @@ test('ordered DataProducer delivers all SCTP messages to the DataConsumer', asyn
 	const numMessages = 200;
 	let sentMessageBytes = 0;
 	let recvMessageBytes = 0;
-	let lastSentMessageId = 0;
-	let lastRecvMessageId = 0;
+	let numSentMessages = 0;
+	let numReceivedMessages = 0;
 
 	// It must be zero because it's the first DataConsumer on the transport.
 	expect(dataConsumer.sctpStreamParameters?.streamId).toBe(0);
 
-	await new Promise<void>((resolve) =>
+	// eslint-disable-next-line no-async-promise-executor
+	await new Promise<void>(async (resolve, reject) =>
 	{
-		// Send SCTP messages over the sctpSendStream created above.
-		const interval = setInterval(() =>
+		sendNextMessage();
+
+		async function sendNextMessage(): Promise<void>
 		{
-			const id = ++lastSentMessageId;
+			const id = ++numSentMessages;
 			const data = Buffer.from(String(id));
 
 			// Set ppid of type WebRTC DataChannel string.
@@ -157,11 +164,11 @@ test('ordered DataProducer delivers all SCTP messages to the DataConsumer', asyn
 			sctpSendStream.write(data);
 			sentMessageBytes += data.byteLength;
 
-			if (id === numMessages)
+			if (id < numMessages)
 			{
-				clearInterval(interval);
+				sendNextMessage();
 			}
-		}, 10);
+		}
 
 		sctpSocket.on('stream', onStream);
 
@@ -171,40 +178,54 @@ test('ordered DataProducer delivers all SCTP messages to the DataConsumer', asyn
 		{
 			// It must be zero because it's the first SCTP incoming stream (so first
 			// DataConsumer).
-			expect(streamId).toBe(0);
+			if (streamId !== 0)
+			{
+				reject(new Error(`streamId should be 0 but it is ${streamId}`));
+
+				return;
+			}
 
 			// @ts-ignore
 			stream.on('data', (data: Buffer) =>
 			{
+				++numReceivedMessages;
 				recvMessageBytes += data.byteLength;
 
 				const id = Number(data.toString('utf8'));
+				// @ts-ignore
+				const ppid = data.ppid;
 
-				if (id === numMessages)
+				if (id !== numReceivedMessages)
 				{
-					clearInterval(interval);
+					reject(
+						new Error(`id ${id} in message should match numReceivedMessages ${numReceivedMessages}`)
+					);
+				}
+				else if (id === numMessages)
+				{
 					resolve();
 				}
-
-				if (id < numMessages / 2)
+				else if (id < numMessages / 2 && ppid !== sctp.PPID.WEBRTC_STRING)
 				{
-					// @ts-ignore
-					expect(data.ppid).toBe(sctp.PPID.WEBRTC_STRING);
+					reject(
+						new Error(`ppid in message with id ${id} should be ${sctp.PPID.WEBRTC_STRING} but it is ${ppid}`)
+					);
 				}
-				else
+				else if (id > numMessages / 2 && ppid !== sctp.PPID.WEBRTC_BINARY)
 				{
-					// @ts-ignore
-					expect(data.ppid).toBe(sctp.PPID.WEBRTC_BINARY);
-				}
+					reject(
+						new Error(`ppid in message with id ${id} should be ${sctp.PPID.WEBRTC_BINARY} but it is ${ppid}`)
+					);
 
-				expect(id).toBe(++lastRecvMessageId);
+					return;
+				}
 			});
 		});
 	});
 
 	expect(onStream).toHaveBeenCalledTimes(1);
-	expect(lastSentMessageId).toBe(numMessages);
-	expect(lastRecvMessageId).toBe(numMessages);
+	expect(numSentMessages).toBe(numMessages);
+	expect(numReceivedMessages).toBe(numMessages);
 	expect(recvMessageBytes).toBe(sentMessageBytes);
 
 	await expect(dataProducer.getStats())


### PR DESCRIPTION
- 'listenererror' event is emitted when an event listener throws (only if it's a synchronous error, otherwise an unhandled rejection will happen anyway).
- Usage:
  ```ts
  consumer.on('listenererror', (eventName, error) => { ... });
  ```
- Fixes issue #1188.

### Bonus Tracks:

- Remove `test.only` in `test-Producer.ts` and fix some tests in that file.

