### PR TITLE
RTCP `CompoundPacket`: Use a single DLRR block to hold all ssrc infos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### NEXT
 
 * Fix RTCP SDES packet size calculation ([PR #1236](https://github.com/versatica/mediasoup/pull/1236) based on PR [PR #1234](https://github.com/versatica/mediasoup/pull/1234) by @ybybwdwd).
+* RTCP Compound Packet: Use a single DLRR report to hold all ssrc info sub-blocks ([PR #1237](https://github.com/versatica/mediasoup/pull/1237)).
 
 
 ### 3.13.4

--- a/worker/include/RTC/RTCP/CompoundPacket.hpp
+++ b/worker/include/RTC/RTCP/CompoundPacket.hpp
@@ -48,14 +48,16 @@ namespace RTC
 			// Adds the given data and returns true if there is enough space to hold it,
 			// false otherwise.
 			bool Add(
-			  SenderReport* senderReport, SdesChunk* sdesChunk, DelaySinceLastRr* delaySinceLastRrReport);
+			  SenderReport* senderReport,
+			  SdesChunk* sdesChunk,
+			  DelaySinceLastRr::SsrcInfo* delaySinceLastRrSsrcInfo);
 			// RTCP additions per Consumer (pipe).
 			// Adds the given data and returns true if there is enough space to hold it,
 			// false otherwise.
 			bool Add(
 			  std::vector<SenderReport*>& senderReports,
 			  std::vector<SdesChunk*>& sdesChunks,
-			  std::vector<DelaySinceLastRr*>& delaySinceLastRrReports);
+			  std::vector<DelaySinceLastRr::SsrcInfo*>& delaySinceLastRrSsrcInfos);
 			// RTCP additions per Producer.
 			// Adds the given data and returns true if there is enough space to hold it,
 			// false otherwise.
@@ -64,7 +66,6 @@ namespace RTC
 			void AddReceiverReport(ReceiverReport* report);
 			void AddSdesChunk(SdesChunk* chunk);
 			void AddReceiverReferenceTime(ReceiverReferenceTime* report);
-			void AddDelaySinceLastRr(DelaySinceLastRr* report);
 			bool HasSenderReport()
 			{
 				return this->senderReportPacket.Begin() != this->senderReportPacket.End();
@@ -77,6 +78,14 @@ namespace RTC
 				  [](const ExtendedReportBlock* report)
 				  { return report->GetType() == ExtendedReportBlock::Type::RRT; });
 			}
+			bool HasDelaySinceLastRr()
+			{
+				return std::any_of(
+				  this->xrPacket.Begin(),
+				  this->xrPacket.End(),
+				  [](const ExtendedReportBlock* report)
+				  { return report->GetType() == ExtendedReportBlock::Type::DLRR; });
+			}
 			void Serialize(uint8_t* data);
 
 		private:
@@ -85,6 +94,7 @@ namespace RTC
 			ReceiverReportPacket receiverReportPacket;
 			SdesPacket sdesPacket;
 			ExtendedReportPacket xrPacket;
+			DelaySinceLastRr* delaySinceLastRr{ nullptr };
 		};
 	} // namespace RTCP
 } // namespace RTC

--- a/worker/include/RTC/RTCP/CompoundPacket.hpp
+++ b/worker/include/RTC/RTCP/CompoundPacket.hpp
@@ -65,7 +65,6 @@ namespace RTC
 			void AddSenderReport(SenderReport* report);
 			void AddReceiverReport(ReceiverReport* report);
 			void AddSdesChunk(SdesChunk* chunk);
