### PR TITLE
Update Catch2 to version 3.4.0

### DIFF
--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -70,18 +70,13 @@ jobs:
       # We need to install npm deps of worker/scripts/package.json.
       - name: npm ci --prefix worker/scripts
         run: npm ci --prefix worker/scripts --foreground-scripts
-        # TODO: Maybe fix this one day.
-        if: runner.os != 'Windows'
 
       - name: invoke -r worker lint
         run: invoke -r worker lint
-        # TODO: Maybe fix this one day.
-        if: runner.os != 'Windows'
 
       - name: invoke -r worker mediasoup-worker
         run: invoke -r worker mediasoup-worker
 
       - name: invoke -r worker test
         run: invoke -r worker test
-        # TODO: Maybe fix this one day.
-        if: runner.os != 'Windows'
+

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -70,13 +70,18 @@ jobs:
       # We need to install npm deps of worker/scripts/package.json.
       - name: npm ci --prefix worker/scripts
         run: npm ci --prefix worker/scripts --foreground-scripts
+        # TODO: Maybe fix this one day.
+        if: runner.os != 'Windows'
 
       - name: invoke -r worker lint
         run: invoke -r worker lint
+        # TODO: Maybe fix this one day.
+        if: runner.os != 'Windows'
 
       - name: invoke -r worker mediasoup-worker
         run: invoke -r worker mediasoup-worker
 
       - name: invoke -r worker test
         run: invoke -r worker test
-
+        # TODO: Maybe fix this one day.
+        if: runner.os != 'Windows'

--- a/worker/subprojects/catch2.wrap
+++ b/worker/subprojects/catch2.wrap
@@ -1,12 +1,11 @@
 [wrap-file]
-directory = Catch2-2.13.7
-source_url = https://github.com/catchorg/Catch2/archive/v2.13.7.zip
-source_filename = Catch2-2.13.7.zip
-source_hash = 3f3ccd90ad3a8fbb1beeb15e6db440ccdcbebe378dfd125d07a1f9a587a927e9
-patch_filename = catch2_2.13.7-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/catch2_2.13.7-1/get_patch
-patch_hash = 2f7369645d747e5bd866317ac1dd4c3d04dc97d3aad4fc6b864bdf75d3b57158
+directory = Catch2-3.4.0
+source_url = https://github.com/catchorg/Catch2/archive/v3.4.0.tar.gz
+source_filename = Catch2-3.4.0.tar.gz
+source_hash = 122928b814b75717316c71af69bd2b43387643ba076a6ec16e7882bfb2dfacbb
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/catch2_3.4.0-1/Catch2-3.4.0.tar.gz
+wrapdb_version = 3.4.0-1
 
 [provide]
 catch2 = catch2_dep
-
+catch2-with-main = catch2_with_main_dep

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -393,32 +393,25 @@ def test(ctx):
             shell=SHELL
         );
 
+    mediasoup_worker_test = 'mediasoup-worker-test.exe' if os.name == 'nt' else 'mediasoup-worker-test';
     mediasoup_test_tags = os.getenv('MEDIASOUP_TEST_TAGS') or '';
 
-    # On Windows lcov doesn't work (at least not yet) and we need to add .exe to
-    # the binary path.
-    if os.name == 'nt':
-        with ctx.cd(WORKER_DIR):
-            ctx.run(
-                f'"{BUILD_DIR}/mediasoup-worker-test.exe" --invisibles --use-colour=yes {mediasoup_test_tags}',
-                echo=True,
-                pty=PTY_SUPPORTED,
-                shell=SHELL
-            );
-    else:
+    # On Windows lcov doesn't work (at least not yet).
+    if os.name != 'nt':
         ctx.run(
             f'"{LCOV}" --directory "{WORKER_DIR}" --zerocounters',
             echo=True,
             pty=PTY_SUPPORTED,
             shell=SHELL
         );
-        with ctx.cd(WORKER_DIR):
-            ctx.run(
-                f'"{BUILD_DIR}/mediasoup-worker-test" --invisibles --use-colour=yes {mediasoup_test_tags}',
-                echo=True,
-                pty=PTY_SUPPORTED,
-                shell=SHELL
-            );
+
+    with ctx.cd(WORKER_DIR):
+        ctx.run(
+            f'"{BUILD_DIR}/{mediasoup_worker_test}" --invisibles --colour-mode=ansi {mediasoup_test_tags}',
+            echo=True,
+            pty=PTY_SUPPORTED,
+            shell=SHELL
+        );
 
 
 @task(pre=[setup, flatc])

