### PR TITLE
JS: Require curly braces in switch cases

### DIFF
--- a/node/.eslintrc.js
+++ b/node/.eslintrc.js
@@ -48,7 +48,7 @@ const eslintConfig =
 		// Unfortunatelly `curly` does not apply to blocks in `switch` cases so
 		// this is needed.
 		// NOTE: We disable this rule since it's producing false positives:
-		// link
+		// https://github.com/versatica/mediasoup/pull/1268
 		// 'no-restricted-syntax'      : [ 2,
 		// 	{
 		// 		'selector' : 'SwitchCase:has(*.consequent[type!="BlockStatement"])',

--- a/node/.eslintrc.js
+++ b/node/.eslintrc.js
@@ -47,14 +47,12 @@ const eslintConfig =
 		'curly'                     : [ 2, 'all' ],
 		// Unfortunatelly `curly` does not apply to blocks in `switch` cases so
 		// this is needed.
-		// NOTE: We disable this rule since it's producing false positives:
-		// https://github.com/versatica/mediasoup/pull/1268
-		// 'no-restricted-syntax'      : [ 2,
-		// 	{
-		// 		'selector' : 'SwitchCase:has(*.consequent[type!="BlockStatement"])',
-		// 		'message'  : 'Switch cases without blocks are disallowed'
-		// 	}
-		// ],
+		'no-restricted-syntax'      : [ 2,
+			{
+				'selector' : 'SwitchCase > *.consequent[type!="BlockStatement"]',
+				'message'  : 'Switch cases without blocks are disallowed'
+			}
+		],
 		'func-call-spacing'         : 2,
 		'generator-star-spacing'    : 2,
 		'guard-for-in'              : 2,

--- a/node/.eslintrc.js
+++ b/node/.eslintrc.js
@@ -45,6 +45,16 @@ const eslintConfig =
 		'computed-property-spacing' : 2,
 		'constructor-super'         : 2,
 		'curly'                     : [ 2, 'all' ],
+		// Unfortunatelly `curly` does not apply to blocks in `switch` cases so
+		// this is needed.
+		// NOTE: We disable this rule since it's producing false positives:
+		// link
+		// 'no-restricted-syntax'      : [ 2,
+		// 	{
+		// 		'selector' : 'SwitchCase:has(*.consequent[type!="BlockStatement"])',
+		// 		'message'  : 'Switch cases without blocks are disallowed'
+		// 	}
+		// ],
 		'func-call-spacing'         : 2,
 		'generator-star-spacing'    : 2,
 		'guard-for-in'              : 2,

--- a/node/src/Channel.ts
+++ b/node/src/Channel.ts
@@ -164,10 +164,13 @@ export class Channel extends EnhancedEventEmitter
 						}
 
 						default:
+						{
 							// eslint-disable-next-line no-console
 							console.warn(
 								`worker[pid:${pid}] unexpected data: %s`,
-								payload.toString('utf8', 1));
+								payload.toString('utf8', 1)
+							);
+						}
 					}
 				}
 				catch (error)
@@ -432,11 +435,16 @@ export class Channel extends EnhancedEventEmitter
 			switch (response.error()!)
 			{
 				case 'TypeError':
+				{
 					sent.reject(new TypeError(response.reason()!));
+
 					break;
+				}
 
 				default:
+				{
 					sent.reject(new Error(response.reason()!));
+				}
 			}
 		}
 		else
@@ -470,24 +478,36 @@ export class Channel extends EnhancedEventEmitter
 		{
 			// 'D' (a debug log).
 			case 'D':
+			{
 				logger.debug(`[pid:${pid}] ${logData.slice(1)}`);
+
 				break;
+			}
 
 			// 'W' (a warn log).
 			case 'W':
+			{
 				logger.warn(`[pid:${pid}] ${logData.slice(1)}`);
+
 				break;
+			}
 
 			// 'E' (a error log).
 			case 'E':
+			{
 				logger.error(`[pid:${pid}] ${logData.slice(1)}`);
+
 				break;
+			}
 
 			// 'X' (a dump log).
 			case 'X':
+			{
 				// eslint-disable-next-line no-console
 				console.log(logData.slice(1));
+
 				break;
+			}
 		}
 	}
 }

