### PR TITLE
Fix issue when `pause`/`resume` events are not emitted

### DIFF
--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -612,14 +612,14 @@ export class Consumer<ConsumerAppData extends AppData = AppData>
 	{
 		logger.debug('pause()');
 
-		const wasPaused = this.#paused || this.#producerPaused;
-
 		await this.#channel.request(
 			FbsRequest.Method.CONSUMER_PAUSE,
 			undefined,
 			undefined,
 			this.#internal.consumerId
 		);
+
+		const wasPaused = this.#paused || this.#producerPaused;
 
 		this.#paused = true;
 
@@ -637,14 +637,14 @@ export class Consumer<ConsumerAppData extends AppData = AppData>
 	{
 		logger.debug('resume()');
 
-		const wasPaused = this.#paused || this.#producerPaused;
-
 		await this.#channel.request(
 			FbsRequest.Method.CONSUMER_RESUME,
 			undefined,
 			undefined,
 			this.#internal.consumerId
 		);
+
+		const wasPaused = this.#paused || this.#producerPaused;
 
 		this.#paused = false;
 

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -407,14 +407,14 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 	{
 		logger.debug('pause()');
 
-		const wasPaused = this.#paused;
-
 		await this.#channel.request(
 			FbsRequest.Method.DATACONSUMER_PAUSE,
 			undefined,
 			undefined,
 			this.#internal.dataConsumerId
 		);
+
+		const wasPaused = this.#paused;
 
 		this.#paused = true;
 
@@ -432,14 +432,14 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 	{
 		logger.debug('resume()');
 
-		const wasPaused = this.#paused;
-
 		await this.#channel.request(
 			FbsRequest.Method.DATACONSUMER_RESUME,
 			undefined,
 			undefined,
 			this.#internal.dataConsumerId
 		);
+
+		const wasPaused = this.#paused;
 
 		this.#paused = false;
 

--- a/node/src/DataProducer.ts
+++ b/node/src/DataProducer.ts
@@ -342,14 +342,14 @@ export class DataProducer<DataProducerAppData extends AppData = AppData>
 	{
 		logger.debug('pause()');
 
-		const wasPaused = this.#paused;
-
 		await this.#channel.request(
 			FbsRequest.Method.DATAPRODUCER_PAUSE,
 			undefined,
 			undefined,
 			this.#internal.dataProducerId
 		);
+
+		const wasPaused = this.#paused;
 
 		this.#paused = true;
 
@@ -367,14 +367,14 @@ export class DataProducer<DataProducerAppData extends AppData = AppData>
 	{
 		logger.debug('resume()');
 
-		const wasPaused = this.#paused;
-
 		await this.#channel.request(
 			FbsRequest.Method.DATAPRODUCER_RESUME,
 			undefined,
 			undefined,
 			this.#internal.dataProducerId
 		);
+
+		const wasPaused = this.#paused;
 
 		this.#paused = false;
 

--- a/node/src/Producer.ts
+++ b/node/src/Producer.ts
@@ -446,14 +446,14 @@ export class Producer<ProducerAppData extends AppData = AppData>
 	{
 		logger.debug('pause()');
 
-		const wasPaused = this.#paused;
-
 		await this.#channel.request(
 			FbsRequest.Method.PRODUCER_PAUSE,
 			undefined,
 			undefined,
 			this.#internal.producerId
 		);
+
+		const wasPaused = this.#paused;
 
 		this.#paused = true;
 
@@ -471,14 +471,14 @@ export class Producer<ProducerAppData extends AppData = AppData>
 	{
 		logger.debug('resume()');
 
-		const wasPaused = this.#paused;
-
 		await this.#channel.request(
 			FbsRequest.Method.PRODUCER_RESUME,
 			undefined,
 			undefined,
 			this.#internal.producerId
 		);
+
+		const wasPaused = this.#paused;
 
 		this.#paused = false;
 

--- a/node/src/tests/test-Consumer.ts
+++ b/node/src/tests/test-Consumer.ts
@@ -838,6 +838,31 @@ test('consumer.pause() and resume() succeed', async () =>
 		.toMatchObject({ paused: false });
 }, 2000);
 