--- a/worker/test/src/PayloadChannel/TestPayloadChannelNotification.cpp
+++ b/worker/test/src/PayloadChannel/TestPayloadChannelNotification.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "PayloadChannel/PayloadChannelNotification.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 SCENARIO("PayloadChannelNotification", "[channel][notification]")
 {

--- a/worker/test/src/PayloadChannel/TestPayloadChannelRequest.cpp
+++ b/worker/test/src/PayloadChannel/TestPayloadChannelRequest.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "PayloadChannel/PayloadChannelRequest.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 SCENARIO("PayloadChannelRequest", "[channel][request]")
 {

--- a/worker/test/src/RTC/Codecs/TestH264.cpp
+++ b/worker/test/src/RTC/Codecs/TestH264.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/Codecs/H264.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC;

--- a/worker/test/src/RTC/Codecs/TestH264_SVC.cpp
+++ b/worker/test/src/RTC/Codecs/TestH264_SVC.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/Codecs/H264_SVC.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC;

--- a/worker/test/src/RTC/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP8.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/Codecs/VP8.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp(), std::memcpy()
 
 using namespace RTC;

--- a/worker/test/src/RTC/Codecs/TestVP9.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP9.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/Codecs/VP9.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC;

--- a/worker/test/src/RTC/RTCP/TestBye.cpp
+++ b/worker/test/src/RTC/RTCP/TestBye.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/Bye.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 #include <string>
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsAfb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsAfb.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsAfb.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsFir.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsFir.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsFir.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsLei.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsLei.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsLei.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsPli.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsPli.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsPli.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsRemb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsRemb.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsRemb.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsRpsi.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsSli.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsSli.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsSli.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsTst.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsTst.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsTst.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsVbcm.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtpEcn.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpNack.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpNack.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtpNack.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpSrReq.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpSrReq.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtpSrReq.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtpTllei.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtpTmmb.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
@@ -1,7 +1,7 @@
 #include "common.hpp"
 #include "Logger.hpp"
 #include "RTC/RTCP/FeedbackRtpTransport.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTCP/TestPacket.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/Packet.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace RTC::RTCP;
 

--- a/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
@@ -1,7 +1,7 @@
 #include "common.hpp"
 #include "RTC/RTCP/ReceiverReport.hpp"
 #include "RTC/RTCP/SenderReport.hpp" // sizeof(SenderReport::Header)
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace RTC::RTCP;
 

--- a/worker/test/src/RTC/RTCP/TestSdes.cpp
+++ b/worker/test/src/RTC/RTCP/TestSdes.cpp
@@ -1,7 +1,7 @@
 #include "common.hpp"
 #include "RTC/RTCP/Packet.hpp"
 #include "RTC/RTCP/Sdes.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 #include <string>
 

--- a/worker/test/src/RTC/RTCP/TestSenderReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestSenderReport.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/SenderReport.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestXr.cpp
+++ b/worker/test/src/RTC/RTCP/TestXr.cpp
@@ -2,7 +2,7 @@
 #include "RTC/RTCP/XR.hpp"
 #include "RTC/RTCP/XrDelaySinceLastRr.hpp"
 #include "RTC/RTCP/XrReceiverReferenceTime.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp(), std::memcpy()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/TestKeyFrameRequestManager.cpp
+++ b/worker/test/src/RTC/TestKeyFrameRequestManager.cpp
@@ -1,7 +1,7 @@
 #include "common.hpp"
 #include "DepLibUV.hpp"
 #include "RTC/KeyFrameRequestManager.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace RTC;
 

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -3,7 +3,7 @@
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
 #include "RTC/NackGenerator.hpp"
 #include "RTC/RtpPacket.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <vector>
 
 using namespace RTC;

--- a/worker/test/src/RTC/TestRateCalculator.cpp
+++ b/worker/test/src/RTC/TestRateCalculator.cpp
@@ -1,7 +1,7 @@
 #include "common.hpp"
 #include "DepLibUV.hpp"
 #include "RTC/RateCalculator.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <vector>
 
 using namespace RTC;

--- a/worker/test/src/RTC/TestRtpEncodingParameters.cpp
+++ b/worker/test/src/RTC/TestRtpEncodingParameters.cpp
@@ -1,5 +1,5 @@
 #include "common.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <regex>
 
 static const std::regex ScalabilityModeRegex(

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -1,7 +1,7 @@
 #include "common.hpp"
 #include "helpers.hpp"
 #include "RTC/RtpPacket.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 #include <string>
 #include <vector>

--- a/worker/test/src/RTC/TestRtpPacketH264Svc.cpp
+++ b/worker/test/src/RTC/TestRtpPacketH264Svc.cpp
@@ -2,7 +2,7 @@
 #include "helpers.hpp"
 #include "RTC/Codecs/H264_SVC.hpp"
 #include "RTC/RtpPacket.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 #include <sstream>
 #include <string>

--- a/worker/test/src/RTC/TestRtpRetransmissionBuffer.cpp
+++ b/worker/test/src/RTC/TestRtpRetransmissionBuffer.cpp
@@ -1,7 +1,7 @@
 #include "common.hpp"
 #include "RTC/RtpPacket.hpp"
 #include "RTC/RtpRetransmissionBuffer.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <vector>
 
 using namespace RTC;

--- a/worker/test/src/RTC/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/TestRtpStreamRecv.cpp
@@ -3,7 +3,7 @@
 #include "RTC/RtpPacket.hpp"
 #include "RTC/RtpStream.hpp"
 #include "RTC/RtpStreamRecv.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <vector>
 
 using namespace RTC;

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -3,7 +3,7 @@
 #include "RTC/RtpPacket.hpp"
 #include "RTC/RtpStream.hpp"
 #include "RTC/RtpStreamSend.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <vector>
 
 // #define PERFORMANCE_TEST 1

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/SeqManager.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <string>
 #include <vector>
 

--- a/worker/test/src/RTC/TestTrendCalculator.cpp
+++ b/worker/test/src/RTC/TestTrendCalculator.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "RTC/TrendCalculator.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace RTC;
 

--- a/worker/test/src/Utils/TestBits.cpp
+++ b/worker/test/src/Utils/TestBits.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "Utils.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 SCENARIO("Utils::Bits::CountSetBits()")
 {

--- a/worker/test/src/Utils/TestByte.cpp
+++ b/worker/test/src/Utils/TestByte.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "Utils.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 SCENARIO("Utils::Byte")
 {

--- a/worker/test/src/Utils/TestIP.cpp
+++ b/worker/test/src/Utils/TestIP.cpp
@@ -1,7 +1,7 @@
 #include "common.hpp"
 #include "MediaSoupErrors.hpp"
 #include "Utils.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 #ifdef _WIN32
 #include <winsock2.h>

--- a/worker/test/src/Utils/TestString.cpp
+++ b/worker/test/src/Utils/TestString.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "Utils.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
 
 using namespace Utils;

--- a/worker/test/src/Utils/TestTime.cpp
+++ b/worker/test/src/Utils/TestTime.cpp
@@ -1,7 +1,7 @@
 #include "common.hpp"
 #include "DepLibUV.hpp"
 #include "Utils.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_test_macros.hpp>
 
 using namespace Utils;
 

--- a/worker/test/src/tests.cpp
+++ b/worker/test/src/tests.cpp
@@ -1,5 +1,3 @@
-#define CATCH_CONFIG_RUNNER
-
 #include "DepLibSRTP.hpp"
 #include "DepLibUV.hpp"
 #include "DepLibWebRTC.hpp"
@@ -8,7 +6,7 @@
 #include "LogLevel.hpp"
 #include "Settings.hpp"
 #include "Utils.hpp"
-#include <catch2/catch.hpp>
+#include <catch2/catch_session.hpp>
 #include <cstdlib> // std::getenv()
 
 int main(int argc, char* argv[])
@@ -53,7 +51,9 @@ int main(int argc, char* argv[])
 	DepLibWebRTC::ClassInit();
 	Utils::Crypto::ClassInit();
 
-	int status = Catch::Session().run(argc, argv);
+	Catch::Session session;
+
+	int status = session.run(argc, argv);
 
 	// Free static stuff.
 	DepLibSRTP::ClassDestroy();


### PR DESCRIPTION
Fixes #987

### Details

- We no longer use the old Catch2 single-header distribution model but the new more standard library distribution model, which comes with much better compile-time performance. Details in https://github.com/catchorg/Catch2/blob/devel/docs/migrate-v2-to-v3.md.