### PR TITLE
Update worker liburing dependency to 2.4-2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* Update worker liburing dependency to 2.4-2 ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)):
+
+
 ### 3.13.8
 
 * LibUring: Enable liburing usage for SCTP data delivery ([PR 1249](https://github.com/versatica/mediasoup/pull/1249)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ### NEXT
 
-* Update worker liburing dependency to 2.4-2 ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)):
+* Update worker liburing dependency to 2.4-2 ([PR #1254](https://github.com/versatica/mediasoup/pull/1254)):
 
 
 ### 3.13.8

--- a/worker/subprojects/liburing.wrap
+++ b/worker/subprojects/liburing.wrap
@@ -3,11 +3,11 @@ directory = liburing-liburing-2.4
 source_url = https://github.com/axboe/liburing/archive/refs/tags/liburing-2.4.tar.gz
 source_filename = liburing-2.4.tar.gz
 source_hash = 2398ec82d967a6f903f3ae1fd4541c754472d3a85a584dc78c5da2fabc90706b
-patch_filename = liburing_2.4-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/liburing_2.4-1/get_patch
-patch_hash = 0dd939828da6a7c6d22c0f4db879405e74f9ac7153927c365642a28f871c92c2
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/liburing_2.4-1/liburing-2.4.tar.gz
-wrapdb_version = 2.4-1
+patch_filename = liburing_2.4-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/liburing_2.4-2/get_patch
+patch_hash = 0435ae1012065fa96a22e1068c2e39e2f7c7c03b58a812774434a6e7455d7f20
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/liburing_2.4-2/liburing-2.4.tar.gz
+wrapdb_version = 2.4-2
 
 [provide]
 dependency_names = liburing


### PR DESCRIPTION
Fixes #1252 after liburing wrap file was fixed by @jmillan in PR https://github.com/mesonbuild/wrapdb/pull/1322.