### PR TITLE
Node: jest, add modulePathIgnorePatters option

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
       "node/src/fbs",
       "node/src/tests"
     ],
-    "cacheDirectory": ".cache/jest"
+    "cacheDirectory": ".cache/jest",
+    "modulePathIgnorePatterns": ["worker/", "rust/"]
   },
   "dependencies": {
     "debug": "^4.3.4",


### PR DESCRIPTION
Indicate Jest not to look in worker/ nor rust/ for node modules.

Since flatbuffers is a npm module and also a subproject in worker folder, jest was complaining that there were two different modules for flatbuffers