+test('producer.pause() and resume() emit events', async () =>
+{
+	let resumedAt, pausedAt;
+	let currentDate = Date.now();
+	const promises = [];
+	
+	audioConsumer.observer.once('resume', () => {
+		resumedAt = currentDate++;
+	});
+
+	audioConsumer.observer.once('pause', () => {
+		pausedAt = currentDate++;
+	});
+
+	promises.push(audioConsumer.pause());
+	promises.push(audioConsumer.resume());
+
+	await Promise.all(promises);
+	
+	expect(pausedAt).toBeDefined();
+	expect(resumedAt).toBeDefined();
+	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(audioConsumer.paused).toBe(false);
+}, 2000);
+
 test('consumer.setPreferredLayers() succeed', async () =>
 {
 	await audioConsumer.setPreferredLayers({ spatialLayer: 1, temporalLayer: 1 });

--- a/node/src/tests/test-Consumer.ts
+++ b/node/src/tests/test-Consumer.ts
@@ -840,16 +840,17 @@ test('consumer.pause() and resume() succeed', async () =>
 
 test('producer.pause() and resume() emit events', async () =>
 {
-	let resumedAt, pausedAt;
-	let currentDate = Date.now();
 	const promises = [];
+	const events: string[] = [];
 	
-	audioConsumer.observer.once('resume', () => {
-		resumedAt = currentDate++;
+	audioConsumer.observer.once('resume', () => 
+	{
+		events.push('resume');
 	});
 
-	audioConsumer.observer.once('pause', () => {
-		pausedAt = currentDate++;
+	audioConsumer.observer.once('pause', () => 
+	{
+		events.push('pause');
 	});
 
 	promises.push(audioConsumer.pause());
@@ -857,9 +858,7 @@ test('producer.pause() and resume() emit events', async () =>
 
 	await Promise.all(promises);
 	
-	expect(pausedAt).toBeDefined();
-	expect(resumedAt).toBeDefined();
-	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(events).toEqual([ 'pause', 'resume' ]);
 	expect(audioConsumer.paused).toBe(false);
 }, 2000);
 

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -224,16 +224,17 @@ test('dataConsumer.pause() and resume() succeed', async () =>
 
 test('producer.pause() and resume() emit events', async () =>
 {
-	let resumedAt, pausedAt;
-	let currentDate = Date.now();
 	const promises = [];
+	const events: string[] = [];
 	
-	dataConsumer1.observer.once('resume', () => {
-		resumedAt = currentDate++;
+	dataConsumer1.observer.once('resume', () => 
+	{
+		events.push('resume');
 	});
 
-	dataConsumer1.observer.once('pause', () => {
-		pausedAt = currentDate++;
+	dataConsumer1.observer.once('pause', () => 
+	{
+		events.push('pause');
 	});
 
 	promises.push(dataConsumer1.pause());
@@ -241,9 +242,7 @@ test('producer.pause() and resume() emit events', async () =>
 
 	await Promise.all(promises);
 	
-	expect(pausedAt).toBeDefined();
-	expect(resumedAt).toBeDefined();
-	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(events).toEqual([ 'pause', 'resume' ]);
 	expect(dataConsumer1.paused).toBe(false);
 }, 2000);
 

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -222,6 +222,31 @@ test('dataConsumer.pause() and resume() succeed', async () =>
 	expect(data.paused).toBe(false);
 }, 2000);
 
+test('producer.pause() and resume() emit events', async () =>
+{
+	let resumedAt, pausedAt;
+	let currentDate = Date.now();
+	const promises = [];
+	
+	dataConsumer1.observer.once('resume', () => {
+		resumedAt = currentDate++;
+	});
+
+	dataConsumer1.observer.once('pause', () => {
+		pausedAt = currentDate++;
+	});
+
+	promises.push(dataConsumer1.pause());
+	promises.push(dataConsumer1.resume());
+
+	await Promise.all(promises);
+	
+	expect(pausedAt).toBeDefined();
+	expect(resumedAt).toBeDefined();
+	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(dataConsumer1.paused).toBe(false);
+}, 2000);
+
 test('dataConsumer.close() succeeds', async () =>
 {
 	const onObserverClose = jest.fn();

--- a/node/src/tests/test-DataProducer.ts
+++ b/node/src/tests/test-DataProducer.ts
@@ -254,6 +254,31 @@ test('dataProducer.pause() and resume() succeed', async () =>
 	expect(data.paused).toBe(false);
 }, 2000);
 
+test('producer.pause() and resume() emit events', async () =>
+{
+	let resumedAt, pausedAt;
+	let currentDate = Date.now();
+	const promises = [];
+	
+	dataProducer1.observer.once('resume', () => {
+		resumedAt = currentDate++;
+	});
+
+	dataProducer1.observer.once('pause', () => {
+		pausedAt = currentDate++;
+	});
+
+	promises.push(dataProducer1.pause());
+	promises.push(dataProducer1.resume());
+
+	await Promise.all(promises);
+	
+	expect(pausedAt).toBeDefined();
+	expect(resumedAt).toBeDefined();
+	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(dataProducer1.paused).toBe(false);
+}, 2000);
+
 test('dataProducer.close() succeeds', async () =>
 {
 	const onObserverClose = jest.fn();

--- a/node/src/tests/test-DataProducer.ts
+++ b/node/src/tests/test-DataProducer.ts
@@ -256,16 +256,17 @@ test('dataProducer.pause() and resume() succeed', async () =>
 
 test('producer.pause() and resume() emit events', async () =>
 {
-	let resumedAt, pausedAt;
-	let currentDate = Date.now();
 	const promises = [];
+	const events: string[] = [];
 	
-	dataProducer1.observer.once('resume', () => {
-		resumedAt = currentDate++;
+	dataProducer1.observer.once('resume', () => 
+	{
+		events.push('resume');
 	});
 
-	dataProducer1.observer.once('pause', () => {
-		pausedAt = currentDate++;
+	dataProducer1.observer.once('pause', () => 
+	{
+		events.push('pause');
 	});
 
 	promises.push(dataProducer1.pause());
@@ -273,9 +274,7 @@ test('producer.pause() and resume() emit events', async () =>
 
 	await Promise.all(promises);
 	
-	expect(pausedAt).toBeDefined();
-	expect(resumedAt).toBeDefined();
-	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(events).toEqual([ 'pause', 'resume' ]);
 	expect(dataProducer1.paused).toBe(false);
 }, 2000);
 

--- a/node/src/tests/test-Producer.ts
+++ b/node/src/tests/test-Producer.ts
@@ -692,16 +692,17 @@ test('producer.pause() and resume() succeed', async () =>
 
 test('producer.pause() and resume() emit events', async () =>
 {
-	let resumedAt, pausedAt;
-	let currentDate = Date.now();
 	const promises = [];
+	const events: string[] = [];
 	
-	audioProducer.observer.once('resume', () => {
-		resumedAt = currentDate++;
+	audioProducer.observer.once('resume', () => 
+	{
+		events.push('resume');
 	});
 
-	audioProducer.observer.once('pause', () => {
-		pausedAt = currentDate++;
+	audioProducer.observer.once('pause', () => 
+	{
+		events.push('pause');
 	});
 
 	promises.push(audioProducer.pause());
@@ -709,9 +710,7 @@ test('producer.pause() and resume() emit events', async () =>
 
 	await Promise.all(promises);
 	
-	expect(pausedAt).toBeDefined();
-	expect(resumedAt).toBeDefined();
-	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(events).toEqual([ 'pause', 'resume' ]);
 	expect(audioProducer.paused).toBe(false);
 }, 2000);
 

--- a/node/src/tests/test-Producer.ts
+++ b/node/src/tests/test-Producer.ts
@@ -690,6 +690,31 @@ test('producer.pause() and resume() succeed', async () =>
 		.toMatchObject({ paused: false });
 }, 2000);
 
+test('producer.pause() and resume() emit events', async () =>
+{
+	let resumedAt, pausedAt;
+	let currentDate = Date.now();
+	const promises = [];
+	
+	audioProducer.observer.once('resume', () => {
+		resumedAt = currentDate++;
+	});
+
+	audioProducer.observer.once('pause', () => {
+		pausedAt = currentDate++;
+	});
+
+	promises.push(audioProducer.pause());
+	promises.push(audioProducer.resume());
+
+	await Promise.all(promises);
+	
+	expect(pausedAt).toBeDefined();
+	expect(resumedAt).toBeDefined();
+	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(audioProducer.paused).toBe(false);
+}, 2000);
+
 test('producer.enableTraceEvent() succeed', async () =>
 {
 	let dump;


### PR DESCRIPTION
Currently if we `pause()`/`resume()` a producer/consumer/dataProducer/dataConsumer very quickly like the code above (without awaiting for promise to be resolved), the `resume` event will not be triggered, but it should.

```
producer.observer.on('pause', () => { ... });
producer.observer.on('resume', () => { ... });

let pausePromise = producer.pause();
let resumePromise = producer.resume();
```
