### PR TITLE
ListenInfo: Ignore given socket flags if not suitable for given IP family or transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 * Avoid modification of user input data ([PR #1285](https://github.com/versatica/mediasoup/pull/1285)).
 * `ListenInfo`: Add transport socket flags ([PR #1291](https://github.com/versatica/mediasoup/pull/1291)).
+* `ListenInfo`: Ignore given socket flags if not suitable for given IP family or transport ([PR #1294](https://github.com/versatica/mediasoup/pull/1294)).
 * Meson: Remove `-Db_pie=true -Db_staticpic=true` args ([PR #1293](https://github.com/versatica/mediasoup/pull/1293)).
 * Add RTCP Sender Report trace event ([PR #1267](https://github.com/versatica/mediasoup/pull/1267) by @GithubUser8080).
 

--- a/node/src/tests/test-PlainTransport.ts
+++ b/node/src/tests/test-PlainTransport.ts
@@ -338,7 +338,8 @@ if (!IS_WINDOWS)
 						protocol : 'udp',
 						ip       : multicastIp,
 						port     : port,
-						flags    : { udpReusePort: true }
+						// NOTE: ipv6Only flag will be ignored since ip is IPv4.
+						flags    : { udpReusePort: true, ipv6Only: true }
 					}
 				});
 

--- a/node/src/tests/test-WebRtcTransport.ts
+++ b/node/src/tests/test-WebRtcTransport.ts
@@ -641,10 +641,14 @@ test('WebRtcTransport methods reject if closed', async () =>
 test('router.createWebRtcTransport() with fixed port succeeds', async () =>
 {
 
-	const port = await pickPort({ ip: '127.0.0.1', reserveTimeout: 0 });
+	const port = await pickPort({ type: 'tcp', ip: '127.0.0.1', reserveTimeout: 0 });
 	const webRtcTransport = await router.createWebRtcTransport(
 		{
-			listenInfos : [ { protocol: 'udp', ip: '127.0.0.1', port } ]
+			listenInfos :
+			[
+				// NOTE: udpReusePort flag will be ignored since protocol is TCP.
+				{ protocol: 'tcp', ip: '127.0.0.1', port, flags: { udpReusePort: true } }
+			]
 		});
 
 	expect(webRtcTransport.iceCandidates[0].port).toEqual(port);

--- a/rust/tests/integration/plain_transport.rs
+++ b/rust/tests/integration/plain_transport.rs
@@ -438,8 +438,9 @@ fn create_two_transports_binding_to_same_ip_port_with_udp_reuse_port_flag_succee
                     ip: multicast_ip,
                     announced_ip: None,
                     port: Some(port),
+                    // NOTE: ipv6Only flag will be ignored since ip is IPv4.
                     flags: Some(SocketFlags {
-                        ipv6_only: false,
+                        ipv6_only: true,
                         udp_reuse_port: true,
                     }),
                     send_buffer_size: None,

--- a/worker/include/RTC/PortManager.hpp
+++ b/worker/include/RTC/PortManager.hpp
@@ -52,7 +52,8 @@ namespace RTC
 		  Transport transport, std::string& ip, uint16_t port, RTC::Transport::SocketFlags& flags);
 		static void Unbind(Transport transport, std::string& ip, uint16_t port);
 		static std::vector<bool>& GetPorts(Transport transport, const std::string& ip);
-		static uint8_t ConvertSocketFlags(RTC::Transport::SocketFlags& flags);
+		static uint8_t ConvertSocketFlags(
+		  RTC::Transport::SocketFlags& flags, Transport transport, int family);
 
 	private:
 		thread_local static absl::flat_hash_map<std::string, std::vector<bool>> mapUdpIpPorts;


### PR DESCRIPTION
For example, by design `libuv` will throw if a IPv4 socket is created with flag `UV_UDP_IPV6ONLY` or `UV_TCP_IPV6ONLY`.