### PR TITLE
Make Node tests independent (part 2)

### DIFF
--- a/node/src/utils.ts
+++ b/node/src/utils.ts
@@ -199,7 +199,7 @@ export function parseStringStringArrayVector(
 }
 
 /**
- * Make make an object or array recursively immutable.
+ * Make an object or array recursively immutable.
  * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze.
  */
 export function deepFreeze<T>(object: T): T

--- a/node/src/utils.ts
+++ b/node/src/utils.ts
@@ -197,3 +197,26 @@ export function parseStringStringArrayVector(
 
 	return array;
 }
+
+/**
+ * Make make an object or array recursively immutable.
+ * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/freeze.
+ */
+export function deepFreeze<T>(object: T): T
+{
+	// Retrieve the property names defined on object.
+	const propNames = Reflect.ownKeys(object as any);
+
+	// Freeze properties before freezing self.
+	for (const name of propNames)
+	{
+		const value = (object as any)[name];
+
+		if ((value && typeof value === 'object') || typeof value === 'function')
+		{
+			deepFreeze(value);
+		}
+	}
+
+	return Object.freeze(object);
+}


### PR DESCRIPTION
### Details

- Just done in `test-Router.ts` as POC.
- Avoid declaring global variables in test files. Put them into `ctx: TestContext` instead.
- Things in `ctx` should be const/frozen or reset in each `test()` execution.
- So use a new `utils.deepFreeze()` function which freezes the object and would throw upon any modification attempt.