### PR TITLE
Simplify meson setup task

### DIFF
--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -140,59 +140,30 @@ def setup(ctx):
     """
     Run meson setup
     """
-    # We add --reconfigure first as a workaround for this issue:
-    # https://github.com/ninja-build/ninja/issues/1997
     if MEDIASOUP_BUILDTYPE == 'Release':
-        try:
-            with ctx.cd(WORKER_DIR):
-                ctx.run(
-                    f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype release -Db_ndebug=true -Db_pie=true -Db_staticpic=true --reconfigure {MESON_ARGS} "{BUILD_DIR}"',
-                    echo=True,
-                    pty=PTY_SUPPORTED,
-                    shell=SHELL
-                );
-        except:
-            with ctx.cd(WORKER_DIR):
-                ctx.run(
-                    f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype release -Db_ndebug=true -Db_pie=true -Db_staticpic=true {MESON_ARGS} "{BUILD_DIR}"',
-                    echo=True,
-                    pty=PTY_SUPPORTED,
-                    shell=SHELL
-                );
+        with ctx.cd(WORKER_DIR):
+            ctx.run(
+                f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype release -Db_ndebug=true -Db_pie=true -Db_staticpic=true {MESON_ARGS} "{BUILD_DIR}"',
+                echo=True,
+                pty=PTY_SUPPORTED,
+                shell=SHELL
+            );
     elif MEDIASOUP_BUILDTYPE == 'Debug':
-        try:
-            with ctx.cd(WORKER_DIR):
-                ctx.run(
-                    f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype debug -Db_pie=true -Db_staticpic=true --reconfigure {MESON_ARGS} "{BUILD_DIR}"',
-                    echo=True,
-                    pty=PTY_SUPPORTED,
-                    shell=SHELL
-                );
-        except:
-            with ctx.cd(WORKER_DIR):
-                ctx.run(
-                    f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype debug -Db_pie=true -Db_staticpic=true {MESON_ARGS} "{BUILD_DIR}"',
-                    echo=True,
-                    pty=PTY_SUPPORTED,
-                    shell=SHELL
-                );
+        with ctx.cd(WORKER_DIR):
+            ctx.run(
+                f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype debug -Db_pie=true -Db_staticpic=true {MESON_ARGS} "{BUILD_DIR}"',
+                echo=True,
+                pty=PTY_SUPPORTED,
+                shell=SHELL
+            );
     else:
-        try:
-            with ctx.cd(WORKER_DIR):
-                ctx.run(
-                    f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype {MEDIASOUP_BUILDTYPE} -Db_ndebug=if-release -Db_pie=true -Db_staticpic=true --reconfigure {MESON_ARGS} "{BUILD_DIR}"',
-                    echo=True,
-                    pty=PTY_SUPPORTED,
-                    shell=SHELL
-                );
-        except:
-            with ctx.cd(WORKER_DIR):
-                ctx.run(
-                    f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype {MEDIASOUP_BUILDTYPE} -Db_ndebug=if-release -Db_pie=true -Db_staticpic=true {MESON_ARGS} "{BUILD_DIR}"',
-                    echo=True,
-                    pty=PTY_SUPPORTED,
-                    shell=SHELL
-                );
+        with ctx.cd(WORKER_DIR):
+            ctx.run(
+                f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype {MEDIASOUP_BUILDTYPE} -Db_ndebug=if-release -Db_pie=true -Db_staticpic=true {MESON_ARGS} "{BUILD_DIR}"',
+                echo=True,
+                pty=PTY_SUPPORTED,
+                shell=SHELL
+            );
 
 
 @task


### PR DESCRIPTION
### Details

- Remove try/except logic when running `meson setup`.
- Do not use `--reconfigure`.

### Rationale

Previous code was a workaround for a potential issue https://github.com/ninja-build/ninja/issues/1997 in ninja, however I cannot reproduce it. This is what I've tried:

1. I've removed the `--reconfigure` argument in the `meson setup` task.
2. I've run `invoke` which runs `mediasoup-worker` task which runs `setup` task. Everything is built properly.
3. I've added a new file `worker/src/foo.cpp` with some random content and added it in `meson.build`.
4. I've run `invoke` again which, according to the issue reported in ninja project, should now fail with "ModuleNotFoundError: No module named 'mesonbuild'". However it doesn't fail.

Perhaps the issue was auto-magically fixed in some recent version of meson or ninja and we didn't notice it when we upgraded those in mediasoup in the recent past.

BTW, even if the issue still exists when manually editing `meson.build` (I couldn't reproduce it as told above), the user could just call `invoke` with `MESON_ARGS="--reconfigure" invoke`. We don't need all those try/except with 99% duplicate code.