### PR TITLE
Enable liburing by default

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -50,7 +50,7 @@ jobs:
       # NOTE: Add --force since otherwise `npm ci` fails in Node 16 because
       # @octokit/auth-token dev dependency requires Node >= 16.
       - name: npm ci
-        run: npm ci --force
+        run: npm ci --force --foreground-scripts
 
       - name: npm run lint:node
         run: npm run lint:node

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -51,8 +51,8 @@ jobs:
           node-version: ${{ matrix.node }}
 
       # We need to install some NPM production deps for npm-scripts.mjs to work.
-      - name: npm ci
-        run: npm ci --ignore-scripts --omit=dev
+      - name: npm ci --ignore-scripts
+        run: npm ci --ignore-scripts --omit=dev --foreground-scripts
 
       # However we also need to install pip invoke manually (since
       # `--ignore-scripts` prevented invoke from being installed).

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -70,7 +70,7 @@ jobs:
 
       # We need to install npm deps of worker/scripts/package.json.
       - name: npm ci --prefix worker/scripts
-        run: npm ci --prefix worker/scripts
+        run: npm ci --prefix worker/scripts --foreground-scripts
         # TODO: Maybe fix this one day.
         if: runner.os != 'Windows'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,14 @@
 
 ### NEXT
 
-* Update worker liburing dependency to 2.4-2 ([PR #1254](https://github.com/versatica/mediasoup/pull/1254)):
+* Update worker liburing dependency to 2.4-2 ([PR #1254](https://github.com/versatica/mediasoup/pull/1254)).
+* liburing: Enable by default ([PR 1255](https://github.com/versatica/mediasoup/pull/1255)).
 
 
 ### 3.13.8
 
-* LibUring: Enable liburing usage for SCTP data delivery ([PR 1249](https://github.com/versatica/mediasoup/pull/1249)).
-* LibUring: Disable by default ([PR 1253](https://github.com/versatica/mediasoup/pull/1253)).
+* liburing: Enable liburing usage for SCTP data delivery ([PR 1249](https://github.com/versatica/mediasoup/pull/1249)).
+* liburing: Disable by default ([PR 1253](https://github.com/versatica/mediasoup/pull/1253)).
 
 
 ### 3.13.7

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -258,7 +258,7 @@ if host_machine.system() == 'windows'
   ]
 endif
 
-if host_machine.system() == 'linux' and get_option('ms_enable_liburing')
+if host_machine.system() == 'linux' and not get_option('ms_disable_liburing')
   kernel_version = run_command('uname', '-r').stdout().strip()
 
   # Enable liburing for kernel versions greather than or equal to 6.

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -259,7 +259,7 @@ if host_machine.system() == 'windows'
 endif
 
 if host_machine.system() == 'linux' and not get_option('ms_disable_liburing')
-  kernel_version = run_command('uname', '-r').stdout().strip()
+  kernel_version = run_command('uname', '-r', check: true).stdout().strip()
 
   # Enable liburing for kernel versions greather than or equal to 6.
   if kernel_version[0].to_int() >= 6

--- a/worker/meson_options.txt
+++ b/worker/meson_options.txt
@@ -1,4 +1,4 @@
-option('ms_log_trace', type : 'boolean', value : false, description : 'When enabled, logs the current method/function if current log level is "debug"')
-option('ms_log_file_line', type : 'boolean', value : false, description : 'When enabled, all the logging macros print more verbose information, including current file and line')
-option('ms_rtc_logger_rtp', type : 'boolean', value : false, description : 'When enabled, prints a line with information for each RTP packet')
-option('ms_enable_liburing', type : 'boolean', value : false, description : 'When enabled, enables liburing')
+option('ms_log_trace', type : 'boolean', value : false, description : 'When set to true, logs the current method/function if current log level is "debug"')
+option('ms_log_file_line', type : 'boolean', value : false, description : 'When set to true, all the logging macros print more verbose information, including current file and line')
+option('ms_rtc_logger_rtp', type : 'boolean', value : false, description : 'When set to true, prints a line with information for each RTP packet')
+option('ms_disable_liburing', type : 'boolean', value : false, description : 'When set to true, disables liburing integration despite current host supports it')


### PR DESCRIPTION
### Details

- Now that PR https://github.com/versatica/mediasoup/pull/1254 is merged (AKA new liburing wrap version with @jmillan's fix https://github.com/mesonbuild/wrapdb/pull/1322) let's enable liburing again by default. 
- `ms_enable_liburing` has been replaced with `ms_disable_liburing` (which of course is `false` by default).

### Bonus tracks

- Add explicit `--foreground-scripts` to all `npm ci` commands in CI actions.
- Fix meson warning (fixes #1256).