### PR TITLE
CI: add mediasoup-worker-fuzzer.yaml

### DIFF
--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -1,0 +1,40 @@
+name: mediasoup-worker-fuzzer
+
+on: [pull_request, workflow_dispatch]
+
+concurrency:
+  # Cancel a currently running workflow from the same PR, branch or tag when a
+  # new workflow is triggered.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    strategy:
+      matrix:
+        build:
+          - os: ubuntu-22.04
+            cc: clang
+            cxx: clang++
+
+    runs-on: ${{ matrix.build.os }}
+
+    env:
+      CC: ${{ matrix.build.cc }}
+      CXX: ${{ matrix.build.cxx }}
+      MEDIASOUP_SKIP_WORKER_PREBUILT_DOWNLOAD: 'true'
+      MEDIASOUP_LOCAL_DEV: 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # We need to install pip invoke manually.
+      - name: pip3 install invoke
+        run: pip3 install invoke
+
+      # Build the mediasoup-worker-fuzzer binary (which uses libFuzzer).
+      - name: invoke -r worker fuzzer
+        run: invoke -r worker fuzzer
+
+      # We don't run mediasoup-worker-fuzzer (maybe in the future).


### PR DESCRIPTION
### Details

- Goal is to build `mediasoup-worker-fuzzer` binary in Linux + clang.
- This should prevent C++ issues in `mediasoup/worker/fuzzer` when some C++ code is changed in `worker/src`. 
- This PR does **NOT** run `mediasoup-worker-fuzzer` since it would run forever and we need some code to make it run for some time and terminate it. This maybe a future work.