--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -999,17 +999,34 @@ function consumerTraceEventTypeToFbs(eventType: ConsumerTraceEventType)
 	switch (eventType)
 	{
 		case 'keyframe':
+		{
 			return FbsConsumer.TraceEventType.KEYFRAME;
+		}
+
 		case 'fir':
+		{
 			return FbsConsumer.TraceEventType.FIR;
+		}
+
 		case 'nack':
+		{
 			return FbsConsumer.TraceEventType.NACK;
+		}
+
 		case 'pli':
+		{
 			return FbsConsumer.TraceEventType.PLI;
+		}
+
 		case 'rtp':
+		{
 			return FbsConsumer.TraceEventType.RTP;
+		}
+
 		default:
+		{
 			throw new TypeError(`invalid ConsumerTraceEventType: ${eventType}`);
+		}
 	}
 }
 
@@ -1019,17 +1036,34 @@ function consumerTraceEventTypeFromFbs(traceType: FbsConsumer.TraceEventType)
 	switch (traceType)
 	{
 		case FbsConsumer.TraceEventType.KEYFRAME:
+		{
 			return 'keyframe';
+		}
+
 		case FbsConsumer.TraceEventType.FIR:
+		{
 			return 'fir';
+		}
+
 		case FbsConsumer.TraceEventType.NACK:
+		{
 			return 'nack';
+		}
+
 		case FbsConsumer.TraceEventType.PLI:
+		{
 			return 'pli';
+		}
+
 		case FbsConsumer.TraceEventType.RTP:
+		{
 			return 'rtp';
+		}
+
 		default:
+		{
 			throw new TypeError(`invalid FbsConsumer.TraceEventType: ${traceType}`);
+		}
 	}
 }
 

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -762,11 +762,19 @@ export function dataConsumerTypeToFbs(type: DataConsumerType): FbsDataProducer.T
 	switch (type)
 	{
 		case 'sctp':
+		{
 			return FbsDataProducer.Type.SCTP;
+		}
+
 		case 'direct':
+		{
 			return FbsDataProducer.Type.DIRECT;
+		}
+
 		default:
+		{
 			throw new TypeError('invalid DataConsumerType: ${type}');
+		}
 	}
 }
 
@@ -775,9 +783,14 @@ export function dataConsumerTypeFromFbs(type: FbsDataProducer.Type): DataConsume
 	switch (type)
 	{
 		case FbsDataProducer.Type.SCTP:
+		{
 			return 'sctp';
+		}
+
 		case FbsDataProducer.Type.DIRECT:
+		{
 			return 'direct';
+		}
 	}
 }
 

--- a/node/src/DataProducer.ts
+++ b/node/src/DataProducer.ts
@@ -475,11 +475,19 @@ export function dataProducerTypeToFbs(type: DataProducerType): FbsDataProducer.T
 	switch (type)
 	{
 		case 'sctp':
+		{
 			return FbsDataProducer.Type.SCTP;
+		}
+
 		case 'direct':
+		{
 			return FbsDataProducer.Type.DIRECT;
+		}
+
 		default:
+		{
 			throw new TypeError('invalid DataConsumerType: ${type}');
+		}
 	}
 }
 
@@ -488,9 +496,14 @@ export function dataProducerTypeFromFbs(type: FbsDataProducer.Type): DataProduce
 	switch (type)
 	{
 		case FbsDataProducer.Type.SCTP:
+		{
 			return 'sctp';
+		}
+
 		case FbsDataProducer.Type.DIRECT:
+		{
 			return 'direct';
+		}
 	}
 }
 

--- a/node/src/Producer.ts
+++ b/node/src/Producer.ts
@@ -630,13 +630,24 @@ export function producerTypeFromFbs(type: FbsRtpParameters.Type): ProducerType
 	switch (type)
 	{
 		case FbsRtpParameters.Type.SIMPLE:
+		{
 			return 'simple';
+		}
+
 		case FbsRtpParameters.Type.SIMULCAST:
+		{
 			return 'simulcast';
+		}
+
 		case FbsRtpParameters.Type.SVC:
+		{
 			return 'svc';
+		}
+
 		default:
+		{
 			throw new TypeError(`invalid FbsRtpParameters.Type: ${type}`);
+		}
 	}
 }
 
