### PR TITLE
meson: remove -Db_pie=true -Db_staticpic=true args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Avoid modification of user input data ([PR #1285](https://github.com/versatica/mediasoup/pull/1285)).
 * `ListenInfo`: Add transport socket flags ([PR #1291](https://github.com/versatica/mediasoup/pull/1291)).
+* Meson: Remove `-Db_pie=true -Db_staticpic=true` args ([PR #1293](https://github.com/versatica/mediasoup/pull/1293)).
 
 
 ### 3.13.13

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -164,6 +164,15 @@ def setup(ctx):
                 shell=SHELL
             );
 
+    # TMP to see meson build args available in current host:
+    with ctx.cd(WORKER_DIR):
+        ctx.run(
+            f'"{MESON}" configure',
+            echo=True,
+            pty=PTY_SUPPORTED,
+            shell=SHELL
+        );
+
 
 @task
 def clean(ctx): # pylint: disable=unused-argument

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -142,7 +142,7 @@ def setup(ctx):
     if MEDIASOUP_BUILDTYPE == 'Release':
         with ctx.cd(WORKER_DIR):
             ctx.run(
-                f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype release -Db_ndebug=true -Db_pie=true -Db_staticpic=true {MESON_ARGS} "{BUILD_DIR}"',
+                f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype release -Db_ndebug=true {MESON_ARGS} "{BUILD_DIR}"',
                 echo=True,
                 pty=PTY_SUPPORTED,
                 shell=SHELL
@@ -150,7 +150,7 @@ def setup(ctx):
     elif MEDIASOUP_BUILDTYPE == 'Debug':
         with ctx.cd(WORKER_DIR):
             ctx.run(
-                f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype debug -Db_pie=true -Db_staticpic=true {MESON_ARGS} "{BUILD_DIR}"',
+                f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype debug {MESON_ARGS} "{BUILD_DIR}"',
                 echo=True,
                 pty=PTY_SUPPORTED,
                 shell=SHELL
@@ -158,7 +158,7 @@ def setup(ctx):
     else:
         with ctx.cd(WORKER_DIR):
             ctx.run(
-                f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype {MEDIASOUP_BUILDTYPE} -Db_ndebug=if-release -Db_pie=true -Db_staticpic=true {MESON_ARGS} "{BUILD_DIR}"',
+                f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype {MEDIASOUP_BUILDTYPE} -Db_ndebug=if-release {MESON_ARGS} "{BUILD_DIR}"',
                 echo=True,
                 pty=PTY_SUPPORTED,
                 shell=SHELL

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -164,15 +164,6 @@ def setup(ctx):
                 shell=SHELL
             );
 
-    # TMP to see meson build args available in current host:
-    with ctx.cd(WORKER_DIR):
-        ctx.run(
-            f'"{MESON}" configure',
-            echo=True,
-            pty=PTY_SUPPORTED,
-            shell=SHELL
-        );
-
 
 @task
 def clean(ctx): # pylint: disable=unused-argument


### PR DESCRIPTION
- May fix #1292
- `PIC` flag was introduced in previous mediasoup gyp build system: https://github.com/versatica/mediasoup/commit/bbc35146468990648fc4925f4d852955b32091b7, it was needed for mediasoup to build on Ubuntu 18.04: https://github.com/versatica/mediasoup/issues/315.
- No idea about the possible implications of this removal. Note that we no longer test mediasoup on Ubuntu 18.04 (oldest Ubuntu we test in CI is 20.04).

### More details

In https://mesonbuild.com/Builtin-options.html#base-options:

> The following options are available. Note that they may not be available on all platforms or with all compilers:
> [...]
> - b_staticpic: Build static libraries as position independent
> - b_pie: Build position-independent executables (since 0.49.0)

Somewhere else:

> Position-independent code is not tied to a specific address. This independence allows the code to execute efficiently at a different address in each process that uses the code. Position-independent code is recommended for the creation of shared objects.

> On some architectures, including x86, -fPIC generates much worse code (i.e. a function call) for loads/stores of data. While this is tolerable for libraries, it is undesirable for executables.

> If the object is to be linked as a shared library, or a static library that will in turn be linked in a shared library, use -fPIC. If the object is to be linked as a position indenpendent executable, or astatic library that will in turn be linked in position independent executable, use -fPIE.

> blablabla