### PR TITLE
worker: Do not use references for async callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 
+### NEXT
+
+* worker: Do not use references for async callbacks ([PR #1274](https://github.com/versatica/mediasoup/pull/1274)).
+
+
 ### 3.13.12
 
 * worker: Disable `RtcLogger` usage if not enabled ([PR #1264](https://github.com/versatica/mediasoup/pull/1264)).

--- a/worker/include/RTC/SenderBandwidthEstimator.hpp
+++ b/worker/include/RTC/SenderBandwidthEstimator.hpp
@@ -89,7 +89,7 @@ namespace RTC
 	public:
 		void TransportConnected();
 		void TransportDisconnected();
-		void RtpPacketSent(SentInfo& sentInfo);
+		void RtpPacketSent(const SentInfo& sentInfo);
 		void ReceiveRtcpTransportFeedback(const RTC::RTCP::FeedbackRtpTransportPacket* feedback);
 		void EstimateAvailableBitrate(CummulativeResult& cummulativeResult);
 		void UpdateRtt(float rtt);

--- a/worker/include/RTC/TransportCongestionControlClient.hpp
+++ b/worker/include/RTC/TransportCongestionControlClient.hpp
@@ -69,7 +69,7 @@ namespace RTC
 		void TransportDisconnected();
 		void InsertPacket(webrtc::RtpPacketSendInfo& packetInfo);
 		webrtc::PacedPacketInfo GetPacingInfo();
-		void PacketSent(webrtc::RtpPacketSendInfo& packetInfo, int64_t nowMs);
+		void PacketSent(const webrtc::RtpPacketSendInfo& packetInfo, int64_t nowMs);
 		void ReceiveEstimatedBitrate(uint32_t bitrate);
 		void ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReportPacket* packet, float rtt, int64_t nowMs);
 		void ReceiveRtcpTransportFeedback(const RTC::RTCP::FeedbackRtpTransportPacket* feedback);

--- a/worker/src/RTC/SenderBandwidthEstimator.cpp
+++ b/worker/src/RTC/SenderBandwidthEstimator.cpp
@@ -47,7 +47,7 @@ namespace RTC
 		this->cummulativeResult.Reset();
 	}
 
-	void SenderBandwidthEstimator::RtpPacketSent(SentInfo& sentInfo)
+	void SenderBandwidthEstimator::RtpPacketSent(const SentInfo& sentInfo)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2493,7 +2493,7 @@ namespace RTC
 			sentInfo.sendingAtMs = DepLibUV::GetTimeMs();
 
 			auto* cb = new onSendCallback(
-			  [tccClientWeakPtr, &packetInfo, senderBweWeakPtr, &sentInfo](bool sent)
+			  [tccClientWeakPtr, packetInfo, senderBweWeakPtr, sentInfo](bool sent)
 			  {
 				  if (sent)
 				  {
@@ -2517,7 +2517,7 @@ namespace RTC
 			SendRtpPacket(consumer, packet, cb);
 #else
 			const auto* cb = new onSendCallback(
-			  [tccClientWeakPtr, &packetInfo](bool sent)
+			  [tccClientWeakPtr, packetInfo](bool sent)
 			  {
 				  if (sent)
 				  {
@@ -2582,7 +2582,7 @@ namespace RTC
 			sentInfo.sendingAtMs = DepLibUV::GetTimeMs();
 
 			auto* cb = new onSendCallback(
-			  [tccClientWeakPtr, &packetInfo, senderBweWeakPtr, &sentInfo](bool sent)
+			  [tccClientWeakPtr, packetInfo, senderBweWeakPtr, sentInfo](bool sent)
 			  {
 				  if (sent)
 				  {
@@ -2606,7 +2606,7 @@ namespace RTC
 			SendRtpPacket(consumer, packet, cb);
 #else
 			const auto* cb = new onSendCallback(
-			  [tccClientWeakPtr, &packetInfo](bool sent)
+			  [tccClientWeakPtr, packetInfo](bool sent)
 			  {
 				  if (sent)
 				  {
@@ -2982,7 +2982,7 @@ namespace RTC
 			sentInfo.sendingAtMs = DepLibUV::GetTimeMs();
 
 			auto* cb = new onSendCallback(
-			  [tccClientWeakPtr, &packetInfo, senderBweWeakPtr, &sentInfo](bool sent)
+			  [tccClientWeakPtr, packetInfo, senderBweWeakPtr, sentInfo](bool sent)
 			  {
 				  if (sent)
 				  {
@@ -3006,7 +3006,7 @@ namespace RTC
 			SendRtpPacket(nullptr, packet, cb);
 #else
 			const auto* cb = new onSendCallback(
-			  [tccClientWeakPtr, &packetInfo](bool sent)
+			  [tccClientWeakPtr, packetInfo](bool sent)
 			  {
 				  if (sent)
 				  {

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -152,7 +152,8 @@ namespace RTC
 		return this->rtpTransportControllerSend->packet_sender()->GetPacingInfo();
 	}
 
-	void TransportCongestionControlClient::PacketSent(webrtc::RtpPacketSendInfo& packetInfo, int64_t nowMs)
+	void TransportCongestionControlClient::PacketSent(
+	  const webrtc::RtpPacketSendInfo& packetInfo, int64_t nowMs)
 	{
 		MS_TRACE();
 


### PR DESCRIPTION
If the callback is not executed in the same uv_loop iteration, the access to such values upon executing the callback is undefined.