@@ -645,13 +656,19 @@ export function producerTypeToFbs(type: ProducerType): FbsRtpParameters.Type
 	switch (type)
 	{
 		case 'simple':
+		{
 			return FbsRtpParameters.Type.SIMPLE;
+		}
 
 		case 'simulcast':
+		{
 			return FbsRtpParameters.Type.SIMULCAST;
+		}
 
 		case 'svc':
+		{
 			return FbsRtpParameters.Type.SVC;
+		}
 	}
 }
 
@@ -661,17 +678,34 @@ function producerTraceEventTypeToFbs(eventType: ProducerTraceEventType)
 	switch (eventType)
 	{
 		case 'keyframe':
+		{
 			return FbsProducer.TraceEventType.KEYFRAME;
+		}
+
 		case 'fir':
+		{
 			return FbsProducer.TraceEventType.FIR;
+		}
+
 		case 'nack':
+		{
 			return FbsProducer.TraceEventType.NACK;
+		}
+
 		case 'pli':
+		{
 			return FbsProducer.TraceEventType.PLI;
+		}
+
 		case 'rtp':
+		{
 			return FbsProducer.TraceEventType.RTP;
+		}
+
 		default:
+		{
 			throw new TypeError(`invalid ProducerTraceEventType: ${eventType}`);
+		}
 	}
 }
 
@@ -681,15 +715,29 @@ function producerTraceEventTypeFromFbs(eventType: FbsProducer.TraceEventType)
 	switch (eventType)
 	{
 		case FbsProducer.TraceEventType.KEYFRAME:
+		{
 			return 'keyframe';
+		}
+
 		case FbsProducer.TraceEventType.FIR:
+		{
 			return 'fir';
+		}
+
 		case FbsProducer.TraceEventType.NACK:
+		{
 			return 'nack';
+		}
+
 		case FbsProducer.TraceEventType.PLI:
+		{
 			return 'pli';
+		}
+
 		case FbsProducer.TraceEventType.RTP:
+		{
 			return 'rtp';
+		}
 	}
 }
 

--- a/node/src/RtpParameters.ts
+++ b/node/src/RtpParameters.ts
@@ -709,27 +709,59 @@ export function rtpHeaderExtensionUriFromFbs(uri: FbsRtpHeaderExtensionUri): Rtp
 	switch (uri)
 	{
 		case FbsRtpHeaderExtensionUri.Mid:
+		{
 			return 'urn:ietf:params:rtp-hdrext:sdes:mid';
+		}
+
 		case FbsRtpHeaderExtensionUri.RtpStreamId:
+		{
 			return 'urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id';
+		}
+
 		case FbsRtpHeaderExtensionUri.RepairRtpStreamId:
+		{
 			return 'urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id';
+		}
+
 		case FbsRtpHeaderExtensionUri.FrameMarkingDraft07:
+		{
 			return 'http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07';
+		}
+
 		case FbsRtpHeaderExtensionUri.FrameMarking:
+		{
 			return 'urn:ietf:params:rtp-hdrext:framemarking';
+		}
+
 		case FbsRtpHeaderExtensionUri.AudioLevel:
+		{
 			return 'urn:ietf:params:rtp-hdrext:ssrc-audio-level';
+		}
+
 		case FbsRtpHeaderExtensionUri.VideoOrientation:
+		{
 			return 'urn:3gpp:video-orientation';
+		}
+
 		case FbsRtpHeaderExtensionUri.TimeOffset:
+		{
 			return 'urn:ietf:params:rtp-hdrext:toffset';
+		}
+
 		case FbsRtpHeaderExtensionUri.TransportWideCcDraft01:
+		{
 			return 'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01';
+		}
+
 		case FbsRtpHeaderExtensionUri.AbsSendTime:
+		{
 			return 'http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time';
+		}
+
 		case FbsRtpHeaderExtensionUri.AbsCaptureTime:
+		{
 			return 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time';
+		}
 	}
 }
 
