### PR TITLE
Add worker prebuild binary for Linux kernel 6

### DIFF
--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -10,11 +10,16 @@ jobs:
     strategy:
       matrix:
         build:
-          # For Linux let's use an old version of Ubuntu (20.04) that builds the
+          # Worker prebuild for Linux with kernel version 5 Ubuntu (20.04).
+          # Let's use an old version of Ubuntu (20.04) that builds the
           # mediasoup-worker binary using an old version of GLib, so it will work
           # on Linux hosts running more modern GLib versions.
           # See https://github.com/versatica/mediasoup/issues/1089.
           - os: ubuntu-20.04
+            cc: gcc
+            cxx: g++
+          # Worker prebuild for Linux with kernel version 6 Ubuntu (22.04).
+          - os: ubuntu-22.04
             cc: gcc
             cxx: g++
           - os: macos-12
@@ -43,14 +48,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      # We need to install some NPM production deps for npm-scripts.mjs to work.
+      # We need to install some NPM production deps for npm-scripts.mjs to
+      # work.
       - name: npm ci --ignore-scripts
         run: npm ci --ignore-scripts --omit=dev --foreground-scripts
-
-      # However we also need to install pip invoke manually (since
-      # `--ignore-scripts` prevented invoke from being installed).
-      - name: pip3 install invoke
-        run: pip3 install invoke
 
       - name: npm run worker:build
         run: npm run worker:build


### PR DESCRIPTION
Fixes #1284

### Details

- Ubuntu 22.04.3 LTS has kernel 6.2.
- CI job: No need to manually install `invoke` since `npm run worker:build` internally installs it if needed.