### PR TITLE
Rust: expose DataChannel string message as binary

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+# NEXT
+
+* Expose DataChannel string message as binary (PR #1289).
+
 # 0.14.0
 
 * Updates from mediasoup TypeScript `3.13.8..=3.13.12`.

--- a/rust/src/data_structures.rs
+++ b/rust/src/data_structures.rs
@@ -1047,7 +1047,7 @@ impl TraceEventDirection {
 #[derive(Debug, Clone)]
 pub enum WebRtcMessage<'a> {
     /// String
-    String(String),
+    String(Cow<'a, [u8]>),
     /// Binary
     Binary(Cow<'a, [u8]>),
     /// EmptyString
@@ -1070,9 +1070,7 @@ impl<'a> WebRtcMessage<'a> {
 
     pub(crate) fn new(ppid: u32, payload: Cow<'a, [u8]>) -> Result<Self, u32> {
         match ppid {
-            51 => Ok(WebRtcMessage::String(
-                String::from_utf8(payload.to_vec()).unwrap(),
-            )),
+            51 => Ok(WebRtcMessage::String(payload)),
             53 => Ok(WebRtcMessage::Binary(payload)),
             56 => Ok(WebRtcMessage::EmptyString),
             57 => Ok(WebRtcMessage::EmptyBinary),
@@ -1082,9 +1080,9 @@ impl<'a> WebRtcMessage<'a> {
 
     pub(crate) fn into_ppid_and_payload(self) -> (u32, Cow<'a, [u8]>) {
         match self {
-            WebRtcMessage::String(string) => (51_u32, Cow::from(string.into_bytes())),
+            WebRtcMessage::String(binary) => (51_u32, binary),
             WebRtcMessage::Binary(binary) => (53_u32, binary),
-            WebRtcMessage::EmptyString => (56_u32, Cow::from(b" ".as_ref())),
+            WebRtcMessage::EmptyString => (56_u32, Cow::from(vec![0_u8])),
             WebRtcMessage::EmptyBinary => (57_u32, Cow::from(vec![0_u8])),
         }
     }
@@ -1092,7 +1090,7 @@ impl<'a> WebRtcMessage<'a> {
     /// Convert to owned message
     pub fn into_owned(self) -> OwnedWebRtcMessage {
         match self {
-            WebRtcMessage::String(string) => OwnedWebRtcMessage::String(string),
+            WebRtcMessage::String(binary) => OwnedWebRtcMessage::String(binary.into_owned()),
             WebRtcMessage::Binary(binary) => OwnedWebRtcMessage::Binary(binary.into_owned()),
             WebRtcMessage::EmptyString => OwnedWebRtcMessage::EmptyString,
             WebRtcMessage::EmptyBinary => OwnedWebRtcMessage::EmptyBinary,
@@ -1105,7 +1103,7 @@ impl<'a> WebRtcMessage<'a> {
 #[derive(Debug, Clone)]
 pub enum OwnedWebRtcMessage {
     /// String
-    String(String),
+    String(Vec<u8>),
     /// Binary
     Binary(Vec<u8>),
     /// EmptyString

--- a/rust/tests/integration/direct_transport.rs
+++ b/rust/tests/integration/direct_transport.rs
@@ -202,19 +202,19 @@ fn send_succeeds() {
 
             move |message| {
                 let id: usize = match message {
-                    WebRtcMessage::String(string) => {
-                        recv_message_bytes.fetch_add(string.as_bytes().len(), Ordering::SeqCst);
-                        string.parse().unwrap()
+                    WebRtcMessage::String(binary) => {
+                        recv_message_bytes.fetch_add(binary.len(), Ordering::SeqCst);
+                        String::from_utf8(binary.to_vec()).unwrap().parse().unwrap()
                     }
                     WebRtcMessage::Binary(binary) => {
                         recv_message_bytes.fetch_add(binary.len(), Ordering::SeqCst);
                         String::from_utf8(binary.to_vec()).unwrap().parse().unwrap()
                     }
                     WebRtcMessage::EmptyString => {
-                        panic!("Unexpected empty messages!");
+                        panic!("Unexpected empty message!");
                     }
                     WebRtcMessage::EmptyBinary => {
-                        panic!("Unexpected empty messages!");
+                        panic!("Unexpected empty message!");
                     }
                 };
 
@@ -266,14 +266,14 @@ fn send_succeeds() {
             }
 
             let message = if id < num_messages / 2 {
-                let content = id.to_string();
+                let content = id.to_string().into_bytes();
                 sent_message_bytes += content.len();
 
                 if !data_producer.paused() && !data_consumer.paused() {
                     effectively_sent_message_bytes += content.len();
                 }
 
-                WebRtcMessage::String(content)
+                WebRtcMessage::String(Cow::from(content))
             } else {
                 let content = id.to_string().into_bytes();
                 sent_message_bytes += content.len();
@@ -388,9 +388,9 @@ fn send_with_subchannels_succeeds() {
 
             move |message| {
                 let text: String = match message {
-                    WebRtcMessage::String(string) => string.parse().unwrap(),
+                    WebRtcMessage::String(binary) => String::from_utf8(binary.to_vec()).unwrap(),
                     _ => {
-                        panic!("Unexpected empty messages!");
+                        panic!("Unexpected empty message!");
                     }
                 };
 
@@ -409,9 +409,9 @@ fn send_with_subchannels_succeeds() {
 
             move |message| {
                 let text: String = match message {
-                    WebRtcMessage::String(string) => string.parse().unwrap(),
+                    WebRtcMessage::String(binary) => String::from_utf8(binary.to_vec()).unwrap(),
                     _ => {
-                        panic!("Unexpected empty messages!");
+                        panic!("Unexpected empty message!");
                     }
                 };
 
@@ -444,13 +444,17 @@ fn send_with_subchannels_succeeds() {
 
         // Must be received by dataConsumer1 and dataConsumer2.
         direct_data_producer
-            .send(WebRtcMessage::String(both.to_string()), None, None)
+            .send(
+                WebRtcMessage::String(std::borrow::Cow::Borrowed(both.as_bytes())),
+                None,
+                None,
+            )
             .expect("Failed to send message");
 
         // Must be received by dataConsumer1 and dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(both.to_string()),
+                WebRtcMessage::String(std::borrow::Cow::Borrowed(both.as_bytes())),
                 Some(vec![1, 2]),
                 None,
             )
@@ -459,7 +463,7 @@ fn send_with_subchannels_succeeds() {
         // Must be received by dataConsumer1 and dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(both.to_string()),
+                WebRtcMessage::String(std::borrow::Cow::Borrowed(both.as_bytes())),
                 Some(vec![11, 22, 33]),
                 Some(666),
             )
@@ -468,7 +472,7 @@ fn send_with_subchannels_succeeds() {
         // Must not be received by neither dataConsumer1 nor dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(none.to_string()),
+                WebRtcMessage::String(std::borrow::Cow::Borrowed(none.as_bytes())),
                 Some(vec![3]),
                 Some(666),
             )
@@ -477,7 +481,7 @@ fn send_with_subchannels_succeeds() {
         // Must not be received by neither dataConsumer1 nor dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(none.to_string()),
+                WebRtcMessage::String(std::borrow::Cow::Borrowed(none.as_bytes())),
                 Some(vec![666]),
                 Some(3),
             )
@@ -485,18 +489,26 @@ fn send_with_subchannels_succeeds() {
 
         // Must be received by dataConsumer1.
         direct_data_producer
-            .send(WebRtcMessage::String(dc1.to_string()), Some(vec![1]), None)
-            .expect("Failed to send message");
-
-        // Must be received by dataConsumer1.
-        direct_data_producer
-            .send(WebRtcMessage::String(dc1.to_string()), Some(vec![11]), None)
+            .send(
+                WebRtcMessage::String(std::borrow::Cow::Borrowed(dc1.as_bytes())),
+                Some(vec![1]),
+                None,
+            )
             .expect("Failed to send message");
 
         // Must be received by dataConsumer1.
         direct_data_producer
             .send(
-                WebRtcMessage::String(dc1.to_string()),
+                WebRtcMessage::String(std::borrow::Cow::Borrowed(dc1.as_bytes())),
+                Some(vec![11]),
+                None,
+            )
+            .expect("Failed to send message");
+
+        // Must be received by dataConsumer1.
+        direct_data_producer
+            .send(
+                WebRtcMessage::String(std::borrow::Cow::Borrowed(dc1.as_bytes())),
                 Some(vec![666]),
                 Some(11),
             )
@@ -505,7 +517,7 @@ fn send_with_subchannels_succeeds() {
         // Must be received by dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(dc2.to_string()),
+                WebRtcMessage::String(std::borrow::Cow::Borrowed(dc2.as_bytes())),
                 Some(vec![666]),
                 Some(2),
             )
@@ -522,7 +534,7 @@ fn send_with_subchannels_succeeds() {
         // Must be received by dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(both.to_string()),
+                WebRtcMessage::String(std::borrow::Cow::Borrowed(both.as_bytes())),
                 Some(vec![1]),
                 Some(666),
             )

--- a/rust/tests/integration/direct_transport.rs
+++ b/rust/tests/integration/direct_transport.rs
@@ -445,7 +445,7 @@ fn send_with_subchannels_succeeds() {
         // Must be received by dataConsumer1 and dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(std::borrow::Cow::Borrowed(both.as_bytes())),
+                WebRtcMessage::String(Cow::Borrowed(both.as_bytes())),
                 None,
                 None,
             )
@@ -454,7 +454,7 @@ fn send_with_subchannels_succeeds() {
         // Must be received by dataConsumer1 and dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(std::borrow::Cow::Borrowed(both.as_bytes())),
+                WebRtcMessage::String(Cow::Borrowed(both.as_bytes())),
                 Some(vec![1, 2]),
                 None,
             )
@@ -463,7 +463,7 @@ fn send_with_subchannels_succeeds() {
         // Must be received by dataConsumer1 and dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(std::borrow::Cow::Borrowed(both.as_bytes())),
+                WebRtcMessage::String(Cow::Borrowed(both.as_bytes())),
                 Some(vec![11, 22, 33]),
                 Some(666),
             )
@@ -472,7 +472,7 @@ fn send_with_subchannels_succeeds() {
         // Must not be received by neither dataConsumer1 nor dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(std::borrow::Cow::Borrowed(none.as_bytes())),
+                WebRtcMessage::String(Cow::Borrowed(none.as_bytes())),
                 Some(vec![3]),
                 Some(666),
             )
@@ -481,7 +481,7 @@ fn send_with_subchannels_succeeds() {
         // Must not be received by neither dataConsumer1 nor dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(std::borrow::Cow::Borrowed(none.as_bytes())),
+                WebRtcMessage::String(Cow::Borrowed(none.as_bytes())),
                 Some(vec![666]),
                 Some(3),
             )
@@ -490,7 +490,7 @@ fn send_with_subchannels_succeeds() {
         // Must be received by dataConsumer1.
         direct_data_producer
             .send(
-                WebRtcMessage::String(std::borrow::Cow::Borrowed(dc1.as_bytes())),
+                WebRtcMessage::String(Cow::Borrowed(dc1.as_bytes())),
                 Some(vec![1]),
                 None,
             )
@@ -499,7 +499,7 @@ fn send_with_subchannels_succeeds() {
         // Must be received by dataConsumer1.
         direct_data_producer
             .send(
-                WebRtcMessage::String(std::borrow::Cow::Borrowed(dc1.as_bytes())),
+                WebRtcMessage::String(Cow::Borrowed(dc1.as_bytes())),
                 Some(vec![11]),
                 None,
             )
@@ -508,7 +508,7 @@ fn send_with_subchannels_succeeds() {
         // Must be received by dataConsumer1.
         direct_data_producer
             .send(
-                WebRtcMessage::String(std::borrow::Cow::Borrowed(dc1.as_bytes())),
+                WebRtcMessage::String(Cow::Borrowed(dc1.as_bytes())),
                 Some(vec![666]),
                 Some(11),
             )
@@ -517,7 +517,7 @@ fn send_with_subchannels_succeeds() {
         // Must be received by dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(std::borrow::Cow::Borrowed(dc2.as_bytes())),
+                WebRtcMessage::String(Cow::Borrowed(dc2.as_bytes())),
                 Some(vec![666]),
                 Some(2),
             )
@@ -534,7 +534,7 @@ fn send_with_subchannels_succeeds() {
         // Must be received by dataConsumer2.
         direct_data_producer
             .send(
-                WebRtcMessage::String(std::borrow::Cow::Borrowed(both.as_bytes())),
+                WebRtcMessage::String(Cow::Borrowed(both.as_bytes())),
                 Some(vec![1]),
                 Some(666),
             )


### PR DESCRIPTION
Fixes #1269

### Details

- Do not convert bytes to (UTF-8) string but let the user app do it based on `ppid` (`WebRtcMessage` type).