@@ -738,29 +770,64 @@ export function rtpHeaderExtensionUriToFbs(uri: RtpHeaderExtensionUri): FbsRtpHe
 	switch (uri)
 	{
 		case 'urn:ietf:params:rtp-hdrext:sdes:mid':
+		{
 			return FbsRtpHeaderExtensionUri.Mid;
+		}
+
 		case 'urn:ietf:params:rtp-hdrext:sdes:rtp-stream-id':
+		{
 			return FbsRtpHeaderExtensionUri.RtpStreamId;
+		}
+
 		case 'urn:ietf:params:rtp-hdrext:sdes:repaired-rtp-stream-id':
+		{
 			return FbsRtpHeaderExtensionUri.RepairRtpStreamId;
+		}
+
 		case 'http://tools.ietf.org/html/draft-ietf-avtext-framemarking-07':
+		{
 			return FbsRtpHeaderExtensionUri.FrameMarkingDraft07;
+		}
+
 		case 'urn:ietf:params:rtp-hdrext:framemarking':
+		{
 			return FbsRtpHeaderExtensionUri.FrameMarking;
+		}
+
 		case 'urn:ietf:params:rtp-hdrext:ssrc-audio-level':
+		{
 			return FbsRtpHeaderExtensionUri.AudioLevel;
+		}
+
 		case 'urn:3gpp:video-orientation':
+		{
 			return FbsRtpHeaderExtensionUri.VideoOrientation;
+		}
+
 		case 'urn:ietf:params:rtp-hdrext:toffset':
+		{
 			return FbsRtpHeaderExtensionUri.TimeOffset;
+		}
+
 		case 'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01':
+		{
 			return FbsRtpHeaderExtensionUri.TransportWideCcDraft01;
+		}
+
 		case 'http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time':
+		{
 			return FbsRtpHeaderExtensionUri.AbsSendTime;
+		}
+
 		case 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time':
+		{
 			return FbsRtpHeaderExtensionUri.AbsCaptureTime;
+		}
+
 		default:
+		{
 			throw new TypeError(`invalid RtpHeaderExtensionUri: ${uri}`);
+		}
 	}
 }
 

--- a/node/src/SrtpParameters.ts
+++ b/node/src/SrtpParameters.ts
@@ -31,16 +31,24 @@ export function cryptoSuiteFromFbs(binary: FbsSrtpParameters.SrtpCryptoSuite): S
 	switch (binary)
 	{
 		case FbsSrtpParameters.SrtpCryptoSuite.AEAD_AES_256_GCM:
+		{
 			return 'AEAD_AES_256_GCM';
+		}
 
 		case FbsSrtpParameters.SrtpCryptoSuite.AEAD_AES_128_GCM:
+		{
 			return 'AEAD_AES_128_GCM';
+		}
 
 		case FbsSrtpParameters.SrtpCryptoSuite.AES_CM_128_HMAC_SHA1_80:
+		{
 			return 'AES_CM_128_HMAC_SHA1_80';
+		}
 
 		case FbsSrtpParameters.SrtpCryptoSuite.AES_CM_128_HMAC_SHA1_32:
+		{
 			return 'AES_CM_128_HMAC_SHA1_32';
+		}
 	}
 }
 
@@ -50,19 +58,29 @@ export function cryptoSuiteToFbs(cryptoSuite: SrtpCryptoSuite)
 	switch (cryptoSuite)
 	{
 		case 'AEAD_AES_256_GCM':
+		{
 			return FbsSrtpParameters.SrtpCryptoSuite.AEAD_AES_256_GCM;
+		}
 
 		case 'AEAD_AES_128_GCM':
+		{
 			return FbsSrtpParameters.SrtpCryptoSuite.AEAD_AES_128_GCM;
+		}
 
 		case 'AES_CM_128_HMAC_SHA1_80':
+		{
 			return FbsSrtpParameters.SrtpCryptoSuite.AES_CM_128_HMAC_SHA1_80;
+		}
 
 		case 'AES_CM_128_HMAC_SHA1_32':
+		{
 			return FbsSrtpParameters.SrtpCryptoSuite.AES_CM_128_HMAC_SHA1_32;
+		}
 
 		default:
+		{
 			throw new TypeError(`invalid SrtpCryptoSuite: ${cryptoSuite}`);
+		}
 	}
 }
 

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -1321,11 +1321,19 @@ function transportTraceEventTypeToFbs(eventType: TransportTraceEventType)
 	switch (eventType)
 	{
 		case 'probation':
+		{
 			return FbsTransport.TraceEventType.PROBATION;
+		}
+
 		case 'bwe':
+		{
 			return FbsTransport.TraceEventType.BWE;
+		}
+
 		default:
+		{
 			throw new TypeError(`invalid TransportTraceEventType: ${eventType}`);
+		}
 	}
 }
 
