### PR TITLE
Test usrsctp with usrsctp_get_timeout()

### DIFF
--- a/worker/include/DepUsrSCTP.hpp
+++ b/worker/include/DepUsrSCTP.hpp
@@ -18,6 +18,7 @@ private:
 	public:
 		void Start();
 		void Stop();
+		void HandleUsrSctpTimers();
 
 		/* Pure virtual methods inherited from TimerHandle::Listener. */
 	public:
@@ -37,6 +38,7 @@ public:
 	static void RegisterSctpAssociation(RTC::SctpAssociation* sctpAssociation);
 	static void DeregisterSctpAssociation(RTC::SctpAssociation* sctpAssociation);
 	static RTC::SctpAssociation* RetrieveSctpAssociation(uintptr_t id);
+	static void HandleUsrSctpTimers();
 
 private:
 	thread_local static Checker* checker;

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -390,6 +390,10 @@ namespace RTC
 #endif
 
 		usrsctp_conninput(reinterpret_cast<void*>(this->id), data, len, 0);
+
+		// TODO: IMHO it makes sense that we handle/refresh usrsctp timers when
+		// SCTP data is received.
+		DepUsrSCTP::HandleUsrSctpTimers();
 	}
 
 	void SctpAssociation::SendSctpMessage(

--- a/worker/subprojects/usrsctp.wrap
+++ b/worker/subprojects/usrsctp.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
-directory = usrsctp-ebb18adac6501bad4501b1f6dccb67a1c85cc299
-source_url = https://github.com/sctplab/usrsctp/archive/ebb18adac6501bad4501b1f6dccb67a1c85cc299.zip
-source_filename = ebb18adac6501bad4501b1f6dccb67a1c85cc299.zip
-source_hash = e77a855ce395b877e9f2aa7ebe070dfaf5cb11cfecdeb424cc876fc0d98e5d11
+directory = usrsctp-0.9.6.0
+source_url = https://github.com/versatica/usrsctp/archive/refs/tags/0.9.6.0.zip
+source_filename = usrsctp-0.9.6.0.zip
+source_hash = 13518f1912631c796da167ba3c3e4fd7f80886de4afa75abc6fcf843160b65f8
 
 [provide]
 usrsctp = usrsctp_dep


### PR DESCRIPTION
### Details

- Related task: https://github.com/versatica/mediasoup/issues/1011. Note that usrsctp author never cared about the existing PR so we are on our own.
- So I've forked usrctp, added the `usrsctp_get_timeout()` feature and released version 0.9.6.0: https://github.com/versatica/usrsctp/pull/1
- And I've made `usrsctp.wrap` point to it.

### Notes

- It would be great to have a way to pass `sctp_debug=true` when building usrsctp Meson subproject so it defines `SCTP_DEBUG` (needed in `DepUsrSCTP.cpp` to show SCTP debug). An manual alternative is to edit `meson.build` of usrsctp and add it unconditionally.
- I'm calling `HandleUsrSctpTimers()` everytime the timer fires (of course), also in `onSendSctpData` callback and also when SCTP data is received (in `SctpAssociation::ProcessSctpData()`. Not sure if correct.
- Extra `MS_DUMP()` added for debugging. Must be removed.
- This PR should not be merged until super tested and NOT before this issue is solved: https://github.com/versatica/mediasoup/issues/1352
- Most consider this: https://github.com/versatica/mediasoup/pull/1353#issuecomment-1983808781