### PR TITLE
Remove `no-async-promise-executor` linter disables

### DIFF
--- a/node/src/test/test-Consumer.ts
+++ b/node/src/test/test-Consumer.ts
@@ -1,4 +1,4 @@
-import {once} from 'node:events';
+import { once } from 'node:events';
 import * as flatbuffers from 'flatbuffers';
 import * as mediasoup from '../';
 import { UnsupportedError } from '../errors';
@@ -999,8 +999,8 @@ test('Consumer emits "producerpause" and "producerresume"', async () => {
 
 		// Let's await for pause() to resolve to avoid aborted channel requests
 		// due to worker closure.
-		ctx.audioProducer!.pause()
-	])
+		ctx.audioProducer!.pause(),
+	]);
 
 	expect(audioConsumer.paused).toBe(false);
 	expect(audioConsumer.producerPaused).toBe(true);
@@ -1010,8 +1010,8 @@ test('Consumer emits "producerpause" and "producerresume"', async () => {
 
 		// Let's await for resume() to resolve to avoid aborted channel requests
 		// due to worker closure.
-		ctx.audioProducer!.resume()
-	])
+		ctx.audioProducer!.resume(),
+	]);
 
 	expect(audioConsumer.paused).toBe(false);
 	expect(audioConsumer.producerPaused).toBe(false);

--- a/node/src/test/test-Consumer.ts
+++ b/node/src/test/test-Consumer.ts
@@ -1,3 +1,4 @@
+import {once} from 'node:events';
 import * as flatbuffers from 'flatbuffers';
 import * as mediasoup from '../';
 import { UnsupportedError } from '../errors';
@@ -993,26 +994,24 @@ test('Consumer emits "producerpause" and "producerresume"', async () => {
 		rtpCapabilities: ctx.consumerDeviceCapabilities,
 	});
 
-	// eslint-disable-next-line no-async-promise-executor
-	await new Promise<void>(async resolve => {
-		audioConsumer.on('producerpause', resolve);
+	await Promise.all([
+		once(audioConsumer, 'producerpause'),
 
 		// Let's await for pause() to resolve to avoid aborted channel requests
 		// due to worker closure.
-		await ctx.audioProducer!.pause();
-	});
+		ctx.audioProducer!.pause()
+	])
 
 	expect(audioConsumer.paused).toBe(false);
 	expect(audioConsumer.producerPaused).toBe(true);
 
-	// eslint-disable-next-line no-async-promise-executor
-	await new Promise<void>(async resolve => {
-		audioConsumer.on('producerresume', resolve);
+	await Promise.all([
+		once(audioConsumer, 'producerresume'),
 
 		// Let's await for resume() to resolve to avoid aborted channel requests
 		// due to worker closure.
-		await ctx.audioProducer!.resume();
-	});
+		ctx.audioProducer!.resume()
+	])
 
 	expect(audioConsumer.paused).toBe(false);
 	expect(audioConsumer.producerPaused).toBe(false);

--- a/node/src/test/test-node-sctp.ts
+++ b/node/src/test/test-node-sctp.ts
@@ -1,5 +1,4 @@
 import * as dgram from 'node:dgram';
-import {once} from 'node:events';
 // @ts-ignore
 import * as sctp from 'sctp';
 import * as mediasoup from '../';

--- a/node/src/test/test-node-sctp.ts
+++ b/node/src/test/test-node-sctp.ts
@@ -1,4 +1,5 @@
 import * as dgram from 'node:dgram';
+import {once} from 'node:events';
 // @ts-ignore
 import * as sctp from 'sctp';
 import * as mediasoup from '../';
@@ -122,8 +123,7 @@ test('ordered DataProducer delivers all SCTP messages to the DataConsumer', asyn
 	// It must be zero because it's the first DataConsumer on the plainTransport.
 	expect(ctx.dataConsumer!.sctpStreamParameters?.streamId).toBe(0);
 
-	// eslint-disable-next-line no-async-promise-executor
-	await new Promise<void>(async (resolve, reject) => {
+	await new Promise<void>((resolve, reject) => {
 		sendNextMessage();
 
 		async function sendNextMessage(): Promise<void> {


### PR DESCRIPTION
Documentation of eslint [no-async-promise-executor](https://eslint.org/docs/latest/rules/no-async-promise-executor) rule says:

> If an async executor function throws an error, the error will be lost and won’t cause the newly-constructed Promise to reject. **This could make it difficult to debug and handle some errors.**

(Bold is mine)

And this is exactly what has happened to me, 16 hours catching a bug due to this :-)

This PR fix and/or replace all the places where the a Promise async executor is being defined, not only in the place where I was having problems. This way, now exceptions are not missed but instead the Promises are properly rejected when an error occurs.

The fixes in the tests that I have done to remove the `eslint-disable` have been:

- combine the waiting event and the method dispatching it with `Promise.all()`
- replace async executors for sync ones where `await` keyword was not being used
- swallow with `void` the returned Promise of an async function, that was being ignored anyway. This is not strictly necessary, but got used to it as a best practice to show [the Promise is intentionally not awaited](https://github.com/typescript-eslint/typescript-eslint/blob/main/packages/eslint-plugin/docs/rules/no-floating-promises.md#ignorevoid)