### PR TITLE
Fix: modify comments about packet loss rate calculation

### DIFF
--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -241,7 +241,7 @@ namespace RTC
 
 	void TransportCongestionControlClient::UpdatePacketLoss(double packetLoss)
 	{
-		// Add the score into the histogram.
+		// Add the lost into the histogram.
 		if (this->packetLossHistory.size() == PacketLossHistogramLength)
 		{
 			this->packetLossHistory.pop_front();

--- a/worker/src/RTC/TransportCongestionControlServer.cpp
+++ b/worker/src/RTC/TransportCongestionControlServer.cpp
@@ -397,7 +397,7 @@ namespace RTC
 
 	void TransportCongestionControlServer::UpdatePacketLoss(double packetLoss)
 	{
-		// Add the score into the histogram.
+		// Add the lost into the histogram.
 		if (this->packetLossHistory.size() == PacketLossHistogramLength)
 		{
 			this->packetLossHistory.pop_front();


### PR DESCRIPTION
There are two errors in the comment on the calculation of packet loss rate for rtcp packet.