-			void AddReceiverReferenceTime(ReceiverReferenceTime* report);
 			bool HasSenderReport()
 			{
 				return this->senderReportPacket.Begin() != this->senderReportPacket.End();

--- a/worker/include/RTC/RTCP/XrDelaySinceLastRr.hpp
+++ b/worker/include/RTC/RTCP/XrDelaySinceLastRr.hpp
@@ -119,6 +119,19 @@ namespace RTC
 			{
 				this->ssrcInfos.push_back(ssrcInfo);
 			}
+			// NOTE: This method not only removes given number of ssrc info sub-blocks
+			// but also deletes their SsrcInfo instances.
+			void RemoveLastSsrcInfos(size_t number)
+			{
+				while (!this->ssrcInfos.empty() && number-- > 0)
+				{
+					auto* ssrcInfo = this->ssrcInfos.back();
+
+					this->ssrcInfos.pop_back();
+
+					delete ssrcInfo;
+				}
+			}
 			Iterator Begin()
 			{
 				return this->ssrcInfos.begin();

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -37,7 +37,7 @@ namespace RTC
 		void ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReport* report);
 		void ReceiveRtcpXrReceiverReferenceTime(RTC::RTCP::ReceiverReferenceTime* report);
 		RTC::RTCP::SenderReport* GetRtcpSenderReport(uint64_t nowMs);
-		RTC::RTCP::DelaySinceLastRr::SsrcInfo* GetRtcpXrDelaySinceLastRr(uint64_t nowMs);
+		RTC::RTCP::DelaySinceLastRr::SsrcInfo* GetRtcpXrDelaySinceLastRrSsrcInfo(uint64_t nowMs);
 		RTC::RTCP::SdesChunk* GetRtcpSdesChunk();
 		void Pause() override;
 		void Resume() override;

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -345,7 +345,7 @@ namespace RTC
 
 		std::vector<RTCP::SenderReport*> senderReports;
 		std::vector<RTCP::SdesChunk*> sdesChunks;
-		std::vector<RTCP::DelaySinceLastRr*> xrReports;
+		std::vector<RTCP::DelaySinceLastRr::SsrcInfo*> delaySinceLastRrSsrcInfos;
 
 		for (auto* rtpStream : this->rtpStreams)
 		{
@@ -362,19 +362,16 @@ namespace RTC
 			auto* sdesChunk = rtpStream->GetRtcpSdesChunk();
 			sdesChunks.push_back(sdesChunk);
 
-			auto* dlrr = rtpStream->GetRtcpXrDelaySinceLastRr(nowMs);
+			auto* delaySinceLastRrSsrcInfo = rtpStream->GetRtcpXrDelaySinceLastRrSsrcInfo(nowMs);
 
-			if (dlrr)
+			if (delaySinceLastRrSsrcInfo)
 			{
-				auto* report = new RTC::RTCP::DelaySinceLastRr();
-				report->AddSsrcInfo(dlrr);
-
-				xrReports.push_back(report);
+				delaySinceLastRrSsrcInfos.push_back(delaySinceLastRrSsrcInfo);
 			}
 		}
 
 		// RTCP Compound packet buffer cannot hold the data.
-		if (!packet->Add(senderReports, sdesChunks, xrReports))
+		if (!packet->Add(senderReports, sdesChunks, delaySinceLastRrSsrcInfos))
 		{
 			return false;
 		}

--- a/worker/src/RTC/RTCP/CompoundPacket.cpp
+++ b/worker/src/RTC/RTCP/CompoundPacket.cpp
@@ -282,12 +282,5 @@ namespace RTC
 
 			this->sdesPacket.AddChunk(chunk);
 		}
-
-		void CompoundPacket::AddReceiverReferenceTime(ReceiverReferenceTime* report)
-		{
-			MS_TRACE();
-
-			this->xrPacket.AddReport(report);
-		}
 	} // namespace RTCP
 } // namespace RTC

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -274,7 +274,7 @@ namespace RTC
 		return report;
 	}
 
-	RTC::RTCP::DelaySinceLastRr::SsrcInfo* RtpStreamSend::GetRtcpXrDelaySinceLastRr(uint64_t nowMs)
+	RTC::RTCP::DelaySinceLastRr::SsrcInfo* RtpStreamSend::GetRtcpXrDelaySinceLastRrSsrcInfo(uint64_t nowMs)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -439,18 +439,10 @@ namespace RTC
 		// Build SDES chunk for this sender.
 		auto* sdesChunk = this->rtpStream->GetRtcpSdesChunk();
 
