### PR TITLE
Enables multiple transports to bind to the same port

### DIFF
--- a/node/src/PlainTransport.ts
+++ b/node/src/PlainTransport.ts
@@ -109,7 +109,8 @@ export type PlainTransportOptions<PlainTransportAppData extends AppData = AppDat
 	srtpCryptoSuite?: SrtpCryptoSuite;
 
 	/**
-	 * Enable Multicast. Default false.
+	 * Enable multicast for UDP in case listening IP is a multicast valid IP.
+	 * Default false.
 	 */
 	enableMulticast?: boolean;
 
@@ -139,7 +140,7 @@ export type PlainTransportObserverEvents = TransportObserverEvents &
 {
 	tuple: [TransportTuple];
 	rtcptuple: [TransportTuple];
-	sctpstatechange: [SctpState];	
+	sctpstatechange: [SctpState];
 };
 
 type PlainTransportConstructorOptions<PlainTransportAppData> =

--- a/node/src/PlainTransport.ts
+++ b/node/src/PlainTransport.ts
@@ -109,6 +109,11 @@ export type PlainTransportOptions<PlainTransportAppData extends AppData = AppDat
 	srtpCryptoSuite?: SrtpCryptoSuite;
 
 	/**
+	 * Enable Multicast. Default false.
+	 */
+	enableMulticast?: boolean;
+
+	/**
 	 * Custom application data.
 	 */
 	appData?: PlainTransportAppData;

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -681,6 +681,7 @@ export class Router<RouterAppData extends AppData = AppData>
 			sctpSendBufferSize = 262144,
 			enableSrtp = false,
 			srtpCryptoSuite = 'AES_CM_128_HMAC_SHA1_80',
+			enableMulticast = false,
 			appData
 		}: PlainTransportOptions<PlainTransportAppData>
 	): Promise<PlainTransport<PlainTransportAppData>>
@@ -726,6 +727,11 @@ export class Router<RouterAppData extends AppData = AppData>
 			};
 		}
 
+		if (enableMulticast)
+		{
+			logger.debug('createPlainTransport() | enableMulticast');
+		}
+
 		const transportId = generateUUIDv4();
 
 		/* Build Request. */
@@ -765,7 +771,8 @@ export class Router<RouterAppData extends AppData = AppData>
 			rtcpMux,
 			comedia,
 			enableSrtp,
-			cryptoSuiteToFbs(srtpCryptoSuite)
+			cryptoSuiteToFbs(srtpCryptoSuite),
+			enableMulticast
 		);
 
 		const requestOffset = new FbsRouter.CreatePlainTransportRequestT(

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -727,11 +727,6 @@ export class Router<RouterAppData extends AppData = AppData>
 			};
 		}
 
-		if (enableMulticast)
-		{
-			logger.debug('createPlainTransport() | enableMulticast');
-		}
-
 		const transportId = generateUUIDv4();
 
 		/* Build Request. */

--- a/node/src/tests/test-PlainTransport.ts
+++ b/node/src/tests/test-PlainTransport.ts
@@ -316,17 +316,39 @@ test('router.createPlainTransport() with non bindable IP rejects with Error', as
 		.toThrow(Error);
 }, 2000);
 