@@ -1335,9 +1343,15 @@ function transportTraceEventTypeFromFbs(eventType: FbsTransport.TraceEventType)
 	switch (eventType)
 	{
 		case FbsTransport.TraceEventType.PROBATION:
+		{
 			return 'probation';
+		}
+
 		case FbsTransport.TraceEventType.BWE:
+		{
 			return 'bwe';
+		}
+
 	}
 }
 
@@ -1346,17 +1360,34 @@ export function parseSctpState(fbsSctpState: FbsSctpState): SctpState
 	switch (fbsSctpState)
 	{
 		case FbsSctpState.NEW:
+		{
 			return 'new';
+		}
+
 		case FbsSctpState.CONNECTING:
+		{
 			return 'connecting';
+		}
+
 		case FbsSctpState.CONNECTED:
+		{
 			return 'connected';
+		}
+
 		case FbsSctpState.FAILED:
+		{
 			return 'failed';
+		}
+
 		case FbsSctpState.CLOSED:
+		{
 			return 'closed';
+		}
+
 		default:
+		{
 			throw new TypeError(`invalid SctpState: ${fbsSctpState}`);
+		}
 	}
 }
 
@@ -1365,10 +1396,14 @@ export function parseProtocol(protocol: FbsTransport.Protocol): TransportProtoco
 	switch (protocol)
 	{
 		case FbsTransport.Protocol.UDP:
+		{
 			return 'udp';
+		}
 
 		case FbsTransport.Protocol.TCP:
+		{
 			return 'tcp';
+		}
 	}
 }
 
@@ -1377,10 +1412,14 @@ export function serializeProtocol(protocol: TransportProtocol): FbsTransport.Pro
 	switch (protocol)
 	{
 		case 'udp':
+		{
 			return FbsTransport.Protocol.UDP;
+		}
 
 		case 'tcp':
+		{
 			return FbsTransport.Protocol.TCP;
+		}
 	}
 }
 

--- a/node/src/WebRtcTransport.ts
+++ b/node/src/WebRtcTransport.ts
@@ -650,13 +650,24 @@ function iceStateFromFbs(fbsIceState: FbsIceState): IceState
 	switch (fbsIceState)
 	{
 		case FbsIceState.NEW:
+		{
 			return 'new';
+		}
+
 		case FbsIceState.CONNECTED:
+		{
 			return 'connected';
+		}
+
 		case FbsIceState.COMPLETED:
+		{
 			return 'completed';
+		}
+
 		case FbsIceState.DISCONNECTED:
+		{
 			return 'disconnected';
+		}
 	}
 }
 
@@ -665,9 +676,14 @@ function iceRoleFromFbs(role: FbsIceRole): IceRole
 	switch (role)
 	{
 		case FbsIceRole.CONTROLLED:
+		{
 			return 'controlled';
+		}
+
 		case FbsIceRole.CONTROLLING:
+		{
 			return 'controlling';
+		}
 	}
 }
 
@@ -676,7 +692,9 @@ function iceCandidateTypeFromFbs(type: FbsIceCandidateType): IceCandidateType
 	switch (type)
 	{
 		case FbsIceCandidateType.HOST:
+		{
 			return 'host';
+		}
 	}
 }
 
@@ -685,7 +703,9 @@ function iceCandidateTcpTypeFromFbs(type: FbsIceCandidateTcpType): IceCandidateT
 	switch (type)
 	{
 		case FbsIceCandidateTcpType.PASSIVE:
+		{
 			return 'passive';
+		}
 	}
 }
 
