### PR TITLE
CI: Add macos-14

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -20,6 +20,8 @@ jobs:
           - os: ubuntu-22.04
             node: 20
           - os: macos-12
+            node: 18
+          - os: macos-14
             node: 20
           - os: windows-2022
             node: 20

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -19,6 +19,7 @@ jobs:
           - ubuntu-20.04
           - ubuntu-22.04
           - macos-12
+          - macos-14
           - windows-2022
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -25,6 +25,9 @@ jobs:
           - os: macos-12
             cc: clang
             cxx: clang++
+          - os: macos-14
+            cc: clang
+            cxx: clang++
           - os: windows-2022
             cc: cl
             cxx: cl

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -28,7 +28,7 @@ jobs:
           - os: macos-12
             cc: gcc
             cxx: g++
-          - os: macos-12
+          - os: macos-14
             cc: clang
             cxx: clang++
           - os: windows-2022

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Make transport-cc feedback work similarly to libwebrtc ([PR #1088](https://github.com/versatica/mediasoup/pull/1088) by @penguinol).
 - `TransportListenInfo`: "announced ip" can also be a hostname ([PR #1322](https://github.com/versatica/mediasoup/pull/1322)).
 - `TransportListenInfo`: Rename "announced ip" to "announced address" ([PR #1324](https://github.com/versatica/mediasoup/pull/1324)).
+- CI: Add `macos-14`.
 
 ### 3.13.17
 

--- a/node/tsconfig.json
+++ b/node/tsconfig.json
@@ -8,13 +8,13 @@
 		"strict": true,
 		"outDir": "lib",
 		"declaration": true,
-		"declarationMap": true,
+		"declarationMap": true
 	},
 	"include": ["src"],
 	"watchOptions": {
 		"watchFile": "useFsEvents",
 		"watchDirectory": "useFsEvents",
 		"fallbackPolling": "dynamicPriority",
-		"synchronousWatchDirectory": true,
-	},
+		"synchronousWatchDirectory": true
+	}
 }

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -228,23 +228,7 @@ async function run() {
 				draft: false,
 			});
 
-			// GitHub mediasoup-worker-prebuild CI action doesn't create mediasoup-worker
-			// prebuilt binary for macOS ARM. If this is a macOS ARM machine, do it here
-			// and upload it to the release.
-			if (os.platform() === 'darwin' && os.arch() === 'arm64') {
-				await prebuildWorker();
-				await uploadMacArmPrebuiltWorker();
-			}
-
 			executeCmd('npm publish');
-
-			break;
-		}
-
-		case 'release:upload-mac-arm-prebuilt-worker': {
-			checkRelease();
-			await prebuildWorker();
-			await uploadMacArmPrebuiltWorker();
 
 			break;
 		}
@@ -594,35 +578,6 @@ async function downloadPrebuiltWorker() {
 
 				resolve(false);
 			});
