### PR TITLE
npm installation: Don't require Python if valid worker prebuilt binary is fetched

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 
 ### NEXT
 
-* worker: Disable RtcLogger usage if not enabled ([PR #1264](https://github.com/versatica/mediasoup/pull/1264)).
+* worker: Disable `RtcLogger` usage if not enabled ([PR #1264](https://github.com/versatica/mediasoup/pull/1264)).
+* npm installation: Don't require Python if valid worker prebuilt binary is fetched ([PR #1265](https://github.com/versatica/mediasoup/pull/1265)).
 
 
 ### 3.13.11

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -47,13 +47,6 @@ async function run()
 {
 	switch (task)
 	{
-		case 'preinstall':
-		{
-			installInvoke();
-
-			break;
-		}
-
 		// As per NPM documentation (https://docs.npmjs.com/cli/v9/using-npm/scripts)
 		// `prepare` script:
 		//
@@ -167,6 +160,8 @@ async function run()
 
 		case 'format:worker':
 		{
+			installInvoke();
+
 			executeCmd(`"${PYTHON}" -m invoke -r worker format`);
 
 			break;
@@ -351,12 +346,16 @@ function buildWorker()
 {
 	logInfo('buildWorker()');
 
+	installInvoke();
+
 	executeCmd(`"${PYTHON}" -m invoke -r worker mediasoup-worker`);
 }
 
 function cleanWorkerArtifacts()
 {
 	logInfo('cleanWorkerArtifacts()');
+
+	installInvoke();
 
 	// Clean build artifacts except `mediasoup-worker`.
 	executeCmd(`"${PYTHON}" -m invoke -r worker clean-build`);
@@ -377,12 +376,16 @@ function lintWorker()
 {
 	logInfo('lintWorker()');
 
+	installInvoke();
+
 	executeCmd(`"${PYTHON}" -m invoke -r worker lint`);
 }
 
 function flatcNode()
 {
 	logInfo('flatcNode()');
+
+	installInvoke();
 
 	// Build flatc if needed.
 	executeCmd(`"${PYTHON}" -m invoke -r worker flatc`);
@@ -410,6 +413,8 @@ function flatcWorker()
 {
 	logInfo('flatcWorker()');
 
+	installInvoke();
+
 	executeCmd(`"${PYTHON}" -m invoke -r worker flatc`);
 }
 
@@ -430,6 +435,8 @@ function testNode()
 function testWorker()
 {
 	logInfo('testWorker()');
+
+	installInvoke();
 
 	executeCmd(`"${PYTHON}" -m invoke -r worker test`);
 }
@@ -575,6 +582,8 @@ async function downloadPrebuiltWorker()
 				{
 					const resolvedBinPath = path.resolve(WORKER_RELEASE_BIN_PATH);
 
+					// This will always fail on purpose, but if status code is 41 then
+					// it's good.
 					execSync(
 						`"${resolvedBinPath}"`,
 						{
@@ -583,15 +592,15 @@ async function downloadPrebuiltWorker()
 							env   : {}
 						}
 					);
-
-					logInfo(
-						'downloadPrebuiltWorker() | fetched mediasoup-worker prebuilt binary is valid for current host'
-					);
 				}
 				catch (error)
 				{
 					if (error.status === 41)
 					{
+						logInfo(
+							'downloadPrebuiltWorker() | fetched mediasoup-worker prebuilt binary is valid for current host'
+						);
+
 						resolve(true);
 					}
 					else

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "nodejs"
   ],
   "scripts": {
-    "preinstall": "node npm-scripts.mjs preinstall",
     "prepare": "node npm-scripts.mjs prepare",
     "postinstall": "node npm-scripts.mjs postinstall",
     "typescript:build": "node npm-scripts.mjs typescript:build",


### PR DESCRIPTION
Based on https://mediasoup.discourse.group/t/using-prebuilt-mediasoup-without-python/5735

So basically, in `npm-scripts`, only install Python Invoke lib if needed, which means that, if not needed, Python is not even needed at all.

**TODO:** Once merged, installation requirements (in documentation web) must be updated.