-test('router.createPlainTransport() with enableMulticast succeeds', async () =>
+if (process.platform === 'linux')
 {
-	// Use default cryptoSuite: 'AES_CM_128_HMAC_SHA1_80'.
-	const transport1 = await router.createPlainTransport(
-		{
-			listenIp   : '127.0.0.1',
-			enableMulticast: true
-		});
+	test('router.createPlainTransport() with enableMulticast succeeds', async () =>
+	{
+		let transport1: mediasoup.types.PlainTransport | undefined = undefined;
+		let transport2: mediasoup.types.PlainTransport | undefined = undefined;
 
-	expect(typeof transport1.id).toBe('string');
-}, 2000);
+		await expect(async () =>
+		{
+			transport1 = await router.createPlainTransport(
+				{
+					listenIp        : '224.0.0.1',
+					enableMulticast : true
+				});
+
+			transport2 = await router.createPlainTransport(
+				{
+					listenIp        : '224.0.0.1',
+					enableMulticast : true
+				});
+		}).not.toThrow();
+
+		if (transport1)
+		{
+			(transport1 as mediasoup.types.PlainTransport).close();
+		}
+
+		if (transport2)
+		{
+			(transport2 as mediasoup.types.PlainTransport).close();
+		}
+	}, 2000);
+}
 
 test('plainTransport.getStats() succeeds', async () =>
 {

--- a/node/src/tests/test-PlainTransport.ts
+++ b/node/src/tests/test-PlainTransport.ts
@@ -316,6 +316,18 @@ test('router.createPlainTransport() with non bindable IP rejects with Error', as
 		.toThrow(Error);
 }, 2000);
 
+test('router.createPlainTransport() with enableMulticast succeeds', async () =>
+{
+	// Use default cryptoSuite: 'AES_CM_128_HMAC_SHA1_80'.
+	const transport1 = await router.createPlainTransport(
+		{
+			listenIp   : '127.0.0.1',
+			enableMulticast: true
+		});
+
+	expect(typeof transport1.id).toBe('string');
+}, 2000);
+
 test('plainTransport.getStats() succeeds', async () =>
 {
 	const data = await transport.getStats();

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -911,6 +911,7 @@ pub(crate) struct RouterCreatePlainTransportData {
     sctp_send_buffer_size: u32,
     enable_srtp: bool,
     srtp_crypto_suite: SrtpCryptoSuite,
+    enable_multicast: bool,
     is_data_channel: bool,
 }
 
@@ -931,6 +932,7 @@ impl RouterCreatePlainTransportData {
             sctp_send_buffer_size: plain_transport_options.sctp_send_buffer_size,
             enable_srtp: plain_transport_options.enable_srtp,
             srtp_crypto_suite: plain_transport_options.srtp_crypto_suite,
+            enable_multicast: plain_transport_options.enable_multicast,
             is_data_channel: false,
         }
     }
@@ -955,6 +957,7 @@ impl RouterCreatePlainTransportData {
             comedia: self.comedia,
             enable_srtp: self.enable_srtp,
             srtp_crypto_suite: Some(SrtpCryptoSuite::to_fbs(self.srtp_crypto_suite)),
+            enable_multicast: self.enable_multicast,
         }
     }
 }

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -73,6 +73,9 @@ pub struct PlainTransportOptions {
     /// The SRTP crypto suite to be used if enableSrtp is set.
     /// Default 'AesCm128HmacSha180'.
     pub srtp_crypto_suite: SrtpCryptoSuite,
+    /// Enable Multicast.
+    /// Default false.
+    pub enable_multicast: bool,
     /// Custom application data.
     pub app_data: AppData,
 }

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -73,7 +73,7 @@ pub struct PlainTransportOptions {
     /// The SRTP crypto suite to be used if enableSrtp is set.
     /// Default 'AesCm128HmacSha180'.
     pub srtp_crypto_suite: SrtpCryptoSuite,
-    /// Enable Multicast.
+    /// Enable multicast for UDP in case listening IP is a multicast valid IP.
     /// Default false.
     pub enable_multicast: bool,
     /// Custom application data.
@@ -95,6 +95,7 @@ impl PlainTransportOptions {
             sctp_send_buffer_size: 262_144,
             enable_srtp: false,
             srtp_crypto_suite: SrtpCryptoSuite::default(),
+            enable_multicast: false,
             app_data: AppData::default(),
         }
     }

--- a/rust/tests/integration/plain_transport.rs
+++ b/rust/tests/integration/plain_transport.rs
@@ -265,6 +265,51 @@ fn create_succeeds() {
                 assert_eq!(transport_dump.sctp_state, transport2.sctp_state());
             }
         }
+
+        #[cfg(target_os = "linux")]
+        {
+            let transport1 = router
+                .create_plain_transport({
+                    let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
+                        protocol: Protocol::Udp,
+                        ip: "224.0.0.1".parse::<IpAddr>().unwrap(),
+                        announced_ip: None,
+                        port: Some(1234),
+                        send_buffer_size: None,
+                        recv_buffer_size: None,
+                    });
+                    plain_transport_options.enable_multicast = true;
+
+                    plain_transport_options
+                })
+                .await
+                .expect("Failed to create Plain transport");
+
+            let transport2 = router
+                .create_plain_transport({
+                    let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
+                        protocol: Protocol::Udp,
+                        ip: "224.0.0.1".parse::<IpAddr>().unwrap(),
+                        announced_ip: None,
+                        port: Some(1234),
+                        send_buffer_size: None,
+                        recv_buffer_size: None,
+                    });
+                    plain_transport_options.enable_multicast = true;
+
+                    plain_transport_options
+                })
+                .await
+                .expect("Failed to create Plain transport");
+
+            let router_dump = router.dump().await.expect("Failed to dump router");
+            assert_eq!(router_dump.transport_ids, {
+                let mut set = HashedSet::default();
+                set.insert(transport1.id());
+                set.insert(transport2.id());
+                set
+            });
+        }
     });
 }
 

