### PR TITLE
Fix issue when pause/resume events are not emitted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* Node: Fix issue when 'pause'/'resume' events are not emitted ([PR #1230](https://github.com/versatica/mediasoup/pull/1230) by @douglaseel).
+
+
 ### 3.13.2
 
 * FBS: `LayersChangeNotification` body must be optional (fixes a crash) ([PR #1227](https://github.com/versatica/mediasoup/pull/1227)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### NEXT
 
-* Node: Fix issue when 'pause'/'resume' events are not emitted ([PR #1230](https://github.com/versatica/mediasoup/pull/1230) by @douglaseel).
+* Node: Fix issue when 'pause'/'resume' events are not emitted ([PR #1231](https://github.com/versatica/mediasoup/pull/1231) by @douglaseel).
 
 
 ### 3.13.2

--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -619,12 +619,12 @@ export class Consumer<ConsumerAppData extends AppData = AppData>
 			this.#internal.consumerId
 		);
 
-		const wasPaused = this.#paused || this.#producerPaused;
+		const wasPaused = this.#paused;
 
 		this.#paused = true;
 
 		// Emit observer event.
-		if (!wasPaused)
+		if (!wasPaused && !this.#producerPaused)
 		{
 			this.#observer.safeEmit('pause');
 		}
@@ -644,7 +644,7 @@ export class Consumer<ConsumerAppData extends AppData = AppData>
 			this.#internal.consumerId
 		);
 
-		const wasPaused = this.#paused || this.#producerPaused;
+		const wasPaused = this.#paused;
 
 		this.#paused = false;
 
@@ -853,14 +853,12 @@ export class Consumer<ConsumerAppData extends AppData = AppData>
 						break;
 					}
 
-					const wasPaused = this.#paused || this.#producerPaused;
-
 					this.#producerPaused = true;
 
 					this.safeEmit('producerpause');
 
 					// Emit observer event.
-					if (!wasPaused)
+					if (!this.#paused)
 					{
 						this.#observer.safeEmit('pause');
 					}
@@ -875,14 +873,12 @@ export class Consumer<ConsumerAppData extends AppData = AppData>
 						break;
 					}
 
-					const wasPaused = this.#paused || this.#producerPaused;
-
 					this.#producerPaused = false;
 
 					this.safeEmit('producerresume');
 
 					// Emit observer event.
-					if (wasPaused && !this.#paused)
+					if (!this.#paused)
 					{
 						this.#observer.safeEmit('resume');
 					}

--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -612,14 +612,14 @@ export class Consumer<ConsumerAppData extends AppData = AppData>
 	{
 		logger.debug('pause()');
 
-		const wasPaused = this.#paused || this.#producerPaused;
-
 		await this.#channel.request(
 			FbsRequest.Method.CONSUMER_PAUSE,
 			undefined,
 			undefined,
 			this.#internal.consumerId
 		);
+
+		const wasPaused = this.#paused || this.#producerPaused;
 
 		this.#paused = true;
 
@@ -637,14 +637,14 @@ export class Consumer<ConsumerAppData extends AppData = AppData>
 	{
 		logger.debug('resume()');
 
-		const wasPaused = this.#paused || this.#producerPaused;
-
 		await this.#channel.request(
 			FbsRequest.Method.CONSUMER_RESUME,
 			undefined,
 			undefined,
 			this.#internal.consumerId
 		);
+
+		const wasPaused = this.#paused || this.#producerPaused;
 
 		this.#paused = false;
 

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -407,14 +407,14 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 	{
 		logger.debug('pause()');
 
-		const wasPaused = this.#paused;
-
 		await this.#channel.request(
 			FbsRequest.Method.DATACONSUMER_PAUSE,
 			undefined,
 			undefined,
 			this.#internal.dataConsumerId
 		);
+
+		const wasPaused = this.#paused;
 
 		this.#paused = true;
 
@@ -432,14 +432,14 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 	{
 		logger.debug('resume()');
 
-		const wasPaused = this.#paused;
-
 		await this.#channel.request(
 			FbsRequest.Method.DATACONSUMER_RESUME,
 			undefined,
 			undefined,
 			this.#internal.dataConsumerId
 		);
+
+		const wasPaused = this.#paused;
 
 		this.#paused = false;
 

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -419,7 +419,7 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 		this.#paused = true;
 
 		// Emit observer event.
-		if (!wasPaused)
+		if (!wasPaused && !this.#dataProducerPaused)
 		{
 			this.#observer.safeEmit('pause');
 		}
@@ -444,7 +444,7 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 		this.#paused = false;
 
 		// Emit observer event.
-		if (wasPaused)
+		if (wasPaused && !this.#dataProducerPaused)
 		{
 			this.#observer.safeEmit('resume');
 		}
@@ -620,14 +620,12 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 						break;
 					}
 
-					const wasPaused = this.#paused || this.#dataProducerPaused;
-
 					this.#dataProducerPaused = true;
 
 					this.safeEmit('dataproducerpause');
 
 					// Emit observer event.
-					if (!wasPaused)
+					if (!this.#paused)
 					{
 						this.#observer.safeEmit('pause');
 					}
@@ -642,14 +640,12 @@ export class DataConsumer<DataConsumerAppData extends AppData = AppData>
 						break;
 					}
 
-					const wasPaused = this.#paused || this.#dataProducerPaused;
-
 					this.#dataProducerPaused = false;
 
 					this.safeEmit('dataproducerresume');
 
 					// Emit observer event.
-					if (wasPaused && !this.#paused)
+					if (!this.#paused)
 					{
 						this.#observer.safeEmit('resume');
 					}

--- a/node/src/DataProducer.ts
+++ b/node/src/DataProducer.ts
@@ -342,14 +342,14 @@ export class DataProducer<DataProducerAppData extends AppData = AppData>
 	{
 		logger.debug('pause()');
 
-		const wasPaused = this.#paused;
-
 		await this.#channel.request(
 			FbsRequest.Method.DATAPRODUCER_PAUSE,
 			undefined,
 			undefined,
 			this.#internal.dataProducerId
 		);
+
+		const wasPaused = this.#paused;
 
 		this.#paused = true;
 
@@ -367,14 +367,14 @@ export class DataProducer<DataProducerAppData extends AppData = AppData>
 	{
 		logger.debug('resume()');
 
-		const wasPaused = this.#paused;
-
 		await this.#channel.request(
 			FbsRequest.Method.DATAPRODUCER_RESUME,
 			undefined,
 			undefined,
 			this.#internal.dataProducerId
 		);
+
+		const wasPaused = this.#paused;
 
 		this.#paused = false;
 

--- a/node/src/Producer.ts
+++ b/node/src/Producer.ts
@@ -446,14 +446,14 @@ export class Producer<ProducerAppData extends AppData = AppData>
 	{
 		logger.debug('pause()');
 
-		const wasPaused = this.#paused;
-
 		await this.#channel.request(
 			FbsRequest.Method.PRODUCER_PAUSE,
 			undefined,
 			undefined,
 			this.#internal.producerId
 		);
+
+		const wasPaused = this.#paused;
 
 		this.#paused = true;
 
@@ -471,14 +471,14 @@ export class Producer<ProducerAppData extends AppData = AppData>
 	{
 		logger.debug('resume()');
 
-		const wasPaused = this.#paused;
-
 		await this.#channel.request(
 			FbsRequest.Method.PRODUCER_RESUME,
 			undefined,
 			undefined,
 			this.#internal.producerId
 		);
+
+		const wasPaused = this.#paused;
 
 		this.#paused = false;
 

--- a/node/src/tests/test-Consumer.ts
+++ b/node/src/tests/test-Consumer.ts
@@ -823,6 +823,12 @@ test('consumer.getStats() succeeds', async () =>
 
 test('consumer.pause() and resume() succeed', async () =>
 {
+	const onObserverPause = jest.fn();
+	const onObserverResume = jest.fn();
+
+	audioConsumer.observer.on('pause', onObserverPause);
+	audioConsumer.observer.on('resume', onObserverResume);
+
 	await audioConsumer.pause();
 	expect(audioConsumer.paused).toBe(true);
 
@@ -836,6 +842,18 @@ test('consumer.pause() and resume() succeed', async () =>
 	await expect(audioConsumer.dump())
 		.resolves
 		.toMatchObject({ paused: false });
+
+	// Even if we don't await for pause()/resume() completion, the observer must
+	// fire 'pause' and 'resume' events if state was the opposite.
+	audioConsumer.pause();
+	audioConsumer.resume();
+	audioConsumer.pause();
+	audioConsumer.pause();
+	audioConsumer.pause();
+	await audioConsumer.resume();
+
+	expect(onObserverPause).toHaveBeenCalledTimes(3);
+	expect(onObserverResume).toHaveBeenCalledTimes(3);
 }, 2000);
 
 test('producer.pause() and resume() emit events', async () =>
@@ -853,10 +871,13 @@ test('producer.pause() and resume() emit events', async () =>
 		events.push('pause');
 	});
 
-	promises.push(audioConsumer.pause());
-	promises.push(audioConsumer.resume());
+	promises.push(audioProducer.pause());
+	promises.push(audioProducer.resume());
 
 	await Promise.all(promises);
+
+	// Must also wait a bit for the corresponding events in the consumer.
+	await new Promise((resolve) => setTimeout(resolve, 100));
 	
 	expect(events).toEqual([ 'pause', 'resume' ]);
 	expect(audioConsumer.paused).toBe(false);

--- a/node/src/tests/test-Consumer.ts
+++ b/node/src/tests/test-Consumer.ts
@@ -838,6 +838,31 @@ test('consumer.pause() and resume() succeed', async () =>
 		.toMatchObject({ paused: false });
 }, 2000);
 
+test('producer.pause() and resume() emit events', async () =>
+{
+	let resumedAt, pausedAt;
+	let currentDate = Date.now();
+	const promises = [];
+	
+	audioConsumer.observer.once('resume', () => {
+		resumedAt = currentDate++;
+	});
+
+	audioConsumer.observer.once('pause', () => {
+		pausedAt = currentDate++;
+	});
+
+	promises.push(audioConsumer.pause());
+	promises.push(audioConsumer.resume());
+
+	await Promise.all(promises);
+	
+	expect(pausedAt).toBeDefined();
+	expect(resumedAt).toBeDefined();
+	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(audioConsumer.paused).toBe(false);
+}, 2000);
+
 test('consumer.setPreferredLayers() succeed', async () =>
 {
 	await audioConsumer.setPreferredLayers({ spatialLayer: 1, temporalLayer: 1 });

--- a/node/src/tests/test-Consumer.ts
+++ b/node/src/tests/test-Consumer.ts
@@ -840,16 +840,17 @@ test('consumer.pause() and resume() succeed', async () =>
 
 test('producer.pause() and resume() emit events', async () =>
 {
-	let resumedAt, pausedAt;
-	let currentDate = Date.now();
 	const promises = [];
+	const events: string[] = [];
 	
-	audioConsumer.observer.once('resume', () => {
-		resumedAt = currentDate++;
+	audioConsumer.observer.once('resume', () => 
+	{
+		events.push('resume');
 	});
 
-	audioConsumer.observer.once('pause', () => {
-		pausedAt = currentDate++;
+	audioConsumer.observer.once('pause', () => 
+	{
+		events.push('pause');
 	});
 
 	promises.push(audioConsumer.pause());
@@ -857,9 +858,7 @@ test('producer.pause() and resume() emit events', async () =>
 
 	await Promise.all(promises);
 	
-	expect(pausedAt).toBeDefined();
-	expect(resumedAt).toBeDefined();
-	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(events).toEqual([ 'pause', 'resume' ]);
 	expect(audioConsumer.paused).toBe(false);
 }, 2000);
 

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -240,7 +240,7 @@ test('dataConsumer.pause() and resume() succeed', async () =>
 	expect(onObserverResume).toHaveBeenCalledTimes(3);
 }, 2000);
 
-test('producer.pause() and resume() emit events', async () =>
+test('dataProducer.pause() and resume() emit events', async () =>
 {
 	const promises = [];
 	const events: string[] = [];
@@ -255,10 +255,13 @@ test('producer.pause() and resume() emit events', async () =>
 		events.push('pause');
 	});
 
-	promises.push(dataConsumer1.pause());
-	promises.push(dataConsumer1.resume());
+	promises.push(dataProducer.pause());
+	promises.push(dataProducer.resume());
 
 	await Promise.all(promises);
+
+	// Must also wait a bit for the corresponding events in the data consumer.
+	await new Promise((resolve) => setTimeout(resolve, 100));
 	
 	expect(events).toEqual([ 'pause', 'resume' ]);
 	expect(dataConsumer1.paused).toBe(false);

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -203,6 +203,12 @@ test('dataConsumer.getStats() on a DirectTransport succeeds', async () =>
 
 test('dataConsumer.pause() and resume() succeed', async () =>
 {
+	const onObserverPause = jest.fn();
+	const onObserverResume = jest.fn();
+
+	dataConsumer1.observer.on('pause', onObserverPause);
+	dataConsumer1.observer.on('resume', onObserverResume);
+
 	let data;
 
 	await dataConsumer1.pause();
@@ -220,6 +226,18 @@ test('dataConsumer.pause() and resume() succeed', async () =>
 	data = await dataConsumer1.dump();
 
 	expect(data.paused).toBe(false);
+
+	// Even if we don't await for pause()/resume() completion, the observer must
+	// fire 'pause' and 'resume' events if state was the opposite.
+	dataConsumer1.pause();
+	dataConsumer1.resume();
+	dataConsumer1.pause();
+	dataConsumer1.pause();
+	dataConsumer1.pause();
+	await dataConsumer1.resume();
+
+	expect(onObserverPause).toHaveBeenCalledTimes(3);
+	expect(onObserverResume).toHaveBeenCalledTimes(3);
 }, 2000);
 
 test('producer.pause() and resume() emit events', async () =>

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -224,16 +224,17 @@ test('dataConsumer.pause() and resume() succeed', async () =>
 
 test('producer.pause() and resume() emit events', async () =>
 {
-	let resumedAt, pausedAt;
-	let currentDate = Date.now();
 	const promises = [];
+	const events: string[] = [];
 	
-	dataConsumer1.observer.once('resume', () => {
-		resumedAt = currentDate++;
+	dataConsumer1.observer.once('resume', () => 
+	{
+		events.push('resume');
 	});
 
-	dataConsumer1.observer.once('pause', () => {
-		pausedAt = currentDate++;
+	dataConsumer1.observer.once('pause', () => 
+	{
+		events.push('pause');
 	});
 
 	promises.push(dataConsumer1.pause());
@@ -241,9 +242,7 @@ test('producer.pause() and resume() emit events', async () =>
 
 	await Promise.all(promises);
 	
-	expect(pausedAt).toBeDefined();
-	expect(resumedAt).toBeDefined();
-	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(events).toEqual([ 'pause', 'resume' ]);
 	expect(dataConsumer1.paused).toBe(false);
 }, 2000);
 

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -222,6 +222,31 @@ test('dataConsumer.pause() and resume() succeed', async () =>
 	expect(data.paused).toBe(false);
 }, 2000);
 
+test('producer.pause() and resume() emit events', async () =>
+{
+	let resumedAt, pausedAt;
+	let currentDate = Date.now();
+	const promises = [];
+	
+	dataConsumer1.observer.once('resume', () => {
+		resumedAt = currentDate++;
+	});
+
+	dataConsumer1.observer.once('pause', () => {
+		pausedAt = currentDate++;
+	});
+
+	promises.push(dataConsumer1.pause());
+	promises.push(dataConsumer1.resume());
+
+	await Promise.all(promises);
+	
+	expect(pausedAt).toBeDefined();
+	expect(resumedAt).toBeDefined();
+	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(dataConsumer1.paused).toBe(false);
+}, 2000);
+
 test('dataConsumer.close() succeeds', async () =>
 {
 	const onObserverClose = jest.fn();

--- a/node/src/tests/test-DataProducer.ts
+++ b/node/src/tests/test-DataProducer.ts
@@ -254,6 +254,31 @@ test('dataProducer.pause() and resume() succeed', async () =>
 	expect(data.paused).toBe(false);
 }, 2000);
 
+test('producer.pause() and resume() emit events', async () =>
+{
+	let resumedAt, pausedAt;
+	let currentDate = Date.now();
+	const promises = [];
+	
+	dataProducer1.observer.once('resume', () => {
+		resumedAt = currentDate++;
+	});
+
+	dataProducer1.observer.once('pause', () => {
+		pausedAt = currentDate++;
+	});
+
+	promises.push(dataProducer1.pause());
+	promises.push(dataProducer1.resume());
+
+	await Promise.all(promises);
+	
+	expect(pausedAt).toBeDefined();
+	expect(resumedAt).toBeDefined();
+	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(dataProducer1.paused).toBe(false);
+}, 2000);
+
 test('dataProducer.close() succeeds', async () =>
 {
 	const onObserverClose = jest.fn();

--- a/node/src/tests/test-DataProducer.ts
+++ b/node/src/tests/test-DataProducer.ts
@@ -256,16 +256,17 @@ test('dataProducer.pause() and resume() succeed', async () =>
 
 test('producer.pause() and resume() emit events', async () =>
 {
-	let resumedAt, pausedAt;
-	let currentDate = Date.now();
 	const promises = [];
+	const events: string[] = [];
 	
-	dataProducer1.observer.once('resume', () => {
-		resumedAt = currentDate++;
+	dataProducer1.observer.once('resume', () => 
+	{
+		events.push('resume');
 	});
 
-	dataProducer1.observer.once('pause', () => {
-		pausedAt = currentDate++;
+	dataProducer1.observer.once('pause', () => 
+	{
+		events.push('pause');
 	});
 
 	promises.push(dataProducer1.pause());
@@ -273,9 +274,7 @@ test('producer.pause() and resume() emit events', async () =>
 
 	await Promise.all(promises);
 	
-	expect(pausedAt).toBeDefined();
-	expect(resumedAt).toBeDefined();
-	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(events).toEqual([ 'pause', 'resume' ]);
 	expect(dataProducer1.paused).toBe(false);
 }, 2000);
 

--- a/node/src/tests/test-DataProducer.ts
+++ b/node/src/tests/test-DataProducer.ts
@@ -235,6 +235,12 @@ test('dataProducer.getStats() succeeds', async () =>
 
 test('dataProducer.pause() and resume() succeed', async () =>
 {
+	const onObserverPause = jest.fn();
+	const onObserverResume = jest.fn();
+
+	dataProducer1.observer.on('pause', onObserverPause);
+	dataProducer1.observer.on('resume', onObserverResume);
+
 	let data;
 
 	await dataProducer1.pause();
@@ -252,6 +258,18 @@ test('dataProducer.pause() and resume() succeed', async () =>
 	data = await dataProducer1.dump();
 
 	expect(data.paused).toBe(false);
+
+	// Even if we don't await for pause()/resume() completion, the observer must
+	// fire 'pause' and 'resume' events if state was the opposite.
+	dataProducer1.pause();
+	dataProducer1.resume();
+	dataProducer1.pause();
+	dataProducer1.pause();
+	dataProducer1.pause();
+	await dataProducer1.resume();
+
+	expect(onObserverPause).toHaveBeenCalledTimes(3);
+	expect(onObserverResume).toHaveBeenCalledTimes(3);
 }, 2000);
 
 test('producer.pause() and resume() emit events', async () =>

--- a/node/src/tests/test-Producer.ts
+++ b/node/src/tests/test-Producer.ts
@@ -675,6 +675,12 @@ test('producer.getStats() succeeds', async () =>
 
 test('producer.pause() and resume() succeed', async () =>
 {
+	const onObserverPause = jest.fn();
+	const onObserverResume = jest.fn();
+
+	audioProducer.observer.on('pause', onObserverPause);
+	audioProducer.observer.on('resume', onObserverResume);
+
 	await audioProducer.pause();
 	expect(audioProducer.paused).toBe(true);
 
@@ -688,6 +694,18 @@ test('producer.pause() and resume() succeed', async () =>
 	await expect(audioProducer.dump())
 		.resolves
 		.toMatchObject({ paused: false });
+
+	// Even if we don't await for pause()/resume() completion, the observer must
+	// fire 'pause' and 'resume' events if state was the opposite.
+	audioProducer.pause();
+	audioProducer.resume();
+	audioProducer.pause();
+	audioProducer.pause();
+	audioProducer.pause();
+	await audioProducer.resume();
+
+	expect(onObserverPause).toHaveBeenCalledTimes(3);
+	expect(onObserverResume).toHaveBeenCalledTimes(3);
 }, 2000);
 
 test('producer.pause() and resume() emit events', async () =>

--- a/node/src/tests/test-Producer.ts
+++ b/node/src/tests/test-Producer.ts
@@ -692,16 +692,17 @@ test('producer.pause() and resume() succeed', async () =>
 
 test('producer.pause() and resume() emit events', async () =>
 {
-	let resumedAt, pausedAt;
-	let currentDate = Date.now();
 	const promises = [];
+	const events: string[] = [];
 	
-	audioProducer.observer.once('resume', () => {
-		resumedAt = currentDate++;
+	audioProducer.observer.once('resume', () => 
+	{
+		events.push('resume');
 	});
 
-	audioProducer.observer.once('pause', () => {
-		pausedAt = currentDate++;
+	audioProducer.observer.once('pause', () => 
+	{
+		events.push('pause');
 	});
 
 	promises.push(audioProducer.pause());
@@ -709,9 +710,7 @@ test('producer.pause() and resume() emit events', async () =>
 
 	await Promise.all(promises);
 	
-	expect(pausedAt).toBeDefined();
-	expect(resumedAt).toBeDefined();
-	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(events).toEqual([ 'pause', 'resume' ]);
 	expect(audioProducer.paused).toBe(false);
 }, 2000);
 

--- a/node/src/tests/test-Producer.ts
+++ b/node/src/tests/test-Producer.ts
@@ -690,6 +690,31 @@ test('producer.pause() and resume() succeed', async () =>
 		.toMatchObject({ paused: false });
 }, 2000);
 
+test('producer.pause() and resume() emit events', async () =>
+{
+	let resumedAt, pausedAt;
+	let currentDate = Date.now();
+	const promises = [];
+	
+	audioProducer.observer.once('resume', () => {
+		resumedAt = currentDate++;
+	});
+
+	audioProducer.observer.once('pause', () => {
+		pausedAt = currentDate++;
+	});
+
+	promises.push(audioProducer.pause());
+	promises.push(audioProducer.resume());
+
+	await Promise.all(promises);
+	
+	expect(pausedAt).toBeDefined();
+	expect(resumedAt).toBeDefined();
+	expect(resumedAt).toBeGreaterThan(pausedAt!);
+	expect(audioProducer.paused).toBe(false);
+}, 2000);
+
 test('producer.enableTraceEvent() succeed', async () =>
 {
 	let dump;

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -815,24 +815,23 @@ impl Consumer {
                         }
                         Notification::ProducerPause => {
                             let mut producer_paused = producer_paused.lock();
-                            let was_paused = *paused.lock() || *producer_paused;
+                            let paused = *paused.lock();
                             *producer_paused = true;
 
                             handlers.producer_pause.call_simple();
 
-                            if !was_paused {
+                            if !paused {
                                 handlers.pause.call_simple();
                             }
                         }
                         Notification::ProducerResume => {
                             let mut producer_paused = producer_paused.lock();
                             let paused = *paused.lock();
-                            let was_paused = paused || *producer_paused;
                             *producer_paused = false;
 
                             handlers.producer_resume.call_simple();
 
-                            if was_paused && !paused {
+                            if !paused {
                                 handlers.resume.call_simple();
                             }
                         }

--- a/rust/src/router/data_consumer.rs
+++ b/rust/src/router/data_consumer.rs
@@ -509,24 +509,23 @@ impl DataConsumer {
                         }
                         Notification::DataProducerPause => {
                             let mut data_producer_paused = data_producer_paused.lock();
-                            let was_paused = *paused.lock() || *data_producer_paused;
+                            let paused = *paused.lock();
                             *data_producer_paused = true;
 
                             handlers.data_producer_pause.call_simple();
 
-                            if !was_paused {
+                            if !paused {
                                 handlers.pause.call_simple();
                             }
                         }
                         Notification::DataProducerResume => {
                             let mut data_producer_paused = data_producer_paused.lock();
                             let paused = *paused.lock();
-                            let was_paused = paused || *data_producer_paused;
                             *data_producer_paused = false;
 
                             handlers.data_producer_resume.call_simple();
 
-                            if was_paused && !paused {
+                            if !paused {
                                 handlers.resume.call_simple();
                             }
                         }


### PR DESCRIPTION
*NOTE:* Forked from https://github.com/versatica/mediasoup/pull/1230 by @douglaseel (since his branch doesn't let me edit it).

----

### Details

- Currently if we `pause()`/`resume()` a producer/consumer/dataProducer/dataConsumer very quickly like the code below (without awaiting for promise to be resolved), the 'resume' event will not be triggered, but it should.
  ```ts
  producer.observer.on('pause', () => { ... });
  producer.observer.on('resume', () => { ... });
  
  let pausePromise = producer.pause();
  let resumePromise = producer.resume();
  ```
- Fix logic of 'pause' and 'resume' events in `Consumer` and `DataConsumer` JS and Rust classes.

