### PR TITLE
announced_ip can be a hostname as per spec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### NEXT
+
+- `TransportListenInfo`: announced ip can also be a hostname ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 3.13.17
 
 - Fix prebuilt worker download ([PR #1319](https://github.com/versatica/mediasoup/pull/1319) by @brynrichards).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- `TransportListenInfo`: announced ip can also be a hostname ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- `TransportListenInfo`: announced ip can also be a hostname ([PR #1322](https://github.com/versatica/mediasoup/pull/1322)).
 
 ### 3.13.17
 

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -72,8 +72,8 @@ export type TransportListenInfo = {
 	ip: string;
 
 	/**
-	 * Announced IPv4 or IPv6 (useful when running mediasoup behind NAT with
-	 * private IP).
+	 * Announced IPv4, IPv6 or hostname (useful when running mediasoup behind NAT
+	 * with private IP).
 	 */
 	announcedIp?: string;
 
@@ -109,8 +109,8 @@ export type TransportListenIp = {
 	ip: string;
 
 	/**
-	 * Announced IPv4 or IPv6 (useful when running mediasoup behind NAT with
-	 * private IP).
+	 * Announced IPv4, IPv6 or hostname (useful when running mediasoup behind NAT
+	 * with private IP).
 	 */
 	announcedIp?: string;
 };

--- a/node/src/test/test-WebRtcServer.ts
+++ b/node/src/test/test-WebRtcServer.ts
@@ -48,7 +48,7 @@ test('worker.createWebRtcServer() succeeds', async () => {
 			{
 				protocol: 'tcp',
 				ip: '127.0.0.1',
-				announcedIp: '1.2.3.4',
+				announcedIp: 'foo.bar.org',
 				port: port2,
 			},
 		],

--- a/node/src/test/test-WebRtcTransport.ts
+++ b/node/src/test/test-WebRtcTransport.ts
@@ -68,13 +68,12 @@ test('router.createWebRtcTransport() succeeds', async () => {
 
 	ctx.router!.observer.once('newtransport', onObserverNewTransport);
 
-	// Create a separate transport here.
 	const webRtcTransport = await ctx.router!.createWebRtcTransport({
 		listenInfos: [
 			{ protocol: 'udp', ip: '127.0.0.1', announcedIp: '9.9.9.1' },
 			{ protocol: 'tcp', ip: '127.0.0.1', announcedIp: '9.9.9.1' },
-			{ protocol: 'udp', ip: '0.0.0.0', announcedIp: '9.9.9.2' },
-			{ protocol: 'tcp', ip: '0.0.0.0', announcedIp: '9.9.9.2' },
+			{ protocol: 'udp', ip: '0.0.0.0', announcedIp: 'foo1.bar.org' },
+			{ protocol: 'tcp', ip: '0.0.0.0', announcedIp: 'foo2.bar.org' },
 			{ protocol: 'udp', ip: '127.0.0.1', announcedIp: undefined },
 			{ protocol: 'tcp', ip: '127.0.0.1', announcedIp: undefined },
 		],
@@ -119,11 +118,11 @@ test('router.createWebRtcTransport() succeeds', async () => {
 	expect(iceCandidates[1].protocol).toBe('tcp');
 	expect(iceCandidates[1].type).toBe('host');
 	expect(iceCandidates[1].tcpType).toBe('passive');
-	expect(iceCandidates[2].ip).toBe('9.9.9.2');
+	expect(iceCandidates[2].ip).toBe('foo1.bar.org');
 	expect(iceCandidates[2].protocol).toBe('udp');
 	expect(iceCandidates[2].type).toBe('host');
 	expect(iceCandidates[2].tcpType).toBeUndefined();
-	expect(iceCandidates[3].ip).toBe('9.9.9.2');
+	expect(iceCandidates[3].ip).toBe('foo2.bar.org');
 	expect(iceCandidates[3].protocol).toBe('tcp');
 	expect(iceCandidates[3].type).toBe('host');
 	expect(iceCandidates[3].tcpType).toBe('passive');

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -644,7 +644,7 @@ impl RouterCreateWebrtcTransportListen {
                     web_rtc_transport::ListenIndividual {
                         listen_infos: listen_infos
                             .iter()
-                            .map(|listen_info| listen_info.clone().to_fbs())
+                            .map(|listen_info| listen_info.to_fbs())
                             .collect(),
                     },
                 ))

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -644,7 +644,7 @@ impl RouterCreateWebrtcTransportListen {
                     web_rtc_transport::ListenIndividual {
                         listen_infos: listen_infos
                             .iter()
-                            .map(|listen_info| listen_info.to_fbs())
+                            .map(|listen_info| listen_info.clone().to_fbs())
                             .collect(),
                     },
                 ))
@@ -921,8 +921,8 @@ impl RouterCreatePlainTransportData {
     ) -> Self {
         Self {
             transport_id,
-            listen_info: plain_transport_options.listen_info,
-            rtcp_listen_info: plain_transport_options.rtcp_listen_info,
+            listen_info: plain_transport_options.listen_info.clone(),
+            rtcp_listen_info: plain_transport_options.rtcp_listen_info.clone(),
             rtcp_mux: plain_transport_options.rtcp_mux,
             comedia: plain_transport_options.comedia,
             enable_sctp: plain_transport_options.enable_sctp,
@@ -947,9 +947,10 @@ impl RouterCreatePlainTransportData {
                 sctp_send_buffer_size: self.sctp_send_buffer_size,
                 is_data_channel: self.is_data_channel,
             }),
-            listen_info: Box::new(self.listen_info.to_fbs()),
+            listen_info: Box::new(self.listen_info.clone().to_fbs()),
             rtcp_listen_info: self
                 .rtcp_listen_info
+                .clone()
                 .map(|listen_info| Box::new(listen_info.to_fbs())),
             rtcp_mux: self.rtcp_mux,
             comedia: self.comedia,
@@ -1055,7 +1056,7 @@ impl RouterCreatePipeTransportData {
     ) -> Self {
         Self {
             transport_id,
-            listen_info: pipe_transport_options.listen_info,
+            listen_info: pipe_transport_options.listen_info.clone(),
             enable_sctp: pipe_transport_options.enable_sctp,
             num_sctp_streams: pipe_transport_options.num_sctp_streams,
             max_sctp_message_size: pipe_transport_options.max_sctp_message_size,
@@ -1078,7 +1079,7 @@ impl RouterCreatePipeTransportData {
                 sctp_send_buffer_size: self.sctp_send_buffer_size,
                 is_data_channel: self.is_data_channel,
             }),
-            listen_info: Box::new(self.listen_info.to_fbs()),
+            listen_info: Box::new(self.listen_info.clone().to_fbs()),
             enable_rtx: self.enable_rtx,
             enable_srtp: self.enable_srtp,
         }

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -608,7 +608,7 @@ impl Router {
     ///         ListenInfo {
     ///             protocol: Protocol::Udp,
     ///             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///             announced_ip: Some("9.9.9.1".parse().unwrap()),
+    ///             announced_ip: Some("9.9.9.1".to_string()),
     ///             port: None,
     ///             flags: None,
     ///             send_buffer_size: None,
@@ -696,7 +696,7 @@ impl Router {
     ///     .create_pipe_transport(PipeTransportOptions::new(ListenInfo {
     ///         protocol: Protocol::Udp,
     ///         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///         announced_ip: Some("9.9.9.1".parse().unwrap()),
+    ///         announced_ip: Some("9.9.9.1".to_string()),
     ///         port: None,
     ///         flags: None,
     ///         send_buffer_size: None,
@@ -762,7 +762,7 @@ impl Router {
     ///     .create_plain_transport(PlainTransportOptions::new(ListenInfo {
     ///         protocol: Protocol::Udp,
     ///         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///         announced_ip: Some("9.9.9.1".parse().unwrap()),
+    ///         announced_ip: Some("9.9.9.1".to_string()),
     ///         port: None,
     ///         flags: None,
     ///         send_buffer_size: None,
@@ -973,7 +973,7 @@ impl Router {
     ///         ListenInfo {
     ///             protocol: Protocol::Udp,
     ///             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///             announced_ip: Some("9.9.9.1".parse().unwrap()),
+    ///             announced_ip: Some("9.9.9.1".to_string()),
     ///             port: None,
     ///             flags: None,
     ///             send_buffer_size: None,
@@ -1016,7 +1016,7 @@ impl Router {
     ///         ListenInfo {
     ///             protocol: Protocol::Udp,
     ///             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///             announced_ip: Some("9.9.9.1".parse().unwrap()),
+    ///             announced_ip: Some("9.9.9.1".to_string()),
     ///             port: None,
     ///             flags: None,
     ///             send_buffer_size: None,
@@ -1202,7 +1202,7 @@ impl Router {
     ///             ListenInfo {
     ///                 protocol: Protocol::Udp,
     ///                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///                 announced_ip: Some("9.9.9.1".parse().unwrap()),
+    ///                 announced_ip: Some("9.9.9.1".to_string()),
     ///                 port: None,
     ///                 flags: None,
     ///                 send_buffer_size: None,
@@ -1234,7 +1234,7 @@ impl Router {
     ///             ListenInfo {
     ///                 protocol: Protocol::Udp,
     ///                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///                 announced_ip: Some("9.9.9.1".parse().unwrap()),
+    ///                 announced_ip: Some("9.9.9.1".to_string()),
     ///                 port: None,
     ///                 flags: None,
     ///                 send_buffer_size: None,

--- a/rust/src/router/plain_transport/tests.rs
+++ b/rust/src/router/plain_transport/tests.rs
@@ -40,7 +40,7 @@ fn router_close_event() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".parse().unwrap()),
+                    announced_ip: Some("4.4.4.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,

--- a/rust/src/router/webrtc_transport/tests.rs
+++ b/rust/src/router/webrtc_transport/tests.rs
@@ -132,7 +132,7 @@ fn create_with_webrtc_server_succeeds() {
         {
             let ice_candidates = transport.ice_candidates();
             assert_eq!(ice_candidates.len(), 1);
-            assert_eq!(ice_candidates[0].ip, IpAddr::V4(Ipv4Addr::LOCALHOST));
+            assert_eq!(ice_candidates[0].ip, "127.0.0.1");
             assert_eq!(ice_candidates[0].protocol, Protocol::Tcp);
             assert_eq!(ice_candidates[0].port, port2);
             assert_eq!(ice_candidates[0].r#type, IceCandidateType::Host);
@@ -233,7 +233,7 @@ fn router_close_event() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,

--- a/rust/src/webrtc_server.rs
+++ b/rust/src/webrtc_server.rs
@@ -95,7 +95,7 @@ impl WebRtcServerListenInfos {
     pub(crate) fn to_fbs(&self) -> Vec<transport::ListenInfo> {
         self.0
             .iter()
-            .map(|listen_info| listen_info.to_fbs())
+            .map(|listen_info| listen_info.clone().to_fbs())
             .collect()
     }
 }

--- a/rust/src/webrtc_server.rs
+++ b/rust/src/webrtc_server.rs
@@ -95,7 +95,7 @@ impl WebRtcServerListenInfos {
     pub(crate) fn to_fbs(&self) -> Vec<transport::ListenInfo> {
         self.0
             .iter()
-            .map(|listen_info| listen_info.clone().to_fbs())
+            .map(|listen_info| listen_info.to_fbs())
             .collect()
     }
 }

--- a/rust/tests/integration/plain_transport.rs
+++ b/rust/tests/integration/plain_transport.rs
@@ -94,7 +94,7 @@ fn create_succeeds() {
                     let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: Some("4.4.4.4".parse().unwrap()),
+                        announced_ip: Some("4.4.4.4".to_string()),
                         port: None,
                         flags: None,
                         send_buffer_size: None,
@@ -133,7 +133,7 @@ fn create_succeeds() {
                     let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: Some("9.9.9.1".parse().unwrap()),
+                        announced_ip: Some("9.9.9.1".to_string()),
                         port: None,
                         flags: None,
                         send_buffer_size: None,
@@ -286,7 +286,7 @@ fn create_with_fixed_port_succeeds() {
                 PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".parse().unwrap()),
+                    announced_ip: Some("4.4.4.4".to_string()),
                     port: Some(port),
                     flags: None,
                     send_buffer_size: None,
@@ -310,7 +310,7 @@ fn weak() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".parse().unwrap()),
+                    announced_ip: Some("4.4.4.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -344,7 +344,7 @@ fn create_enable_srtp_succeeds() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -532,7 +532,7 @@ fn get_stats_succeeds() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".parse().unwrap()),
+                    announced_ip: Some("4.4.4.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -590,7 +590,7 @@ fn connect_succeeds() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".parse().unwrap()),
+                    announced_ip: Some("4.4.4.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -666,7 +666,7 @@ fn connect_wrong_arguments() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".parse().unwrap()),
+                    announced_ip: Some("4.4.4.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -707,7 +707,7 @@ fn close_event() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".parse().unwrap()),
+                    announced_ip: Some("4.4.4.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,

--- a/rust/tests/integration/webrtc_server.rs
+++ b/rust/tests/integration/webrtc_server.rs
@@ -71,7 +71,7 @@ fn create_webrtc_server_succeeds() {
                 let listen_infos = listen_infos.insert(ListenInfo {
                     protocol: Protocol::Tcp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
+                    announced_ip: Some("foo.bar.org".to_string()),
                     port: Some(port2),
                     flags: None,
                     send_buffer_size: None,
@@ -167,7 +167,7 @@ fn create_webrtc_server_without_specifying_port_succeeds() {
                 let listen_infos = listen_infos.insert(ListenInfo {
                     protocol: Protocol::Tcp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
+                    announced_ip: Some("1.2.3.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -283,7 +283,7 @@ fn unavailable_infos_fails() {
                     let listen_infos = listen_infos.insert(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                        announced_ip: Some(IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4))),
+                        announced_ip: Some("1.2.3.4".to_string()),
                         port: Some(port1),
                         flags: None,
                         send_buffer_size: None,

--- a/rust/tests/integration/webrtc_transport.rs
+++ b/rust/tests/integration/webrtc_transport.rs
@@ -98,7 +98,7 @@ fn create_succeeds() {
                     WebRtcTransportListenInfos::new(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: Some("9.9.9.1".parse().unwrap()),
+                        announced_ip: Some("9.9.9.1".to_string()),
                         port: None,
                         flags: None,
                         send_buffer_size: None,
@@ -136,7 +136,7 @@ fn create_succeeds() {
                             ListenInfo {
                                 protocol: Protocol::Udp,
                                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                                announced_ip: Some("9.9.9.1".parse().unwrap()),
+                                announced_ip: Some("9.9.9.1".to_string()),
                                 port: None,
                                 flags: None,
                                 send_buffer_size: None,
@@ -145,7 +145,7 @@ fn create_succeeds() {
                             ListenInfo {
                                 protocol: Protocol::Udp,
                                 ip: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                                announced_ip: Some("9.9.9.2".parse().unwrap()),
+                                announced_ip: Some("foo1.bar.org".to_string()),
                                 port: None,
                                 flags: None,
                                 send_buffer_size: None,
@@ -200,19 +200,19 @@ fn create_succeeds() {
             {
                 let ice_candidates = transport1.ice_candidates();
                 assert_eq!(ice_candidates.len(), 3);
-                assert_eq!(ice_candidates[0].ip, "9.9.9.1".parse::<IpAddr>().unwrap());
+                assert_eq!(ice_candidates[0].ip, "9.9.9.1");
                 assert_eq!(ice_candidates[0].protocol, Protocol::Udp);
                 assert_eq!(ice_candidates[0].r#type, IceCandidateType::Host);
                 assert_eq!(ice_candidates[0].tcp_type, None);
-                assert_eq!(ice_candidates[1].ip, "9.9.9.2".parse::<IpAddr>().unwrap());
+                assert_eq!(ice_candidates[1].ip, "foo1.bar.org");
                 assert_eq!(ice_candidates[1].protocol, Protocol::Udp);
                 assert_eq!(ice_candidates[1].r#type, IceCandidateType::Host);
                 assert_eq!(ice_candidates[1].tcp_type, None);
-                assert_eq!(ice_candidates[2].ip, "127.0.0.1".parse::<IpAddr>().unwrap());
+                assert_eq!(ice_candidates[2].ip, "127.0.0.1");
                 assert_eq!(ice_candidates[2].protocol, Protocol::Udp);
                 assert_eq!(ice_candidates[2].r#type, IceCandidateType::Host);
                 assert_eq!(ice_candidates[2].tcp_type, None);
-                assert_eq!(ice_candidates[2].ip, "127.0.0.1".parse::<IpAddr>().unwrap());
+                assert_eq!(ice_candidates[2].ip, "127.0.0.1");
                 assert_eq!(ice_candidates[2].protocol, Protocol::Udp);
                 assert_eq!(ice_candidates[2].r#type, IceCandidateType::Host);
                 assert_eq!(ice_candidates[2].tcp_type, None);
@@ -265,7 +265,7 @@ fn create_with_fixed_port_succeeds() {
                 WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: Some(port),
                     flags: None,
                     send_buffer_size: None,
@@ -289,7 +289,7 @@ fn weak() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -343,7 +343,7 @@ fn get_stats_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -395,7 +395,7 @@ fn connect_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -445,7 +445,7 @@ fn set_max_incoming_bitrate_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -478,7 +478,7 @@ fn set_max_outgoing_bitrate_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -511,7 +511,7 @@ fn set_min_outgoing_bitrate_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -544,7 +544,7 @@ fn set_max_outgoing_bitrate_fails_if_value_is_lower_than_current_min_limit() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -582,7 +582,7 @@ fn set_min_outgoing_bitrate_fails_if_value_is_higher_than_current_max_limit() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -620,7 +620,7 @@ fn restart_ice_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -656,7 +656,7 @@ fn enable_trace_event_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -732,7 +732,7 @@ fn close_event() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".parse().unwrap()),
+                    announced_ip: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,


### PR DESCRIPTION
Fixes #1321

As explained in the ticket, only Rust changes are needed since in Node (and Worker) `announcedIp` was already defined as optional string.