### PR TITLE
mediasoup-worker linux prebuilt with io-uring support (part 1)

### DIFF
--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -16,7 +16,7 @@ const WORKER_RELEASE_DIR = 'worker/out/Release';
 const WORKER_RELEASE_BIN = IS_WINDOWS ? 'mediasoup-worker.exe' : 'mediasoup-worker';
 const WORKER_RELEASE_BIN_PATH = `${WORKER_RELEASE_DIR}/${WORKER_RELEASE_BIN}`;
 const WORKER_PREBUILD_DIR = 'worker/prebuild';
-const WORKER_PREBUILD_TAR = `mediasoup-worker-${PKG.version}-${os.platform()}-${os.arch()}.tgz`;
+const WORKER_PREBUILD_TAR = getWorkerPrebuildTarName();
 const WORKER_PREBUILD_TAR_PATH = `${WORKER_PREBUILD_DIR}/${WORKER_PREBUILD_TAR}`;
 const GH_OWNER = 'versatica';
 const GH_REPO = 'mediasoup';
@@ -298,6 +298,22 @@ function getPython()
 	}
 
 	return python;
+}
+
+function getWorkerPrebuildTarName()
+{
+	let name = `mediasoup-worker-${PKG.version}-${os.platform()}-${os.arch()}`;
+
+	// In Linux we want to know about kernel version since kernel >= 6 supports
+	// io-uring.
+	if (os.platform() === 'linux')
+	{
+		const kernelMajorVersion = Number(os.release().split('.')[0]);
+
+		name += `-kernel${kernelMajorVersion}`;
+	}
+
+	return `${name}.tgz`;
 }
 
 function installInvoke()


### PR DESCRIPTION
This PR exposes kernel mayor number in the mediasoup-worker binary name to make it possible to have prebuilts for Linux with kernel 5 and 6 (the latter supports `io-uring`).

**NOTE 1:** This is related to issue #1282 but doesn't complete it.

**TODO:** In `mediasoup-worker-prebuild.yaml` we must include an Ubuntu version with kernel >= 6. Problem is that Ubuntu 22.04 still uses kernel 5.15 and there are no other more modern Ubuntu versions in GitHub CI.

**NOTE 2:** When that is done (in part 2 of this task), we must still keep Ubuntu 20.04 since, as documented in the job file, it uses an older version of GLib and otherwise we'd run into this issue again: https://github.com/versatica/mediasoup/issues/1089.