### PR TITLE
Add a test to check issue #1366 and use Debug mode

### DIFF
--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -101,8 +101,11 @@ jobs:
         # TODO: Maybe fix this one day.
         if: runner.os != 'Windows'
 
-      - name: invoke -r worker mediasoup-worker
-        run: invoke -r worker mediasoup-worker
+      # - name: invoke -r worker mediasoup-worker
+      #   run: invoke -r worker mediasoup-worker
+
+      - name: MEDIASOUP_BUILDTYPE=Debug invoke -r worker mediasoup-worker
+        run: MEDIASOUP_BUILDTYPE=Debug invoke -r worker mediasoup-worker
 
       # - name: invoke -r worker test
       #   run: invoke -r worker test

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   ci:
     strategy:
+      fail-fast: false
       matrix:
         build:
           - os: ubuntu-20.04

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -104,10 +104,10 @@ jobs:
       - name: invoke -r worker mediasoup-worker
         run: invoke -r worker mediasoup-worker
 
-      - name: invoke -r worker test
-        run: invoke -r worker test
-        # TODO: Maybe fix this one day.
-        if: runner.os != 'Windows'
+      # - name: invoke -r worker test
+      #   run: invoke -r worker test
+      #   # TODO: Maybe fix this one day.
+      #   if: runner.os != 'Windows'
 
       - name: MEDIASOUP_BUILDTYPE=Debug invoke -r worker test
         run: MEDIASOUP_BUILDTYPE=Debug invoke -r worker test

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -108,3 +108,8 @@ jobs:
         run: invoke -r worker test
         # TODO: Maybe fix this one day.
         if: runner.os != 'Windows'
+
+      - name: MEDIASOUP_BUILDTYPE=Debug invoke -r worker test
+        run: MEDIASOUP_BUILDTYPE=Debug invoke -r worker test
+        # TODO: Maybe fix this one day.
+        if: runner.os != 'Windows'

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -61,6 +61,7 @@ jobs:
       CXX: ${{ matrix.build.cxx }}
       MEDIASOUP_SKIP_WORKER_PREBUILT_DOWNLOAD: 'true'
       MEDIASOUP_LOCAL_DEV: 'true'
+      MEDIASOUP_BUILDTYPE: 'Debug'
 
     steps:
       - name: Checkout
@@ -101,18 +102,10 @@ jobs:
         # TODO: Maybe fix this one day.
         if: runner.os != 'Windows'
 
-      # - name: invoke -r worker mediasoup-worker
-      #   run: invoke -r worker mediasoup-worker
+      - name: invoke -r worker mediasoup-worker
+        run: invoke -r worker mediasoup-worker
 
-      - name: MEDIASOUP_BUILDTYPE=Debug invoke -r worker mediasoup-worker
-        run: MEDIASOUP_BUILDTYPE=Debug invoke -r worker mediasoup-worker
-
-      # - name: invoke -r worker test
-      #   run: invoke -r worker test
-      #   # TODO: Maybe fix this one day.
-      #   if: runner.os != 'Windows'
-
-      - name: MEDIASOUP_BUILDTYPE=Debug invoke -r worker test
-        run: MEDIASOUP_BUILDTYPE=Debug invoke -r worker test
+      - name: invoke -r worker test
+        run: invoke -r worker test
         # TODO: Maybe fix this one day.
         if: runner.os != 'Windows'

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -159,16 +159,16 @@ SCENARIO("ISSUE 1366: https://github.com/versatica/mediasoup/issues/1366")
 		REQUIRE(recoveredList.size() == 3);
 	}
 
-	SECTION("absl::btree_set")
-	{
-		absl::btree_set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;
+	// SECTION("absl::btree_set")
+	// {
+	// 	absl::btree_set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;
 
-		recoveredList.insert(10000);
-		recoveredList.insert(40000);
-		recoveredList.insert(60000);
+	// 	recoveredList.insert(10000);
+	// 	recoveredList.insert(40000);
+	// 	recoveredList.insert(60000);
 
-		REQUIRE(recoveredList.size() == 3);
-	}
+	// 	REQUIRE(recoveredList.size() == 3);
+	// }
 }
 
 SCENARIO("NACK generator", "[rtp][rtcp]")

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -148,20 +148,9 @@ SCENARIO("ISSUE 1366: https://github.com/versatica/mediasoup/issues/1366")
 		REQUIRE(RTC::SeqManager<uint16_t>::IsSeqLowerThan(10000, 60000) == false);
 	}
 
-	SECTION("std::set")
-	{
-		std::set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;
-
-		recoveredList.insert(10000);
-		recoveredList.insert(40000);
-		recoveredList.insert(60000);
-
-		REQUIRE(recoveredList.size() == 3);
-	}
-
-	// SECTION("absl::btree_set")
+	// SECTION("std::set")
 	// {
-	// 	absl::btree_set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;
+	// 	std::set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;
 
 	// 	recoveredList.insert(10000);
 	// 	recoveredList.insert(40000);
@@ -169,6 +158,17 @@ SCENARIO("ISSUE 1366: https://github.com/versatica/mediasoup/issues/1366")
 
 	// 	REQUIRE(recoveredList.size() == 3);
 	// }
