### PR TITLE
Reliable make clean-all

### DIFF
--- a/worker/Makefile
+++ b/worker/Makefile
@@ -74,6 +74,7 @@ endif
 	clean-pip \
 	clean-subprojects \
 	clean-all \
+	foo \
 	update-wrap-file \
 	mediasoup-worker \
 	libmediasoup-worker \
@@ -190,7 +191,9 @@ clean-pip:
 clean-subprojects: meson-ninja
 	$(MESON) subprojects purge --include-cache --confirm
 
-clean-all: clean-subprojects
+# Clean subprojects (ignore if it fails) and delete out dir.
+clean-all:
+	-$(MESON) subprojects purge --include-cache --confirm
 	$(RM) -rf $(MEDIASOUP_OUT_DIR)
 
 # Update the wrap file of a subproject. Usage example:

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -74,7 +74,6 @@ endif
 	clean-pip \
 	clean-subprojects \
 	clean-all \
-	foo \
 	update-wrap-file \
 	mediasoup-worker \
 	libmediasoup-worker \


### PR DESCRIPTION
- Before this PR, `clean-all` task in `Makefile` is not reliable since it depends on `clean-subprojects` task, which depends on `meson-ninja` and it calls `meson` command to purge subprojects. If the `meson` binary is not installed or if it doesn't correspond to current OS (which may happen when running a Docker image) then the `clean-subprojects` task will fail and hence `MEDIASOUP_OUT_DIR` won't be deleted (so wrong meson, pip, ninja packages will remain in there, making everything fail).
- This PR fixes it by making `clean-all` task do a best effor to clean subprojects and, if that fails, keep doing thing (delete `MEDIASOUP_OUT_DIR` anyway).

**Here an example:**

- mediasoup installed in macOS (proper macOS meson, ninja and pip packages installed, worker compiled, etc).
- Run `make docker-alpine && make docker-alpine-run`.
- Within the container run `npm ci`. It fails because installed `meson` is not appropriate (or whatever, I don't care):
  ``` /mediasoup/worker # npm ci
  
  > mediasoup@3.13.2 postinstall
  > node npm-scripts.mjs postinstall

  npm-scripts.mjs [INFO] [postinstall] downloadPrebuiltWorker() [tarUrl:https://github.com/versatica/mediasoup/releases/download/3.13.2/mediasoup-worker-3.13.2-linux-x64.tgz]
  npm-scripts.mjs [INFO] [postinstall] ensureDir() [dir:worker/prebuild]
  npm-scripts.mjs [INFO] [postinstall] ensureDir() [dir:worker/out/Release]
  npm-scripts.mjs [INFO] [postinstall] downloadPrebuiltWorker() | got mediasoup-worker prebuilt binary
  npm-scripts.mjs [INFO] [postinstall] downloadPrebuiltWorker() | checking fetched mediasoup-worker prebuilt binary in current host
  npm-scripts.mjs [ERROR] [postinstall] downloadPrebuiltWorker() | fetched mediasoup-worker prebuilt binary fails to run in this host [status:127]
  npm-scripts.mjs [INFO] [postinstall] couldn't fetch any mediasoup-worker prebuilt binary, building it locally
  npm-scripts.mjs [INFO] [postinstall] buildWorker()
  npm-scripts.mjs [INFO] [postinstall] executeCmd(): make -C worker make: Entering directory '/mediasoup/worker' /mediasoup/worker/out/pip/bin/meson setup \
    --prefix /mediasoup/worker/out/Release \ --bindir '' \ --libdir '' \
    --buildtype release \ -Db_ndebug=true \ -Db_pie=true \ -Db_staticpic=true \ 
    --reconfigure \ "" \ /mediasoup/worker/out/Release/build || \ /mediasoup/worker/out/pip/bin/meson setup \
    --prefix /mediasoup/worker/out/Release \ --bindir '' \ --libdir '' \ --buildtype release \
    -Db_ndebug=true \ -Db_pie=true \ -Db_staticpic=true \ "" \ 
    /mediasoup/worker/out/Release/build /bin/sh: /mediasoup/worker/out/pip/bin/meson: not found /bin/sh:
    /mediasoup/worker/out/pip/bin/meson: not found make: *** [Makefile:115: setup] Error 127
    make: Leaving directory '/mediasoup/worker'
  npm-scripts.mjs [ERROR] [postinstall] executeCmd() failed, exiting: Error: Command failed: make -C worker npm ERR! code 1 npm ERR! path /mediasoup npm ERR! command failed npm ERR! command sh -c node npm-scripts.mjs postinstall
  
  npm ERR! A complete log of this run can be found in: /root/.npm/_logs/2023-11-18T12_49_48_082Z-debug-0.log
  ```
- Now run `make clean-all` in worker directory. This would fail before this PR, now it doesn't:
  ```
  /mediasoup/worker # make clean-all
  
  /mediasoup/worker/out/pip/bin/meson subprojects purge --include-cache --confirm make: 
    /mediasoup/worker/out/pip/bin/meson: No such file or directory make: [Makefile:196: clean-all] Error 127 (ignored)
  rm -f -rf /mediasoup/worker/out
  ```
- Now `npm ci` does work (it installs proper meson, pip, ninja, etc).