### PR TITLE
Fix missing bitrateByLayer field in stats of RtpRecvStream in Node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### Next
+
+- Node: Fix missing `bitrateByLayer` field in stats of `RtpRecvStream` in Node ([PR #1349](https://github.com/versatica/mediasoup/pull/1349)).
+
 ### 3.13.23
 
 - Fix DTLS packets do not honor configured DTLS MTU (attempt 3) ([PR #1345](https://github.com/versatica/mediasoup/pull/1345)).

--- a/node/src/RtpStream.ts
+++ b/node/src/RtpStream.ts
@@ -1,13 +1,15 @@
 import * as FbsRtpStream from './fbs/rtp-stream';
 import * as FbsRtpParameters from './fbs/rtp-parameters';
 
+type BitrateByLayer = { [key: string]: number };
+
 export type RtpStreamRecvStats = BaseRtpStreamStats & {
 	type: string;
 	jitter: number;
 	packetCount: number;
 	byteCount: number;
 	bitrate: number;
-	bitrateByLayer?: any;
+	bitrateByLayer: BitrateByLayer;
 };
 
 export type RtpStreamSendStats = BaseRtpStreamStats & {
@@ -118,7 +120,7 @@ function parseBaseStreamStats(
 	};
 }
 
-function parseBitrateByLayer(binary: FbsRtpStream.RecvStats): any {
+function parseBitrateByLayer(binary: FbsRtpStream.RecvStats): BitrateByLayer {
 	if (binary.bitrateByLayerLength() === 0) {
 		return {};
 	}
@@ -131,4 +133,6 @@ function parseBitrateByLayer(binary: FbsRtpStream.RecvStats): any {
 
 		bitRateByLayer[layer] = Number(bitrate);
 	}
+
+	return bitRateByLayer;
 }


### PR DESCRIPTION
### Details

Ok, some `any` as return type in a function and the author forgot to return something :)

![CleanShot-2024-03-01-at-11 26 31@2x](https://github.com/versatica/mediasoup/assets/16191/505c34fe-4c80-4962-bde0-30e79e8d1287)
