### PR TITLE
[Node] Fix router.createWebRtcTransport() with listenIps

### DIFF
--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -507,13 +507,13 @@ export class Router<
 
 			const orderedProtocols: TransportProtocol[] = [];
 
-			if (enableUdp && (!enableTcp || preferUdp)) {
+			if (enableUdp && (preferUdp || !enableTcp || !preferTcp)) {
 				orderedProtocols.push('udp');
 
 				if (enableTcp) {
 					orderedProtocols.push('tcp');
 				}
-			} else if (enableTcp && (!enableUdp || (preferTcp && !preferUdp))) {
+			} else if (enableTcp && ((preferTcp && !preferUdp) || !enableUdp)) {
 				orderedProtocols.push('tcp');
 
 				if (enableUdp) {

--- a/node/src/test/test-WebRtcTransport.ts
+++ b/node/src/test/test-WebRtcTransport.ts
@@ -172,6 +172,31 @@ test('router.createWebRtcTransport() succeeds', async () => {
 	expect(webRtcTransport.closed).toBe(true);
 }, 2000);
 
+test('router.createWebRtcTransport() with deprecated listenIps succeeds', async () => {
+	const webRtcTransport = await ctx.router!.createWebRtcTransport({
+		listenIps: [{ ip: '127.0.0.1', announcedIp: undefined }],
+		enableUdp: true,
+		enableTcp: true,
+		preferUdp: false,
+		initialAvailableOutgoingBitrate: 1000000,
+	});
+
+	expect(Array.isArray(webRtcTransport.iceCandidates)).toBe(true);
+	expect(webRtcTransport.iceCandidates.length).toBe(2);
+
+	const iceCandidates = webRtcTransport.iceCandidates;
+
+	expect(iceCandidates[0].ip).toBe('127.0.0.1');
+	expect(iceCandidates[0].protocol).toBe('udp');
+	expect(iceCandidates[0].type).toBe('host');
+	expect(iceCandidates[0].tcpType).toBeUndefined();
+	expect(iceCandidates[1].ip).toBe('127.0.0.1');
+	expect(iceCandidates[1].protocol).toBe('tcp');
+	expect(iceCandidates[1].type).toBe('host');
+	expect(iceCandidates[1].tcpType).toBe('passive');
+	expect(iceCandidates[0].priority).toBeGreaterThan(iceCandidates[1].priority);
+}, 2000);
+
 test('router.createWebRtcTransport() with wrong arguments rejects with TypeError', async () => {
 	// @ts-ignore
 	await expect(ctx.router!.createWebRtcTransport({})).rejects.toThrow(


### PR DESCRIPTION
- Fix a regression that produces empty candidates if `preferUdp === false` when using deprecated `listenIps` in `router.createWebRtcTransport()` instead of the new `listenInfos` since version 3.13.0.
- Reported in https://mediasoup.discourse.group/t/produce-failed-after-upgrading-from-3-12-x-to-3-13-x/5838