### PR TITLE
libsrtp: use our own fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 ### NEXT
 
 * liburing: avoid extra memcpy on RTP ([PR #1258](https://github.com/versatica/mediasoup/pull/1258)).
+* libsrtp: use our own fork ([PR #1260](https://github.com/versatica/mediasoup/pull/1260)).
 
 
 ### 3.13.10

--- a/worker/subprojects/libsrtp2.wrap
+++ b/worker/subprojects/libsrtp2.wrap
@@ -1,9 +1,8 @@
 [wrap-file]
-directory = libsrtp-2.5.0
-source_url = https://github.com/cisco/libsrtp/archive/refs/tags/v2.5.0.tar.gz
-source_filename = libsrtp-2.5.0.tar.gz
-source_hash = 8a43ef8e9ae2b665292591af62aa1a4ae41e468b6d98d8258f91478735da4e09
-wrapdb_version = 2.5.0-1
+directory = libsrtp-4c9f0956f2933ac0650208d69c8d897625ba6301
+source_url = https://github.com/versatica/libsrtp/archive/4c9f0956f2933ac0650208d69c8d897625ba6301.zip
+source_filename = libsrtp-4c9f0956f2933ac0650208d69c8d897625ba6301.zip
+source_hash = 4f3af61e26df398569605fc4bcf377587ca2d8bd34b2b4bf9cdb9590cadbd662
 
 [provide]
 libsrtp2 = libsrtp2_dep


### PR DESCRIPTION
It uses a list hash rather than a single list to store stream contexts.

By distributing the stream contexts in multiple lists (32) we enhance the list traversal time for the stream we are looking, by 32 times in the best case.

I made a PR in the project but it didn't succeed https://github.com/cisco/libsrtp/pull/659

They'll work on a different solution. In the meantime we can use this approach. It saves 2% CPU for a Router with 1 AV Producer and 40 A/V Consumers. The gains are bigger as the number of Consumers increase.