--- a/worker/fbs/plainTransport.fbs
+++ b/worker/fbs/plainTransport.fbs
@@ -12,6 +12,7 @@ table PlainTransportOptions {
     comedia: bool;
     enable_srtp: bool;
     srtp_crypto_suite: FBS.SrtpParameters.SrtpCryptoSuite = null;
+    enable_multicast: bool;
 }
 
 table ConnectRequest {

--- a/worker/include/RTC/PlainTransport.hpp
+++ b/worker/include/RTC/PlainTransport.hpp
@@ -85,6 +85,7 @@ namespace RTC
 		size_t srtpMasterLength{ 0 };
 		std::string srtpKeyBase64;
 		bool connectCalled{ false }; // Whether connect() was succesfully called.
+		bool multicast{ false };
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/PlainTransport.hpp
+++ b/worker/include/RTC/PlainTransport.hpp
@@ -85,7 +85,6 @@ namespace RTC
 		size_t srtpMasterLength{ 0 };
 		std::string srtpKeyBase64;
 		bool connectCalled{ false }; // Whether connect() was succesfully called.
-		bool multicast{ false };
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/PortManager.hpp
+++ b/worker/include/RTC/PortManager.hpp
@@ -20,13 +20,13 @@ namespace RTC
 		};
 
 	public:
-		static uv_udp_t* BindUdp(std::string& ip)
+		static uv_udp_t* BindUdp(std::string& ip, bool enableMulticast = false)
 		{
-			return reinterpret_cast<uv_udp_t*>(Bind(Transport::UDP, ip));
+			return reinterpret_cast<uv_udp_t*>(Bind(Transport::UDP, ip, enableMulticast));
 		}
-		static uv_udp_t* BindUdp(std::string& ip, uint16_t port)
+		static uv_udp_t* BindUdp(std::string& ip, uint16_t port, bool enableMulticast = false)
 		{
-			return reinterpret_cast<uv_udp_t*>(Bind(Transport::UDP, ip, port));
+			return reinterpret_cast<uv_udp_t*>(Bind(Transport::UDP, ip, port, enableMulticast));
 		}
 		static uv_tcp_t* BindTcp(std::string& ip)
 		{
@@ -46,8 +46,8 @@ namespace RTC
 		}
 
 	private:
-		static uv_handle_t* Bind(Transport transport, std::string& ip);
-		static uv_handle_t* Bind(Transport transport, std::string& ip, uint16_t port);
+		static uv_handle_t* Bind(Transport transport, std::string& ip, bool enableMulticast = false);
+		static uv_handle_t* Bind(Transport transport, std::string& ip, uint16_t port, bool enableMulticast = false);
 		static void Unbind(Transport transport, std::string& ip, uint16_t port);
 		static std::vector<bool>& GetPorts(Transport transport, const std::string& ip);
 

--- a/worker/include/RTC/PortManager.hpp
+++ b/worker/include/RTC/PortManager.hpp
@@ -47,7 +47,8 @@ namespace RTC
 
 	private:
 		static uv_handle_t* Bind(Transport transport, std::string& ip, bool enableMulticast = false);
-		static uv_handle_t* Bind(Transport transport, std::string& ip, uint16_t port, bool enableMulticast = false);
+		static uv_handle_t* Bind(
+		  Transport transport, std::string& ip, uint16_t port, bool enableMulticast = false);
 		static void Unbind(Transport transport, std::string& ip, uint16_t port);
 		static std::vector<bool>& GetPorts(Transport transport, const std::string& ip);
 

--- a/worker/include/RTC/UdpSocket.hpp
+++ b/worker/include/RTC/UdpSocket.hpp
@@ -21,8 +21,8 @@ namespace RTC
 		};
 
 	public:
