### PR TITLE
Fix prebuilt worker download

### DIFF
--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -488,7 +488,9 @@ async function prebuildWorker() {
 async function downloadPrebuiltWorker() {
 	const releaseBase =
 		process.env.MEDIASOUP_WORKER_PREBUILT_DOWNLOAD_BASE_URL ||
-		`${PKG.repository.url.replace(/\.git$/, '')}/releases/download`;
+		`${PKG.repository.url
+			.replace(/^git\+/, '')
+			.replace(/\.git$/, '')}/releases/download`;
 
 	const tarUrl = `${releaseBase}/${PKG.version}/${WORKER_PREBUILD_TAR}`;
 


### PR DESCRIPTION
Needed because the repository url in package.json now has a git+ prefix.