### PR TITLE
Fix regression (crash) in transport-cc feedback generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Next
+
+- Fix regression (crash) in transport-cc feedback generation ([PR #1339](https://github.com/versatica/mediasoup/pull/1339)).
+
 ### 3.13.19
 
 - Node: Fix `router.createWebRtcTransport()` with `listenIps` ([PR #1330](https://github.com/versatica/mediasoup/pull/1330)).

--- a/worker/include/RTC/RTCP/FeedbackRtpTransport.hpp
+++ b/worker/include/RTC/RTCP/FeedbackRtpTransport.hpp
@@ -212,6 +212,10 @@ namespace RTC
 			~FeedbackRtpTransportPacket() override;
 
 		public:
+			bool IsBaseSet() const
+			{
+				return this->baseSet;
+			}
 			void SetBase(uint16_t sequenceNumber, uint64_t timestamp);
 			AddPacketResult AddPacket(uint16_t sequenceNumber, uint64_t timestamp, size_t maxRtcpPacketLen);
 			// Just for locally generated packets.

--- a/worker/include/RTC/TransportCongestionControlServer.hpp
+++ b/worker/include/RTC/TransportCongestionControlServer.hpp
@@ -63,6 +63,7 @@ namespace RTC
 		void MayDropOldPacketArrivalTimes(uint16_t seqNum, uint64_t nowMs);
 		void MaySendLimitationRembFeedback(uint64_t nowMs);
 		void UpdatePacketLoss(double packetLoss);
+		void ResetTransportCcFeedback(uint8_t feedbackPacketCount);
 
 		/* Pure virtual methods inherited from webrtc::RemoteBitrateEstimator::Listener. */
 	public:

--- a/worker/include/RTC/TransportCongestionControlServer.hpp
+++ b/worker/include/RTC/TransportCongestionControlServer.hpp
@@ -58,7 +58,8 @@ namespace RTC
 		void FillAndSendTransportCcFeedback();
 
 	private:
-		void SendTransportCcFeedback();
+		// Returns true if a feedback packet was sent.
+		bool SendTransportCcFeedback();
 		void MayDropOldPacketArrivalTimes(uint16_t seqNum, uint64_t nowMs);
 		void MaySendLimitationRembFeedback(uint64_t nowMs);
 		void UpdatePacketLoss(double packetLoss);

--- a/worker/include/RTC/TransportCongestionControlServer.hpp
+++ b/worker/include/RTC/TransportCongestionControlServer.hpp
@@ -95,6 +95,7 @@ namespace RTC
 		// Whether any packet with transport wide sequence number was received.
 		bool transportWideSeqNumberReceived{ false };
 		uint16_t transportCcFeedbackWideSeqNumStart{ 0u };
+		// Map of arrival timestamp (ms) indexed by wide seq number.
 		std::map<uint16_t, uint64_t, RTC::SeqManager<uint16_t>::SeqLowerThan> mapPacketArrivalTimes;
 	};
 } // namespace RTC

--- a/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
+++ b/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
@@ -299,8 +299,8 @@ namespace RTC
 			MS_ASSERT(this->baseSet, "base not set");
 			MS_ASSERT(!IsFull(), "packet is full");
 
-			// If the wide sequence number of the new packet is lower than the latest seen,
-			// ignore it.
+			// If the wide sequence number of the new packet is lower than the latest
+			// seen, ignore it.
 			// NOTE: Not very spec compliant but libwebrtc does it.
 			// Also ignore if the sequence number matches the latest seen.
 			if (!RTC::SeqManager<uint16_t>::IsSeqHigherThan(sequenceNumber, this->latestSequenceNumber))
@@ -342,7 +342,8 @@ namespace RTC
 			// Delta in 16 bits signed.
 			auto delta = static_cast<int16_t>(delta64);
 
-			// Check whether another chunks and corresponding delta infos could be added.
+			// Check whether another chunks and corresponding delta infos could be
+			// added.
 			{
 				// Fixed packet size.
 				size_t size = FeedbackRtpPacket::GetSize();

--- a/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
+++ b/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
@@ -282,6 +282,8 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			MS_ASSERT(!this->baseSet, "base already set");
+
 			this->baseSet              = true;
 			this->baseSequenceNumber   = sequenceNumber;
 			this->referenceTime        = static_cast<int32_t>((timestamp & 0x1FFFFFC0) / 64);


### PR DESCRIPTION
- Fixes #1336

### Details

- Regression introduced in PR #1088, which has many issues.
- Basically there are cases in which `this->transportCcFeedbackPacket` is reset so it's a complete new packet and hence its `baseSet` is `false`.
- However in `TransportCongestionControlServer::FillAndSendTransportCcFeedback()` in which we just call `this->transportCcFeedbackPacket.SetBase()` once at the top, but then we enter a loop in which the packet maybe full so it's sent (or other things) and hence we **reset** the packet while in the loop. And then at the top of the loop `this->transportCcFeedbackPacket.AddPacket()` is called so the assertion fails because its `SetBase()` was not called on that fresh packet.
- So this PR calls `SetBase()` conditionally in every iteration of the loop by checking if current feedback has the base set or not.
- Also add a missing `break` in a `case` block in that loop.
- Also set proper packet count in all cases in which we reset `this->transportCcFeedbackPacket`.
- Fix crash scenario in which feedback-cc packet is full but cannot be sent: https://github.com/versatica/mediasoup/pull/1339/commits/b8a411b1d2b200040f053a1a79649b96f68d2085

