### PR TITLE
CI: Disable machines with arch arm64

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -17,12 +17,12 @@ jobs:
             node: 18
           - os: ubuntu-22.04
             node: 20
-          - os: ubuntu-20.04
-            node: 18
-            arch: arm64
-          - os: ubuntu-22.04
-            node: 20
-            arch: arm64
+          # - os: ubuntu-20.04
+          #   node: 18
+          #   arch: arm64
+          # - os: ubuntu-22.04
+          #   node: 20
+          #   arch: arm64
           - os: macos-12
             node: 18
           - os: macos-14

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -17,14 +17,6 @@ jobs:
             node: 18
           - os: ubuntu-22.04
             node: 20
-          # NOTE: Disabled until CI arm64 runners are publicly available:
-          #   https://github.com/versatica/mediasoup/issues/1372
-          # - os: ubuntu-20.04
-          #   node: 18
-          #   arch: arm64
-          # - os: ubuntu-22.04
-          #   node: 20
-          #   arch: arm64
           - os: macos-12
             node: 18
           - os: macos-14

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -17,6 +17,8 @@ jobs:
             node: 18
           - os: ubuntu-22.04
             node: 20
+          # NOTE: Disabled until CI arm64 runners are publicly available:
+          #   https://github.com/versatica/mediasoup/issues/1372
           # - os: ubuntu-20.04
           #   node: 18
           #   arch: arm64

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -18,12 +18,6 @@ jobs:
         ci:
           - os: ubuntu-20.04
           - os: ubuntu-22.04
-          # NOTE: Disabled until CI arm64 runners are publicly available:
-          #   https://github.com/versatica/mediasoup/issues/1372
-          # - os: ubuntu-20.04
-          #   arch: arm64
-          # - os: ubuntu-22.04
-          #   arch: arm64
           - os: macos-12
           - os: macos-14
           - os: windows-2022

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -18,6 +18,8 @@ jobs:
         ci:
           - os: ubuntu-20.04
           - os: ubuntu-22.04
+          # NOTE: Disabled until CI arm64 runners are publicly available:
+          #   https://github.com/versatica/mediasoup/issues/1372
           # - os: ubuntu-20.04
           #   arch: arm64
           # - os: ubuntu-22.04

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -18,10 +18,10 @@ jobs:
         ci:
           - os: ubuntu-20.04
           - os: ubuntu-22.04
-          - os: ubuntu-20.04
-            arch: arm64
-          - os: ubuntu-22.04
-            arch: arm64
+          # - os: ubuntu-20.04
+          #   arch: arm64
+          # - os: ubuntu-22.04
+          #   arch: arm64
           - os: macos-12
           - os: macos-14
           - os: windows-2022

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -16,10 +16,10 @@ jobs:
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
-          - os: ubuntu-22.04
-            cc: clang
-            cxx: clang++
-            arch: arm64
+          # - os: ubuntu-22.04
+          #   cc: clang
+          #   cxx: clang++
+          #   arch: arm64
         build-type:
           - Release
           - Debug

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -16,12 +16,6 @@ jobs:
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
-          # NOTE: Disabled until CI arm64 runners are publicly available:
-          #   https://github.com/versatica/mediasoup/issues/1372
-          # - os: ubuntu-22.04
-          #   cc: clang
-          #   cxx: clang++
-          #   arch: arm64
         build-type:
           - Release
           - Debug

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -16,6 +16,8 @@ jobs:
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
+          # NOTE: Disabled until CI arm64 runners are publicly available:
+          #   https://github.com/versatica/mediasoup/issues/1372
           # - os: ubuntu-22.04
           #   cc: clang
           #   cxx: clang++

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -22,18 +22,6 @@ jobs:
           - os: ubuntu-22.04
             cc: gcc
             cxx: g++