-		RTC::RTCP::DelaySinceLastRr* delaySinceLastRrReport{ nullptr };
-
-		auto* dlrr = this->rtpStream->GetRtcpXrDelaySinceLastRr(nowMs);
-
-		if (dlrr)
-		{
-			delaySinceLastRrReport = new RTC::RTCP::DelaySinceLastRr();
-			delaySinceLastRrReport->AddSsrcInfo(dlrr);
-		}
+		auto* delaySinceLastRrSsrcInfo = this->rtpStream->GetRtcpXrDelaySinceLastRrSsrcInfo(nowMs);
 
 		// RTCP Compound packet buffer cannot hold the data.
-		if (!packet->Add(senderReport, sdesChunk, delaySinceLastRrReport))
+		if (!packet->Add(senderReport, sdesChunk, delaySinceLastRrSsrcInfo))
 		{
 			return false;
 		}

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -1081,18 +1081,10 @@ namespace RTC
 		// Build SDES chunk for this sender.
 		auto* sdesChunk = this->rtpStream->GetRtcpSdesChunk();
 
-		RTC::RTCP::DelaySinceLastRr* delaySinceLastRrReport{ nullptr };
-
-		auto* dlrr = this->rtpStream->GetRtcpXrDelaySinceLastRr(nowMs);
-
-		if (dlrr)
-		{
-			delaySinceLastRrReport = new RTC::RTCP::DelaySinceLastRr();
-			delaySinceLastRrReport->AddSsrcInfo(dlrr);
-		}
+		auto* delaySinceLastRrSsrcInfo = this->rtpStream->GetRtcpXrDelaySinceLastRrSsrcInfo(nowMs);
 
 		// RTCP Compound packet buffer cannot hold the data.
-		if (!packet->Add(senderReport, sdesChunk, delaySinceLastRrReport))
+		if (!packet->Add(senderReport, sdesChunk, delaySinceLastRrSsrcInfo))
 		{
 			return false;
 		}

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -795,18 +795,10 @@ namespace RTC
 		// Build SDES chunk for this sender.
 		auto* sdesChunk = this->rtpStream->GetRtcpSdesChunk();
 
-		RTC::RTCP::DelaySinceLastRr* delaySinceLastRrReport{ nullptr };
-
-		auto* dlrr = this->rtpStream->GetRtcpXrDelaySinceLastRr(nowMs);
-
-		if (dlrr)
-		{
-			delaySinceLastRrReport = new RTC::RTCP::DelaySinceLastRr();
-			delaySinceLastRrReport->AddSsrcInfo(dlrr);
-		}
+		auto* delaySinceLastRrSsrcInfo = this->rtpStream->GetRtcpXrDelaySinceLastRrSsrcInfo(nowMs);
 
 		// RTCP Compound packet buffer cannot hold the data.
-		if (!packet->Add(senderReport, sdesChunk, delaySinceLastRrReport))
+		if (!packet->Add(senderReport, sdesChunk, delaySinceLastRrSsrcInfo))
 		{
 			return false;
 		}


### PR DESCRIPTION
Fixes #1211

### Details

- Previously, our `CompoundPacket` has a XR packet with many DLRR blocks, each one with a single ssrc info sub-block.
- Now our `CompoundPacket` has a XR pacjet with a single DLRR block with many ssrc info sub-blocks.
- Both approaches are spec compliant **BUT** libwebrtc thinks it makes no sense to have multiple blocks of the same type in an XR packet: https://codereview.webrtc.org/2378113002
- Thanks @ybybwdwd for reporting the issue and for the references.

### TODO

* [x] Same should be done for other blocks. This must be verified. **Done** in https://github.com/versatica/mediasoup/issues/1238.