### PR TITLE
Fix RTCP DLRR (Delay Since Last Receiver Report) block parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* Fix RTCP DLRR (Delay Since Last Receiver Report) block parsing ([PR #1234](https://github.com/versatica/mediasoup/pull/1234)).
+
+
 ### 3.13.3
 
 * Node: Fix issue when 'pause'/'resume' events are not emitted ([PR #1231](https://github.com/versatica/mediasoup/pull/1231) by @douglaseel).

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -213,7 +213,7 @@ libmediasoup-worker: setup flatc
 flatc: setup
 	$(MESON) compile -C $(BUILD_DIR) flatbuffers-generator
 
-xcode: setup
+xcode: setup flatc
 	$(MESON) setup --buildtype debug --backend xcode $(MEDIASOUP_OUT_DIR)/xcode
 
 lint:
@@ -234,7 +234,7 @@ else
 	$(BUILD_DIR)/mediasoup-worker-test --invisibles --use-colour=yes $(MEDIASOUP_TEST_TAGS)
 endif
 
-test-asan: setup
+test-asan: setup flatc
 	$(MESON) compile -C $(BUILD_DIR) -j $(CORES) mediasoup-worker-test-asan
 	$(MESON) install -C $(BUILD_DIR) --no-rebuild --tags mediasoup-worker-test-asan
 	ASAN_OPTIONS=detect_leaks=1 $(BUILD_DIR)/mediasoup-worker-test-asan --invisibles --use-colour=yes $(MEDIASOUP_TEST_TAGS)
@@ -249,7 +249,7 @@ tidy:
 		-checks=$(MEDIASOUP_TIDY_CHECKS) \
 		-quiet
 
-fuzzer: setup
+fuzzer: setup flatc
 	$(MESON) compile -C $(BUILD_DIR) -j $(CORES) mediasoup-worker-fuzzer
 	$(MESON) install -C $(BUILD_DIR) --no-rebuild --tags mediasoup-worker-fuzzer
 

--- a/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.cc
@@ -289,6 +289,8 @@ void RemoteBitrateEstimatorAbsSendTime::IncomingPacketInfo(
     if (payload_size > kMinProbePacketSize &&
         (!remote_rate_.ValidEstimate() ||
          now_ms - first_packet_time_ms_ < kInitialProbingIntervalMs)) {
+
+#if MS_LOG_DEV_LEVEL == 3
       // TODO(holmer): Use a map instead to get correct order?
       if (total_probes_received_ < kMaxProbePackets) {
         int send_delta_ms = -1;
@@ -306,6 +308,8 @@ void RemoteBitrateEstimatorAbsSendTime::IncomingPacketInfo(
             send_delta_ms,
             recv_delta_ms);
       }
+#endif
+
       probes_.push_back(Probe(send_time_ms, arrival_time_ms, payload_size));
       ++total_probes_received_;
       // Make sure that a probe which updated the bitrate immediately has an

--- a/worker/src/RTC/RTCP/XrDelaySinceLastRr.cpp
+++ b/worker/src/RTC/RTCP/XrDelaySinceLastRr.cpp
@@ -75,14 +75,12 @@ namespace RTC
 				{
 					report->AddSsrcInfo(ssrcInfo);
 					offset += ssrcInfo->GetSize();
+					reportLength -= ssrcInfo->GetSize();
 				}
 				else
 				{
 					return report.release();
 				}
-
-				offset += ssrcInfo->GetSize();
-				reportLength -= DelaySinceLastRr::SsrcInfo::BodySize;
 			}
 
 			return report.release();

--- a/worker/test/src/RTC/RTCP/TestXr.cpp
+++ b/worker/test/src/RTC/RTCP/TestXr.cpp
@@ -1,10 +1,97 @@
 #include "common.hpp"
+#include "RTC/RTCP/XR.hpp"
 #include "RTC/RTCP/XrDelaySinceLastRr.hpp"
 #include "RTC/RTCP/XrReceiverReferenceTime.hpp"
 #include <catch2/catch.hpp>
 #include <cstring> // std::memcmp
 
 using namespace RTC::RTCP;
+
+SCENARIO("RTCP XR parsing", "[parser][rtcp][xr]")
+{
+	// clang-format off
+	uint8_t buffer[] =
+	{
+		0xa0, 0xcf, 0x00, 0x08, // Padding, Type: 207 (XR), Length: 8
+		0x5d, 0x93, 0x15, 0x34, // Sender SSRC: 0x5d931534
+		// Extended Report DLRR
+		0x05, 0x00, 0x00, 0x06, // BT: 5 (DLRR), Block Length: 6
+		0x11, 0x12, 0x13, 0x14, // SSRC 1
+		0x00, 0x11, 0x00, 0x11, // LRR 1
+		0x11, 0x00, 0x11, 0x00, // DLRR 1
+		0x21, 0x22, 0x23, 0x24, // SSRC 2
+		0x00, 0x22, 0x00, 0x22, // LRR 2
+		0x22, 0x00, 0x22, 0x00, // DLRR 2
+		0x00, 0x00, 0x00, 0x04 // Padding (4 bytes)
+	};
+	// clang-format on
+
+	SECTION("parse XR packet")
+	{
+		auto* packet = ExtendedReportPacket::Parse(buffer, sizeof(buffer));
+
+		REQUIRE(packet);
+		// Despite total buffer size is 40 bytes, our GetSize() method doesn't not
+		// consider RTCP padding (4 bytes in this case).
+		REQUIRE(packet->GetSize() == 36);
+		REQUIRE(packet->GetCount() == 0);
+		REQUIRE(packet->GetSsrc() == 0x5d931534);
+
+		size_t blockIdx{ 0u };
+
+		for (auto it = packet->Begin(); it != packet->End(); ++it, ++blockIdx)
+		{
+			auto* block = *it;
+
+			switch (blockIdx)
+			{
+				case 0:
+				{
+					REQUIRE(block->GetSize() == 28);
+
+					size_t ssrcInfoIdx{ 0u };
+					auto* dlrrBlock = reinterpret_cast<DelaySinceLastRr*>(block);
+
+					for (auto it2 = dlrrBlock->Begin(); it2 != dlrrBlock->End(); ++it2, ++ssrcInfoIdx)
+					{
+						auto* ssrcInfo = *it2;
+
+						switch (ssrcInfoIdx)
+						{
+							case 0:
+							{
+								REQUIRE(ssrcInfo->GetSsrc() == 0x11121314);
+								REQUIRE(ssrcInfo->GetLastReceiverReport() == 0x00110011);
+								REQUIRE(ssrcInfo->GetDelaySinceLastReceiverReport() == 0x11001100);
+
+								break;
+							}
+
+							case 1:
+							{
+								REQUIRE(ssrcInfo->GetSsrc() == 0x21222324);
+								REQUIRE(ssrcInfo->GetLastReceiverReport() == 0x00220022);
+								REQUIRE(ssrcInfo->GetDelaySinceLastReceiverReport() == 0x22002200);
+
+								break;
+							}
+						}
+					}
+
+					// There are 2 SSRC infos.
+					REQUIRE(ssrcInfoIdx == 2);
+
+					break;
+				}
+			}
+		}
+
+		// There are 1 block (the DLRR block).
+		REQUIRE(blockIdx == 1);
+
+		delete packet;
+	}
+}
 
 SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
 {


### PR DESCRIPTION
Fixes #1211

### Details

- Bug fixed but I'm not happy. A complete RTCP refactor is needed. Exposed here: https://github.com/versatica/mediasoup/issues/1233
- Bonus track: In `Makefile` add "flatc" dep to various tasks.
- Bonus track: Get rid of the tedious "variable 'send_delta_ms' set but not used" warning in `remote_bitrate_estimator_abs_send_time.cc`.