### PR TITLE
Disable liburing by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### Next
 
 * LibUring: Enable liburing usage for SCTP data delivery ([PR 1249](https://github.com/versatica/mediasoup/pull/1249)).
+* LibUring: Disable by default ([PR 1253](https://github.com/versatica/mediasoup/pull/1253)).
 
 
 ### 3.13.7

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -258,7 +258,7 @@ if host_machine.system() == 'windows'
   ]
 endif
 
-if host_machine.system() == 'linux'
+if host_machine.system() == 'linux' and get_option('ms_enable_liburing')
   kernel_version = run_command('uname', '-r').stdout().strip()
 
   # Enable liburing for kernel versions greather than or equal to 6.

--- a/worker/meson_options.txt
+++ b/worker/meson_options.txt
@@ -1,3 +1,4 @@
 option('ms_log_trace', type : 'boolean', value : false, description : 'When enabled, logs the current method/function if current log level is "debug"')
 option('ms_log_file_line', type : 'boolean', value : false, description : 'When enabled, all the logging macros print more verbose information, including current file and line')
 option('ms_rtc_logger_rtp', type : 'boolean', value : false, description : 'When enabled, prints a line with information for each RTP packet')
+option('ms_enable_liburing', type : 'boolean', value : false, description : 'When enabled, enables liburing')


### PR DESCRIPTION
While investigating issue #1252, disable liburing by default.

In order to enable it, use MESON_ARGS as usual. ie:

`MESON_ARGS=-Dms_enable_liburing=true npm install`