### PR TITLE
Rename "announced ip" to "announced address"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Make transport-cc feedback work similarly to libwebrtc ([PR #1088](https://github.com/versatica/mediasoup/pull/1088) by @penguinol).
 - `TransportListenInfo`: "announced ip" can also be a hostname ([PR #1322](https://github.com/versatica/mediasoup/pull/1322)).
-- `TransportListenInfo`: Rename "announced ip" to "announced address" ([PR #1323](https://github.com/versatica/mediasoup/pull/1323)).
+- `TransportListenInfo`: Rename "announced ip" to "announced address" ([PR #1324](https://github.com/versatica/mediasoup/pull/1324)).
 
 ### 3.13.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ### NEXT
 
 - Make transport-cc feedback work similarly to libwebrtc ([PR #1088](https://github.com/versatica/mediasoup/pull/1088) by @penguinol).
-- `TransportListenInfo`: announced ip can also be a hostname ([PR #1322](https://github.com/versatica/mediasoup/pull/1322)).
+- `TransportListenInfo`: "announced ip" can also be a hostname ([PR #1322](https://github.com/versatica/mediasoup/pull/1322)).
+- `TransportListenInfo`: Rename "announced ip" to "announced address" ([PR #1323](https://github.com/versatica/mediasoup/pull/1323)).
 
 ### 3.13.17
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,7 +1354,7 @@ checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 
 [[package]]
 name = "mediasoup"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "actix",
  "actix-web",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "mediasoup-sys"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "planus",
  "planus-codegen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "mediasoup-sys"
-version = "0.7.3"
+version = "0.8.0"
 dependencies = [
  "planus",
  "planus-codegen",

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -867,7 +867,7 @@ export class Router<
 			listenInfo = {
 				protocol: 'udp',
 				ip: listenIp.ip,
-				announcedIp: listenIp.announcedIp,
+				announcedAddress: listenIp.announcedIp,
 				port: port,
 			};
 		}
@@ -896,7 +896,7 @@ export class Router<
 					? FbsTransportProtocol.UDP
 					: FbsTransportProtocol.TCP,
 				listenInfo!.ip,
-				listenInfo!.announcedIp,
+				listenInfo!.announcedAddress,
 				listenInfo!.port,
 				socketFlagsToFbs(listenInfo!.flags),
 				listenInfo!.sendBufferSize,
@@ -1162,12 +1162,12 @@ export class Router<
 					.then(() => {
 						return Promise.all([
 							localPipeTransport.connect({
-								ip: remotePipeTransport.tuple.localIp,
+								ip: remotePipeTransport.tuple.localAddress,
 								port: remotePipeTransport.tuple.localPort,
 								srtpParameters: remotePipeTransport.srtpParameters,
 							}),
 							remotePipeTransport.connect({
-								ip: localPipeTransport.tuple.localIp,
+								ip: localPipeTransport.tuple.localAddress,
 								port: localPipeTransport.tuple.localPort,
 								srtpParameters: localPipeTransport.srtpParameters,
 							}),

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -526,7 +526,7 @@ export class Router<
 					listenInfos.push({
 						protocol: protocol,
 						ip: listenIp.ip,
-						announcedIp: listenIp.announcedIp,
+						announcedAddress: listenIp.announcedIp,
 						port: port,
 					});
 				}
@@ -557,7 +557,7 @@ export class Router<
 							? FbsTransportProtocol.UDP
 							: FbsTransportProtocol.TCP,
 						listenInfo.ip,
-						listenInfo.announcedIp,
+						listenInfo.announcedAddress ?? listenInfo.announcedIp,
 						listenInfo.port,
 						socketFlagsToFbs(listenInfo.flags),
 						listenInfo.sendBufferSize,
@@ -715,7 +715,7 @@ export class Router<
 			listenInfo = {
 				protocol: 'udp',
 				ip: listenIp.ip,
-				announcedIp: listenIp.announcedIp,
+				announcedAddress: listenIp.announcedIp,
 				port: port,
 			};
 		}
@@ -744,7 +744,7 @@ export class Router<
 					? FbsTransportProtocol.UDP
 					: FbsTransportProtocol.TCP,
 				listenInfo!.ip,
-				listenInfo!.announcedIp,
+				listenInfo!.announcedAddress ?? listenInfo!.announcedIp,
 				listenInfo!.port,
 				socketFlagsToFbs(listenInfo!.flags),
 				listenInfo!.sendBufferSize,
@@ -756,7 +756,7 @@ export class Router<
 							? FbsTransportProtocol.UDP
 							: FbsTransportProtocol.TCP,
 						rtcpListenInfo.ip,
-						rtcpListenInfo.announcedIp,
+						rtcpListenInfo.announcedAddress ?? rtcpListenInfo.announcedIp,
 						rtcpListenInfo.port,
 						socketFlagsToFbs(rtcpListenInfo.flags),
 						rtcpListenInfo.sendBufferSize,
@@ -896,7 +896,7 @@ export class Router<
 					? FbsTransportProtocol.UDP
 					: FbsTransportProtocol.TCP,
 				listenInfo!.ip,
-				listenInfo!.announcedAddress,
+				listenInfo!.announcedAddress ?? listenInfo!.announcedIp,
 				listenInfo!.port,
 				socketFlagsToFbs(listenInfo!.flags),
 				listenInfo!.sendBufferSize,
@@ -1105,7 +1105,7 @@ export class Router<
 			listenInfo = {
 				protocol: 'udp',
 				ip: listenIp.ip,
-				announcedIp: listenIp.announcedIp,
+				announcedAddress: listenIp.announcedIp,
 			};
 		}
 

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -72,10 +72,18 @@ export type TransportListenInfo = {
 	ip: string;
 
 	/**
+	 * @deprecated Use |announcedAddress| instead.
+	 *
 	 * Announced IPv4, IPv6 or hostname (useful when running mediasoup behind NAT
 	 * with private IP).
 	 */
 	announcedIp?: string;
+
+	/**
+	 * Announced IPv4, IPv6 or hostname (useful when running mediasoup behind NAT
+	 * with private IP).
+	 */
+	announcedAddress?: string;
 
 	/**
 	 * Listening port.
@@ -136,7 +144,9 @@ export type TransportSocketFlags = {
 };
 
 export type TransportTuple = {
+	// @deprecated Use localAddress instead.
 	localIp: string;
+	localAddress: string;
 	localPort: number;
 	remoteIp?: string;
 	remotePort?: number;
@@ -1354,7 +1364,9 @@ export function serializeProtocol(
 
 export function parseTuple(binary: FbsTransport.Tuple): TransportTuple {
 	return {
-		localIp: binary.localIp()!,
+		// @deprecated Use localAddress instead.
+		localIp: binary.localAddress()!,
+		localAddress: binary.localAddress()!,
 		localPort: binary.localPort(),
 		remoteIp: binary.remoteIp() ?? undefined,
 		remotePort: binary.remotePort(),

--- a/node/src/WebRtcTransport.ts
+++ b/node/src/WebRtcTransport.ts
@@ -138,7 +138,9 @@ export type IceParameters = {
 export type IceCandidate = {
 	foundation: string;
 	priority: number;
+	// @deprecated Use |address| instead.
 	ip: string;
+	address: string;
 	protocol: TransportProtocol;
 	port: number;
 	type: IceCandidateType;
@@ -864,7 +866,8 @@ function parseIceCandidate(
 	return {
 		foundation: binary.foundation()!,
 		priority: binary.priority(),
-		ip: binary.ip()!,
+		ip: binary.address()!,
+		address: binary.address()!,
 		protocol: parseProtocol(binary.protocol()),
 		port: binary.port(),
 		type: iceCandidateTypeFromFbs(binary.type()),

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -699,7 +699,7 @@ export class Worker<
 						? FbsTransportProtocol.UDP
 						: FbsTransportProtocol.TCP,
 					listenInfo.ip,
-					listenInfo.announcedIp,
+					listenInfo.announcedAddress ?? listenInfo.announcedIp,
 					listenInfo.port,
 					socketFlagsToFbs(listenInfo.flags),
 					listenInfo.sendBufferSize,

--- a/node/src/test/test-PlainTransport.ts
+++ b/node/src/test/test-PlainTransport.ts
@@ -73,7 +73,11 @@ test('router.createPlainTransport() succeeds', async () => {
 
 	// Create a separate transport here.
 	const plainTransport2 = await ctx.router!.createPlainTransport({
-		listenInfo: { protocol: 'udp', ip: '127.0.0.1', announcedIp: '9.9.9.1' },
+		listenInfo: {
+			protocol: 'udp',
+			ip: '127.0.0.1',
+			announcedAddress: '9.9.9.1',
+		},
 		enableSctp: true,
 		appData: { foo: 'bar' },
 	});

--- a/node/src/test/test-PlainTransport.ts
+++ b/node/src/test/test-PlainTransport.ts
@@ -84,7 +84,9 @@ test('router.createPlainTransport() succeeds', async () => {
 	expect(plainTransport2.closed).toBe(false);
 	expect(plainTransport2.appData).toEqual({ foo: 'bar' });
 	expect(typeof plainTransport2.tuple).toBe('object');
+	// @deprecated Use tuple.localAddress instead.
 	expect(plainTransport2.tuple.localIp).toBe('9.9.9.1');
+	expect(plainTransport2.tuple.localAddress).toBe('9.9.9.1');
 	expect(typeof plainTransport2.tuple.localPort).toBe('number');
 	expect(plainTransport2.tuple.protocol).toBe('udp');
 	expect(plainTransport2.rtcpTuple).toBeUndefined();
@@ -138,11 +140,15 @@ test('router.createPlainTransport() succeeds', async () => {
 	expect(transport2.closed).toBe(false);
 	expect(transport2.appData).toEqual({});
 	expect(typeof transport2.tuple).toBe('object');
+	// @deprecated Use tuple.localAddress instead.
 	expect(transport2.tuple.localIp).toBe('127.0.0.1');
+	expect(transport2.tuple.localAddress).toBe('127.0.0.1');
 	expect(transport2.tuple.localPort).toBe(rtpPort);
 	expect(transport2.tuple.protocol).toBe('udp');
 	expect(typeof transport2.rtcpTuple).toBe('object');
+	// @deprecated Use tuple.localAddress instead.
 	expect(transport2.rtcpTuple?.localIp).toBe('127.0.0.1');
+	expect(transport2.rtcpTuple?.localAddress).toBe('127.0.0.1');
 	expect(transport2.rtcpTuple?.localPort).toBe(rtcpPort);
 	expect(transport2.rtcpTuple?.protocol).toBe('udp');
 	expect(transport2.sctpParameters).toBeUndefined();
@@ -395,7 +401,9 @@ test('plainTransport.getStats() succeeds', async () => {
 	expect(stats[0].probationBytesSent).toBe(0);
 	expect(stats[0].probationSendBitrate).toBe(0);
 	expect(typeof stats[0].tuple).toBe('object');
+	// @deprecated Use tuple.localAddress instead.
 	expect(stats[0].tuple.localIp).toBe('127.0.0.1');
+	expect(stats[0].tuple.localAddress).toBe('127.0.0.1');
 	expect(typeof stats[0].tuple.localPort).toBe('number');
 	expect(stats[0].tuple.protocol).toBe('udp');
 	expect(stats[0].rtcpTuple).toBeUndefined();

--- a/node/src/test/test-WebRtcServer.ts
+++ b/node/src/test/test-WebRtcServer.ts
@@ -48,7 +48,7 @@ test('worker.createWebRtcServer() succeeds', async () => {
 			{
 				protocol: 'tcp',
 				ip: '127.0.0.1',
-				announcedIp: 'foo.bar.org',
+				announcedAddress: 'foo.bar.org',
 				port: port2,
 			},
 		],
@@ -105,7 +105,7 @@ test('worker.createWebRtcServer() without specifying port succeeds', async () =>
 			{
 				protocol: 'tcp',
 				ip: '127.0.0.1',
-				announcedIp: '1.2.3.4',
+				announcedAddress: '1.2.3.4',
 			},
 		],
 		appData: { foo: 123 },
@@ -210,7 +210,7 @@ test('worker.createWebRtcServer() with unavailable listenInfos rejects with Erro
 				{
 					protocol: 'udp',
 					ip: '127.0.0.1',
-					announcedIp: '1.2.3.4',
+					announcedAddress: '1.2.3.4',
 					port: port1,
 				},
 			],

--- a/node/src/test/test-WebRtcTransport.ts
+++ b/node/src/test/test-WebRtcTransport.ts
@@ -541,7 +541,9 @@ test('WebRtcTransport events succeed', async () => {
 
 	const onIceSelectedTuple = jest.fn();
 	const iceSelectedTuple: TransportTuple = {
+		// @deprecated Use localAddress.
 		localIp: '1.1.1.1',
+		localAddress: '1.1.1.1',
 		localPort: 1111,
 		remoteIp: '2.2.2.2',
 		remotePort: 2222,
@@ -554,7 +556,7 @@ test('WebRtcTransport events succeed', async () => {
 	const iceSelectedTupleChangeNotification =
 		new FbsWebRtcTransport.IceSelectedTupleChangeNotificationT(
 			new FbsTransport.TupleT(
-				iceSelectedTuple.localIp,
+				iceSelectedTuple.localAddress,
 				iceSelectedTuple.localPort,
 				iceSelectedTuple.remoteIp,
 				iceSelectedTuple.remotePort,

--- a/node/src/test/test-WebRtcTransport.ts
+++ b/node/src/test/test-WebRtcTransport.ts
@@ -70,12 +70,12 @@ test('router.createWebRtcTransport() succeeds', async () => {
 
 	const webRtcTransport = await ctx.router!.createWebRtcTransport({
 		listenInfos: [
-			{ protocol: 'udp', ip: '127.0.0.1', announcedIp: '9.9.9.1' },
-			{ protocol: 'tcp', ip: '127.0.0.1', announcedIp: '9.9.9.1' },
-			{ protocol: 'udp', ip: '0.0.0.0', announcedIp: 'foo1.bar.org' },
-			{ protocol: 'tcp', ip: '0.0.0.0', announcedIp: 'foo2.bar.org' },
-			{ protocol: 'udp', ip: '127.0.0.1', announcedIp: undefined },
-			{ protocol: 'tcp', ip: '127.0.0.1', announcedIp: undefined },
+			{ protocol: 'udp', ip: '127.0.0.1', announcedAddress: '9.9.9.1' },
+			{ protocol: 'tcp', ip: '127.0.0.1', announcedAddress: '9.9.9.1' },
+			{ protocol: 'udp', ip: '0.0.0.0', announcedAddress: 'foo1.bar.org' },
+			{ protocol: 'tcp', ip: '0.0.0.0', announcedAddress: 'foo2.bar.org' },
+			{ protocol: 'udp', ip: '127.0.0.1', announcedAddress: undefined },
+			{ protocol: 'tcp', ip: '127.0.0.1', announcedAddress: undefined },
 		],
 		enableTcp: true,
 		preferUdp: true,
@@ -221,7 +221,9 @@ test('router.createWebRtcTransport() with non bindable IP rejects with Error', a
 
 test('webRtcTransport.getStats() succeeds', async () => {
 	const webRtcTransport = await ctx.router!.createWebRtcTransport({
-		listenInfos: [{ protocol: 'udp', ip: '127.0.0.1', announcedIp: '9.9.9.1' }],
+		listenInfos: [
+			{ protocol: 'udp', ip: '127.0.0.1', announcedAddress: '9.9.9.1' },
+		],
 	});
 
 	const stats = await webRtcTransport.getStats();
@@ -255,7 +257,9 @@ test('webRtcTransport.getStats() succeeds', async () => {
 
 test('webRtcTransport.connect() succeeds', async () => {
 	const webRtcTransport = await ctx.router!.createWebRtcTransport({
-		listenInfos: [{ protocol: 'udp', ip: '127.0.0.1', announcedIp: '9.9.9.1' }],
+		listenInfos: [
+			{ protocol: 'udp', ip: '127.0.0.1', announcedAddress: '9.9.9.1' },
+		],
 	});
 
 	const dtlsRemoteParameters: mediasoup.types.DtlsParameters = {
@@ -283,7 +287,9 @@ test('webRtcTransport.connect() succeeds', async () => {
 
 test('webRtcTransport.connect() with wrong arguments rejects with TypeError', async () => {
 	const webRtcTransport = await ctx.router!.createWebRtcTransport({
-		listenInfos: [{ protocol: 'udp', ip: '127.0.0.1', announcedIp: '9.9.9.1' }],
+		listenInfos: [
+			{ protocol: 'udp', ip: '127.0.0.1', announcedAddress: '9.9.9.1' },
+		],
 	});
 
 	let dtlsRemoteParameters: mediasoup.types.DtlsParameters;
@@ -341,7 +347,9 @@ test('webRtcTransport.connect() with wrong arguments rejects with TypeError', as
 
 test('webRtcTransport.setMaxIncomingBitrate() succeeds', async () => {
 	const webRtcTransport = await ctx.router!.createWebRtcTransport({
-		listenInfos: [{ protocol: 'udp', ip: '127.0.0.1', announcedIp: '9.9.9.1' }],
+		listenInfos: [
+			{ protocol: 'udp', ip: '127.0.0.1', announcedAddress: '9.9.9.1' },
+		],
 	});
 
 	await expect(

--- a/node/src/test/test-node-sctp.ts
+++ b/node/src/test/test-node-sctp.ts
@@ -39,7 +39,7 @@ beforeEach(async () => {
 		ctx.udpSocket!.bind(0, '127.0.0.1', resolve);
 	});
 
-	const remoteUdpIp = ctx.plainTransport.tuple.localIp;
+	const remoteUdpIp = ctx.plainTransport.tuple.localAddress;
 	const remoteUdpPort = ctx.plainTransport.tuple.localPort;
 	const { OS, MIS } = ctx.plainTransport.sctpParameters!;
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+# 0.16.0
+
+* Updates from mediasoup TypeScript `3.13.13..=3.13.17`.
+* General mediasoup changes:
+  * `TransportListenInfo.announced_ip` can also be a hostname (PR #1322).
+  * `TransportListenInfo.announced_ip` is now `announced_address`, `IceCandidate.ip` is now `IceCandidate.address` and `TransportTuple.local_ip` is not `TransportTuple.local_address` (PR #1323).
+
 # 0.15.0
 
 * Expose DataChannel string message as binary (PR #1289).

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -5,7 +5,7 @@
 * Updates from mediasoup TypeScript `3.13.13..=3.13.17`.
 * General mediasoup changes:
   * `TransportListenInfo.announced_ip` can also be a hostname (PR #1322).
-  * `TransportListenInfo.announced_ip` is now `announced_address`, `IceCandidate.ip` is now `IceCandidate.address` and `TransportTuple.local_ip` is not `TransportTuple.local_address` (PR #1323).
+  * `TransportListenInfo.announced_ip` is now `announced_address`, `IceCandidate.ip` is now `IceCandidate.address` and `TransportTuple.local_ip` is not `TransportTuple.local_address` (PR #1324).
 
 # 0.15.0
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -46,7 +46,7 @@ version = "0.8.1"
 
 [dependencies.mediasoup-sys]
 path = "../worker"
-version = "0.7.3"
+version = "0.8.0"
 
 [dependencies.parking_lot]
 version = "0.12.1"

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup"
-version = "0.15.0"
+version = "0.16.0"
 description = "Cutting Edge WebRTC Video Conferencing in Rust"
 categories = ["api-bindings", "multimedia", "network-programming"]
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
@@ -46,7 +46,7 @@ version = "0.8.1"
 
 [dependencies.mediasoup-sys]
 path = "../worker"
-version = "0.7.2"
+version = "0.7.3"
 
 [dependencies.parking_lot]
 version = "0.12.1"

--- a/rust/benches/producer.rs
+++ b/rust/benches/producer.rs
@@ -65,7 +65,7 @@ async fn init() -> (Worker, Router, WebRtcTransport, WebRtcTransport) {
         WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
             protocol: Protocol::Udp,
             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-            announced_ip: None,
+            announced_address: None,
             port: None,
             flags: None,
             send_buffer_size: None,

--- a/rust/examples/echo.rs
+++ b/rust/examples/echo.rs
@@ -185,7 +185,7 @@ impl EchoConnection {
             WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
                 protocol: Protocol::Udp,
                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                announced_ip: None,
+                announced_address: None,
                 port: None,
                 flags: None,
                 send_buffer_size: None,

--- a/rust/examples/multiopus.rs
+++ b/rust/examples/multiopus.rs
@@ -148,7 +148,7 @@ impl EchoConnection {
                 let mut options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -198,9 +198,9 @@ impl EchoConnection {
             RTCP listening on {}:{}\n  \
             PT=100\n  \
             SSRC=1111",
-            plain_transport.tuple().local_ip(),
+            plain_transport.tuple().local_address(),
             plain_transport.tuple().local_port(),
-            plain_transport.rtcp_tuple().unwrap().local_ip(),
+            plain_transport.rtcp_tuple().unwrap().local_address(),
             plain_transport.rtcp_tuple().unwrap().local_port(),
         );
 
@@ -220,9 +220,9 @@ impl EchoConnection {
                 rtpbin.send_rtp_sink_0 \\\n  \
                 rtpbin.send_rtp_src_0 ! udpsink host={} port={} sync=false async=false \\\n  \
                 rtpbin.send_rtcp_src_0 ! udpsink host={} port={} sync=false async=false",
-                plain_transport.tuple().local_ip(),
+                plain_transport.tuple().local_address(),
                 plain_transport.tuple().local_port(),
-                plain_transport.rtcp_tuple().unwrap().local_ip(),
+                plain_transport.rtcp_tuple().unwrap().local_address(),
                 plain_transport.rtcp_tuple().unwrap().local_port(),
         );
 
@@ -234,7 +234,7 @@ impl EchoConnection {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,

--- a/rust/examples/svc-simulcast.rs
+++ b/rust/examples/svc-simulcast.rs
@@ -205,7 +205,7 @@ impl SvcSimulcastConnection {
             WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
                 protocol: Protocol::Udp,
                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                announced_ip: None,
+                announced_address: None,
                 port: None,
                 flags: None,
                 send_buffer_size: None,

--- a/rust/examples/videoroom.rs
+++ b/rust/examples/videoroom.rs
@@ -499,7 +499,7 @@ mod participant {
                 WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,

--- a/rust/src/data_structures.rs
+++ b/rust/src/data_structures.rs
@@ -297,14 +297,14 @@ impl IceState {
 /// `PipeTransport`, or via dynamic detection as it happens in `WebRtcTransport` (in which the
 /// remote media address is detected by ICE means), or in `PlainTransport` (when using `comedia`
 /// mode).
-#[derive(Debug, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Deserialize, Serialize)]
+#[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum TransportTuple {
     /// Transport tuple with remote endpoint info.
     #[serde(rename_all = "camelCase")]
     WithRemote {
         /// Local IP address or hostname.
-        local_address: IpAddr,
+        local_address: String,
         /// Local port.
         local_port: u16,
         /// Remote IP address.
@@ -318,7 +318,7 @@ pub enum TransportTuple {
     #[serde(rename_all = "camelCase")]
     LocalOnly {
         /// Local IP address or hostname.
-        local_address: IpAddr,
+        local_address: String,
         /// Local port.
         local_port: u16,
         /// Protocol
@@ -328,7 +328,7 @@ pub enum TransportTuple {
 
 impl TransportTuple {
     /// Local IP address or hostname.
-    pub fn local_address(&self) -> IpAddr {
+    pub fn local_address(&self) -> String {
         let (Self::WithRemote { local_address, .. } | Self::LocalOnly { local_address, .. }) = self;
         *local_address
     }

--- a/rust/src/data_structures.rs
+++ b/rust/src/data_structures.rs
@@ -369,14 +369,14 @@ impl TransportTuple {
                 local_address: tuple
                     .local_address
                     .parse()
-                    .expect("Error parsing IP address"),
+                    .expect("Error parsing local address"),
                 local_port: tuple.local_port,
                 remote_ip: tuple
                     .remote_ip
                     .as_ref()
                     .unwrap()
                     .parse()
-                    .expect("Error parsing IP address"),
+                    .expect("Error parsing remote IP address"),
                 remote_port: tuple.remote_port,
                 protocol: Protocol::from_fbs(tuple.protocol),
             },
@@ -384,7 +384,7 @@ impl TransportTuple {
                 local_address: tuple
                     .local_address
                     .parse()
-                    .expect("Error parsing IP address"),
+                    .expect("Error parsing local address"),
                 local_port: tuple.local_port,
                 protocol: Protocol::from_fbs(tuple.protocol),
             },

--- a/rust/src/data_structures.rs
+++ b/rust/src/data_structures.rs
@@ -328,9 +328,9 @@ pub enum TransportTuple {
 
 impl TransportTuple {
     /// Local IP address or hostname.
-    pub fn local_address(&self) -> String {
+    pub fn local_address(&self) -> &String {
         let (Self::WithRemote { local_address, .. } | Self::LocalOnly { local_address, .. }) = self;
-        *local_address
+        local_address
     }
 
     /// Local port.

--- a/rust/src/data_structures.rs
+++ b/rust/src/data_structures.rs
@@ -50,7 +50,8 @@ impl AppData {
 /// Listening protocol, IP and port for [`WebRtcServer`](crate::webrtc_server::WebRtcServer) to listen on.
 ///
 /// # Notes on usage
-/// If you use "0.0.0.0" or "::" as ip value, then you need to also provide `announced_ip`.
+/// If you use "0.0.0.0" or "::" as ip value, then you need to also provide
+/// `announced_address`.
 #[derive(Debug, Clone, Ord, PartialOrd, Eq, PartialEq, Hash, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct ListenInfo {
@@ -61,7 +62,7 @@ pub struct ListenInfo {
     /// Announced IPv4, IPv6 or hostname (useful when running mediasoup behind
     /// NAT with private IP).
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub announced_ip: Option<String>,
+    pub announced_address: Option<String>,
     /// Listening port.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub port: Option<u16>,
@@ -84,7 +85,10 @@ impl ListenInfo {
                 Protocol::Udp => transport::Protocol::Udp,
             },
             ip: self.ip.to_string(),
-            announced_ip: self.announced_ip.clone().map(|ip| ip.to_string()),
+            announced_address: self
+                .announced_address
+                .clone()
+                .map(|address| address.to_string()),
             port: self.port.unwrap_or(0),
             flags: Box::new(self.flags.unwrap_or_default().to_fbs()),
             send_buffer_size: self.send_buffer_size.unwrap_or(0),
@@ -231,7 +235,7 @@ pub struct IceCandidate {
     /// The assigned priority of the candidate.
     pub priority: u32,
     /// The IP address or hostname of the candidate.
-    pub ip: String,
+    pub address: String,
     /// The protocol of the candidate.
     pub protocol: Protocol,
     /// The port for the candidate.
@@ -248,7 +252,7 @@ impl IceCandidate {
         Self {
             foundation: candidate.foundation.clone(),
             priority: candidate.priority,
-            ip: candidate.ip.clone(),
+            address: candidate.address.clone(),
             protocol: Protocol::from_fbs(candidate.protocol),
             port: candidate.port,
             r#type: IceCandidateType::from_fbs(candidate.type_),
@@ -299,8 +303,8 @@ pub enum TransportTuple {
     /// Transport tuple with remote endpoint info.
     #[serde(rename_all = "camelCase")]
     WithRemote {
-        /// Local IP address.
-        local_ip: IpAddr,
+        /// Local IP address or hostname.
+        local_address: IpAddr,
         /// Local port.
         local_port: u16,
         /// Remote IP address.
@@ -313,8 +317,8 @@ pub enum TransportTuple {
     /// Transport tuple without remote endpoint info.
     #[serde(rename_all = "camelCase")]
     LocalOnly {
-        /// Local IP address.
-        local_ip: IpAddr,
+        /// Local IP address or hostname.
+        local_address: IpAddr,
         /// Local port.
         local_port: u16,
         /// Protocol
@@ -323,10 +327,10 @@ pub enum TransportTuple {
 }
 
 impl TransportTuple {
-    /// Local IP address.
-    pub fn local_ip(&self) -> IpAddr {
-        let (Self::WithRemote { local_ip, .. } | Self::LocalOnly { local_ip, .. }) = self;
-        *local_ip
+    /// Local IP address or hostname.
+    pub fn local_address(&self) -> IpAddr {
+        let (Self::WithRemote { local_address, .. } | Self::LocalOnly { local_address, .. }) = self;
+        *local_address
     }
 
     /// Local port.
@@ -362,7 +366,10 @@ impl TransportTuple {
     pub(crate) fn from_fbs(tuple: &transport::Tuple) -> TransportTuple {
         match &tuple.remote_ip {
             Some(_remote_ip) => TransportTuple::WithRemote {
-                local_ip: tuple.local_ip.parse().expect("Error parsing IP address"),
+                local_address: tuple
+                    .local_address
+                    .parse()
+                    .expect("Error parsing IP address"),
                 local_port: tuple.local_port,
                 remote_ip: tuple
                     .remote_ip
@@ -374,7 +381,10 @@ impl TransportTuple {
                 protocol: Protocol::from_fbs(tuple.protocol),
             },
             None => TransportTuple::LocalOnly {
-                local_ip: tuple.local_ip.parse().expect("Error parsing IP address"),
+                local_address: tuple
+                    .local_address
+                    .parse()
+                    .expect("Error parsing IP address"),
                 local_port: tuple.local_port,
                 protocol: Protocol::from_fbs(tuple.protocol),
             },

--- a/rust/src/data_structures.rs
+++ b/rust/src/data_structures.rs
@@ -167,13 +167,13 @@ impl IceParameters {
 #[serde(rename_all = "lowercase")]
 pub enum IceCandidateType {
     /// The candidate is a host candidate, whose IP address as specified in the
-    /// [`IceCandidate::ip`] property is in fact the true address of the remote peer.
+    /// [`IceCandidate::address`] property is in fact the true address of the remote peer.
     Host,
-    /// The candidate is a server reflexive candidate; the [`IceCandidate::ip`] indicates an
+    /// The candidate is a server reflexive candidate; the [`IceCandidate::address`] indicates an
     /// intermediary address assigned by the STUN server to represent the candidate's peer
     /// anonymously.
     Srflx,
-    /// The candidate is a peer reflexive candidate; the [`IceCandidate::ip`] is an intermediary
+    /// The candidate is a peer reflexive candidate; the [`IceCandidate::address`] is an intermediary
     /// address assigned by the STUN server to represent the candidate's peer anonymously.
     Prflx,
     /// The candidate is a relay candidate, obtained from a TURN server. The relay candidate's IP

--- a/rust/src/data_structures.rs
+++ b/rust/src/data_structures.rs
@@ -87,7 +87,7 @@ impl ListenInfo {
             ip: self.ip.to_string(),
             announced_address: self
                 .announced_address
-                .clone()
+                .as_ref()
                 .map(|address| address.to_string()),
             port: self.port.unwrap_or(0),
             flags: Box::new(self.flags.unwrap_or_default().to_fbs()),

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -1482,7 +1482,7 @@ impl Router {
             let tuple = remote_pipe_transport.tuple();
 
             PipeTransportRemoteParameters {
-                ip: tuple.local_address(),
+                ip: tuple.local_address().parse::<IpAddr>().unwrap(),
                 port: tuple.local_port(),
                 srtp_parameters: remote_pipe_transport.srtp_parameters(),
             }
@@ -1492,7 +1492,7 @@ impl Router {
             let tuple = local_pipe_transport.tuple();
 
             PipeTransportRemoteParameters {
-                ip: tuple.local_address(),
+                ip: tuple.local_address().parse::<IpAddr>().unwrap(),
                 port: tuple.local_port(),
                 srtp_parameters: local_pipe_transport.srtp_parameters(),
             }

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -145,7 +145,7 @@ impl PipeToRouterOptions {
             listen_info: ListenInfo {
                 protocol: Protocol::Udp,
                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                announced_ip: None,
+                announced_address: None,
                 port: None,
                 flags: None,
                 send_buffer_size: None,
@@ -608,7 +608,7 @@ impl Router {
     ///         ListenInfo {
     ///             protocol: Protocol::Udp,
     ///             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///             announced_ip: Some("9.9.9.1".to_string()),
+    ///             announced_address: Some("9.9.9.1".to_string()),
     ///             port: None,
     ///             flags: None,
     ///             send_buffer_size: None,
@@ -696,7 +696,7 @@ impl Router {
     ///     .create_pipe_transport(PipeTransportOptions::new(ListenInfo {
     ///         protocol: Protocol::Udp,
     ///         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///         announced_ip: Some("9.9.9.1".to_string()),
+    ///         announced_address: Some("9.9.9.1".to_string()),
     ///         port: None,
     ///         flags: None,
     ///         send_buffer_size: None,
@@ -762,7 +762,7 @@ impl Router {
     ///     .create_plain_transport(PlainTransportOptions::new(ListenInfo {
     ///         protocol: Protocol::Udp,
     ///         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///         announced_ip: Some("9.9.9.1".to_string()),
+    ///         announced_address: Some("9.9.9.1".to_string()),
     ///         port: None,
     ///         flags: None,
     ///         send_buffer_size: None,
@@ -973,7 +973,7 @@ impl Router {
     ///         ListenInfo {
     ///             protocol: Protocol::Udp,
     ///             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///             announced_ip: Some("9.9.9.1".to_string()),
+    ///             announced_address: Some("9.9.9.1".to_string()),
     ///             port: None,
     ///             flags: None,
     ///             send_buffer_size: None,
@@ -1016,7 +1016,7 @@ impl Router {
     ///         ListenInfo {
     ///             protocol: Protocol::Udp,
     ///             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///             announced_ip: Some("9.9.9.1".to_string()),
+    ///             announced_address: Some("9.9.9.1".to_string()),
     ///             port: None,
     ///             flags: None,
     ///             send_buffer_size: None,
@@ -1202,7 +1202,7 @@ impl Router {
     ///             ListenInfo {
     ///                 protocol: Protocol::Udp,
     ///                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///                 announced_ip: Some("9.9.9.1".to_string()),
+    ///                 announced_address: Some("9.9.9.1".to_string()),
     ///                 port: None,
     ///                 flags: None,
     ///                 send_buffer_size: None,
@@ -1234,7 +1234,7 @@ impl Router {
     ///             ListenInfo {
     ///                 protocol: Protocol::Udp,
     ///                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-    ///                 announced_ip: Some("9.9.9.1".to_string()),
+    ///                 announced_address: Some("9.9.9.1".to_string()),
     ///                 port: None,
     ///                 flags: None,
     ///                 send_buffer_size: None,
@@ -1482,7 +1482,7 @@ impl Router {
             let tuple = remote_pipe_transport.tuple();
 
             PipeTransportRemoteParameters {
-                ip: tuple.local_ip(),
+                ip: tuple.local_address(),
                 port: tuple.local_port(),
                 srtp_parameters: remote_pipe_transport.srtp_parameters(),
             }
@@ -1492,7 +1492,7 @@ impl Router {
             let tuple = local_pipe_transport.tuple();
 
             PipeTransportRemoteParameters {
-                ip: tuple.local_ip(),
+                ip: tuple.local_address(),
                 port: tuple.local_port(),
                 srtp_parameters: local_pipe_transport.srtp_parameters(),
             }

--- a/rust/src/router/consumer/tests.rs
+++ b/rust/src/router/consumer/tests.rs
@@ -85,7 +85,7 @@ async fn init() -> (Router, WebRtcTransport, WebRtcTransport) {
         WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
             protocol: Protocol::Udp,
             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-            announced_ip: None,
+            announced_address: None,
             port: None,
             flags: None,
             send_buffer_size: None,

--- a/rust/src/router/data_consumer/tests.rs
+++ b/rust/src/router/data_consumer/tests.rs
@@ -39,7 +39,7 @@ async fn init() -> (Router, DataProducer) {
                 WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -73,7 +73,7 @@ fn data_producer_close_event() {
                 let mut transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -127,7 +127,7 @@ fn transport_close_event() {
                 let mut transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,

--- a/rust/src/router/data_producer/tests.rs
+++ b/rust/src/router/data_producer/tests.rs
@@ -39,7 +39,7 @@ async fn init() -> (Router, WebRtcTransport) {
                 WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -719,7 +719,7 @@ impl PipeTransport {
     ///
     /// # Notes on usage
     /// * Once the pipe transport is created, `transport.tuple()` will contain information about
-    ///   its `local_ip`, `local_port` and `protocol`.
+    ///   its `local_address`, `local_port` and `protocol`.
     /// * Information about `remote_ip` and `remote_port` will be set after calling `connect()`
     ///   method.
     #[must_use]

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -724,7 +724,7 @@ impl PipeTransport {
     ///   method.
     #[must_use]
     pub fn tuple(&self) -> TransportTuple {
-        *self.inner.data.tuple.lock()
+        self.inner.data.tuple.lock().clone()
     }
 
     /// Local SCTP parameters. Or `None` if SCTP is not enabled.

--- a/rust/src/router/pipe_transport/tests.rs
+++ b/rust/src/router/pipe_transport/tests.rs
@@ -101,7 +101,7 @@ async fn init() -> (Router, Router, WebRtcTransport, WebRtcTransport) {
         WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
             protocol: Protocol::Udp,
             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-            announced_ip: None,
+            announced_address: None,
             port: None,
             flags: None,
             send_buffer_size: None,

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -903,7 +903,7 @@ impl PlainTransport {
     ///
     /// # Notes on usage
     /// * Once the plain transport is created, `transport.tuple()` will contain information about
-    ///   its `local_ip`, `local_port` and `protocol`.
+    ///   its `local_address`, `local_port` and `protocol`.
     /// * Information about `remote_ip` and `remote_port` will be set:
     ///   * after calling `connect()` method, or
     ///   * via dynamic remote address detection when using `comedia` mode.
@@ -917,7 +917,7 @@ impl PlainTransport {
     ///
     /// # Notes on usage
     /// * Once the plain transport is created (with RTCP-mux disabled), `transport.rtcp_tuple()`
-    ///   will contain information about its `local_ip`, `local_port` and `protocol`.
+    ///   will contain information about its `local_address`, `local_port` and `protocol`.
     /// * Information about `remote_ip` and `remote_port` will be set:
     ///   * after calling `connect()` method, or
     ///   * via dynamic remote address detection when using `comedia` mode.

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -686,12 +686,12 @@ impl PlainTransport {
                 match Notification::from_fbs(notification) {
                     Ok(notification) => match notification {
                         Notification::Tuple { tuple } => {
-                            *data.tuple.lock() = tuple;
+                            *data.tuple.lock() = tuple.clone();
 
                             handlers.tuple.call_simple(&tuple);
                         }
                         Notification::RtcpTuple { rtcp_tuple } => {
-                            data.rtcp_tuple.lock().replace(rtcp_tuple);
+                            data.rtcp_tuple.lock().replace(rtcp_tuple.clone());
 
                             handlers.rtcp_tuple.call_simple(&rtcp_tuple);
                         }
@@ -923,7 +923,7 @@ impl PlainTransport {
     ///   * via dynamic remote address detection when using `comedia` mode.
     #[must_use]
     pub fn rtcp_tuple(&self) -> Option<TransportTuple> {
-        *self.inner.data.rtcp_tuple.lock()
+        self.inner.data.rtcp_tuple.lock().clone()
     }
 
     /// Current SCTP state. Or `None` if SCTP is not enabled.

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -909,7 +909,7 @@ impl PlainTransport {
     ///   * via dynamic remote address detection when using `comedia` mode.
     #[must_use]
     pub fn tuple(&self) -> TransportTuple {
-        *self.inner.data.tuple.lock()
+        self.inner.data.tuple.lock().clone()
     }
 
     /// The transport tuple for RTCP. If RTCP-mux is enabled (`rtcp_mux` is set), its value is

--- a/rust/src/router/plain_transport/tests.rs
+++ b/rust/src/router/plain_transport/tests.rs
@@ -40,7 +40,7 @@ fn router_close_event() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".to_string()),
+                    announced_address: Some("4.4.4.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,

--- a/rust/src/router/producer/tests.rs
+++ b/rust/src/router/producer/tests.rs
@@ -70,7 +70,7 @@ async fn init() -> (Router, WebRtcTransport) {
         WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
             protocol: Protocol::Udp,
             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-            announced_ip: None,
+            announced_address: None,
             port: None,
             flags: None,
             send_buffer_size: None,

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -1021,7 +1021,7 @@ impl WebRtcTransport {
     /// ICE is not established (no working candidate pair was found).
     #[must_use]
     pub fn ice_selected_tuple(&self) -> Option<TransportTuple> {
-        *self.inner.data.ice_selected_tuple.lock()
+        self.inner.data.ice_selected_tuple.lock().clone()
     }
 
     /// Local DTLS parameters.

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -88,8 +88,8 @@ impl TryFrom<Vec<ListenInfo>> for WebRtcTransportListenInfos {
 /// # Notes on usage
 /// * Do not use "0.0.0.0" into `listen_infos`. Values in `listen_infos` must be specific bindable IPs
 ///   on the host.
-/// * If you use "0.0.0.0" or "::" into `listen_infos`, then you need to also provide `announced_ip`
-///   in the corresponding entry in `listen_infos`.
+/// * If you use "0.0.0.0" or "::" into `listen_infos`, then you need to also provide
+/// `announced_address` in the corresponding entry in `listen_infos`.
 #[derive(Debug, Clone)]
 pub enum WebRtcTransportListen {
     /// Listen on individual protocol/IP/port combinations specific to this transport.

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -809,7 +809,9 @@ impl WebRtcTransport {
                             });
                         }
                         Notification::IceSelectedTupleChange { ice_selected_tuple } => {
-                            data.ice_selected_tuple.lock().replace(ice_selected_tuple);
+                            data.ice_selected_tuple
+                                .lock()
+                                .replace(ice_selected_tuple.clone());
                             handlers
                                 .ice_selected_tuple_change
                                 .call_simple(&ice_selected_tuple);

--- a/rust/src/router/webrtc_transport/tests.rs
+++ b/rust/src/router/webrtc_transport/tests.rs
@@ -55,7 +55,7 @@ fn create_with_webrtc_server_succeeds() {
                 let listen_infos = WebRtcServerListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: Some(port1),
                     flags: None,
                     send_buffer_size: None,
@@ -64,7 +64,7 @@ fn create_with_webrtc_server_succeeds() {
                 let listen_infos = listen_infos.insert(ListenInfo {
                     protocol: Protocol::Tcp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: Some(port2),
                     flags: None,
                     send_buffer_size: None,
@@ -132,7 +132,7 @@ fn create_with_webrtc_server_succeeds() {
         {
             let ice_candidates = transport.ice_candidates();
             assert_eq!(ice_candidates.len(), 1);
-            assert_eq!(ice_candidates[0].ip, "127.0.0.1");
+            assert_eq!(ice_candidates[0].address, "127.0.0.1");
             assert_eq!(ice_candidates[0].protocol, Protocol::Tcp);
             assert_eq!(ice_candidates[0].port, port2);
             assert_eq!(ice_candidates[0].r#type, IceCandidateType::Host);
@@ -233,7 +233,7 @@ fn router_close_event() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -275,7 +275,7 @@ fn webrtc_server_close_event() {
                 let listen_infos = WebRtcServerListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: Some(port1),
                     flags: None,
                     send_buffer_size: None,
@@ -284,7 +284,7 @@ fn webrtc_server_close_event() {
                 let listen_infos = listen_infos.insert(ListenInfo {
                     protocol: Protocol::Tcp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: Some(port2),
                     flags: None,
                     send_buffer_size: None,

--- a/rust/src/webrtc_server/tests.rs
+++ b/rust/src/webrtc_server/tests.rs
@@ -36,7 +36,7 @@ fn worker_close_event() {
                 ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: Some(port),
                     flags: None,
                     send_buffer_size: None,

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -350,7 +350,7 @@ async fn init() -> (
         WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
             protocol: Protocol::Udp,
             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-            announced_ip: None,
+            announced_address: None,
             port: None,
             flags: None,
             send_buffer_size: None,

--- a/rust/tests/integration/data_consumer.rs
+++ b/rust/tests/integration/data_consumer.rs
@@ -66,7 +66,7 @@ async fn init() -> (Worker, Router, WebRtcTransport, DataProducer) {
                 WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -98,7 +98,7 @@ fn consume_data_succeeds() {
                 let mut transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -208,7 +208,7 @@ fn weak() {
                 let mut transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -573,7 +573,7 @@ fn close_event() {
                 let mut transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,

--- a/rust/tests/integration/data_producer.rs
+++ b/rust/tests/integration/data_producer.rs
@@ -52,7 +52,7 @@ async fn init() -> (Worker, Router, WebRtcTransport, PlainTransport) {
                 WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -71,7 +71,7 @@ async fn init() -> (Worker, Router, WebRtcTransport, PlainTransport) {
             let mut transport_options = PlainTransportOptions::new(ListenInfo {
                 protocol: Protocol::Udp,
                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                announced_ip: None,
+                announced_address: None,
                 port: None,
                 flags: None,
                 send_buffer_size: None,

--- a/rust/tests/integration/multiopus.rs
+++ b/rust/tests/integration/multiopus.rs
@@ -133,7 +133,7 @@ async fn init() -> (Router, WebRtcTransport) {
         WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
             protocol: Protocol::Udp,
             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-            announced_ip: None,
+            announced_address: None,
             port: None,
             flags: None,
             send_buffer_size: None,

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -259,7 +259,7 @@ async fn init() -> (
         WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
             protocol: Protocol::Udp,
             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-            announced_ip: None,
+            announced_address: None,
             port: None,
             flags: None,
             send_buffer_size: None,
@@ -604,7 +604,7 @@ fn weak() {
                 let mut options = PipeTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -639,7 +639,7 @@ fn create_with_fixed_port_succeeds() {
                 PipeTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: Some(port),
                     flags: None,
                     send_buffer_size: None,
@@ -663,7 +663,7 @@ fn create_with_enable_rtx_succeeds() {
                 let mut options = PipeTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -776,7 +776,7 @@ fn create_with_enable_srtp_succeeds() {
                 let mut options = PipeTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -832,7 +832,7 @@ fn create_with_invalid_srtp_parameters_fails() {
             .create_pipe_transport(PipeTransportOptions::new(ListenInfo {
                 protocol: Protocol::Udp,
                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                announced_ip: None,
+                announced_address: None,
                 port: None,
                 flags: None,
                 send_buffer_size: None,
@@ -1159,7 +1159,7 @@ fn pipe_to_router_called_twice_generates_single_pair() {
             WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
                 protocol: Protocol::Udp,
                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                announced_ip: None,
+                announced_address: None,
                 port: None,
                 flags: None,
                 send_buffer_size: None,

--- a/rust/tests/integration/plain_transport.rs
+++ b/rust/tests/integration/plain_transport.rs
@@ -169,7 +169,7 @@ fn create_succeeds() {
                 ..
             } = transport1.tuple()
             {
-                assert_eq!(local_address, "9.9.9.1".parse::<IpAddr>().unwrap());
+                assert_eq!(local_address, "9.9.9.1");
                 assert_eq!(protocol, Protocol::Udp);
             }
             assert_eq!(transport1.rtcp_tuple(), None);
@@ -244,7 +244,7 @@ fn create_succeeds() {
                 ..
             } = transport2.tuple()
             {
-                assert_eq!(local_address, "127.0.0.1".parse::<IpAddr>().unwrap());
+                assert_eq!(local_address, "127.0.0.1");
                 assert_eq!(protocol, Protocol::Udp);
             }
             assert!(transport2.rtcp_tuple().is_some());
@@ -255,7 +255,7 @@ fn create_succeeds() {
                 ..
             } = transport2.rtcp_tuple().unwrap()
             {
-                assert_eq!(local_address, "127.0.0.1".parse::<IpAddr>().unwrap());
+                assert_eq!(local_address, "127.0.0.1");
                 assert_eq!(local_port, rtcp_port);
                 assert_eq!(protocol, Protocol::Udp);
             }
@@ -577,10 +577,10 @@ fn get_stats_succeeds() {
             local_address,
             protocol,
             ..
-        } = stats[0].tuple
+        } = &stats[0].tuple
         {
-            assert_eq!(local_address, "4.4.4.4".parse::<IpAddr>().unwrap());
-            assert_eq!(protocol, Protocol::Udp);
+            assert_eq!(local_address, "4.4.4.4");
+            assert_eq!(*protocol, Protocol::Udp);
         }
         assert_eq!(stats[0].rtcp_tuple, None);
     });

--- a/rust/tests/integration/plain_transport.rs
+++ b/rust/tests/integration/plain_transport.rs
@@ -94,7 +94,7 @@ fn create_succeeds() {
                     let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: Some("4.4.4.4".to_string()),
+                        announced_address: Some("4.4.4.4".to_string()),
                         port: None,
                         flags: None,
                         send_buffer_size: None,
@@ -133,7 +133,7 @@ fn create_succeeds() {
                     let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: Some("9.9.9.1".to_string()),
+                        announced_address: Some("9.9.9.1".to_string()),
                         port: None,
                         flags: None,
                         send_buffer_size: None,
@@ -164,10 +164,12 @@ fn create_succeeds() {
                 TransportTuple::LocalOnly { .. },
             ));
             if let TransportTuple::LocalOnly {
-                local_ip, protocol, ..
+                local_address,
+                protocol,
+                ..
             } = transport1.tuple()
             {
-                assert_eq!(local_ip, "9.9.9.1".parse::<IpAddr>().unwrap());
+                assert_eq!(local_address, "9.9.9.1".parse::<IpAddr>().unwrap());
                 assert_eq!(protocol, Protocol::Udp);
             }
             assert_eq!(transport1.rtcp_tuple(), None);
@@ -207,7 +209,7 @@ fn create_succeeds() {
                     let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: None,
+                        announced_address: None,
                         port: None,
                         flags: None,
                         send_buffer_size: None,
@@ -218,7 +220,7 @@ fn create_succeeds() {
                     plain_transport_options.rtcp_listen_info = Some(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: None,
+                        announced_address: None,
                         port: Some(rtcp_port),
                         flags: None,
                         send_buffer_size: None,
@@ -237,21 +239,23 @@ fn create_succeeds() {
                 TransportTuple::LocalOnly { .. },
             ));
             if let TransportTuple::LocalOnly {
-                local_ip, protocol, ..
+                local_address,
+                protocol,
+                ..
             } = transport2.tuple()
             {
-                assert_eq!(local_ip, "127.0.0.1".parse::<IpAddr>().unwrap());
+                assert_eq!(local_address, "127.0.0.1".parse::<IpAddr>().unwrap());
                 assert_eq!(protocol, Protocol::Udp);
             }
             assert!(transport2.rtcp_tuple().is_some());
             if let TransportTuple::LocalOnly {
-                local_ip,
+                local_address,
                 local_port,
                 protocol,
                 ..
             } = transport2.rtcp_tuple().unwrap()
             {
-                assert_eq!(local_ip, "127.0.0.1".parse::<IpAddr>().unwrap());
+                assert_eq!(local_address, "127.0.0.1".parse::<IpAddr>().unwrap());
                 assert_eq!(local_port, rtcp_port);
                 assert_eq!(protocol, Protocol::Udp);
             }
@@ -286,7 +290,7 @@ fn create_with_fixed_port_succeeds() {
                 PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".to_string()),
+                    announced_address: Some("4.4.4.4".to_string()),
                     port: Some(port),
                     flags: None,
                     send_buffer_size: None,
@@ -310,7 +314,7 @@ fn weak() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".to_string()),
+                    announced_address: Some("4.4.4.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -344,7 +348,7 @@ fn create_enable_srtp_succeeds() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -410,7 +414,7 @@ fn create_non_bindable_ip() {
                 .create_plain_transport(PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: "8.8.8.8".parse().unwrap(),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -436,7 +440,7 @@ fn create_two_transports_binding_to_same_ip_port_with_udp_reuse_port_flag_succee
                 PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: multicast_ip,
-                    announced_ip: None,
+                    announced_address: None,
                     port: Some(port),
                     // NOTE: ipv6Only flag will be ignored since ip is IPv4.
                     flags: Some(SocketFlags {
@@ -455,7 +459,7 @@ fn create_two_transports_binding_to_same_ip_port_with_udp_reuse_port_flag_succee
                 PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: multicast_ip,
-                    announced_ip: None,
+                    announced_address: None,
                     port: Some(port),
                     flags: Some(SocketFlags {
                         ipv6_only: false,
@@ -487,7 +491,7 @@ fn create_two_transports_binding_to_same_ip_port_without_udp_reuse_port_flag_fai
                 PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: multicast_ip,
-                    announced_ip: None,
+                    announced_address: None,
                     port: Some(port),
                     flags: Some(SocketFlags {
                         ipv6_only: false,
@@ -505,7 +509,7 @@ fn create_two_transports_binding_to_same_ip_port_without_udp_reuse_port_flag_fai
                 .create_plain_transport(PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: multicast_ip,
-                    announced_ip: None,
+                    announced_address: None,
                     port: Some(port),
                     flags: Some(SocketFlags {
                         ipv6_only: false,
@@ -532,7 +536,7 @@ fn get_stats_succeeds() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".to_string()),
+                    announced_address: Some("4.4.4.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -570,10 +574,12 @@ fn get_stats_succeeds() {
         assert_eq!(stats[0].rtp_packet_loss_sent, None);
         assert!(matches!(stats[0].tuple, TransportTuple::LocalOnly { .. },));
         if let TransportTuple::LocalOnly {
-            local_ip, protocol, ..
+            local_address,
+            protocol,
+            ..
         } = stats[0].tuple
         {
-            assert_eq!(local_ip, "4.4.4.4".parse::<IpAddr>().unwrap());
+            assert_eq!(local_address, "4.4.4.4".parse::<IpAddr>().unwrap());
             assert_eq!(protocol, Protocol::Udp);
         }
         assert_eq!(stats[0].rtcp_tuple, None);
@@ -590,7 +596,7 @@ fn connect_succeeds() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".to_string()),
+                    announced_address: Some("4.4.4.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -666,7 +672,7 @@ fn connect_wrong_arguments() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".to_string()),
+                    announced_address: Some("4.4.4.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -707,7 +713,7 @@ fn close_event() {
                 let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("4.4.4.4".to_string()),
+                    announced_address: Some("4.4.4.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,

--- a/rust/tests/integration/producer.rs
+++ b/rust/tests/integration/producer.rs
@@ -205,7 +205,7 @@ async fn init() -> (Worker, Router, WebRtcTransport, WebRtcTransport) {
         WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
             protocol: Protocol::Udp,
             ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-            announced_ip: None,
+            announced_address: None,
             port: None,
             flags: None,
             send_buffer_size: None,

--- a/rust/tests/integration/smoke.rs
+++ b/rust/tests/integration/smoke.rs
@@ -86,7 +86,7 @@ fn smoke() {
                     WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: None,
+                        announced_address: None,
                         port: None,
                         flags: None,
                         send_buffer_size: None,
@@ -273,7 +273,7 @@ fn smoke() {
                 let mut options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,

--- a/rust/tests/integration/webrtc_server.rs
+++ b/rust/tests/integration/webrtc_server.rs
@@ -62,7 +62,7 @@ fn create_webrtc_server_succeeds() {
                 let listen_infos = WebRtcServerListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: Some(port1),
                     flags: None,
                     send_buffer_size: None,
@@ -71,7 +71,7 @@ fn create_webrtc_server_succeeds() {
                 let listen_infos = listen_infos.insert(ListenInfo {
                     protocol: Protocol::Tcp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("foo.bar.org".to_string()),
+                    announced_address: Some("foo.bar.org".to_string()),
                     port: Some(port2),
                     flags: None,
                     send_buffer_size: None,
@@ -158,7 +158,7 @@ fn create_webrtc_server_without_specifying_port_succeeds() {
                 let listen_infos = WebRtcServerListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -167,7 +167,7 @@ fn create_webrtc_server_without_specifying_port_succeeds() {
                 let listen_infos = listen_infos.insert(ListenInfo {
                     protocol: Protocol::Tcp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("1.2.3.4".to_string()),
+                    announced_address: Some("1.2.3.4".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -241,7 +241,7 @@ fn unavailable_infos_fails() {
                     let listen_infos = WebRtcServerListenInfos::new(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: None,
+                        announced_address: None,
                         port: Some(port1),
                         flags: None,
                         send_buffer_size: None,
@@ -250,7 +250,7 @@ fn unavailable_infos_fails() {
                     let listen_infos = listen_infos.insert(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::new(1, 2, 3, 4)),
-                        announced_ip: None,
+                        announced_address: None,
                         port: Some(port2),
                         flags: None,
                         send_buffer_size: None,
@@ -274,7 +274,7 @@ fn unavailable_infos_fails() {
                     let listen_infos = WebRtcServerListenInfos::new(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: None,
+                        announced_address: None,
                         port: Some(port1),
                         flags: None,
                         send_buffer_size: None,
@@ -283,7 +283,7 @@ fn unavailable_infos_fails() {
                     let listen_infos = listen_infos.insert(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
-                        announced_ip: Some("1.2.3.4".to_string()),
+                        announced_address: Some("1.2.3.4".to_string()),
                         port: Some(port1),
                         flags: None,
                         send_buffer_size: None,
@@ -307,7 +307,7 @@ fn unavailable_infos_fails() {
                     ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: None,
+                        announced_address: None,
                         port: Some(port1),
                         flags: None,
                         send_buffer_size: None,
@@ -322,7 +322,7 @@ fn unavailable_infos_fails() {
                     ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: None,
+                        announced_address: None,
                         port: Some(port1),
                         flags: None,
                         send_buffer_size: None,
@@ -351,7 +351,7 @@ fn close_event() {
                 ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: None,
+                    announced_address: None,
                     port: Some(port),
                     flags: None,
                     send_buffer_size: None,

--- a/rust/tests/integration/webrtc_transport.rs
+++ b/rust/tests/integration/webrtc_transport.rs
@@ -98,7 +98,7 @@ fn create_succeeds() {
                     WebRtcTransportListenInfos::new(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                        announced_ip: Some("9.9.9.1".to_string()),
+                        announced_address: Some("9.9.9.1".to_string()),
                         port: None,
                         flags: None,
                         send_buffer_size: None,
@@ -136,7 +136,7 @@ fn create_succeeds() {
                             ListenInfo {
                                 protocol: Protocol::Udp,
                                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                                announced_ip: Some("9.9.9.1".to_string()),
+                                announced_address: Some("9.9.9.1".to_string()),
                                 port: None,
                                 flags: None,
                                 send_buffer_size: None,
@@ -145,7 +145,7 @@ fn create_succeeds() {
                             ListenInfo {
                                 protocol: Protocol::Udp,
                                 ip: IpAddr::V4(Ipv4Addr::UNSPECIFIED),
-                                announced_ip: Some("foo1.bar.org".to_string()),
+                                announced_address: Some("foo1.bar.org".to_string()),
                                 port: None,
                                 flags: None,
                                 send_buffer_size: None,
@@ -154,7 +154,7 @@ fn create_succeeds() {
                             ListenInfo {
                                 protocol: Protocol::Udp,
                                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                                announced_ip: None,
+                                announced_address: None,
                                 port: None,
                                 flags: None,
                                 send_buffer_size: None,
@@ -200,19 +200,19 @@ fn create_succeeds() {
             {
                 let ice_candidates = transport1.ice_candidates();
                 assert_eq!(ice_candidates.len(), 3);
-                assert_eq!(ice_candidates[0].ip, "9.9.9.1");
+                assert_eq!(ice_candidates[0].address, "9.9.9.1");
                 assert_eq!(ice_candidates[0].protocol, Protocol::Udp);
                 assert_eq!(ice_candidates[0].r#type, IceCandidateType::Host);
                 assert_eq!(ice_candidates[0].tcp_type, None);
-                assert_eq!(ice_candidates[1].ip, "foo1.bar.org");
+                assert_eq!(ice_candidates[1].address, "foo1.bar.org");
                 assert_eq!(ice_candidates[1].protocol, Protocol::Udp);
                 assert_eq!(ice_candidates[1].r#type, IceCandidateType::Host);
                 assert_eq!(ice_candidates[1].tcp_type, None);
-                assert_eq!(ice_candidates[2].ip, "127.0.0.1");
+                assert_eq!(ice_candidates[2].address, "127.0.0.1");
                 assert_eq!(ice_candidates[2].protocol, Protocol::Udp);
                 assert_eq!(ice_candidates[2].r#type, IceCandidateType::Host);
                 assert_eq!(ice_candidates[2].tcp_type, None);
-                assert_eq!(ice_candidates[2].ip, "127.0.0.1");
+                assert_eq!(ice_candidates[2].address, "127.0.0.1");
                 assert_eq!(ice_candidates[2].protocol, Protocol::Udp);
                 assert_eq!(ice_candidates[2].r#type, IceCandidateType::Host);
                 assert_eq!(ice_candidates[2].tcp_type, None);
@@ -265,7 +265,7 @@ fn create_with_fixed_port_succeeds() {
                 WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: Some(port),
                     flags: None,
                     send_buffer_size: None,
@@ -289,7 +289,7 @@ fn weak() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -320,7 +320,7 @@ fn create_non_bindable_ip() {
                     WebRtcTransportListenInfos::new(ListenInfo {
                         protocol: Protocol::Udp,
                         ip: "8.8.8.8".parse().unwrap(),
-                        announced_ip: None,
+                        announced_address: None,
                         port: None,
                         flags: None,
                         send_buffer_size: None,
@@ -343,7 +343,7 @@ fn get_stats_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -395,7 +395,7 @@ fn connect_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -445,7 +445,7 @@ fn set_max_incoming_bitrate_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -478,7 +478,7 @@ fn set_max_outgoing_bitrate_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -511,7 +511,7 @@ fn set_min_outgoing_bitrate_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -544,7 +544,7 @@ fn set_max_outgoing_bitrate_fails_if_value_is_lower_than_current_min_limit() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -582,7 +582,7 @@ fn set_min_outgoing_bitrate_fails_if_value_is_higher_than_current_max_limit() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -620,7 +620,7 @@ fn restart_ice_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -656,7 +656,7 @@ fn enable_trace_event_succeeds() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,
@@ -732,7 +732,7 @@ fn close_event() {
                 WebRtcTransportListenInfos::new(ListenInfo {
                     protocol: Protocol::Udp,
                     ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
-                    announced_ip: Some("9.9.9.1".to_string()),
+                    announced_address: Some("9.9.9.1".to_string()),
                     port: None,
                     flags: None,
                     send_buffer_size: None,

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup-sys"
-version = "0.7.3"
+version = "0.8.0"
 description = "FFI bindings to C++ libmediasoup-worker"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition = "2021"

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup-sys"
-version = "0.7.2"
+version = "0.7.3"
 description = "FFI bindings to C++ libmediasoup-worker"
 authors = ["Nazar Mokrynskyi <nazar@mokrynskyi.com>"]
 edition = "2021"

--- a/worker/fbs/transport.fbs
+++ b/worker/fbs/transport.fbs
@@ -21,7 +21,7 @@ table SocketFlags {
 table ListenInfo {
     protocol: Protocol = UDP;
     ip: string (required);
-    announced_ip: string;
+    announced_address: string;
     port: uint16 = 0;
     flags: SocketFlags (required);
     send_buffer_size: uint32 = 0;
@@ -87,7 +87,7 @@ table ConsumeDataRequest {
 }
 
 table Tuple {
-    local_ip: string (required);
+    local_address: string (required);
     local_port: uint16;
     remote_ip: string;
     remote_port: uint16;

--- a/worker/fbs/webRtcTransport.fbs
+++ b/worker/fbs/webRtcTransport.fbs
@@ -86,7 +86,7 @@ enum IceState: uint8 {
 table IceCandidate {
     foundation: string (required);
     priority: uint32;
-    ip: string (required);
+    address: string (required);
     protocol: FBS.Transport.Protocol = UDP;
     port: uint16;
     type: IceCandidateType;

--- a/worker/include/RTC/IceCandidate.hpp
+++ b/worker/include/RTC/IceCandidate.hpp
@@ -35,27 +35,27 @@ namespace RTC
 
 	public:
 		IceCandidate(RTC::UdpSocket* udpSocket, uint32_t priority)
-		  : foundation("udpcandidate"), priority(priority), ip(udpSocket->GetLocalIp()),
+		  : foundation("udpcandidate"), priority(priority), address(udpSocket->GetLocalIp()),
 		    protocol(Protocol::UDP), port(udpSocket->GetLocalPort())
 		{
 		}
 
-		IceCandidate(RTC::UdpSocket* udpSocket, uint32_t priority, std::string& announcedIp)
-		  : foundation("udpcandidate"), priority(priority), ip(announcedIp), protocol(Protocol::UDP),
-		    port(udpSocket->GetLocalPort())
+		IceCandidate(RTC::UdpSocket* udpSocket, uint32_t priority, std::string& announcedAddress)
+		  : foundation("udpcandidate"), priority(priority), address(announcedAddress),
+		    protocol(Protocol::UDP), port(udpSocket->GetLocalPort())
 		{
 		}
 
 		IceCandidate(RTC::TcpServer* tcpServer, uint32_t priority)
-		  : foundation("tcpcandidate"), priority(priority), ip(tcpServer->GetLocalIp()),
+		  : foundation("tcpcandidate"), priority(priority), address(tcpServer->GetLocalIp()),
 		    protocol(Protocol::TCP), port(tcpServer->GetLocalPort())
 
 		{
 		}
 
-		IceCandidate(RTC::TcpServer* tcpServer, uint32_t priority, std::string& announcedIp)
-		  : foundation("tcpcandidate"), priority(priority), ip(announcedIp), protocol(Protocol::TCP),
-		    port(tcpServer->GetLocalPort())
+		IceCandidate(RTC::TcpServer* tcpServer, uint32_t priority, std::string& announcedAddress)
+		  : foundation("tcpcandidate"), priority(priority), address(announcedAddress),
+		    protocol(Protocol::TCP), port(tcpServer->GetLocalPort())
 
 		{
 		}
@@ -67,7 +67,7 @@ namespace RTC
 		// Others.
 		std::string foundation;
 		uint32_t priority{ 0u };
-		std::string ip;
+		std::string address;
 		Protocol protocol;
 		uint16_t port{ 0u };
 		CandidateType type{ CandidateType::HOST };

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -128,7 +128,7 @@ namespace RTC
 		struct ListenInfo
 		{
 			std::string ip;
-			std::string announcedIp;
+			std::string announcedAddress;
 			uint16_t port{ 0u };
 			SocketFlags flags;
 			uint32_t sendBufferSize{ 0u };

--- a/worker/include/RTC/TransportTuple.hpp
+++ b/worker/include/RTC/TransportTuple.hpp
@@ -41,7 +41,7 @@ namespace RTC
 
 		explicit TransportTuple(const TransportTuple* tuple)
 		  : hash(tuple->hash), udpSocket(tuple->udpSocket), udpRemoteAddr(tuple->udpRemoteAddr),
-		    tcpConnection(tuple->tcpConnection), localAnnouncedIp(tuple->localAnnouncedIp),
+		    tcpConnection(tuple->tcpConnection), localAnnouncedAddress(tuple->localAnnouncedAddress),
 		    protocol(tuple->protocol)
 		{
 			if (protocol == TransportTuple::Protocol::UDP)
@@ -92,9 +92,9 @@ namespace RTC
 			return this->hash == tuple->hash;
 		}
 
-		void SetLocalAnnouncedIp(std::string& localAnnouncedIp)
+		void SetLocalAnnouncedAddress(std::string& localAnnouncedAddress)
 		{
-			this->localAnnouncedIp = localAnnouncedIp;
+			this->localAnnouncedAddress = localAnnouncedAddress;
 		}
 
 		void Send(const uint8_t* data, size_t len, RTC::TransportTuple::onSendCallback* cb = nullptr)
@@ -243,7 +243,7 @@ namespace RTC
 		RTC::UdpSocket* udpSocket{ nullptr };
 		struct sockaddr* udpRemoteAddr{ nullptr };
 		RTC::TcpConnection* tcpConnection{ nullptr };
-		std::string localAnnouncedIp;
+		std::string localAnnouncedAddress;
 		// Others.
 		struct sockaddr_storage udpRemoteAddrStorage
 		{

--- a/worker/include/RTC/WebRtcServer.hpp
+++ b/worker/include/RTC/WebRtcServer.hpp
@@ -28,14 +28,15 @@ namespace RTC
 		struct UdpSocketOrTcpServer
 		{
 			// Expose a constructor to use vector.emplace_back().
-			UdpSocketOrTcpServer(RTC::UdpSocket* udpSocket, RTC::TcpServer* tcpServer, std::string& announcedIp)
-			  : udpSocket(udpSocket), tcpServer(tcpServer), announcedIp(announcedIp)
+			UdpSocketOrTcpServer(
+			  RTC::UdpSocket* udpSocket, RTC::TcpServer* tcpServer, std::string& announcedAddress)
+			  : udpSocket(udpSocket), tcpServer(tcpServer), announcedAddress(announcedAddress)
 			{
 			}
 
 			RTC::UdpSocket* udpSocket;
 			RTC::TcpServer* tcpServer;
-			std::string announcedIp;
+			std::string announcedAddress;
 		};
 
 	private:

--- a/worker/include/RTC/WebRtcTransport.hpp
+++ b/worker/include/RTC/WebRtcTransport.hpp
@@ -153,7 +153,7 @@ namespace RTC
 		WebRtcTransportListener* webRtcTransportListener{ nullptr };
 		// Allocated by this.
 		RTC::IceServer* iceServer{ nullptr };
-		// Map of UdpSocket/TcpServer and local announced IP (if any).
+		// Map of UdpSocket/TcpServer and local announced address (if any).
 		absl::flat_hash_map<RTC::UdpSocket*, std::string> udpSockets;
 		absl::flat_hash_map<RTC::TcpServer*, std::string> tcpServers;
 		RTC::DtlsTransport* dtlsTransport{ nullptr };

--- a/worker/src/RTC/IceCandidate.cpp
+++ b/worker/src/RTC/IceCandidate.cpp
@@ -69,8 +69,8 @@ namespace RTC
 		  this->foundation.c_str(),
 		  // priority.
 		  this->priority,
-		  // ip.
-		  this->ip.c_str(),
+		  // address.
+		  this->address.c_str(),
 		  // protocol.
 		  protocol,
 		  // port.

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -40,14 +40,16 @@ namespace RTC
 		// This may throw.
 		Utils::IP::NormalizeIp(this->listenInfo.ip);
 
-		if (flatbuffers::IsFieldPresent(options->listenInfo(), FBS::Transport::ListenInfo::VT_ANNOUNCEDIP))
+		if (flatbuffers::IsFieldPresent(
+		      options->listenInfo(), FBS::Transport::ListenInfo::VT_ANNOUNCEDADDRESS))
 		{
-			this->listenInfo.announcedIp.assign(options->listenInfo()->announcedIp()->str());
+			this->listenInfo.announcedAddress.assign(options->listenInfo()->announcedAddress()->str());
 		}
 
-		if (flatbuffers::IsFieldPresent(options->listenInfo(), FBS::Transport::ListenInfo::VT_ANNOUNCEDIP))
+		if (flatbuffers::IsFieldPresent(
+		      options->listenInfo(), FBS::Transport::ListenInfo::VT_ANNOUNCEDADDRESS))
 		{
-			this->listenInfo.announcedIp.assign(options->listenInfo()->announcedIp()->str());
+			this->listenInfo.announcedAddress.assign(options->listenInfo()->announcedAddress()->str());
 		}
 
 		this->listenInfo.port               = options->listenInfo()->port();
@@ -151,13 +153,13 @@ namespace RTC
 		{
 			std::string localIp;
 
-			if (this->listenInfo.announcedIp.empty())
+			if (this->listenInfo.announcedAddress.empty())
 			{
 				localIp = this->udpSocket->GetLocalIp();
 			}
 			else
 			{
-				localIp = this->listenInfo.announcedIp;
+				localIp = this->listenInfo.announcedAddress;
 			}
 
 			tuple = FBS::Transport::CreateTupleDirect(
@@ -202,13 +204,13 @@ namespace RTC
 		{
 			std::string localIp;
 
-			if (this->listenInfo.announcedIp.empty())
+			if (this->listenInfo.announcedAddress.empty())
 			{
 				localIp = this->udpSocket->GetLocalIp();
 			}
 			else
 			{
-				localIp = this->listenInfo.announcedIp;
+				localIp = this->listenInfo.announcedAddress;
 			}
 
 			tuple = FBS::Transport::CreateTupleDirect(
@@ -408,9 +410,9 @@ namespace RTC
 					this->tuple = new RTC::TransportTuple(
 					  this->udpSocket, reinterpret_cast<struct sockaddr*>(&this->remoteAddrStorage));
 
-					if (!this->listenInfo.announcedIp.empty())
+					if (!this->listenInfo.announcedAddress.empty())
 					{
-						this->tuple->SetLocalAnnouncedIp(this->listenInfo.announcedIp);
+						this->tuple->SetLocalAnnouncedAddress(this->listenInfo.announcedAddress);
 					}
 				}
 				catch (const MediaSoupError& error)

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -47,9 +47,10 @@ namespace RTC
 		// This may throw.
 		Utils::IP::NormalizeIp(this->listenInfo.ip);
 
-		if (flatbuffers::IsFieldPresent(options->listenInfo(), FBS::Transport::ListenInfo::VT_ANNOUNCEDIP))
+		if (flatbuffers::IsFieldPresent(
+		      options->listenInfo(), FBS::Transport::ListenInfo::VT_ANNOUNCEDADDRESS))
 		{
-			this->listenInfo.announcedIp.assign(options->listenInfo()->announcedIp()->str());
+			this->listenInfo.announcedAddress.assign(options->listenInfo()->announcedAddress()->str());
 		}
 
 		this->listenInfo.port               = options->listenInfo()->port();
@@ -77,9 +78,10 @@ namespace RTC
 				Utils::IP::NormalizeIp(this->rtcpListenInfo.ip);
 
 				if (flatbuffers::IsFieldPresent(
-				      options->rtcpListenInfo(), FBS::Transport::ListenInfo::VT_ANNOUNCEDIP))
+				      options->rtcpListenInfo(), FBS::Transport::ListenInfo::VT_ANNOUNCEDADDRESS))
 				{
-					this->rtcpListenInfo.announcedIp.assign(options->rtcpListenInfo()->announcedIp()->str());
+					this->rtcpListenInfo.announcedAddress.assign(
+					  options->rtcpListenInfo()->announcedAddress()->str());
 				}
 
 				this->rtcpListenInfo.port           = options->rtcpListenInfo()->port();
@@ -254,13 +256,13 @@ namespace RTC
 		{
 			std::string localIp;
 
-			if (this->listenInfo.announcedIp.empty())
+			if (this->listenInfo.announcedAddress.empty())
 			{
 				localIp = this->udpSocket->GetLocalIp();
 			}
 			else
 			{
-				localIp = this->listenInfo.announcedIp;
+				localIp = this->listenInfo.announcedAddress;
 			}
 
 			tuple = FBS::Transport::CreateTupleDirect(
@@ -285,13 +287,13 @@ namespace RTC
 			{
 				std::string localIp;
 
-				if (this->rtcpListenInfo.announcedIp.empty())
+				if (this->rtcpListenInfo.announcedAddress.empty())
 				{
 					localIp = this->rtcpUdpSocket->GetLocalIp();
 				}
 				else
 				{
-					localIp = this->rtcpListenInfo.announcedIp;
+					localIp = this->rtcpListenInfo.announcedAddress;
 				}
 
 				rtcpTuple = FBS::Transport::CreateTupleDirect(
@@ -336,13 +338,13 @@ namespace RTC
 		{
 			std::string localIp;
 
-			if (this->listenInfo.announcedIp.empty())
+			if (this->listenInfo.announcedAddress.empty())
 			{
 				localIp = this->udpSocket->GetLocalIp();
 			}
 			else
 			{
-				localIp = this->listenInfo.announcedIp;
+				localIp = this->listenInfo.announcedAddress;
 			}
 
 			tuple = FBS::Transport::CreateTupleDirect(
@@ -605,9 +607,9 @@ namespace RTC
 						this->tuple = new RTC::TransportTuple(
 						  this->udpSocket, reinterpret_cast<struct sockaddr*>(&this->remoteAddrStorage));
 
-						if (!this->listenInfo.announcedIp.empty())
+						if (!this->listenInfo.announcedAddress.empty())
 						{
-							this->tuple->SetLocalAnnouncedIp(this->listenInfo.announcedIp);
+							this->tuple->SetLocalAnnouncedAddress(this->listenInfo.announcedAddress);
 						}
 
 						if (!this->rtcpMux)
@@ -655,9 +657,9 @@ namespace RTC
 							  this->rtcpUdpSocket,
 							  reinterpret_cast<struct sockaddr*>(&this->rtcpRemoteAddrStorage));
 
-							if (!this->rtcpListenInfo.announcedIp.empty())
+							if (!this->rtcpListenInfo.announcedAddress.empty())
 							{
-								this->rtcpTuple->SetLocalAnnouncedIp(this->rtcpListenInfo.announcedIp);
+								this->rtcpTuple->SetLocalAnnouncedAddress(this->rtcpListenInfo.announcedAddress);
 							}
 						}
 					}
@@ -980,9 +982,9 @@ namespace RTC
 
 			this->tuple = new RTC::TransportTuple(tuple);
 
-			if (!this->listenInfo.announcedIp.empty())
+			if (!this->listenInfo.announcedAddress.empty())
 			{
-				this->tuple->SetLocalAnnouncedIp(this->listenInfo.announcedIp);
+				this->tuple->SetLocalAnnouncedAddress(this->listenInfo.announcedAddress);
 			}
 
 			// If not yet connected do it now.
@@ -1045,9 +1047,9 @@ namespace RTC
 
 			this->tuple = new RTC::TransportTuple(tuple);
 
-			if (!this->listenInfo.announcedIp.empty())
+			if (!this->listenInfo.announcedAddress.empty())
 			{
-				this->tuple->SetLocalAnnouncedIp(this->listenInfo.announcedIp);
+				this->tuple->SetLocalAnnouncedAddress(this->listenInfo.announcedAddress);
 			}
 
 			// If not yet connected do it now.
@@ -1074,9 +1076,9 @@ namespace RTC
 
 			this->rtcpTuple = new RTC::TransportTuple(tuple);
 
-			if (!this->rtcpListenInfo.announcedIp.empty())
+			if (!this->rtcpListenInfo.announcedAddress.empty())
 			{
-				this->rtcpTuple->SetLocalAnnouncedIp(this->rtcpListenInfo.announcedIp);
+				this->rtcpTuple->SetLocalAnnouncedAddress(this->rtcpListenInfo.announcedAddress);
 			}
 
 			// Notify the Node PlainTransport.
@@ -1131,9 +1133,9 @@ namespace RTC
 
 			this->tuple = new RTC::TransportTuple(tuple);
 
-			if (!this->listenInfo.announcedIp.empty())
+			if (!this->listenInfo.announcedAddress.empty())
 			{
-				this->tuple->SetLocalAnnouncedIp(this->listenInfo.announcedIp);
+				this->tuple->SetLocalAnnouncedAddress(this->listenInfo.announcedAddress);
 			}
 
 			// If not yet connected do it now.

--- a/worker/src/RTC/TransportTuple.cpp
+++ b/worker/src/RTC/TransportTuple.cpp
@@ -46,8 +46,6 @@ namespace RTC
 
 		Utils::IP::GetAddressInfo(GetLocalAddress(), family, localIp, localPort);
 
-		localIp = this->localAnnouncedIp.empty() ? localIp : this->localAnnouncedIp;
-
 		std::string remoteIp;
 		uint16_t remotePort;
 
@@ -56,7 +54,12 @@ namespace RTC
 		auto protocol = TransportTuple::ProtocolToFbs(GetProtocol());
 
 		return FBS::Transport::CreateTupleDirect(
-		  builder, localIp.c_str(), localPort, remoteIp.c_str(), remotePort, protocol);
+		  builder,
+		  (this->localAnnouncedAddress.empty() ? localIp : this->localAnnouncedAddress).c_str(),
+		  localPort,
+		  remoteIp.c_str(),
+		  remotePort,
+		  protocol);
 	}
 
 	void TransportTuple::Dump() const

--- a/worker/src/RTC/WebRtcServer.cpp
+++ b/worker/src/RTC/WebRtcServer.cpp
@@ -77,11 +77,11 @@ namespace RTC
 				// This may throw.
 				Utils::IP::NormalizeIp(ip);
 
-				std::string announcedIp;
+				std::string announcedAddress;
 
-				if (flatbuffers::IsFieldPresent(listenInfo, FBS::Transport::ListenInfo::VT_ANNOUNCEDIP))
+				if (flatbuffers::IsFieldPresent(listenInfo, FBS::Transport::ListenInfo::VT_ANNOUNCEDADDRESS))
 				{
-					announcedIp = listenInfo->announcedIp()->str();
+					announcedAddress = listenInfo->announcedAddress()->str();
 				}
 
 				RTC::Transport::SocketFlags flags;
@@ -103,7 +103,7 @@ namespace RTC
 						udpSocket = new RTC::UdpSocket(this, ip, flags);
 					}
 
-					this->udpSocketOrTcpServers.emplace_back(udpSocket, nullptr, announcedIp);
+					this->udpSocketOrTcpServers.emplace_back(udpSocket, nullptr, announcedAddress);
 
 					if (listenInfo->sendBufferSize() != 0)
 					{
@@ -135,7 +135,7 @@ namespace RTC
 						tcpServer = new RTC::TcpServer(this, this, ip, flags);
 					}
 
-					this->udpSocketOrTcpServers.emplace_back(nullptr, tcpServer, announcedIp);
+					this->udpSocketOrTcpServers.emplace_back(nullptr, tcpServer, announcedAddress);
 
 					if (listenInfo->sendBufferSize() != 0)
 					{
@@ -310,14 +310,14 @@ namespace RTC
 
 				const uint32_t icePriority = generateIceCandidatePriority(iceLocalPreference);
 
-				if (item.announcedIp.empty())
+				if (item.announcedAddress.empty())
 				{
 					iceCandidates.emplace_back(item.udpSocket, icePriority);
 				}
 				else
 				{
 					iceCandidates.emplace_back(
-					  item.udpSocket, icePriority, const_cast<std::string&>(item.announcedIp));
+					  item.udpSocket, icePriority, const_cast<std::string&>(item.announcedAddress));
 				}
 			}
 			else if (item.tcpServer && enableTcp)
@@ -331,14 +331,14 @@ namespace RTC
 
 				const uint32_t icePriority = generateIceCandidatePriority(iceLocalPreference);
 
-				if (item.announcedIp.empty())
+				if (item.announcedAddress.empty())
 				{
 					iceCandidates.emplace_back(item.tcpServer, icePriority);
 				}
 				else
 				{
 					iceCandidates.emplace_back(
-					  item.tcpServer, icePriority, const_cast<std::string&>(item.announcedIp));
+					  item.tcpServer, icePriority, const_cast<std::string&>(item.announcedAddress));
 				}
 			}
 

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -55,11 +55,11 @@ namespace RTC
 				// This may throw.
 				Utils::IP::NormalizeIp(ip);
 
-				std::string announcedIp;
+				std::string announcedAddress;
 
-				if (flatbuffers::IsFieldPresent(listenInfo, FBS::Transport::ListenInfo::VT_ANNOUNCEDIP))
+				if (flatbuffers::IsFieldPresent(listenInfo, FBS::Transport::ListenInfo::VT_ANNOUNCEDADDRESS))
 				{
-					announcedIp = listenInfo->announcedIp()->str();
+					announcedAddress = listenInfo->announcedAddress()->str();
 				}
 
 				RTC::Transport::SocketFlags flags;
@@ -84,15 +84,15 @@ namespace RTC
 						udpSocket = new RTC::UdpSocket(this, ip, flags);
 					}
 
-					this->udpSockets[udpSocket] = announcedIp;
+					this->udpSockets[udpSocket] = announcedAddress;
 
-					if (announcedIp.empty())
+					if (announcedAddress.empty())
 					{
 						this->iceCandidates.emplace_back(udpSocket, icePriority);
 					}
 					else
 					{
-						this->iceCandidates.emplace_back(udpSocket, icePriority, announcedIp);
+						this->iceCandidates.emplace_back(udpSocket, icePriority, announcedAddress);
 					}
 
 					if (listenInfo->sendBufferSize() != 0)
@@ -126,15 +126,15 @@ namespace RTC
 						tcpServer = new RTC::TcpServer(this, this, ip, flags);
 					}
 
-					this->tcpServers[tcpServer] = announcedIp;
+					this->tcpServers[tcpServer] = announcedAddress;
 
-					if (announcedIp.empty())
+					if (announcedAddress.empty())
 					{
 						this->iceCandidates.emplace_back(tcpServer, icePriority);
 					}
 					else
 					{
-						this->iceCandidates.emplace_back(tcpServer, icePriority, announcedIp);
+						this->iceCandidates.emplace_back(tcpServer, icePriority, announcedAddress);
 					}
 
 					if (listenInfo->sendBufferSize() != 0)


### PR DESCRIPTION
Fixes #1323

- Rust: In `TransportListenInfo` rename `announced_ip` to `announced_address`.
- Rust: In `IceCandidate` rename `ip` to `address`.
- Rust: In `TransportTuple` rename `local_ip` to `local_address`.
- Node: In `TransportListenInfo` rename `announcedIp` to `announcedAddress` and keep backwards compatibility.
- Node: In `IceCandidate` rename `ip` to `address` and keep backwards compatibility.
- Node: In `TransportTuple` rename `localIp` to `localAddress` and keep backwards compatibility.

**NOTE:** Why has been `TransportTuple.localIp` renamed to `TransportTuple.localAddress`? Because indeed its value is an announced address if a hostname was given in `announcedAddress` in a `TransportListenInfo`.