### PR TITLE
Fix Rust DataConsumer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 
 * liburing: avoid extra memcpy on RTP ([PR #1258](https://github.com/versatica/mediasoup/pull/1258)).
 * libsrtp: use our own fork ([PR #1260](https://github.com/versatica/mediasoup/pull/1260)).
-* Fix Rust `DataConsumer` in tests ([PR #1262](https://github.com/versatica/mediasoup/pull/1262)).
+* Fix Rust `DataConsumer` ([PR #1262](https://github.com/versatica/mediasoup/pull/1262)).
 
 
 ### 3.13.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * liburing: avoid extra memcpy on RTP ([PR #1258](https://github.com/versatica/mediasoup/pull/1258)).
 * libsrtp: use our own fork ([PR #1260](https://github.com/versatica/mediasoup/pull/1260)).
+* Fix Rust `DataConsumer` in tests ([PR #1262](https://github.com/versatica/mediasoup/pull/1262)).
 
 
 ### 3.13.10

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -71,7 +71,7 @@ test('transport.consumeData() succeeds', async () =>
 	expect(dataConsumer1.label).toBe('foo');
 	expect(dataConsumer1.protocol).toBe('bar');
 	expect(dataConsumer1.paused).toBe(false);
-	expect(dataConsumer1.subchannels.sort((a, b) => a - b)).toEqual([ 0, 1, 2, 100, 65535 ]);
+	expect(dataConsumer1.subchannels).toEqual([ 0, 1, 2, 100, 65535 ]);
 	expect(dataConsumer1.appData).toEqual({ baz: 'LOL' });
 
 	const dump = await router.dump();
@@ -134,7 +134,7 @@ test('dataConsumer.setSubchannels() succeeds', async () =>
 {
 	await dataConsumer1.setSubchannels([ 999, 999, 998, 65536 ]);
 
-	expect(dataConsumer1.subchannels.sort((a, b) => a - b)).toEqual([ 0, 998, 999 ]);
+	expect(dataConsumer1.subchannels).toEqual([ 0, 998, 999 ]);
 }, 2000);
 
 test('transport.consumeData() on a DirectTransport succeeds', async () =>

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -71,7 +71,8 @@ test('transport.consumeData() succeeds', async () =>
 	expect(dataConsumer1.label).toBe('foo');
 	expect(dataConsumer1.protocol).toBe('bar');
 	expect(dataConsumer1.paused).toBe(false);
-	expect(dataConsumer1.subchannels.sort()).toEqual([ 0, 1, 2, 100, 65535 ]);
+	expect(dataConsumer1.subchannels.sort((a, b) => a - b))
+		.toEqual([ 0, 1, 2, 100, 65535 ]);
 	expect(dataConsumer1.appData).toEqual({ baz: 'LOL' });
 
 	const dump = await router.dump();
@@ -134,7 +135,8 @@ test('dataConsumer.setSubchannels() succeeds', async () =>
 {
 	await dataConsumer1.setSubchannels([ 999, 999, 998, 65536 ]);
 
-	expect(dataConsumer1.subchannels.sort()).toEqual([ 0, 998, 999 ]);
+	expect(dataConsumer1.subchannels.sort((a, b) => a - b))
+		.toEqual([ 0, 998, 999 ]);
 }, 2000);
 
 test('transport.consumeData() on a DirectTransport succeeds', async () =>

--- a/node/src/tests/test-DataConsumer.ts
+++ b/node/src/tests/test-DataConsumer.ts
@@ -71,7 +71,7 @@ test('transport.consumeData() succeeds', async () =>
 	expect(dataConsumer1.label).toBe('foo');
 	expect(dataConsumer1.protocol).toBe('bar');
 	expect(dataConsumer1.paused).toBe(false);
-	expect(dataConsumer1.subchannels).toEqual([ 0, 1, 2, 100, 65535 ]);
+	expect(dataConsumer1.subchannels.sort()).toEqual([ 0, 1, 2, 100, 65535 ]);
 	expect(dataConsumer1.appData).toEqual({ baz: 'LOL' });
 
 	const dump = await router.dump();
@@ -134,7 +134,7 @@ test('dataConsumer.setSubchannels() succeeds', async () =>
 {
 	await dataConsumer1.setSubchannels([ 999, 999, 998, 65536 ]);
 
-	expect(dataConsumer1.subchannels).toEqual([ 0, 998, 999 ]);
+	expect(dataConsumer1.subchannels.sort()).toEqual([ 0, 998, 999 ]);
 }, 2000);
 
 test('transport.consumeData() on a DirectTransport succeeds', async () =>

--- a/rust/src/router/data_consumer.rs
+++ b/rust/src/router/data_consumer.rs
@@ -381,6 +381,7 @@ impl fmt::Debug for RegularDataConsumer {
             .field("data_producer_id", &self.inner.data_producer_id)
             .field("paused", &self.inner.paused)
             .field("data_producer_paused", &self.inner.data_producer_paused)
+            .field("subchannels", &self.inner.subchannels)
             .field("transport", &self.inner.transport)
             .field("closed", &self.inner.closed)
             .finish()

--- a/rust/src/router/data_consumer.rs
+++ b/rust/src/router/data_consumer.rs
@@ -411,6 +411,7 @@ impl fmt::Debug for DirectDataConsumer {
             .field("data_producer_id", &self.inner.data_producer_id)
             .field("paused", &self.inner.paused)
             .field("data_producer_paused", &self.inner.data_producer_paused)
+            .field("subchannels", &self.inner.subchannels)
             .field("transport", &self.inner.transport)
             .field("closed", &self.inner.closed)
             .finish()
@@ -788,6 +789,22 @@ impl DataConsumer {
             .await
     }
 
+    /// Sets subchannels to the worker DataConsumer.
+        pub async fn set_subchannels(&self, subchannels: Vec<u16>) -> Result<(), RequestError> {
+            let response = self
+                .inner()
+                .channel
+                .request(
+                    self.id(),
+                    DataConsumerSetSubchannelsRequest { subchannels },
+                )
+                .await?;
+
+            *self.inner().subchannels.lock() = response.subchannels;
+
+            Ok(())
+        }
+
     /// Callback is called when a message has been received from the corresponding data producer.
     ///
     /// # Notes on usage
@@ -917,22 +934,6 @@ impl DirectDataConsumer {
                 },
             )
             .await
-    }
-
-    /// Sets subchannels to the worker DataConsumer.
-    pub async fn set_subchannels(&self, subchannels: Vec<u16>) -> Result<(), RequestError> {
-        let response = self
-            .inner
-            .channel
-            .request(
-                self.inner.id,
-                DataConsumerSetSubchannelsRequest { subchannels },
-            )
-            .await?;
-
-        *self.inner.subchannels.lock() = response.subchannels;
-
-        Ok(())
     }
 }
 

--- a/rust/src/router/data_consumer.rs
+++ b/rust/src/router/data_consumer.rs
@@ -791,20 +791,17 @@ impl DataConsumer {
     }
 
     /// Sets subchannels to the worker DataConsumer.
-        pub async fn set_subchannels(&self, subchannels: Vec<u16>) -> Result<(), RequestError> {
-            let response = self
-                .inner()
-                .channel
-                .request(
-                    self.id(),
-                    DataConsumerSetSubchannelsRequest { subchannels },
-                )
-                .await?;
+    pub async fn set_subchannels(&self, subchannels: Vec<u16>) -> Result<(), RequestError> {
+        let response = self
+            .inner()
+            .channel
+            .request(self.id(), DataConsumerSetSubchannelsRequest { subchannels })
+            .await?;
 
-            *self.inner().subchannels.lock() = response.subchannels;
+        *self.inner().subchannels.lock() = response.subchannels;
 
-            Ok(())
-        }
+        Ok(())
+    }
 
     /// Callback is called when a message has been received from the corresponding data producer.
     ///

--- a/rust/tests/integration/data_consumer.rs
+++ b/rust/tests/integration/data_consumer.rs
@@ -153,7 +153,11 @@ fn consume_data_succeeds() {
         }
         assert_eq!(data_consumer.label().as_str(), "foo");
         assert_eq!(data_consumer.protocol().as_str(), "bar");
-        assert_eq!(data_consumer.subchannels(), [0, 1, 2, 100, 65535]);
+
+        let mut sorted_subchannels = data_consumer.subchannels();
+        sorted_subchannels.sort();
+
+        assert_eq!(sorted_subchannels, [0, 1, 2, 100, 65535]);
         assert_eq!(
             data_consumer
                 .app_data()
@@ -324,12 +328,10 @@ fn set_subchannels() {
 
         let data_consumer = transport1
             .consume_data({
-                let options = DataConsumerOptions::new_sctp_unordered_with_life_time(
+                DataConsumerOptions::new_sctp_unordered_with_life_time(
                     data_producer.id(),
                     4000,
                 );
-
-                options
             })
             .await
             .expect("Failed to consume data");
@@ -339,7 +341,10 @@ fn set_subchannels() {
             .await
             .expect("Failed to set data consumer subchannels");
 
-        assert_eq!(data_consumer.subchannels(), [0, 998, 999]);
+        let mut sorted_subchannels = data_consumer.subchannels();
+        sorted_subchannels.sort();
+
+        assert_eq!(sorted_subchannels, [0, 998, 999]);
     });
 }
 

--- a/rust/tests/integration/data_consumer.rs
+++ b/rust/tests/integration/data_consumer.rs
@@ -327,12 +327,10 @@ fn set_subchannels() {
         let (_worker, _router, transport1, data_producer) = init().await;
 
         let data_consumer = transport1
-            .consume_data({
-                DataConsumerOptions::new_sctp_unordered_with_life_time(
-                    data_producer.id(),
-                    4000,
-                );
-            })
+            .consume_data(DataConsumerOptions::new_sctp_unordered_with_life_time(
+                data_producer.id(),
+                4000,
+            ))
             .await
             .expect("Failed to consume data");
 

--- a/rust/tests/integration/data_consumer.rs
+++ b/rust/tests/integration/data_consumer.rs
@@ -335,11 +335,11 @@ fn set_subchannels() {
             .expect("Failed to consume data");
 
         data_consumer
-            .set_subchannels([ 999, 999, 998, 0 ].to_vec())
+            .set_subchannels([999, 999, 998, 0].to_vec())
             .await
             .expect("Failed to set data consumer subchannels");
 
-        assert_eq!(data_consumer.subchannels(), [ 0, 998, 999 ]);
+        assert_eq!(data_consumer.subchannels(), [0, 998, 999]);
     });
 }
 

--- a/rust/tests/integration/data_consumer.rs
+++ b/rust/tests/integration/data_consumer.rs
@@ -320,7 +320,7 @@ fn get_stats_succeeds() {
 #[test]
 fn set_subchannels() {
     future::block_on(async move {
-        let (_worker, router, transport1, data_producer) = init().await;
+        let (_worker, _router, transport1, data_producer) = init().await;
 
         let data_consumer = transport1
             .consume_data({
@@ -335,7 +335,7 @@ fn set_subchannels() {
             .expect("Failed to consume data");
 
         data_consumer
-            .set_subchannels([ 999, 999, 998, 65536 ].to_vec())
+            .set_subchannels([ 999, 999, 998, 0 ].to_vec())
             .await
             .expect("Failed to set data consumer subchannels");
 

--- a/rust/tests/integration/direct_transport.rs
+++ b/rust/tests/integration/direct_transport.rs
@@ -430,7 +430,7 @@ fn send_with_subchannels_succeeds() {
             }
         };
 
-        let direct_data_consumer_2 = match &data_consumer_2 {
+        let _ = match &data_consumer_2 {
             DataConsumer::Direct(direct_data_consumer) => direct_data_consumer,
             _ => {
                 panic!("Expected direct data consumer")
@@ -514,7 +514,7 @@ fn send_with_subchannels_succeeds() {
         let mut subchannels = data_consumer_2.subchannels();
         subchannels.push(1);
 
-        direct_data_consumer_2
+        data_consumer_2
             .set_subchannels(subchannels)
             .await
             .expect("Failed to set subchannels");

--- a/worker/include/RTC/DataConsumer.hpp
+++ b/worker/include/RTC/DataConsumer.hpp
@@ -6,7 +6,7 @@
 #include "Channel/ChannelSocket.hpp"
 #include "RTC/SctpDictionaries.hpp"
 #include "RTC/Shared.hpp"
-#include <absl/container/btree_set.h>
+#include <absl/container/flat_hash_set.h>
 #include <string>
 
 namespace RTC
@@ -126,7 +126,7 @@ namespace RTC
 		RTC::SctpStreamParameters sctpStreamParameters;
 		std::string label;
 		std::string protocol;
-		absl::btree_set<uint16_t> subchannels;
+		absl::flat_hash_set<uint16_t> subchannels;
 		bool transportConnected{ false };
 		bool sctpAssociationConnected{ false };
 		bool paused{ false };

--- a/worker/include/RTC/DataConsumer.hpp
+++ b/worker/include/RTC/DataConsumer.hpp
@@ -6,7 +6,7 @@
 #include "Channel/ChannelSocket.hpp"
 #include "RTC/SctpDictionaries.hpp"
 #include "RTC/Shared.hpp"
-#include <absl/container/flat_hash_set.h>
+#include <absl/container/btree_set.h>
 #include <string>
 
 namespace RTC
@@ -126,7 +126,7 @@ namespace RTC
 		RTC::SctpStreamParameters sctpStreamParameters;
 		std::string label;
 		std::string protocol;
-		absl::flat_hash_set<uint16_t> subchannels;
+		absl::btree_set<uint16_t> subchannels;
 		bool transportConnected{ false };
 		bool sctpAssociationConnected{ false };
 		bool paused{ false };


### PR DESCRIPTION
- `set_subchannels()` method must exist not only in `DirectDataConsumer` but also in `RegularDataConsumer`.
- Fix wrong usage of `DataConsumer` in tests.