@@ -694,15 +714,29 @@ function dtlsStateFromFbs(fbsDtlsState: FbsDtlsState): DtlsState
 	switch (fbsDtlsState)
 	{
 		case FbsDtlsState.NEW:
+		{
 			return 'new';
+		}
+
 		case FbsDtlsState.CONNECTING:
+		{
 			return 'connecting';
+		}
+
 		case FbsDtlsState.CONNECTED:
+		{
 			return 'connected';
+		}
+
 		case FbsDtlsState.FAILED:
+		{
 			return 'failed';
+		}
+
 		case FbsDtlsState.CLOSED:
+		{
 			return 'closed';
+		}
 	}
 }
 
@@ -711,11 +745,19 @@ function dtlsRoleFromFbs(role: FbsDtlsRole): DtlsRole
 	switch (role)
 	{
 		case FbsDtlsRole.AUTO:
+		{
 			return 'auto';
+		}
+
 		case FbsDtlsRole.CLIENT:
+		{
 			return 'client';
+		}
+
 		case FbsDtlsRole.SERVER:
+		{
 			return 'server';
+		}
 	}
 }
 
@@ -725,15 +767,29 @@ function fingerprintAlgorithmsFromFbs(algorithm: FbsFingerprintAlgorithm)
 	switch (algorithm)
 	{
 		case FbsFingerprintAlgorithm.SHA1:
+		{
 			return 'sha-1';
+		}
+
 		case FbsFingerprintAlgorithm.SHA224:
+		{
 			return 'sha-224';
+		}
+
 		case FbsFingerprintAlgorithm.SHA256:
+		{
 			return 'sha-256';
+		}
+
 		case FbsFingerprintAlgorithm.SHA384:
+		{
 			return 'sha-384';
+		}
+
 		case FbsFingerprintAlgorithm.SHA512:
+		{
 			return 'sha-512';
+		}
 	}
 }
 
@@ -743,17 +799,34 @@ function fingerprintAlgorithmToFbs(algorithm: FingerprintAlgorithm)
 	switch (algorithm)
 	{
 		case 'sha-1':
+		{
 			return FbsFingerprintAlgorithm.SHA1;
+		}
+
 		case 'sha-224':
+		{
 			return FbsFingerprintAlgorithm.SHA224;
+		}
+
 		case 'sha-256':
+		{
 			return FbsFingerprintAlgorithm.SHA256;
+		}
+
 		case 'sha-384':
+		{
 			return FbsFingerprintAlgorithm.SHA384;
+		}
+
 		case 'sha-512':
+		{
 			return FbsFingerprintAlgorithm.SHA512;
+		}
+
 		default:
+		{
 			throw new TypeError(`invalid FingerprintAlgorithm: ${algorithm}`);
+		}
 	}
 }
 
@@ -762,13 +835,24 @@ function dtlsRoleToFbs(role: DtlsRole): FbsDtlsRole
 	switch (role)
 	{
 		case 'auto':
+		{
 			return FbsDtlsRole.AUTO;
+		}
+
 		case 'client':
+		{
 			return FbsDtlsRole.CLIENT;
+		}
+
 		case 'server':
+		{
 			return FbsDtlsRole.SERVER;
+		}
+
 		default:
+		{
 			throw new TypeError(`invalid DtlsRole: ${role}`);
+		}
 	}
 }
 

--- a/node/src/utils.ts
+++ b/node/src/utils.ts
@@ -57,13 +57,19 @@ export function getRtpParametersType(
 	switch (producerType)
 	{
 		case 'simple':
+		{
 			return FbsRtpParametersType.SIMPLE;
+		}
 
 		case 'simulcast':
+		{
 			return FbsRtpParametersType.SIMULCAST;
+		}
 
 		case 'svc':
+		{
 			return FbsRtpParametersType.SVC;
+		}
 	}
 }
 


### PR DESCRIPTION
### Details

- Require `{` `}` in each `case` block.
- There is no real ESLint rule for it so we must use this:
  ```js
  'no-restricted-syntax'      : [ 2,
    {
      'selector' : 'SwitchCase > *.consequent[type!="BlockStatement"]'
      'message'  : 'Switch cases without blocks are disallowed'
    }
  ]
  ```
