### PR TITLE
Only install Python Invoke if mediasoup-worker must be locally built

### DIFF
--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -54,10 +54,10 @@ jobs:
       - name: npm ci
         run: npm ci --ignore-scripts --omit=dev
 
-      # However we also need to install pip invoke by manually invoking the NPM
-      # 'preinstall' script (since `--ignore-scripts` above made it not run).
-      - name: npm run preinstall
-        run: npm run preinstall
+      # However we also need to install pip invoke manually (since
+      # `--ignore-scripts` prevented invoke from being installed).
+      - name: pip3 install invoke
+        run: pip3 install invoke
 
       - name: npm run worker:build
         run: npm run worker:build

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -68,10 +68,10 @@ jobs:
       - name: npm ci
         run: npm ci --ignore-scripts --omit=dev
 
-      # However we also need to install pip invoke by manually invoking the NPM
-      # 'preinstall' script (since `--ignore-scripts` above made it not run).
-      - name: npm run preinstall
-        run: npm run preinstall
+      # However we also need to install pip invoke manually (since
+      # `--ignore-scripts` prevented invoke from being installed).
+      - name: pip3 install invoke
+        run: pip3 install invoke
 
       # We need to install deps on worker/scripts/package.json.
       - name: npm run install-worker-dev-tools

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -41,13 +41,6 @@ async function run()
 {
 	switch (task)
 	{
-		case 'preinstall':
-		{
-			installInvoke();
-
-			break;
-		}
-
 		// As per NPM documentation (https://docs.npmjs.com/cli/v9/using-npm/scripts)
 		// `prepare` script:
 		//
@@ -92,6 +85,7 @@ async function run()
 			{
 				logInfo('skipping mediasoup-worker prebuilt download, building it locally');
 
+				installInvoke();
 				buildWorker();
 
 				if (!process.env.MEDIASOUP_LOCAL_DEV)
@@ -104,6 +98,7 @@ async function run()
 			{
 				logInfo(`couldn't fetch any mediasoup-worker prebuilt binary, building it locally`);
 
+				installInvoke();
 				buildWorker();
 
 				if (!process.env.MEDIASOUP_LOCAL_DEV)
@@ -379,14 +374,6 @@ function cleanWorkerArtifacts()
 	executeCmd(`${PYTHON} -m invoke -r worker clean-subprojects`);
 	// Clean PIP/Meson/Ninja.
 	executeCmd(`${PYTHON} -m invoke -r worker clean-pip`);
-
-	if (IS_WINDOWS)
-	{
-		if (fs.existsSync('worker/out/msys'))
-		{
-			executeCmd('rd /s /q worker\\out\\msys');
-		}
-	}
 }
 
 function lintNode()
@@ -406,9 +393,6 @@ function lintWorker()
 function flatcNode()
 {
 	logInfo('flatcNode()');
-
-	// Build flatc if needed.
-	executeCmd(`${PYTHON} -m invoke -r worker flatc`);
 
 	const buildType = process.env.MEDIASOUP_BUILDTYPE || 'Release';
 	const extension = IS_WINDOWS ? '.exe' : '';

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
     "nodejs"
   ],
   "scripts": {
-    "preinstall": "node npm-scripts.mjs preinstall",
     "prepare": "node npm-scripts.mjs prepare",
     "postinstall": "node npm-scripts.mjs postinstall",
     "typescript:build": "node npm-scripts.mjs typescript:build",


### PR DESCRIPTION
- Also make `flatc:node` NPM script do NOT invoke worker "flatc" task.

NOTE: Now I see that this PR is not valid but will create this PR for discussing about it. Problem is that, indeed, running worker "flatc" task is needed for `flatc:node` NPM script to succeed. Otherwise we get this error:

https://github.com/versatica/mediasoup/actions/runs/6988996456/job/19017138136
```
npm-scripts.mjs [INFO] [prepare] flatcNode()
npm-scripts.mjs [INFO] [prepare] executeCmd(): for file in /home/runner/work/mediasoup/mediasoup/worker/fbs/*.fbs; do /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc --ts --ts-no-import-ext --gen-object-api -o /home/runner/work/mediasoup/mediasoup/node/src  ${file}; done
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
/bin/sh: 1: /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc: not found
npm-scripts.mjs [ERROR] [prepare] executeCmd() failed, exiting: Error: Command failed: for file in /home/runner/work/mediasoup/mediasoup/worker/fbs/*.fbs; do /home/runner/work/mediasoup/mediasoup/worker/out/Release/build/subprojects/flatbuffers-23.3.3/flatc --ts --ts-no-import-ext --gen-object-api -o /home/runner/work/mediasoup/mediasoup/node/src  ${file}; done
npm ERR! code 1
```

So the problem is that, in theory, Python was only a dependency in case the mediasoup-worker binary should be locally built. However, now Python is mandatory even if a prebuilt worker binary is fetched. Why? Because despite there is a prebuilt worker binary, mediasoup npm installation needs to compile flatc files to TypeScript and for that it needs to run the worker "flatc" task, which depends on Python Invoke (it depended on `make`), so Python 3 is needed anyway.

My question is: why does "flatc:node" depend on worker "flatc" task?