### PR TITLE
add arm64 prebuilt workers for linux

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -19,6 +19,15 @@ jobs:
             node: 18
           - os: ubuntu-22.04
             node: 20
+          - os: ubuntu-20.04
+            node: 16
+            arch: arm64
+          - os: ubuntu-20.04
+            node: 18
+            arch: arm64
+          - os: ubuntu-22.04
+            node: 20
+            arch: arm64
           - os: macos-12
             node: 18
           - os: macos-14

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -15,14 +15,19 @@ jobs:
   ci:
     strategy:
       matrix:
-        os:
-          - ubuntu-20.04
-          - ubuntu-22.04
-          - macos-12
-          - macos-14
-          - windows-2022
+        ci:
+          - os: ubuntu-20.04
+          - os: ubuntu-22.04
+          - os: ubuntu-20.04
+            arch: arm64
+          - os: ubuntu-22.04
+            arch: arm64
+          - os: macos-12
+          - os: macos-14
+          - os: windows-2022
 
-    runs-on: ${{ matrix.os }}
+
+    runs-on: ${{ matrix.ci.os }}
 
     env:
       KEEP_BUILD_ARTIFACTS: '1'
@@ -37,7 +42,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ matrix.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ matrix.ci.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: cargo fmt
         run: cargo fmt --all -- --check

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -26,7 +26,6 @@ jobs:
           - os: macos-14
           - os: windows-2022
 
-
     runs-on: ${{ matrix.ci.os }}
 
     env:

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -21,7 +21,6 @@ jobs:
             cxx: clang++
             arch: arm64
 
-
     runs-on: ${{ matrix.build.os }}
 
     env:

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -16,6 +16,11 @@ jobs:
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
+          - os: ubuntu-22.04
+            cc: clang
+            cxx: clang++
+            arch: arm64
+
 
     runs-on: ${{ matrix.build.os }}
 

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -22,6 +22,16 @@ jobs:
           - os: ubuntu-22.04
             cc: gcc
             cxx: g++
+          # Worker prebuild for Linux on arm64.
+          - os: ubuntu-20.04
+            cc: gcc
+            cxx: g++
+            arch: arm64
+          # Worker prebuild for Linux on arm64.
+          - os: ubuntu-22.04
+            cc: gcc
+            cxx: g++
+            arch: arm64
           - os: macos-12
             cc: clang
             cxx: clang++

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -25,6 +25,22 @@ jobs:
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
+          - os: ubuntu-20.04
+            cc: gcc
+            cxx: g++
+            arch: arm64
+          - os: ubuntu-20.04
+            cc: clang
+            cxx: clang++
+            arch: arm64
+          - os: ubuntu-22.04
+            cc: gcc
+            cxx: g++
+            arch: arm64
+          - os: ubuntu-22.04
+            cc: clang
+            cxx: clang++
+            arch: arm64
           - os: macos-12
             cc: gcc
             cxx: g++


### PR DESCRIPTION
Updates GH action to also build pre-built workers for linux instances running on arm64/aarch64