-		UdpSocket(Listener* listener, std::string& ip);
-		UdpSocket(Listener* listener, std::string& ip, uint16_t port);
+		UdpSocket(Listener* listener, std::string& ip, bool enableMulticast = false);
+		UdpSocket(Listener* listener, std::string& ip, uint16_t port, bool enableMulticast = false);
 		~UdpSocket() override;
 
 		/* Pure virtual methods inherited from ::UdpSocketHandle. */

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -86,6 +86,8 @@ namespace Utils
 		}
 
 		static void NormalizeIp(std::string& ip);
+
+		static bool IsMulticast(const struct sockaddr_storage* addr, const int& family);
 	};
 
 	class File

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -87,7 +87,7 @@ namespace Utils
 
 		static void NormalizeIp(std::string& ip);
 
-		static bool IsMulticast(const struct sockaddr_storage* addr, const int& family);
+		static bool IsMulticast(const struct sockaddr_storage* addr, const int family);
 	};
 
 	class File

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -155,18 +155,17 @@ namespace RTC
 			this->srtpKeyBase64 = Utils::String::Base64Encode(this->srtpKey);
 		}
 
-		this->multicast = options->enableMulticast();
-
 		try
 		{
 			// This may throw.
 			if (this->listenInfo.port != 0)
 			{
-				this->udpSocket = new RTC::UdpSocket(this, this->listenInfo.ip, this->listenInfo.port, this->multicast);
+				this->udpSocket = new RTC::UdpSocket(
+				  this, this->listenInfo.ip, this->listenInfo.port, options->enableMulticast());
 			}
 			else
 			{
-				this->udpSocket = new RTC::UdpSocket(this, this->listenInfo.ip, this->multicast);
+				this->udpSocket = new RTC::UdpSocket(this, this->listenInfo.ip, options->enableMulticast());
 			}
 
 			if (this->listenInfo.sendBufferSize != 0)
@@ -186,12 +185,13 @@ namespace RTC
 				// This may throw.
 				if (this->rtcpListenInfo.port != 0)
 				{
-					this->rtcpUdpSocket =
-					  new RTC::UdpSocket(this, this->rtcpListenInfo.ip, this->rtcpListenInfo.port, this->multicast);
+					this->rtcpUdpSocket = new RTC::UdpSocket(
+					  this, this->rtcpListenInfo.ip, this->rtcpListenInfo.port, options->enableMulticast());
 				}
 				else
 				{
-					this->rtcpUdpSocket = new RTC::UdpSocket(this, this->rtcpListenInfo.ip, this->multicast);
+					this->rtcpUdpSocket =
+					  new RTC::UdpSocket(this, this->rtcpListenInfo.ip, options->enableMulticast());
 				}
 
 				if (this->rtcpListenInfo.sendBufferSize != 0)

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -155,16 +155,18 @@ namespace RTC
 			this->srtpKeyBase64 = Utils::String::Base64Encode(this->srtpKey);
 		}
 
