### PR TITLE
Node: Add new worker.on('subprocessclose') to fix Node tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### NEXT
+
+- Node: Add new `worker.on('subprocessclose')` event ([PR #1307](https://github.com/versatica/mediasoup/pull/1307)).
+
 ### 3.13.15
 
 - Add worker prebuild binary for Linux kernel 6 ([PR #1300](https://github.com/versatica/mediasoup/pull/1300)).

--- a/node/src/Channel.ts
+++ b/node/src/Channel.ts
@@ -228,15 +228,13 @@ export class Channel extends EnhancedEventEmitter {
 		this.#producerSocket.removeAllListeners('error');
 		this.#producerSocket.on('error', () => {});
 
-		// Destroy the socket after a while to allow pending incoming messages.
-		setTimeout(() => {
-			try {
-				this.#producerSocket.destroy();
-			} catch (error) {}
-			try {
-				this.#consumerSocket.destroy();
-			} catch (error) {}
-		}, 200);
+		// Destroy the sockets.
+		try {
+			this.#producerSocket.destroy();
+		} catch (error) {}
+		try {
+			this.#consumerSocket.destroy();
+		} catch (error) {}
 	}
 
 	/**

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -575,7 +575,6 @@ export class Worker<
 		this.#closed = true;
 
 		// Kill the worker process.
-		this.#child.unref();
 		this.#child.kill('SIGTERM');
 
 		// Close the Channel instance.

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -200,6 +200,7 @@ export type WorkerDump = {
 
 export type WorkerEvents = {
 	died: [Error];
+	subprocessclose: [];
 	listenererror: [string, Error];
 	// Private events.
 	'@success': [];
@@ -244,7 +245,7 @@ export class Worker<
 	WorkerAppData extends AppData = AppData,
 > extends EnhancedEventEmitter<WorkerEvents> {
 	// mediasoup-worker child process.
-	#child?: ChildProcess;
+	#child: ChildProcess;
 
 	// Worker process PID.
 	readonly #pid: number;
@@ -257,6 +258,9 @@ export class Worker<
 
 	// Died dlag.
 	#died = false;
+
+	// Worker subprocess closed flag.
+	#subprocessClosed = false;
 
 	// Custom app data.
 	#appData: WorkerAppData;
@@ -389,7 +393,10 @@ export class Worker<
 		});
 
 		this.#child.on('exit', (code, signal) => {
-			this.#child = undefined;
+			// If killed by ourselves, do nothing.
+			if (this.#child.killed) {
+				return;
+			}
 
 			if (!spawnDone) {
 				spawnDone = true;
@@ -431,7 +438,10 @@ export class Worker<
 		});
 
 		this.#child.on('error', error => {
-			this.#child = undefined;
+			// If killed by ourselves, do nothing.
+			if (this.#child.killed) {
+				return;
+			}
 
 			if (!spawnDone) {
 				spawnDone = true;
@@ -453,6 +463,19 @@ export class Worker<
 
 				this.workerDied(error);
 			}
+		});
+
+		this.#child.on('close', (code, signal) => {
+			logger.debug(
+				'worker process closed [pid:%s, code:%s, signal:%s]',
+				this.#pid,
+				code,
+				signal,
+			);
+
+			this.#subprocessClosed = true;
+
+			this.safeEmit('subprocessclose');
 		});
 
 		// Be ready for 3rd party worker libraries logging to stdout.
@@ -493,6 +516,13 @@ export class Worker<
 	 */
 	get died(): boolean {
 		return this.#died;
+	}
+
+	/**
+	 * Whether the Worker subprocess is closed.
+	 */
+	get subprocessClosed(): boolean {
+		return this.#subprocessClosed;
 	}
 
 	/**
@@ -545,15 +575,8 @@ export class Worker<
 		this.#closed = true;
 
 		// Kill the worker process.
-		if (this.#child) {
-			// Remove event listeners but leave a fake 'error' hander to avoid
-			// propagation.
-			this.#child.removeAllListeners('exit');
-			this.#child.removeAllListeners('error');
-			this.#child.on('error', () => {});
-			this.#child.kill('SIGTERM');
-			this.#child = undefined;
-		}
+		this.#child.unref();
+		this.#child.kill('SIGTERM');
 
 		// Close the Channel instance.
 		this.#channel.close();

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -467,7 +467,7 @@ export class Worker<
 
 		this.#child.on('close', (code, signal) => {
 			logger.debug(
-				'worker process closed [pid:%s, code:%s, signal:%s]',
+				'worker subprocess closed [pid:%s, code:%s, signal:%s]',
 				this.#pid,
 				code,
 				signal,

--- a/node/src/test/test-ActiveSpeakerObserver.ts
+++ b/node/src/test/test-ActiveSpeakerObserver.ts
@@ -27,8 +27,14 @@ beforeEach(async () => {
 	ctx.router = await ctx.worker.createRouter({ mediaCodecs: ctx.mediaCodecs });
 });
 
-afterEach(() => {
+afterEach(async () => {
 	ctx.worker?.close();
+
+	if (ctx.worker?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
+		);
+	}
 });
 
 test('router.createActiveSpeakerObserver() succeeds', async () => {

--- a/node/src/test/test-AudioLevelObserver.ts
+++ b/node/src/test/test-AudioLevelObserver.ts
@@ -27,8 +27,14 @@ beforeEach(async () => {
 	ctx.router = await ctx.worker.createRouter({ mediaCodecs: ctx.mediaCodecs });
 });
 
-afterEach(() => {
+afterEach(async () => {
 	ctx.worker?.close();
+
+	if (ctx.worker?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
+		);
+	}
 });
 
 test('router.createAudioLevelObserver() succeeds', async () => {

--- a/node/src/test/test-DataConsumer.ts
+++ b/node/src/test/test-DataConsumer.ts
@@ -40,8 +40,14 @@ beforeEach(async () => {
 	);
 });
 
-afterEach(() => {
+afterEach(async () => {
 	ctx.worker?.close();
+
+	if (ctx.worker?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
+		);
+	}
 });
 
 test('transport.consumeData() succeeds', async () => {

--- a/node/src/test/test-DataProducer.ts
+++ b/node/src/test/test-DataProducer.ts
@@ -44,8 +44,14 @@ beforeEach(async () => {
 	});
 });
 
-afterEach(() => {
+afterEach(async () => {
 	ctx.worker?.close();
+
+	if (ctx.worker?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
+		);
+	}
 });
 
 test('webRtcTransport1.produceData() succeeds', async () => {

--- a/node/src/test/test-DirectTransport.ts
+++ b/node/src/test/test-DirectTransport.ts
@@ -12,8 +12,14 @@ beforeEach(async () => {
 	ctx.router = await ctx.worker.createRouter();
 });
 
-afterEach(() => {
+afterEach(async () => {
 	ctx.worker?.close();
+
+	if (ctx.worker?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
+		);
+	}
 });
 
 test('router.createDirectTransport() succeeds', async () => {
@@ -138,7 +144,7 @@ test('dataProducer.send() succeeds', async () => {
 			);
 		});
 
-		sendNextMessage();
+		await sendNextMessage();
 
 		async function sendNextMessage(): Promise<void> {
 			const id = ++numSentMessages;

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -195,9 +195,21 @@ beforeEach(async () => {
 	);
 });
 
-afterEach(() => {
+afterEach(async () => {
 	ctx.worker1?.close();
 	ctx.worker2?.close();
+
+	if (ctx.worker1?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker1?.on('subprocessclose', resolve),
+		);
+	}
+
+	if (ctx.worker2?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker2?.on('subprocessclose', resolve),
+		);
+	}
 });
 
 test('router.pipeToRouter() succeeds with audio', async () => {

--- a/node/src/test/test-PlainTransport.ts
+++ b/node/src/test/test-PlainTransport.ts
@@ -49,8 +49,14 @@ beforeEach(async () => {
 	ctx.router = await ctx.worker.createRouter({ mediaCodecs: ctx.mediaCodecs });
 });
 
-afterEach(() => {
+afterEach(async () => {
 	ctx.worker?.close();
+
+	if (ctx.worker?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
+		);
+	}
 });
 
 test('router.createPlainTransport() succeeds', async () => {

--- a/node/src/test/test-Producer.ts
+++ b/node/src/test/test-Producer.ts
@@ -144,8 +144,14 @@ beforeEach(async () => {
 	});
 });
 
-afterEach(() => {
+afterEach(async () => {
 	ctx.worker?.close();
+
+	if (ctx.worker?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
+		);
+	}
 });
 
 test('webRtcTransport1.produce() succeeds', async () => {

--- a/node/src/test/test-Router.ts
+++ b/node/src/test/test-Router.ts
@@ -42,8 +42,14 @@ beforeEach(async () => {
 	ctx.worker = await mediasoup.createWorker();
 });
 
-afterEach(() => {
+afterEach(async () => {
 	ctx.worker?.close();
+
+	if (ctx.worker?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
+		);
+	}
 });
 
 test('worker.createRouter() succeeds', async () => {

--- a/node/src/test/test-WebRtcServer.ts
+++ b/node/src/test/test-WebRtcServer.ts
@@ -13,8 +13,14 @@ beforeEach(async () => {
 	ctx.worker = await mediasoup.createWorker();
 });
 
-afterEach(() => {
+afterEach(async () => {
 	ctx.worker?.close();
+
+	if (ctx.worker?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
+		);
+	}
 });
 
 test('worker.createWebRtcServer() succeeds', async () => {

--- a/node/src/test/test-WebRtcTransport.ts
+++ b/node/src/test/test-WebRtcTransport.ts
@@ -54,8 +54,14 @@ beforeEach(async () => {
 	ctx.router = await ctx.worker.createRouter({ mediaCodecs: ctx.mediaCodecs });
 });
 
-afterEach(() => {
+afterEach(async () => {
 	ctx.worker?.close();
+
+	if (ctx.worker?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
+		);
+	}
 });
 
 test('router.createWebRtcTransport() succeeds', async () => {

--- a/node/src/test/test-multiopus.ts
+++ b/node/src/test/test-multiopus.ts
@@ -103,8 +103,14 @@ beforeEach(async () => {
 	});
 });
 
-afterEach(() => {
+afterEach(async () => {
 	ctx.worker?.close();
+
+	if (ctx.worker?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
+		);
+	}
 });
 
 test('produce() and consume() succeed', async () => {

--- a/node/src/test/test-node-sctp.ts
+++ b/node/src/test/test-node-sctp.ts
@@ -99,10 +99,16 @@ afterEach(async () => {
 	ctx.sctpSocket?.end();
 	ctx.worker?.close();
 
+	if (ctx.worker?.subprocessClosed === false) {
+		await new Promise<void>(
+			resolve => ctx.worker?.on('subprocessclose', resolve),
+		);
+	}
+
 	// NOTE: For some reason we have to wait a bit for the SCTP stuff to release
 	// internal things, otherwise Jest reports open handles. We don't care much
 	// honestly.
-	await new Promise(resolve => setTimeout(resolve, 2000));
+	await new Promise(resolve => setTimeout(resolve, 1000));
 });
 
 test('ordered DataProducer delivers all SCTP messages to the DataConsumer', async () => {

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -296,7 +296,7 @@ function installInvoke() {
 	// Install pip invoke into custom location, so we don't depend on system-wide
 	// installation.
 	executeCmd(
-		`"${PYTHON}" -m pip install --upgrade --no-user --target="${PIP_INVOKE_DIR}" invoke`,
+		`"${PYTHON}" -m pip install --upgrade --no-user --target "${PIP_INVOKE_DIR}" invoke`,
 		/* exitOnError */ true,
 	);
 }
@@ -420,7 +420,7 @@ function flatcWorker() {
 function testNode() {
 	logInfo('testNode()');
 
-	executeCmd(`jest --detectOpenHandles ${args}`);
+	executeCmd(`jest --silent false --detectOpenHandles ${args}`);
 }
 
 function testWorker() {

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -47,7 +47,7 @@ invoke:
 ifeq ($(wildcard $(PIP_INVOKE_DIR)),)
 	# Install pip invoke into custom location, so we don't depend on system-wide
 	# installation.
-	$(PYTHON) -m pip install --upgrade --no-user --target="$(PIP_INVOKE_DIR)" invoke
+	$(PYTHON) -m pip install --upgrade --no-user --target "$(PIP_INVOKE_DIR)" invoke
 endif
 
 meson-ninja: invoke

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -47,75 +47,75 @@ invoke:
 ifeq ($(wildcard $(PIP_INVOKE_DIR)),)
 	# Install pip invoke into custom location, so we don't depend on system-wide
 	# installation.
-	$(PYTHON) -m pip install --upgrade --no-user --target "$(PIP_INVOKE_DIR)" invoke
+	"$(PYTHON)" -m pip install --upgrade --no-user --target "$(PIP_INVOKE_DIR)" invoke
 endif
 
 meson-ninja: invoke
-	$(PYTHON) -m invoke meson-ninja
+	"$(PYTHON)" -m invoke meson-ninja
 
 setup: invoke
-	$(PYTHON) -m invoke setup
+	"$(PYTHON)" -m invoke setup
 
 clean: invoke
-	$(PYTHON) -m invoke clean
+	"$(PYTHON)" -m invoke clean
 
 clean-build: invoke
-	$(PYTHON) -m invoke clean-build
+	"$(PYTHON)" -m invoke clean-build
 
 clean-pip: invoke
-	$(PYTHON) -m invoke clean-pip
+	"$(PYTHON)" -m invoke clean-pip
 
 clean-subprojects: invoke
-	$(PYTHON) -m invoke clean-subprojects
+	"$(PYTHON)" -m invoke clean-subprojects
 
 clean-all: invoke
-	$(PYTHON) -m invoke clean-all
+	"$(PYTHON)" -m invoke clean-all
 
 # It requires the SUBPROJECT environment variable.
 update-wrap-file: invoke
-	$(PYTHON) -m invoke subprojects $(SUBPROJECT)
+	"$(PYTHON)" -m invoke subprojects $(SUBPROJECT)
 
 mediasoup-worker: invoke
-	$(PYTHON) -m invoke mediasoup-worker
+	"$(PYTHON)" -m invoke mediasoup-worker
 
 libmediasoup-worker: invoke
-	$(PYTHON) -m invoke libmediasoup-worker
+	"$(PYTHON)" -m invoke libmediasoup-worker
 
 flatc: invoke
-	$(PYTHON) -m invoke flatc
+	"$(PYTHON)" -m invoke flatc
 
 xcode: invoke
-	$(PYTHON) -m invoke xcode
+	"$(PYTHON)" -m invoke xcode
 
 lint: invoke
-	$(PYTHON) -m invoke lint
+	"$(PYTHON)" -m invoke lint
 
 format: invoke
-	$(PYTHON) -m invoke format
+	"$(PYTHON)" -m invoke format
 
 test: invoke
-	$(PYTHON) -m invoke test
+	"$(PYTHON)" -m invoke test
 
 test-asan: invoke
-	$(PYTHON) -m invoke test-asan
+	"$(PYTHON)" -m invoke test-asan
 
 tidy: invoke
-	$(PYTHON) -m invoke tidy
+	"$(PYTHON)" -m invoke tidy
 
 fuzzer: invoke
-	$(PYTHON) -m invoke fuzzer
+	"$(PYTHON)" -m invoke fuzzer
 
 fuzzer-run-all: invoke
-	$(PYTHON) -m invoke fuzzer-run-all
+	"$(PYTHON)" -m invoke fuzzer-run-all
 
 docker: invoke
-	$(PYTHON) -m invoke docker
+	"$(PYTHON)" -m invoke docker
 
 docker-run: invoke
-	$(PYTHON) -m invoke docker-run
+	"$(PYTHON)" -m invoke docker-run
 
 docker-alpine: invoke
-	$(PYTHON) -m invoke docker-alpine
+	"$(PYTHON)" -m invoke docker-alpine
 
 docker-alpine-run: invoke
-	$(PYTHON) -m invoke docker-alpine-run
+	"$(PYTHON)" -m invoke docker-alpine-run

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -140,7 +140,7 @@ def setup(ctx):
     Run meson setup
     """
     if MEDIASOUP_BUILDTYPE == 'Release':
-        with ctx.cd(WORKER_DIR):
+        with ctx.cd(f'"{WORKER_DIR}"'):
             ctx.run(
                 f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype release -Db_ndebug=true {MESON_ARGS} "{BUILD_DIR}"',
                 echo=True,
@@ -148,7 +148,7 @@ def setup(ctx):
                 shell=SHELL
             );
     elif MEDIASOUP_BUILDTYPE == 'Debug':
-        with ctx.cd(WORKER_DIR):
+        with ctx.cd(f'"{WORKER_DIR}"'):
             ctx.run(
                 f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype debug {MESON_ARGS} "{BUILD_DIR}"',
                 echo=True,
@@ -156,7 +156,7 @@ def setup(ctx):
                 shell=SHELL
             );
     else:
-        with ctx.cd(WORKER_DIR):
+        with ctx.cd(f'"{WORKER_DIR}"'):
             ctx.run(
                 f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype {MEDIASOUP_BUILDTYPE} -Db_ndebug=if-release {MESON_ARGS} "{BUILD_DIR}"',
                 echo=True,
@@ -208,7 +208,7 @@ def clean_subprojects(ctx):
     """
     Clean meson subprojects
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" subprojects purge --include-cache --confirm',
             echo=True,
@@ -222,7 +222,7 @@ def clean_all(ctx):
     """
     Clean meson subprojects and all installed/built artificats
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         try:
             ctx.run(
                 f'"{MESON}" subprojects purge --include-cache --confirm',
@@ -244,7 +244,7 @@ def update_wrap_file(ctx, subproject):
     """
     Update the wrap file of a subproject
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" subprojects update --reset {subproject}',
             echo=True,
@@ -258,7 +258,7 @@ def flatc(ctx):
     """
     Compile FlatBuffers FBS files
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" compile -C "{BUILD_DIR}" flatbuffers-generator',
             echo=True,
@@ -276,14 +276,14 @@ def mediasoup_worker(ctx):
         print('skipping mediasoup-worker compilation due to the existence of the MEDIASOUP_WORKER_BIN environment variable');
         return;
 
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" compile -C "{BUILD_DIR}" -j {NUM_CORES} mediasoup-worker',
             echo=True,
             pty=PTY_SUPPORTED,
             shell=SHELL
         );
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" install -C "{BUILD_DIR}" --no-rebuild --tags mediasoup-worker',
             echo=True,
@@ -297,14 +297,14 @@ def libmediasoup_worker(ctx):
     """
     Compile libmediasoup-worker library
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" compile -C "{BUILD_DIR}" -j {NUM_CORES} libmediasoup-worker',
             echo=True,
             pty=PTY_SUPPORTED,
             shell=SHELL
         );
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" install -C "{BUILD_DIR}" --no-rebuild --tags libmediasoup-worker',
             echo=True,
@@ -318,7 +318,7 @@ def xcode(ctx):
     """
     Setup Xcode project
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" setup --buildtype {MEDIASOUP_BUILDTYPE.lower()} --backend xcode "{MEDIASOUP_OUT_DIR}/xcode"',
             echo=True,
@@ -332,7 +332,7 @@ def lint(ctx):
     """
     Lint source code
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{NPM}" run lint --prefix scripts/',
             echo=True,
@@ -349,7 +349,7 @@ def lint(ctx):
             shell=SHELL
         );
 
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{PYTHON}" -m pylint tasks.py',
             echo=True,
@@ -363,7 +363,7 @@ def format(ctx):
     """
     Format source code according to lint rules
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{NPM}" run format --prefix scripts/',
             echo=True,
@@ -377,14 +377,14 @@ def test(ctx):
     """
     Run worker tests
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" compile -C "{BUILD_DIR}" -j {NUM_CORES} mediasoup-worker-test',
             echo=True,
             pty=PTY_SUPPORTED,
             shell=SHELL
         );
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" install -C "{BUILD_DIR}" --no-rebuild --tags mediasoup-worker-test',
             echo=True,
@@ -395,7 +395,7 @@ def test(ctx):
     mediasoup_worker_test = 'mediasoup-worker-test.exe' if os.name == 'nt' else 'mediasoup-worker-test';
     mediasoup_test_tags = os.getenv('MEDIASOUP_TEST_TAGS') or '';
 
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{BUILD_DIR}/{mediasoup_worker_test}" --invisibles --colour-mode=ansi {mediasoup_test_tags}',
             echo=True,
@@ -409,14 +409,14 @@ def test_asan(ctx):
     """
     Run worker test with Address Sanitizer
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" compile -C "{BUILD_DIR}" -j {NUM_CORES} mediasoup-worker-test-asan',
             echo=True,
             pty=PTY_SUPPORTED,
             shell=SHELL
         );
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" install -C "{BUILD_DIR}" --no-rebuild --tags mediasoup-worker-test-asan',
             echo=True,
@@ -426,7 +426,7 @@ def test_asan(ctx):
 
     mediasoup_test_tags = os.getenv('MEDIASOUP_TEST_TAGS') or '';
 
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'ASAN_OPTIONS=detect_leaks=1 "{BUILD_DIR}/mediasoup-worker-test-asan" --invisibles --use-colour=yes {mediasoup_test_tags}',
             echo=True,
@@ -442,7 +442,7 @@ def tidy(ctx):
     """
     mediasoup_tidy_checks = os.getenv('MEDIASOUP_TIDY_CHECKS') or '';
 
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{PYTHON}" ./scripts/clang-tidy.py -clang-tidy-binary=./scripts/node_modules/.bin/clang-tidy -clang-apply-replacements-binary=./scripts/node_modules/.bin/clang-apply-replacements -header-filter="(Channel/**/*.hpp|DepLibSRTP.hpp|DepLibUV.hpp|DepLibWebRTC.hpp|DepOpenSSL.hpp|DepUsrSCTP.hpp|LogLevel.hpp|Logger.hpp|MediaSoupError.hpp|RTC/**/*.hpp|Settings.hpp|Utils.hpp|Worker.hpp|common.hpp|handles/**/*.hpp)" -p="{BUILD_DIR}" -j={NUM_CORES} -checks={mediasoup_tidy_checks} -quiet',
             echo=True,
@@ -456,14 +456,14 @@ def fuzzer(ctx):
     """
     Build the mediasoup-worker-fuzzer binary (which uses libFuzzer)
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" compile -C "{BUILD_DIR}" -j {NUM_CORES} mediasoup-worker-fuzzer',
             echo=True,
             pty=PTY_SUPPORTED,
             shell=SHELL
         );
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{MESON}" install -C "{BUILD_DIR}" --no-rebuild --tags mediasoup-worker-fuzzer',
             echo=True,
@@ -477,7 +477,7 @@ def fuzzer_run_all(ctx):
     """
     Run all fuzzer cases
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'LSAN_OPTIONS=verbosity=1:log_threads=1 "{BUILD_DIR}/mediasoup-worker-fuzzer" -artifact_prefix=fuzzer/reports/ -max_len=1400 fuzzer/new-corpus deps/webrtc-fuzzer-corpora/corpora/stun-corpus deps/webrtc-fuzzer-corpora/corpora/rtp-corpus deps/webrtc-fuzzer-corpora/corpora/rtcp-corpus',
             echo=True,
@@ -492,7 +492,7 @@ def docker(ctx):
     Build a Linux Ubuntu Docker image with fuzzer capable clang++
     """
     if os.getenv('DOCKER_NO_CACHE') == 'true':
-        with ctx.cd(WORKER_DIR):
+        with ctx.cd(f'"{WORKER_DIR}"'):
             ctx.run(
                 f'"{DOCKER}" build -f Dockerfile --no-cache --tag mediasoup/docker:latest .',
                 echo=True,
@@ -500,7 +500,7 @@ def docker(ctx):
                 shell=SHELL
             );
     else:
-        with ctx.cd(WORKER_DIR):
+        with ctx.cd(f'"{WORKER_DIR}"'):
             ctx.run(
                 f'"{DOCKER}" build -f Dockerfile --tag mediasoup/docker:latest .',
                 echo=True,
@@ -514,7 +514,7 @@ def docker_run(ctx):
     """
     Run a container of the Ubuntu Docker image created in the docker task
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{DOCKER}" run --name=mediasoupDocker -it --rm --privileged --cap-add SYS_PTRACE -v "{WORKER_DIR}/../:/mediasoup" mediasoup/docker:latest',
             echo=True,
@@ -529,7 +529,7 @@ def docker_alpine(ctx):
     Build a Linux Alpine Docker image
     """
     if os.getenv('DOCKER_NO_CACHE') == 'true':
-        with ctx.cd(WORKER_DIR):
+        with ctx.cd(f'"{WORKER_DIR}"'):
             ctx.run(
                 f'"{DOCKER}" build -f Dockerfile.alpine --no-cache --tag mediasoup/docker-alpine:latest .',
                 echo=True,
@@ -537,7 +537,7 @@ def docker_alpine(ctx):
                 shell=SHELL
             );
     else:
-        with ctx.cd(WORKER_DIR):
+        with ctx.cd(f'"{WORKER_DIR}"'):
             ctx.run(
                 f'"{DOCKER}" build -f Dockerfile.alpine --tag mediasoup/docker-alpine:latest .',
                 echo=True,
@@ -551,7 +551,7 @@ def docker_alpine_run(ctx):
     """
     Run a container of the Alpine Docker image created in the docker_alpine task
     """
-    with ctx.cd(WORKER_DIR):
+    with ctx.cd(f'"{WORKER_DIR}"'):
         ctx.run(
             f'"{DOCKER}" run --name=mediasoupDockerAlpine -it --rm --privileged --cap-add SYS_PTRACE -v "{WORKER_DIR}/../:/mediasoup" mediasoup/docker-alpine:latest',
             echo=True,

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -107,14 +107,14 @@ def meson_ninja(ctx):
     # fallback to command without `--system` if the first one fails.
     try:
         ctx.run(
-            f'"{PYTHON}" -m pip install --system --upgrade --no-user --target="{PIP_MESON_NINJA_DIR}" pip setuptools',
+            f'"{PYTHON}" -m pip install --system --upgrade --no-user --target "{PIP_MESON_NINJA_DIR}" pip setuptools',
             echo=True,
             hide=True,
             shell=SHELL
         );
     except:
         ctx.run(
-            f'"{PYTHON}" -m pip install --upgrade --no-user --target="{PIP_MESON_NINJA_DIR}" pip setuptools',
+            f'"{PYTHON}" -m pip install --upgrade --no-user --target "{PIP_MESON_NINJA_DIR}" pip setuptools',
             echo=True,
             pty=PTY_SUPPORTED,
             shell=SHELL
@@ -127,7 +127,7 @@ def meson_ninja(ctx):
     # Install meson and ninja using pip into our custom location, so we don't
     # depend on system-wide installation.
     ctx.run(
-        f'"{PYTHON}" -m pip install --upgrade --no-user --target="{PIP_MESON_NINJA_DIR}" {pip_build_binaries} meson=={MESON_VERSION} ninja=={NINJA_VERSION}',
+        f'"{PYTHON}" -m pip install --upgrade --no-user --target "{PIP_MESON_NINJA_DIR}" {pip_build_binaries} meson=={MESON_VERSION} ninja=={NINJA_VERSION}',
         echo=True,
         pty=PTY_SUPPORTED,
         shell=SHELL


### PR DESCRIPTION
Fixes #1306

### Details

- Problem only happened when running a test file separately (it worked by accident when running all tests together as usual).
- Problem was that the `ChildProcess` object in `Worker` (the `this.#child` member) remains open for a bit until it emits 'close' event, which is emitted after 'exit' event or after 'error' event.
- But we didn't await for that event at all since out `worker.close()` method is sync and we do not care of what is happening in the subprocess after calling it. And this is good. However it's bad for tests if we use `--detectOpenHandles` in Jest command.
- Here we have added a new 'subprocessclose' event in `Worker` which is emitted when the worker subprocess has closed. It may be (and it will be) emitted AFTER calling `worker.close()` but not immediately after it.
- This event is basically useful for scenarios like testing where we want to verify that nothing remains running/open when a test is finished.
- Also added a `worker.subprocessClosed` getter.
- Removed an ugly `setTimeout` in `Channel::close()` method. If the app wants to get the very latest notifications/logs from worker when closing it, use the above event to wait for final closure.

### Bonus Tracks

- Be consistent in command line arguments and always use `--option-foo bar` instead of `--option-foo=bar`.
- Make `tasks.py` and `Makefile` more resistant to paths with spaces.