-	});
-}
-
-async function uploadMacArmPrebuiltWorker() {
-	if (os.platform() !== 'darwin' || os.arch() !== 'arm64') {
-		logError('uploadMacArmPrebuiltWorker() | invalid platform or architecture');
-
-		exitWithError();
-	}
-
-	const octokit = await getOctokit();
-
-	logInfo('uploadMacArmPrebuiltWorker() | getting release info');
-
-	const release = await octokit.rest.repos.getReleaseByTag({
-		owner: GH_OWNER,
-		repo: GH_REPO,
-		tag: PKG.version,
-	});
-
-	logInfo('uploadMacArmPrebuiltWorker() | uploading release asset');
-
-	await octokit.rest.repos.uploadReleaseAsset({
-		owner: GH_OWNER,
-		repo: GH_REPO,
-		// eslint-disable-next-line camelcase
-		release_id: release.data.id,
-		name: WORKER_PREBUILD_TAR,
-		data: fs.readFileSync(WORKER_PREBUILD_TAR_PATH),
 	});
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
 			"devDependencies": {
 				"@octokit/rest": "^20.0.2",
 				"@types/debug": "^4.1.12",
-				"@types/jest": "^29.5.11",
-				"@types/node": "^20.11.15",
+				"@types/jest": "^29.5.12",
+				"@types/node": "^20.11.16",
 				"@typescript-eslint/eslint-plugin": "^6.20.0",
 				"@typescript-eslint/parser": "^6.20.0",
 				"eslint": "^8.56.0",
@@ -29,10 +29,10 @@
 				"eslint-plugin-jest": "^27.6.3",
 				"eslint-plugin-prettier": "^5.1.3",
 				"jest": "^29.7.0",
-				"marked": "^11.2.0",
+				"marked": "^12.0.0",
 				"open-cli": "^8.0.0",
 				"pick-port": "^2.0.1",
-				"prettier": "^3.2.4",
+				"prettier": "^3.2.5",
 				"sctp": "^1.0.0",
 				"ts-jest": "^29.1.2",
 				"typescript": "^5.3.3"
@@ -1605,9 +1605,9 @@
 			}
 		},
 		"node_modules/@types/jest": {
-			"version": "29.5.11",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
-			"integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
+			"version": "29.5.12",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+			"integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
 			"dev": true,
 			"dependencies": {
 				"expect": "^29.0.0",
@@ -1626,9 +1626,9 @@
 			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
 		},
 		"node_modules/@types/node": {
-			"version": "20.11.15",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.15.tgz",
-			"integrity": "sha512-gscmuADZfvNULx1eyirVbr3kVOVZtpQtzKMCZpeSZcN6MfbkRXAR4s9/gsQ4CzxLHw6EStDtKLNtSDL3vbq05A==",
+			"version": "20.11.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
+			"integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
 			"dev": true,
 			"dependencies": {
 				"undici-types": "~5.26.4"
@@ -4731,9 +4731,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-11.2.0.tgz",
-			"integrity": "sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-12.0.0.tgz",
+			"integrity": "sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==",
 			"dev": true,
 			"bin": {
 				"marked": "bin/marked.js"
@@ -5248,9 +5248,9 @@
 			}
 		},
 		"node_modules/prettier": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-			"integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+			"integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
 			"dev": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
@@ -7493,9 +7493,9 @@
 			}
 		},
 		"@types/jest": {
-			"version": "29.5.11",
-			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.11.tgz",
-			"integrity": "sha512-S2mHmYIVe13vrm6q4kN6fLYYAka15ALQki/vgDC3mIukEOx8WJlv0kQPM+d4w8Gp6u0uSdKND04IlTXBv0rwnQ==",
+			"version": "29.5.12",
+			"resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+			"integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
 			"dev": true,
 			"requires": {
 				"expect": "^29.0.0",
@@ -7514,9 +7514,9 @@
 			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
 		},
 		"@types/node": {
-			"version": "20.11.15",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.15.tgz",
-			"integrity": "sha512-gscmuADZfvNULx1eyirVbr3kVOVZtpQtzKMCZpeSZcN6MfbkRXAR4s9/gsQ4CzxLHw6EStDtKLNtSDL3vbq05A==",
+			"version": "20.11.16",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.16.tgz",
+			"integrity": "sha512-gKb0enTmRCzXSSUJDq6/sPcqrfCv2mkkG6Jt/clpn5eiCbKTY+SgZUxo+p8ZKMof5dCp9vHQUAB7wOUTod22wQ==",
 			"dev": true,
 			"requires": {
 				"undici-types": "~5.26.4"
@@ -9688,9 +9688,9 @@
 			}
 		},
 		"marked": {
-			"version": "11.2.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-11.2.0.tgz",
-			"integrity": "sha512-HR0m3bvu0jAPYiIvLUUQtdg1g6D247//lvcekpHO1WMvbwDlwSkZAX9Lw4F4YHE1T0HaaNve0tuAWuV1UJ6vtw==",
+			"version": "12.0.0",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-12.0.0.tgz",
+			"integrity": "sha512-Vkwtq9rLqXryZnWaQc86+FHLC6tr/fycMfYAhiOIXkrNmeGAyhSxjqu0Rs1i0bBqw5u0S7+lV9fdH2ZSVaoa0w==",
 			"dev": true
 		},
 		"meow": {
@@ -10044,9 +10044,9 @@
 			"dev": true
 		},
 		"prettier": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.4.tgz",
-			"integrity": "sha512-FWu1oLHKCrtpO1ypU6J0SbK2d9Ckwysq6bHj/uaCP26DxrPpppCLQRGVuqAxSTvhF00AcvDRyYrLNW7ocBhFFQ==",
+			"version": "3.2.5",
+			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
+			"integrity": "sha512-3/GWa9aOC0YeD7LUfvOG2NiDyhOWRvt1k+rcKhOuYnMY24iiCphgneUfJDyFXd6rZCAnuLBv6UeAULtrhT/F4A==",
 			"dev": true
 		},
 		"prettier-linter-helpers": {

--- a/package.json
+++ b/package.json
@@ -110,8 +110,8 @@
 	"devDependencies": {
 		"@octokit/rest": "^20.0.2",
 		"@types/debug": "^4.1.12",
-		"@types/jest": "^29.5.11",
-		"@types/node": "^20.11.15",
+		"@types/jest": "^29.5.12",
+		"@types/node": "^20.11.16",
 		"@typescript-eslint/eslint-plugin": "^6.20.0",
 		"@typescript-eslint/parser": "^6.20.0",
 		"eslint": "^8.56.0",
@@ -119,10 +119,10 @@
 		"eslint-plugin-jest": "^27.6.3",
 		"eslint-plugin-prettier": "^5.1.3",
 		"jest": "^29.7.0",
-		"marked": "^11.2.0",
+		"marked": "^12.0.0",
 		"open-cli": "^8.0.0",
 		"pick-port": "^2.0.1",
-		"prettier": "^3.2.4",
+		"prettier": "^3.2.5",
 		"sctp": "^1.0.0",
 		"ts-jest": "^29.1.2",
 		"typescript": "^5.3.3"

--- a/package.json
+++ b/package.json
@@ -69,8 +69,7 @@
 		"test:worker": "node npm-scripts.mjs test:worker",
 		"coverage:node": "node npm-scripts.mjs coverage:node",
 		"release:check": "node npm-scripts.mjs release:check",
-		"release": "node npm-scripts.mjs release",
-		"release:upload-mac-arm-prebuilt-worker": "node npm-scripts.mjs release:upload-mac-arm-prebuilt-worker"
+		"release": "node npm-scripts.mjs release"
 	},
 	"jest": {
 		"verbose": true,


### PR DESCRIPTION
As per GH announcement: https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/

Also remove the NPM 'release:upload-mac-arm-prebuilt-worker' since it's no longer needed.