+		this->multicast = options->enableMulticast();
+
 		try
 		{
 			// This may throw.
 			if (this->listenInfo.port != 0)
 			{
-				this->udpSocket = new RTC::UdpSocket(this, this->listenInfo.ip, this->listenInfo.port);
+				this->udpSocket = new RTC::UdpSocket(this, this->listenInfo.ip, this->listenInfo.port, this->multicast);
 			}
 			else
 			{
-				this->udpSocket = new RTC::UdpSocket(this, this->listenInfo.ip);
+				this->udpSocket = new RTC::UdpSocket(this, this->listenInfo.ip, this->multicast);
 			}
 
 			if (this->listenInfo.sendBufferSize != 0)
@@ -185,11 +187,11 @@ namespace RTC
 				if (this->rtcpListenInfo.port != 0)
 				{
 					this->rtcpUdpSocket =
-					  new RTC::UdpSocket(this, this->rtcpListenInfo.ip, this->rtcpListenInfo.port);
+					  new RTC::UdpSocket(this, this->rtcpListenInfo.ip, this->rtcpListenInfo.port, this->multicast);
 				}
 				else
 				{
-					this->rtcpUdpSocket = new RTC::UdpSocket(this, this->rtcpListenInfo.ip);
+					this->rtcpUdpSocket = new RTC::UdpSocket(this, this->rtcpListenInfo.ip, this->multicast);
 				}
 
 				if (this->rtcpListenInfo.sendBufferSize != 0)

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -218,13 +218,13 @@ namespace RTC
 				case Transport::UDP:
 				{
 #if defined(__linux__)
-					if (enableMulticast && Utils::IP::IsMulticast(&bindAddr, family))
+					if (enableMulticast && Utils::IP::IsMulticast(std::addressof(bindAddr), family))
 					{
-						flags |= UV_UDP_REUSEADDR;
 						MS_DEBUG_DEV("enabling UV_UDP_REUSEADDR");
+
+						flags |= UV_UDP_REUSEADDR;
 					}
 #endif
-
 					err = uv_udp_bind(
 					  reinterpret_cast<uv_udp_t*>(uvHandle),
 					  reinterpret_cast<const struct sockaddr*>(&bindAddr),
@@ -481,13 +481,13 @@ namespace RTC
 			case Transport::UDP:
 			{
 #if defined(__linux__)
-				if (enableMulticast && Utils::IP::IsMulticast(&bindAddr, family))
+				if (enableMulticast && Utils::IP::IsMulticast(std::addressof(bindAddr), family))
 				{
-					flags |= UV_UDP_REUSEADDR;
 					MS_DEBUG_DEV("enabling UV_UDP_REUSEADDR");
+
+					flags |= UV_UDP_REUSEADDR;
 				}
 #endif
-
 				err = uv_udp_bind(
 				  reinterpret_cast<uv_udp_t*>(uvHandle),
 				  reinterpret_cast<const struct sockaddr*>(&bindAddr),

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -218,25 +218,9 @@ namespace RTC
 				case Transport::UDP:
 				{
 #if defined(__linux__)
-					switch (family)
+					if (Utils::IP::IsMulticast(&bindAddr, family))
 					{
-						case AF_INET:
-						{
-							uint32_t s_addr = ntohl((reinterpret_cast<const struct sockaddr_in*>(&bindAddr))->sin_addr.s_addr);
-							if (s_addr >= 0xe0000000 && s_addr <= 0xefffffff) { // multicast address.
-								flags |= UV_UDP_REUSEADDR;
-							}
-							break;
-						}
-
-						case AF_INET6:
-						{
-							uint8_t _s6_addr = (reinterpret_cast<const struct sockaddr_in6*>(&bindAddr))->sin6_addr.s6_addr[0];
-							if (_s6_addr == 0xFF) { // multicast address.
-								flags |= UV_UDP_REUSEADDR;
-							}
-							break;
-						}
+						flags |= UV_UDP_REUSEADDR;
 					}
 #endif
 
@@ -496,25 +480,9 @@ namespace RTC
 			case Transport::UDP:
 			{
 #if defined(__linux__)
-				switch (family)
+				if (Utils::IP::IsMulticast(&bindAddr, family))
 				{
-					case AF_INET:
-					{
-						uint32_t s_addr = ntohl((reinterpret_cast<const struct sockaddr_in*>(&bindAddr))->sin_addr.s_addr);
-						if (s_addr >= 0xe0000000 && s_addr <= 0xefffffff) { // multicast address.
-							flags |= UV_UDP_REUSEADDR;
-						}
-						break;
-					}
-
-					case AF_INET6:
-					{
-						uint8_t _s6_addr = (reinterpret_cast<const struct sockaddr_in6*>(&bindAddr))->sin6_addr.s6_addr[0];
-						if (_s6_addr == 0xFF) { // multicast address.
-							flags |= UV_UDP_REUSEADDR;
-						}
-						break;
-					}
+					flags |= UV_UDP_REUSEADDR;
 				}
 #endif
 

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -38,7 +38,7 @@ namespace RTC
 
 	/* Class methods. */
 
-	uv_handle_t* PortManager::Bind(Transport transport, std::string& ip)
+	uv_handle_t* PortManager::Bind(Transport transport, std::string& ip, bool enableMulticast)
 	{
 		MS_TRACE();
 
@@ -218,9 +218,10 @@ namespace RTC
 				case Transport::UDP:
 				{
 #if defined(__linux__)
-					if (Utils::IP::IsMulticast(&bindAddr, family))
+					if (enableMulticast && Utils::IP::IsMulticast(&bindAddr, family))
 					{
 						flags |= UV_UDP_REUSEADDR;
+						MS_DEBUG_DEV("enabling UV_UDP_REUSEADDR");
 					}
 #endif
 
@@ -363,7 +364,7 @@ namespace RTC
 		return static_cast<uv_handle_t*>(uvHandle);
 	}
 
-	uv_handle_t* PortManager::Bind(Transport transport, std::string& ip, uint16_t port)
+	uv_handle_t* PortManager::Bind(Transport transport, std::string& ip, uint16_t port, bool enableMulticast)
 	{
 		MS_TRACE();
 
@@ -480,9 +481,10 @@ namespace RTC
 			case Transport::UDP:
 			{
 #if defined(__linux__)
-				if (Utils::IP::IsMulticast(&bindAddr, family))
+				if (enableMulticast && Utils::IP::IsMulticast(&bindAddr, family))
 				{
 					flags |= UV_UDP_REUSEADDR;
+					MS_DEBUG_DEV("enabling UV_UDP_REUSEADDR");
 				}
 #endif
 

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -217,6 +217,29 @@ namespace RTC
 			{
 				case Transport::UDP:
 				{
+#if defined(__linux__)
+					switch (family)
+					{
+						case AF_INET:
+						{
+							uint32_t s_addr = ntohl((reinterpret_cast<const struct sockaddr_in*>(&bindAddr))->sin_addr.s_addr);
+							if (s_addr >= 0xe0000000 && s_addr <= 0xefffffff) { // multicast address.
+								flags |= UV_UDP_REUSEADDR;
+							}
+							break;
+						}
+
+						case AF_INET6:
+						{
+							uint8_t _s6_addr = (reinterpret_cast<const struct sockaddr_in6*>(&bindAddr))->sin6_addr.s6_addr[0];
+							if (_s6_addr == 0xFF) { // multicast address.
+								flags |= UV_UDP_REUSEADDR;
+							}
+							break;
+						}
+					}
+#endif
+
 					err = uv_udp_bind(
 					  reinterpret_cast<uv_udp_t*>(uvHandle),
 					  reinterpret_cast<const struct sockaddr*>(&bindAddr),
@@ -472,6 +495,29 @@ namespace RTC
 		{
 			case Transport::UDP:
 			{
+#if defined(__linux__)
+				switch (family)
+				{
+					case AF_INET:
+					{
+						uint32_t s_addr = ntohl((reinterpret_cast<const struct sockaddr_in*>(&bindAddr))->sin_addr.s_addr);
+						if (s_addr >= 0xe0000000 && s_addr <= 0xefffffff) { // multicast address.
+							flags |= UV_UDP_REUSEADDR;
+						}
+						break;
+					}
+
+					case AF_INET6:
+					{
+						uint8_t _s6_addr = (reinterpret_cast<const struct sockaddr_in6*>(&bindAddr))->sin6_addr.s6_addr[0];
+						if (_s6_addr == 0xFF) { // multicast address.
+							flags |= UV_UDP_REUSEADDR;
+						}
+						break;
+					}
+				}
+#endif
+
 				err = uv_udp_bind(
 				  reinterpret_cast<uv_udp_t*>(uvHandle),
 				  reinterpret_cast<const struct sockaddr*>(&bindAddr),

--- a/worker/src/RTC/UdpSocket.cpp
+++ b/worker/src/RTC/UdpSocket.cpp
@@ -10,16 +10,16 @@ namespace RTC
 {
 	/* Instance methods. */
 
-	UdpSocket::UdpSocket(Listener* listener, std::string& ip)
+	UdpSocket::UdpSocket(Listener* listener, std::string& ip, bool enableMulticast)
 	  : // This may throw.
-	    ::UdpSocketHandle::UdpSocketHandle(PortManager::BindUdp(ip)), listener(listener)
+	    ::UdpSocketHandle::UdpSocketHandle(PortManager::BindUdp(ip, enableMulticast)), listener(listener)
 	{
 		MS_TRACE();
 	}
 
-	UdpSocket::UdpSocket(Listener* listener, std::string& ip, uint16_t port)
+	UdpSocket::UdpSocket(Listener* listener, std::string& ip, uint16_t port, bool enableMulticast)
 	  : // This may throw.
-	    ::UdpSocketHandle::UdpSocketHandle(PortManager::BindUdp(ip, port)), listener(listener),
+	    ::UdpSocketHandle::UdpSocketHandle(PortManager::BindUdp(ip, port, enableMulticast)), listener(listener),
 	    fixedPort(true)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/UdpSocket.cpp
+++ b/worker/src/RTC/UdpSocket.cpp
@@ -12,15 +12,16 @@ namespace RTC
 
 	UdpSocket::UdpSocket(Listener* listener, std::string& ip, bool enableMulticast)
 	  : // This may throw.
-	    ::UdpSocketHandle::UdpSocketHandle(PortManager::BindUdp(ip, enableMulticast)), listener(listener)
+	    ::UdpSocketHandle::UdpSocketHandle(PortManager::BindUdp(ip, enableMulticast)),
+	    listener(listener)
 	{
 		MS_TRACE();
 	}
 
 	UdpSocket::UdpSocket(Listener* listener, std::string& ip, uint16_t port, bool enableMulticast)
 	  : // This may throw.
-	    ::UdpSocketHandle::UdpSocketHandle(PortManager::BindUdp(ip, port, enableMulticast)), listener(listener),
-	    fixedPort(true)
+	    ::UdpSocketHandle::UdpSocketHandle(PortManager::BindUdp(ip, port, enableMulticast)),
+	    listener(listener), fixedPort(true)
 	{
 		MS_TRACE();
 	}

--- a/worker/src/Utils/IP.cpp
+++ b/worker/src/Utils/IP.cpp
@@ -156,7 +156,7 @@ namespace Utils
 		}
 	}
 
-	bool IP::IsMulticast(const struct sockaddr_storage* addr, const int& family)
+	bool IP::IsMulticast(const struct sockaddr_storage* addr, const int family)
 	{
 		MS_TRACE();
 
@@ -165,21 +165,15 @@ namespace Utils
 			case AF_INET:
 			{
 				uint32_t s_addr = ntohl((reinterpret_cast<const struct sockaddr_in*>(addr))->sin_addr.s_addr);
-				if (s_addr >= 0xe0000000 && s_addr <= 0xefffffff)
-				{
-					return true;
-				}
-				break;
+
+				return (s_addr >= 0xe0000000 && s_addr <= 0xefffffff);
 			}
 
 			case AF_INET6:
 			{
 				uint8_t _s6_addr = (reinterpret_cast<const struct sockaddr_in6*>(addr))->sin6_addr.s6_addr[0];
-				if (_s6_addr == 0xFF)
-				{
-					return true;
-				}
-				break;
+
+				return (_s6_addr == 0xFF);
 			}
 
 			default:
@@ -187,7 +181,5 @@ namespace Utils
 				MS_THROW_TYPE_ERROR("invalid family");
 			}
 		}
-
-		return false;
 	}
 } // namespace Utils

--- a/worker/src/Utils/IP.cpp
+++ b/worker/src/Utils/IP.cpp
@@ -155,4 +155,39 @@ namespace Utils
 			}
 		}
 	}
+
+	bool IP::IsMulticast(const struct sockaddr_storage* addr, const int& family)
+	{
+		MS_TRACE();
+
+		switch (family)
+		{
+			case AF_INET:
+			{
+				uint32_t s_addr = ntohl((reinterpret_cast<const struct sockaddr_in*>(addr))->sin_addr.s_addr);
+				if (s_addr >= 0xe0000000 && s_addr <= 0xefffffff)
+				{
+					return true;
+				}
+				break;
+			}
+
+			case AF_INET6:
+			{
+				uint8_t _s6_addr = (reinterpret_cast<const struct sockaddr_in6*>(addr))->sin6_addr.s6_addr[0];
+				if (_s6_addr == 0xFF)
+				{
+					return true;
+				}
+				break;
+			}
+
+			default:
+			{
+				MS_THROW_TYPE_ERROR("invalid family");
+			}
+		}
+
+		return false;
+	}
 } // namespace Utils


### PR DESCRIPTION
This change specifies UV_UDP_REUSEADDR  and SO_REUSEPORT for the socket in Transport::UDP.
In Linux, by combining the multicast address and SO_REUSEPORT, multiple transports across workers can bind to the same port.
When distributing a stream to multiple workers, this eliminates the need to send the stream via unicast to each worker.
This should be convenient for broadcasting.

Example:

```typescript
const same_port = 1234;
const router1 = await worker1.createRouter(...);
const router2 = await worker2.createRouter(...);
transport1 = await router1.createPlainTransport({ listenIp: "224.0.0.1", comedia: true, port: same_port });
transport1 = await router2.createPlainTransport({ listenIp: "224.0.0.1", comedia: true, port: same_port }); // This does not cause an error.
```