### PR TITLE
Avoid C++ unused goto symbol warning when liburing is not supported

### DIFF
--- a/worker/src/handles/TcpConnectionHandle.cpp
+++ b/worker/src/handles/TcpConnectionHandle.cpp
@@ -265,6 +265,8 @@ void TcpConnectionHandle::Write(
 
 		return;
 	}
+#else
+	goto write_libuv;
 #endif
 
 write_libuv:

--- a/worker/src/handles/TcpConnectionHandle.cpp
+++ b/worker/src/handles/TcpConnectionHandle.cpp
@@ -265,18 +265,17 @@ void TcpConnectionHandle::Write(
 
 		return;
 	}
-#else
-	goto write_libuv;
-#endif
 
 write_libuv:
+#endif
+
+	// First try uv_try_write(). In case it can not directly write all the given
+	// data then build a uv_req_t and use uv_write().
+
 	const size_t totalLen = len1 + len2;
 	uv_buf_t buffers[2];
 	int written{ 0 };
 	int err;
-
-	// First try uv_try_write(). In case it can not directly write all the given
-	// data then build a uv_req_t and use uv_write().
 
 	buffers[0] = uv_buf_init(reinterpret_cast<char*>(const_cast<uint8_t*>(data1)), len1);
 	buffers[1] = uv_buf_init(reinterpret_cast<char*>(const_cast<uint8_t*>(data2)), len2);

--- a/worker/src/handles/UdpSocketHandle.cpp
+++ b/worker/src/handles/UdpSocketHandle.cpp
@@ -190,11 +190,10 @@ void UdpSocketHandle::Send(
 
 		return;
 	}
-#else
-	goto send_libuv;
-#endif
 
 send_libuv:
+#endif
+
 	// First try uv_udp_try_send(). In case it can not directly send the datagram
 	// then build a uv_req_t and use uv_udp_send().
 

--- a/worker/src/handles/UdpSocketHandle.cpp
+++ b/worker/src/handles/UdpSocketHandle.cpp
@@ -190,6 +190,8 @@ void UdpSocketHandle::Send(
 
 		return;
 	}
+#else
+	goto send_libuv;
 #endif
 
 send_libuv:


### PR DESCRIPTION
When compiling worker in macOS (for example) we got this warnings:

```
../../../src/handles/TcpConnectionHandle.cpp:270:1: warning: unused label 'write_libuv' [-Wunused-label]
write_libuv:
^~~~~~~~~~~~
1 warning generated.

../../../src/handles/UdpSocketHandle.cpp:195:1: warning: unused label 'send_libuv' [-Wunused-label]
send_libuv:
^~~~~~~~~~~
1 warning generated.
```

This PR fixes them.