+
+	SECTION("absl::btree_set")
+	{
+		absl::btree_set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;
+
+		recoveredList.insert(10000);
+		recoveredList.insert(40000);
+		recoveredList.insert(60000);
+
+		REQUIRE(recoveredList.size() == 3);
+	}
 }
 
 SCENARIO("NACK generator", "[rtp][rtcp]")

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -141,7 +141,7 @@ void validate(std::vector<TestNackGeneratorInput>& inputs)
 
 SCENARIO("ISSUE 1366: https://github.com/versatica/mediasoup/issues/1366")
 {
-	SECTION("absl::btree_set")
+	SECTION("foo")
 	{
 		REQUIRE(RTC::SeqManager<uint16_t>::IsSeqLowerThan(10000, 40000) == true);
 		REQUIRE(RTC::SeqManager<uint16_t>::IsSeqLowerThan(40000, 60000) == true);
@@ -159,16 +159,16 @@ SCENARIO("ISSUE 1366: https://github.com/versatica/mediasoup/issues/1366")
 		REQUIRE(recoveredList.size() == 3);
 	}
 
-	// SECTION("absl::btree_set")
-	// {
-	// 	absl::btree_set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;
+	SECTION("absl::btree_set")
+	{
+		absl::btree_set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;
 
-	// 	recoveredList.insert(10000);
-	// 	recoveredList.insert(40000);
-	// 	recoveredList.insert(60000);
+		recoveredList.insert(10000);
+		recoveredList.insert(40000);
+		recoveredList.insert(60000);
 
-	// 	REQUIRE(recoveredList.size() == 3);
-	// }
+		REQUIRE(recoveredList.size() == 3);
+	}
 }
 
 SCENARIO("NACK generator", "[rtp][rtcp]")

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -139,6 +139,38 @@ void validate(std::vector<TestNackGeneratorInput>& inputs)
 	}
 };
 
+SCENARIO("ISSUE 1366: https://github.com/versatica/mediasoup/issues/1366")
+{
+	SECTION("absl::btree_set")
+	{
+		REQUIRE(RTC::SeqManager<uint16_t>::IsSeqLowerThan(10000, 40000) == true);
+		REQUIRE(RTC::SeqManager<uint16_t>::IsSeqLowerThan(40000, 60000) == true);
+		REQUIRE(RTC::SeqManager<uint16_t>::IsSeqLowerThan(10000, 60000) == false);
+	}
+
+	SECTION("std::set")
+	{
+		std::set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;
+
+		recoveredList.insert(10000);
+		recoveredList.insert(40000);
+		recoveredList.insert(60000);
+
+		REQUIRE(recoveredList.size() == 3);
+	}
+
+	// SECTION("absl::btree_set")
+	// {
+	// 	absl::btree_set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;
+
+	// 	recoveredList.insert(10000);
+	// 	recoveredList.insert(40000);
+	// 	recoveredList.insert(60000);
+
+	// 	REQUIRE(recoveredList.size() == 3);
+	// }
+}
+
 SCENARIO("NACK generator", "[rtp][rtcp]")
 {
 	SECTION("no NACKs required")


### PR DESCRIPTION
Temporal PR just to test https://github.com/versatica/mediasoup/issues/1366 in different machines.

CC @jmillan @shaymagsumov

### Results using `absl::btree_set`

```c++
SECTION("absl::btree_set")
{
	absl::btree_set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;

	recoveredList.insert(10000);
	recoveredList.insert(40000);
	recoveredList.insert(60000);

	REQUIRE(recoveredList.size() == 3);
}
```

Here we can see that, when compiled in debug mode, `mediasoup-worker` CI fail in all OS and archs and compilers (in all but Windows) due to the transitivity violation, i.e. `comp(a,b) && comp(b,c) -> comp(a,c)`.

All CI fail: https://github.com/versatica/mediasoup/actions/runs/8612477995/


### Results using `std::set`

```c++
SECTION("std::set")
{
	std::set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> recoveredList;

	recoveredList.insert(10000);
	recoveredList.insert(40000);
	recoveredList.insert(60000);

	REQUIRE(recoveredList.size() == 3);
}
```

Despite C++ containers are supposed to also require transitivity (https://en.cppreference.com/w/cpp/container/set, https://en.cppreference.com/w/cpp/named_req/Compare), the same transitivity violation doesn't affect standard C++ STD containers when compiled in debug mode. Why? No idea, but it doesn't fail in any OS/arch/compiler.

All CI passes: https://github.com/versatica/mediasoup/actions/runs/8612301409/


### Conclusion

- Ok, we use abseil containers to gain more performance.
- But they are hell.
- We **SHOULD** be able to run mediasoup-worker in debug mode without crashes. Otherwise, what do we want the debug mode for? To detect problems? How are we gonna detect problems if we are literally introducing problems when we run mediasoup-worker in debug mode due to the required transitivity in abseil containers? It doesn't make any sense.
- So IMHO we **MUST NOT** use abseil conatiners with compare functions that do not honor the transitivity requirement,  and this is the task that must be done.