### PR TITLE
worker: disable RtcLogger usage if not enabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* worker: Disable RtcLogger usage if not enabled ([PR #1264](https://github.com/versatica/mediasoup/pull/1264)).
+
+
 ### 3.13.11
 
 * liburing: Avoid extra memcpy on RTP ([PR #1258](https://github.com/versatica/mediasoup/pull/1258)).

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -5,7 +5,9 @@
 #include "Utils.hpp"
 #include "FBS/rtpPacket.h"
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
+#ifdef MS_RTC_LOGGER_RTP
 #include "RTC/RtcLogger.hpp"
+#endif
 #include <flatbuffers/flatbuffers.h>
 #include <absl/container/flat_hash_map.h>
 #include <array>
@@ -649,8 +651,10 @@ namespace RTC
 
 		void ShiftPayload(size_t payloadOffset, size_t shift, bool expand = true);
 
+#ifdef MS_RTC_LOGGER_RTP
 	public:
 		RtcLogger::RtpPacket logger;
+#endif
 
 	private:
 		void ParseExtensions();

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -219,11 +219,15 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifdef MS_RTC_LOGGER_RTP
 		packet->logger.consumerId = this->id;
+#endif
 
 		if (!IsActive())
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);
+#endif
 
 			return;
 		}
@@ -236,7 +240,9 @@ namespace RTC
 		{
 			MS_DEBUG_DEV("payload type not supported [payloadType:%" PRIu8 "]", payloadType);
 
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE);
+#endif
 
 			return;
 		}
@@ -250,7 +256,9 @@ namespace RTC
 		// the packet.
 		if (syncRequired && this->keyFrameSupported && !packet->IsKeyFrame())
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+#endif
 
 			return;
 		}
@@ -284,8 +292,10 @@ namespace RTC
 		packet->SetSsrc(ssrc);
 		packet->SetSequenceNumber(seq);
 
+#ifdef MS_RTC_LOGGER_RTP
 		packet->logger.sendRtpTimestamp = packet->GetTimestamp();
 		packet->logger.sendSeqNumber    = seq;
+#endif
 
 		if (isSyncPacket)
 		{

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -562,7 +562,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifdef MS_RTC_LOGGER_RTP
 		packet->logger.producerId = this->id;
+#endif
 
 		// Reset current packet.
 		this->currentRtpPacket = nullptr;
@@ -576,7 +578,9 @@ namespace RTC
 		{
 			MS_WARN_TAG(rtp, "no stream found for received packet [ssrc:%" PRIu32 "]", packet->GetSsrc());
 
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::RECV_RTP_STREAM_NOT_FOUND);
+#endif
 
 			return ReceiveRtpPacketResult::DISCARDED;
 		}
@@ -601,7 +605,9 @@ namespace RTC
 					NotifyNewRtpStream(rtpStream);
 				}
 
+#ifdef MS_RTC_LOGGER_RTP
 				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::RECV_RTP_STREAM_DISCARDED);
+#endif
 
 				return result;
 			}
@@ -615,7 +621,9 @@ namespace RTC
 			// Process the packet.
 			if (!rtpStream->ReceiveRtxPacket(packet))
 			{
+#ifdef MS_RTC_LOGGER_RTP
 				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::RECV_RTP_STREAM_NOT_FOUND);
+#endif
 
 				return result;
 			}

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -652,7 +652,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifdef MS_RTC_LOGGER_RTP
 		packet->logger.routerId = this->id;
+#endif
 
 		auto& consumers = this->mapProducerConsumers.at(producer);
 

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -49,7 +49,6 @@ namespace RTC
 
 		void RtpPacket::Log() const
 		{
-#ifdef MS_RTC_LOGGER_RTP
 			MS_TRACE();
 
 			std::cout << "{";
@@ -83,7 +82,6 @@ namespace RTC
 			std::cout << ", \"dropped\": " << (this->dropped ? "true" : "false");
 			std::cout << ", \"dropReason\": '" << dropReason2String[this->dropReason] << "'";
 			std::cout << "}" << std::endl;
-#endif
 		}
 
 		void RtpPacket::Clear()

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -301,11 +301,15 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifdef MS_RTC_LOGGER_RTP
 		packet->logger.consumerId = this->id;
+#endif
 
 		if (!IsActive())
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);
+#endif
 
 			return;
 		}
@@ -318,7 +322,9 @@ namespace RTC
 		{
 			MS_DEBUG_DEV("payload type not supported [payloadType:%" PRIu8 "]", payloadType);
 
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE);
+#endif
 
 			return;
 		}
@@ -336,7 +342,9 @@ namespace RTC
 
 			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::DROPPED_BY_CODEC);
+#endif
 
 			return;
 		}
@@ -345,7 +353,9 @@ namespace RTC
 		// the packet.
 		if (this->syncRequired && this->keyFrameSupported && !packet->IsKeyFrame())
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+#endif
 
 			return;
 		}
@@ -379,8 +389,10 @@ namespace RTC
 		packet->SetSsrc(this->rtpParameters.encodings[0].ssrc);
 		packet->SetSequenceNumber(seq);
 
+#ifdef MS_RTC_LOGGER_RTP
 		packet->logger.sendRtpTimestamp = packet->GetTimestamp();
 		packet->logger.sendSeqNumber    = seq;
