### PR TITLE
[Node] Bring transport rtpPacketLossReceived and rtpPacketLossSent stats back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### NEXT
+
+- Node: Bring transport `rtpPacketLossReceived` and `rtpPacketLossSent` stats back ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 3.14.0
 
 - `TransportListenInfo`: Add `portRange` (deprecate worker port range) ([PR #1365](https://github.com/versatica/mediasoup/pull/1365)).

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -285,6 +285,10 @@ export type BaseTransportStats = {
 	availableOutgoingBitrate?: number;
 	availableIncomingBitrate?: number;
 	maxIncomingBitrate?: number;
+	maxOutgoingBitrate?: number;
+	minOutgoingBitrate?: number;
+	rtpPacketLossReceived: number;
+	rtpPacketLossSent: number;
 };
 
 type TransportData =
@@ -1480,6 +1484,14 @@ export function parseBaseTransportStats(
 		maxIncomingBitrate: binary.maxIncomingBitrate()
 			? Number(binary.maxIncomingBitrate())
 			: undefined,
+		maxOutgoingBitrate: binary.maxOutgoingBitrate()
+			? Number(binary.maxOutgoingBitrate())
+			: undefined,
+		minOutgoingBitrate: binary.minOutgoingBitrate()
+			? Number(binary.minOutgoingBitrate())
+			: undefined,
+		rtpPacketLossReceived: Number(binary.rtpPacketLossReceived()),
+		rtpPacketLossSent: Number(binary.rtpPacketLossSent()),
 	};
 }
 

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -287,8 +287,8 @@ export type BaseTransportStats = {
 	maxIncomingBitrate?: number;
 	maxOutgoingBitrate?: number;
 	minOutgoingBitrate?: number;
-	rtpPacketLossReceived: number;
-	rtpPacketLossSent: number;
+	rtpPacketLossReceived?: number;
+	rtpPacketLossSent?: number;
 };
 
 type TransportData =
@@ -1479,19 +1479,34 @@ export function parseBaseTransportStats(
 		rtxSendBitrate: Number(binary.rtxSendBitrate()),
 		probationBytesSent: Number(binary.probationBytesSent()),
 		probationSendBitrate: Number(binary.probationSendBitrate()),
-		availableOutgoingBitrate: Number(binary.availableOutgoingBitrate()),
-		availableIncomingBitrate: Number(binary.availableIncomingBitrate()),
-		maxIncomingBitrate: binary.maxIncomingBitrate()
-			? Number(binary.maxIncomingBitrate())
-			: undefined,
-		maxOutgoingBitrate: binary.maxOutgoingBitrate()
-			? Number(binary.maxOutgoingBitrate())
-			: undefined,
-		minOutgoingBitrate: binary.minOutgoingBitrate()
-			? Number(binary.minOutgoingBitrate())
-			: undefined,
-		rtpPacketLossReceived: Number(binary.rtpPacketLossReceived()),
-		rtpPacketLossSent: Number(binary.rtpPacketLossSent()),
+		availableOutgoingBitrate:
+			typeof binary.availableOutgoingBitrate() === 'number'
+				? Number(binary.availableOutgoingBitrate())
+				: undefined,
+		availableIncomingBitrate:
+			typeof binary.availableIncomingBitrate() === 'number'
+				? Number(binary.availableIncomingBitrate())
+				: undefined,
+		maxIncomingBitrate:
+			typeof binary.maxIncomingBitrate() === 'number'
+				? Number(binary.maxIncomingBitrate())
+				: undefined,
+		maxOutgoingBitrate:
+			typeof binary.maxOutgoingBitrate() === 'number'
+				? Number(binary.maxOutgoingBitrate())
+				: undefined,
+		minOutgoingBitrate:
+			typeof binary.minOutgoingBitrate() === 'number'
+				? Number(binary.minOutgoingBitrate())
+				: undefined,
+		rtpPacketLossReceived:
+			typeof binary.rtpPacketLossReceived() === 'number'
+				? Number(binary.rtpPacketLossReceived())
+				: undefined,
+		rtpPacketLossSent:
+			typeof binary.rtpPacketLossSent() === 'number'
+				? Number(binary.rtpPacketLossSent())
+				: undefined,
 	};
 }
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -502,10 +502,10 @@ namespace RTC
 		  // minOutgoingBitrate.
 		  this->minOutgoingBitrate ? flatbuffers::Optional<uint32_t>(this->minOutgoingBitrate)
 		                           : flatbuffers::nullopt,
-		  // packetLossReceived.
+		  // rtpPacketLossReceived.
 		  this->tccServer ? flatbuffers::Optional<double>(this->tccServer->GetPacketLoss())
 		                  : flatbuffers::nullopt,
-		  // packetLossSent.
+		  // rtpPacketLossSent.
 		  this->tccClient ? flatbuffers::Optional<double>(this->tccClient->GetPacketLoss())
 		                  : flatbuffers::nullopt);
 	}


### PR DESCRIPTION
They were removed somehow during flatbufferts migration.

BTW those stats are custom ones that consist on a number (from 0 to 1) indicating the current "quality" of the RTP transmission based on packet loss / total packets.