-          # NOTE: Disabled until CI arm64 runners are publicly available:
-          #   https://github.com/versatica/mediasoup/issues/1372
-          # Worker prebuild for Linux on arm64.
-          # - os: ubuntu-20.04
-          #   cc: gcc
-          #   cxx: g++
-          #   arch: arm64
-          # Worker prebuild for Linux on arm64.
-          # - os: ubuntu-22.04
-          #   cc: gcc
-          #   cxx: g++
-          #   arch: arm64
           - os: macos-12
             cc: clang
             cxx: clang++

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -22,6 +22,8 @@ jobs:
           - os: ubuntu-22.04
             cc: gcc
             cxx: g++
+          # NOTE: Disabled until CI arm64 runners are publicly available:
+          #   https://github.com/versatica/mediasoup/issues/1372
           # Worker prebuild for Linux on arm64.
           # - os: ubuntu-20.04
           #   cc: gcc

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -23,15 +23,15 @@ jobs:
             cc: gcc
             cxx: g++
           # Worker prebuild for Linux on arm64.
-          - os: ubuntu-20.04
-            cc: gcc
-            cxx: g++
-            arch: arm64
+          # - os: ubuntu-20.04
+          #   cc: gcc
+          #   cxx: g++
+          #   arch: arm64
           # Worker prebuild for Linux on arm64.
-          - os: ubuntu-22.04
-            cc: gcc
-            cxx: g++
-            arch: arm64
+          # - os: ubuntu-22.04
+          #   cc: gcc
+          #   cxx: g++
+          #   arch: arm64
           - os: macos-12
             cc: clang
             cxx: clang++

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -25,6 +25,8 @@ jobs:
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
+          # NOTE: Disabled until CI arm64 runners are publicly available:
+          #   https://github.com/versatica/mediasoup/issues/1372
           # - os: ubuntu-20.04
           #   cc: gcc
           #   cxx: g++

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -25,24 +25,6 @@ jobs:
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
-          # NOTE: Disabled until CI arm64 runners are publicly available:
-          #   https://github.com/versatica/mediasoup/issues/1372
-          # - os: ubuntu-20.04
-          #   cc: gcc
-          #   cxx: g++
-          #   arch: arm64
-          # - os: ubuntu-20.04
-          #   cc: clang
-          #   cxx: clang++
-          #   arch: arm64
-          # - os: ubuntu-22.04
-          #   cc: gcc
-          #   cxx: g++
-          #   arch: arm64
-          # - os: ubuntu-22.04
-          #   cc: clang
-          #   cxx: clang++
-          #   arch: arm64
           - os: macos-12
             cc: gcc
             cxx: g++

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -25,22 +25,22 @@ jobs:
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
-          - os: ubuntu-20.04
-            cc: gcc
-            cxx: g++
-            arch: arm64
-          - os: ubuntu-20.04
-            cc: clang
-            cxx: clang++
-            arch: arm64
-          - os: ubuntu-22.04
-            cc: gcc
-            cxx: g++
-            arch: arm64
-          - os: ubuntu-22.04
-            cc: clang
-            cxx: clang++
-            arch: arm64
+          # - os: ubuntu-20.04
+          #   cc: gcc
+          #   cxx: g++
+          #   arch: arm64
+          # - os: ubuntu-20.04
+          #   cc: clang
+          #   cxx: clang++
+          #   arch: arm64
+          # - os: ubuntu-22.04
+          #   cc: gcc
+          #   cxx: g++
+          #   arch: arm64
+          # - os: ubuntu-22.04
+          #   cc: clang
+          #   cxx: clang++
+          #   arch: arm64
           - os: macos-12
             cc: gcc
             cxx: g++


### PR DESCRIPTION
- Fixes issue #1372
- As told here https://github.com/versatica/mediasoup/issues/1372#issuecomment-2045722727, it turns out GitHub arm64 runners are still in private beta: https://github.blog/changelog/2023-10-30-accelerate-your-ci-cd-with-arm-based-hosted-runners-in-github-actions/
- Let's remove them (to avoid running same CI actions basically twice) and will add them in the future when ARM64 support in CI is available and we know the syntax.