+#endif
 
 		if (isSyncPacket)
 		{

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -712,18 +712,24 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifdef MS_RTC_LOGGER_RTP
 		packet->logger.consumerId = this->id;
+#endif
 
 		if (!IsActive())
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);
+#endif
 
 			return;
 		}
 
 		if (this->targetTemporalLayer == -1)
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::INVALID_TARGET_LAYER);
+#endif
 
 			return;
 		}
@@ -736,7 +742,9 @@ namespace RTC
 		{
 			MS_DEBUG_DEV("payload type not supported [payloadType:%" PRIu8 "]", payloadType);
 
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE);
+#endif
 
 			return;
 		}
@@ -751,7 +759,9 @@ namespace RTC
 			// Ignore if not a key frame.
 			if (!packet->IsKeyFrame())
 			{
+#ifdef MS_RTC_LOGGER_RTP
 				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+#endif
 
 				return;
 			}
@@ -766,7 +776,9 @@ namespace RTC
 		// drop it.
 		else if (spatialLayer != this->currentSpatialLayer)
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::SPATIAL_LAYER_MISMATCH);
+#endif
 
 			return;
 		}
@@ -774,7 +786,9 @@ namespace RTC
 		// If we need to sync and this is not a key frame, ignore the packet.
 		if (this->syncRequired && !packet->IsKeyFrame())
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+#endif
 
 			return;
 		}
@@ -890,7 +904,9 @@ namespace RTC
 					this->syncRequired       = false;
 					this->spatialLayerToSync = -1;
 
+#ifdef MS_RTC_LOGGER_RTP
 					packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::TOO_HIGH_TIMESTAMP_EXTRA_NEEDED);
+#endif
 
 					return;
 				}
@@ -932,8 +948,10 @@ namespace RTC
 			if (SeqManager<uint16_t>::IsSeqLowerThan(
 			      packet->GetSequenceNumber(), this->snReferenceSpatialLayer))
 			{
+#ifdef MS_RTC_LOGGER_RTP
 				packet->logger.Dropped(
 				  RtcLogger::RtpPacket::DropReason::PACKET_PREVIOUS_TO_SPATIAL_LAYER_SWITCH);
+#endif
 
 				return;
 			}
@@ -979,7 +997,9 @@ namespace RTC
 			{
 				this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
+#ifdef MS_RTC_LOGGER_RTP
 				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::DROPPED_BY_CODEC);
+#endif
 
 				return;
 			}
@@ -1006,8 +1026,10 @@ namespace RTC
 		packet->SetSequenceNumber(seq);
 		packet->SetTimestamp(timestamp);
 
+#ifdef MS_RTC_LOGGER_RTP
 		packet->logger.sendRtpTimestamp = timestamp;
 		packet->logger.sendSeqNumber    = seq;
+#endif
 
 		if (isSyncPacket)
 		{
@@ -1050,7 +1072,9 @@ namespace RTC
 			  origSeq,
 			  origTimestamp);
 
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::SEND_RTP_STREAM_DISCARDED);
+#endif
 		}
 
 		// Restore packet fields.

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -627,11 +627,15 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifdef MS_RTC_LOGGER_RTP
 		packet->logger.consumerId = this->id;
+#endif
 
 		if (!IsActive())
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);
+#endif
 
 			return;
 		}
@@ -643,7 +647,9 @@ namespace RTC
 		)
 		// clang-format on
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::INVALID_TARGET_LAYER);
+#endif
 
 			return;
 		}
@@ -656,7 +662,9 @@ namespace RTC
 		{
 			MS_DEBUG_DEV("payload type not supported [payloadType:%" PRIu8 "]", payloadType);
 
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE);
+#endif
 
 			return;
 		}
@@ -664,7 +672,9 @@ namespace RTC
 		// If we need to sync and this is not a key frame, ignore the packet.
 		if (this->syncRequired && !packet->IsKeyFrame())
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+#endif
 
 			return;
 		}
@@ -696,7 +706,9 @@ namespace RTC
 		{
 			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::DROPPED_BY_CODEC);
+#endif
 
 			return;
 		}
@@ -725,8 +737,10 @@ namespace RTC
 		packet->SetSsrc(this->rtpParameters.encodings[0].ssrc);
 		packet->SetSequenceNumber(seq);
 
+#ifdef MS_RTC_LOGGER_RTP
 		packet->logger.sendRtpTimestamp = packet->GetTimestamp();
 		packet->logger.sendSeqNumber    = seq;
+#endif
 
 		if (marker)
 		{

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1546,7 +1546,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifdef MS_RTC_LOGGER_RTP
 		packet->logger.recvTransportId = this->id;
+#endif
 
 		// Apply the Transport RTP header extension ids so the RTP listener can use them.
 		packet->SetMidExtensionId(this->recvRtpHeaderExtensionIds.mid);
@@ -1568,7 +1570,9 @@ namespace RTC
 
 		if (!producer)
 		{
+#ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::PRODUCER_NOT_FOUND);
+#endif
 
 			MS_WARN_TAG(
 			  rtp,
@@ -2442,8 +2446,10 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifdef MS_RTC_LOGGER_RTP
 		packet->logger.sendTransportId = this->id;
 		packet->logger.Sent();
+#endif
 
 		// Update abs-send-time if present.
 		packet->UpdateAbsSendTime(DepLibUV::GetTimeMs());


### PR DESCRIPTION
Surround `RtcLogger` usage with the corresponding macro directive.

This was taking >1% CPU without any need. 