### PR TITLE
Node: add enhancedOnce() typed function

### DIFF
--- a/node/src/ActiveSpeakerObserver.ts
+++ b/node/src/ActiveSpeakerObserver.ts
@@ -1,5 +1,5 @@
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import {
 	RtpObserver,
 	RtpObserverEvents,

--- a/node/src/AudioLevelObserver.ts
+++ b/node/src/AudioLevelObserver.ts
@@ -1,5 +1,5 @@
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import {
 	RtpObserver,
 	RtpObserverEvents,

--- a/node/src/Channel.ts
+++ b/node/src/Channel.ts
@@ -3,7 +3,7 @@ import { Duplex } from 'node:stream';
 import { info, warn } from 'node:console';
 import * as flatbuffers from 'flatbuffers';
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import { InvalidStateError } from './errors';
 import { Body as RequestBody, Method, Request } from './fbs/request';
 import { Response } from './fbs/response';

--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -1,5 +1,5 @@
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import { Channel } from './Channel';
 import { TransportInternal } from './Transport';
 import { ProducerStat } from './Producer';

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -1,5 +1,5 @@
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import { Channel } from './Channel';
 import { TransportInternal } from './Transport';
 import {

--- a/node/src/DataProducer.ts
+++ b/node/src/DataProducer.ts
@@ -1,5 +1,5 @@
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import { Channel } from './Channel';
 import { TransportInternal } from './Transport';
 import {

--- a/node/src/Producer.ts
+++ b/node/src/Producer.ts
@@ -1,5 +1,5 @@
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import { Channel } from './Channel';
 import { TransportInternal } from './Transport';
 import { MediaKind, RtpParameters, parseRtpParameters } from './RtpParameters';

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -1,5 +1,5 @@
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import * as ortc from './ortc';
 import { InvalidStateError } from './errors';
 import { Channel } from './Channel';

--- a/node/src/RtpObserver.ts
+++ b/node/src/RtpObserver.ts
@@ -1,5 +1,5 @@
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import { Channel } from './Channel';
 import { RouterInternal } from './Router';
 import { Producer } from './Producer';

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -1,6 +1,6 @@
 import * as flatbuffers from 'flatbuffers';
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import * as ortc from './ortc';
 import { Channel } from './Channel';
 import { RouterInternal } from './Router';

--- a/node/src/WebRtcServer.ts
+++ b/node/src/WebRtcServer.ts
@@ -1,5 +1,5 @@
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import { Channel } from './Channel';
 import { TransportListenInfo } from './Transport';
 import { WebRtcTransport } from './WebRtcTransport';

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -3,7 +3,7 @@ import * as path from 'node:path';
 import { spawn, ChildProcess } from 'node:child_process';
 import { version } from './';
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import * as ortc from './ortc';
 import { Channel } from './Channel';
 import { Router, RouterOptions } from './Router';

--- a/node/src/enhancedEvents.ts
+++ b/node/src/enhancedEvents.ts
@@ -1,7 +1,7 @@
-import { EventEmitter } from 'node:events';
+import { EventEmitter, once } from 'node:events';
 import { Logger } from './Logger';
 
-const logger = new Logger('EnhancedEventEmitter');
+const enhancedEventEmitterLogger = new Logger('EnhancedEventEmitter');
 
 type Events = Record<string, any[]>;
 
@@ -24,7 +24,7 @@ export class EnhancedEventEmitter<
 		try {
 			return super.emit(eventName, ...args);
 		} catch (error) {
-			logger.error(
+			enhancedEventEmitterLogger.error(
 				'safeEmit() | event listener threw an error [eventName:%s]:%o',
 				eventName,
 				error
@@ -120,4 +120,21 @@ export class EnhancedEventEmitter<
 	rawListeners<K extends keyof E & string>(eventName: K): Function[] {
 		return super.rawListeners(eventName);
 	}
+}
+
+/**
+ * TypeScript version of events.once():
+ *   https://nodejs.org/api/events.html#eventsonceemitter-name-options
+ *
+ * Usage example:
+ * ```ts
+ * await enhancedOnce<ConsumerEvents>(videoConsumer, 'producerpause');
+ * ````
+ */
+export async function enhancedOnce<E extends Events = Events>(
+	emmiter: EnhancedEventEmitter<E>,
+	eventName: keyof E & string,
+	options?: any
+): Promise<any[]> {
+	return once(emmiter, eventName, options);
 }

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -1,5 +1,5 @@
 import { Logger } from './Logger';
-import { EnhancedEventEmitter } from './EnhancedEventEmitter';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import { workerBin, Worker, WorkerSettings } from './Worker';
 import * as utils from './utils';
 import { supportedRtpCapabilities } from './supportedRtpCapabilities';

--- a/node/src/test/test-ActiveSpeakerObserver.ts
+++ b/node/src/test/test-ActiveSpeakerObserver.ts
@@ -1,4 +1,6 @@
 import * as mediasoup from '../';
+import { enhancedOnce } from '../enhancedEvents';
+import { WorkerEvents, ActiveSpeakerObserverEvents } from '../types';
 import * as utils from '../utils';
 
 type TestContext = {
@@ -31,9 +33,7 @@ afterEach(async () => {
 	ctx.worker?.close();
 
 	if (ctx.worker?.subprocessClosed === false) {
-		await new Promise<void>(resolve =>
-			ctx.worker?.on('subprocessclose', resolve)
-		);
+		await enhancedOnce<WorkerEvents>(ctx.worker, 'subprocessclose');
 	}
 });
 
@@ -105,10 +105,13 @@ test('activeSpeakerObserver.close() succeeds', async () => {
 test('ActiveSpeakerObserver emits "routerclose" if Router is closed', async () => {
 	const activeSpeakerObserver = await ctx.router!.createAudioLevelObserver();
 
-	await new Promise<void>(resolve => {
-		activeSpeakerObserver.on('routerclose', resolve);
-		ctx.router!.close();
-	});
+	const promise = enhancedOnce<ActiveSpeakerObserverEvents>(
+		activeSpeakerObserver,
+		'routerclose'
+	);
+
+	ctx.router!.close();
+	await promise;
 
 	expect(activeSpeakerObserver.closed).toBe(true);
 }, 2000);
@@ -116,10 +119,13 @@ test('ActiveSpeakerObserver emits "routerclose" if Router is closed', async () =
 test('ActiveSpeakerObserver emits "routerclose" if Worker is closed', async () => {
 	const activeSpeakerObserver = await ctx.router!.createAudioLevelObserver();
 
-	await new Promise<void>(resolve => {
-		activeSpeakerObserver.on('routerclose', resolve);
-		ctx.worker!.close();
-	});
+	const promise = enhancedOnce<ActiveSpeakerObserverEvents>(
+		activeSpeakerObserver,
+		'routerclose'
+	);
+
+	ctx.worker!.close();
+	await promise;
 
 	expect(activeSpeakerObserver.closed).toBe(true);
 }, 2000);

--- a/node/src/test/test-AudioLevelObserver.ts
+++ b/node/src/test/test-AudioLevelObserver.ts
@@ -1,4 +1,6 @@
 import * as mediasoup from '../';
+import { enhancedOnce } from '../enhancedEvents';
+import { WorkerEvents, AudioLevelObserverEvents } from '../types';
 import * as utils from '../utils';
 
 type TestContext = {
@@ -31,9 +33,7 @@ afterEach(async () => {
 	ctx.worker?.close();
 
 	if (ctx.worker?.subprocessClosed === false) {
-		await new Promise<void>(resolve =>
-			ctx.worker?.on('subprocessclose', resolve)
-		);
+		await enhancedOnce<WorkerEvents>(ctx.worker, 'subprocessclose');
 	}
 });
 
@@ -114,10 +114,13 @@ test('audioLevelObserver.close() succeeds', async () => {
 test('AudioLevelObserver emits "routerclose" if Router is closed', async () => {
 	const audioLevelObserver = await ctx.router!.createAudioLevelObserver();
 
-	await new Promise<void>(resolve => {
-		audioLevelObserver.on('routerclose', resolve);
-		ctx.router!.close();
-	});
+	const promise = enhancedOnce<AudioLevelObserverEvents>(
+		audioLevelObserver,
+		'routerclose'
+	);
+
+	ctx.router!.close();
+	await promise;
 
 	expect(audioLevelObserver.closed).toBe(true);
 }, 2000);
@@ -125,10 +128,13 @@ test('AudioLevelObserver emits "routerclose" if Router is closed', async () => {
 test('AudioLevelObserver emits "routerclose" if Worker is closed', async () => {
 	const audioLevelObserver = await ctx.router!.createAudioLevelObserver();
 
-	await new Promise<void>(resolve => {
-		audioLevelObserver.on('routerclose', resolve);
-		ctx.worker!.close();
-	});
+	const promise = enhancedOnce<AudioLevelObserverEvents>(
+		audioLevelObserver,
+		'routerclose'
+	);
+
+	ctx.worker!.close();
+	await promise;
 
 	expect(audioLevelObserver.closed).toBe(true);
 }, 2000);

--- a/node/src/test/test-Consumer.ts
+++ b/node/src/test/test-Consumer.ts
@@ -1,6 +1,7 @@
-import { once } from 'node:events';
 import * as flatbuffers from 'flatbuffers';
 import * as mediasoup from '../';
+import { enhancedOnce } from '../enhancedEvents';
+import { WorkerEvents, ConsumerEvents } from '../types';
 import { UnsupportedError } from '../errors';
 import * as utils from '../utils';
 import {
@@ -248,9 +249,7 @@ afterEach(async () => {
 	ctx.worker?.close();
 
 	if (ctx.worker?.subprocessClosed === false) {
-		await new Promise<void>(resolve =>
-			ctx.worker?.on('subprocessclose', resolve)
-		);
+		await enhancedOnce<WorkerEvents>(ctx.worker, 'subprocessclose');
 	}
 });
 
@@ -1025,7 +1024,7 @@ test('Consumer emits "producerpause" and "producerresume"', async () => {
 	});
 
 	await Promise.all([
-		once(audioConsumer, 'producerpause'),
+		enhancedOnce<ConsumerEvents>(audioConsumer, 'producerpause'),
 
 		// Let's await for pause() to resolve to avoid aborted channel requests
 		// due to worker closure.
@@ -1036,7 +1035,7 @@ test('Consumer emits "producerpause" and "producerresume"', async () => {
 	expect(audioConsumer.producerPaused).toBe(true);
 
 	await Promise.all([
-		once(audioConsumer, 'producerresume'),
+		enhancedOnce<ConsumerEvents>(audioConsumer, 'producerresume'),
 
 		// Let's await for resume() to resolve to avoid aborted channel requests
 		// due to worker closure.
@@ -1162,10 +1161,10 @@ test('Consumer emits "producerclose" if Producer is closed', async () => {
 
 	audioConsumer.observer.once('close', onObserverClose);
 
-	await new Promise<void>(resolve => {
-		audioConsumer.on('producerclose', resolve);
-		ctx.audioProducer!.close();
-	});
+	const promise = enhancedOnce<ConsumerEvents>(audioConsumer, 'producerclose');
+
+	ctx.audioProducer!.close();
+	await promise;
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(audioConsumer.closed).toBe(true);
@@ -1181,10 +1180,10 @@ test('Consumer emits "transportclose" if Transport is closed', async () => {
 
 	videoConsumer.observer.once('close', onObserverClose);
 
-	await new Promise<void>(resolve => {
-		videoConsumer.on('transportclose', resolve);
-		ctx.webRtcTransport2!.close();
-	});
+	const promise = enhancedOnce<ConsumerEvents>(videoConsumer, 'transportclose');
+
+	ctx.webRtcTransport2!.close();
+	await promise;
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(videoConsumer.closed).toBe(true);

--- a/node/src/test/test-DataConsumer.ts
+++ b/node/src/test/test-DataConsumer.ts
@@ -1,4 +1,6 @@
 import * as mediasoup from '../';
+import { enhancedOnce } from '../enhancedEvents';
+import { WorkerEvents, DataConsumerEvents } from '../types';
 import * as utils from '../utils';
 
 type TestContext = {
@@ -44,9 +46,7 @@ afterEach(async () => {
 	ctx.worker?.close();
 
 	if (ctx.worker?.subprocessClosed === false) {
-		await new Promise<void>(resolve =>
-			ctx.worker?.on('subprocessclose', resolve)
-		);
+		await enhancedOnce<WorkerEvents>(ctx.worker, 'subprocessclose');
 	}
 });
 
@@ -374,11 +374,13 @@ test('DataConsumer emits "dataproducerclose" if DataProducer is closed', async (
 
 	dataConsumer.observer.once('close', onObserverClose);
 
-	await new Promise<void>(resolve => {
-		dataConsumer.on('dataproducerclose', resolve);
+	const promise = enhancedOnce<DataConsumerEvents>(
+		dataConsumer,
+		'dataproducerclose'
+	);
 
-		ctx.dataProducer!.close();
-	});
+	ctx.dataProducer!.close();
+	await promise;
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(dataConsumer.closed).toBe(true);
@@ -392,11 +394,13 @@ test('DataConsumer emits "transportclose" if Transport is closed', async () => {
 
 	dataConsumer.observer.once('close', onObserverClose);
 
-	await new Promise<void>(resolve => {
-		dataConsumer.on('transportclose', resolve);
+	const promise = enhancedOnce<DataConsumerEvents>(
+		dataConsumer,
+		'transportclose'
+	);
 
-		ctx.webRtcTransport2!.close();
-	});
+	ctx.webRtcTransport2!.close();
+	await promise;
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(dataConsumer.closed).toBe(true);

--- a/node/src/test/test-DirectTransport.ts
+++ b/node/src/test/test-DirectTransport.ts
@@ -1,4 +1,6 @@
 import * as mediasoup from '../';
+import { enhancedOnce } from '../enhancedEvents';
+import { WorkerEvents, DirectTransportEvents } from '../types';
 
 type TestContext = {
 	worker?: mediasoup.types.Worker;
@@ -16,9 +18,7 @@ afterEach(async () => {
 	ctx.worker?.close();
 
 	if (ctx.worker?.subprocessClosed === false) {
-		await new Promise<void>(resolve =>
-			ctx.worker?.on('subprocessclose', resolve)
-		);
+		await enhancedOnce<WorkerEvents>(ctx.worker, 'subprocessclose');
 	}
 });
 
@@ -397,11 +397,13 @@ test('DirectTransport emits "routerclose" if Router is closed', async () => {
 
 	directTransport.observer.once('close', onObserverClose);
 
-	await new Promise<void>(resolve => {
-		directTransport.on('routerclose', resolve);
+	const promise = enhancedOnce<DirectTransportEvents>(
+		directTransport,
+		'routerclose'
+	);
 
-		ctx.router!.close();
-	});
+	ctx.router!.close();
+	await promise;
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(directTransport.closed).toBe(true);
@@ -413,11 +415,13 @@ test('DirectTransport emits "routerclose" if Worker is closed', async () => {
 
 	directTransport.observer.once('close', onObserverClose);
 
-	await new Promise<void>(resolve => {
-		directTransport.on('routerclose', resolve);
+	const promise = enhancedOnce<DirectTransportEvents>(
+		directTransport,
+		'routerclose'
+	);
 
-		ctx.worker!.close();
-	});
+	ctx.worker!.close();
+	await promise;
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(directTransport.closed).toBe(true);

--- a/node/src/test/test-Producer.ts
+++ b/node/src/test/test-Producer.ts
@@ -1,5 +1,7 @@
 import * as flatbuffers from 'flatbuffers';
 import * as mediasoup from '../';
+import { enhancedOnce } from '../enhancedEvents';
+import { WorkerEvents, ProducerEvents } from '../types';
 import { UnsupportedError } from '../errors';
 import * as utils from '../utils';
 import {
@@ -148,9 +150,7 @@ afterEach(async () => {
 	ctx.worker?.close();
 
 	if (ctx.worker?.subprocessClosed === false) {
-		await new Promise<void>(resolve =>
-			ctx.worker?.on('subprocessclose', resolve)
-		);
+		await enhancedOnce<WorkerEvents>(ctx.worker, 'subprocessclose');
 	}
 });
 
@@ -823,10 +823,10 @@ test('Producer emits "transportclose" if Transport is closed', async () => {
 
 	videoProducer.observer.once('close', onObserverClose);
 
-	await new Promise<void>(resolve => {
-		videoProducer.on('transportclose', resolve);
-		ctx.webRtcTransport2!.close();
-	});
+	const promise = enhancedOnce<ProducerEvents>(videoProducer, 'transportclose');
+
+	ctx.webRtcTransport2!.close();
+	await promise;
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(videoProducer.closed).toBe(true);

--- a/node/src/test/test-Router.ts
+++ b/node/src/test/test-Router.ts
@@ -1,4 +1,6 @@
 import * as mediasoup from '../';
+import { enhancedOnce } from '../enhancedEvents';
+import { WorkerEvents, RouterEvents } from '../types';
 import { InvalidStateError } from '../errors';
 import * as utils from '../utils';
 
@@ -46,9 +48,7 @@ afterEach(async () => {
 	ctx.worker?.close();
 
 	if (ctx.worker?.subprocessClosed === false) {
-		await new Promise<void>(resolve =>
-			ctx.worker?.on('subprocessclose', resolve)
-		);
+		await enhancedOnce<WorkerEvents>(ctx.worker, 'subprocessclose');
 	}
 });
 
@@ -148,11 +148,10 @@ test('Router emits "workerclose" if Worker is closed', async () => {
 
 	router.observer.once('close', onObserverClose);
 
-	await new Promise<void>(resolve => {
-		router.on('workerclose', resolve);
+	const promise = enhancedOnce<RouterEvents>(router, 'workerclose');
 
-		ctx.worker!.close();
-	});
+	ctx.worker!.close();
+	await promise;
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(router.closed).toBe(true);

--- a/node/src/test/test-WebRtcTransport.ts
+++ b/node/src/test/test-WebRtcTransport.ts
@@ -1,6 +1,8 @@
 import { pickPort } from 'pick-port';
 import * as flatbuffers from 'flatbuffers';
 import * as mediasoup from '../';
+import { enhancedOnce } from '../enhancedEvents';
+import { WorkerEvents, WebRtcTransportEvents } from '../types';
 import * as utils from '../utils';
 import { serializeProtocol, TransportTuple } from '../Transport';
 import {
@@ -57,9 +59,7 @@ afterEach(async () => {
 	ctx.worker?.close();
 
 	if (ctx.worker?.subprocessClosed === false) {
-		await new Promise<void>(resolve =>
-			ctx.worker?.on('subprocessclose', resolve)
-		);
+		await enhancedOnce<WorkerEvents>(ctx.worker, 'subprocessclose');
 	}
 });
 
@@ -844,11 +844,13 @@ test('WebRtcTransport emits "routerclose" if Router is closed', async () => {
 
 	webRtcTransport.observer.once('close', onObserverClose);
 
-	await new Promise<void>(resolve => {
-		webRtcTransport.on('routerclose', resolve);
+	const promise = enhancedOnce<WebRtcTransportEvents>(
+		webRtcTransport,
+		'routerclose'
+	);
 
-		ctx.router!.close();
-	});
+	ctx.router!.close();
+	await promise;
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(webRtcTransport.closed).toBe(true);
@@ -869,11 +871,13 @@ test('WebRtcTransport emits "routerclose" if Worker is closed', async () => {
 
 	webRtcTransport.observer.once('close', onObserverClose);
 
-	await new Promise<void>(resolve => {
-		webRtcTransport.on('routerclose', resolve);
+	const promise = enhancedOnce<WebRtcTransportEvents>(
+		webRtcTransport,
+		'routerclose'
+	);
 
-		ctx.worker!.close();
-	});
+	ctx.worker!.close();
+	await promise;
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(webRtcTransport.closed).toBe(true);

--- a/node/src/test/test-Worker.ts
+++ b/node/src/test/test-Worker.ts
@@ -2,6 +2,8 @@ import * as os from 'node:os';
 import * as process from 'node:process';
 import * as path from 'node:path';
 import * as mediasoup from '../';
+import { enhancedOnce } from '../enhancedEvents';
+import { WorkerEvents } from '../types';
 import { InvalidStateError } from '../errors';
 
 test('Worker.workerBin matches mediasoup-worker absolute path', () => {
@@ -48,7 +50,7 @@ test('createWorker() succeeds', async () => {
 
 	worker1.close();
 
-	await new Promise<void>(resolve => worker1.on('subprocessclose', resolve));
+	await enhancedOnce<WorkerEvents>(worker1, 'subprocessclose');
 
 	expect(worker1.closed).toBe(true);
 	expect(worker1.died).toBe(false);
@@ -72,7 +74,7 @@ test('createWorker() succeeds', async () => {
 
 	worker2.close();
 
-	await new Promise<void>(resolve => worker2.on('subprocessclose', resolve));
+	await enhancedOnce<WorkerEvents>(worker2, 'subprocessclose');
 
 	expect(worker2.closed).toBe(true);
 	expect(worker2.died).toBe(false);
@@ -116,7 +118,7 @@ test('worker.updateSettings() succeeds', async () => {
 
 	worker.close();
 
-	await new Promise<void>(resolve => worker.on('subprocessclose', resolve));
+	await enhancedOnce<WorkerEvents>(worker, 'subprocessclose');
 }, 2000);
 
 test('worker.updateSettings() with wrong settings rejects with TypeError', async () => {
@@ -129,7 +131,7 @@ test('worker.updateSettings() with wrong settings rejects with TypeError', async
 
 	worker.close();
 
-	await new Promise<void>(resolve => worker.on('subprocessclose', resolve));
+	await enhancedOnce<WorkerEvents>(worker, 'subprocessclose');
 }, 2000);
 
 test('worker.updateSettings() rejects with InvalidStateError if closed', async () => {
@@ -137,7 +139,7 @@ test('worker.updateSettings() rejects with InvalidStateError if closed', async (
 
 	worker.close();
 
-	await new Promise<void>(resolve => worker.on('subprocessclose', resolve));
+	await enhancedOnce<WorkerEvents>(worker, 'subprocessclose');
 
 	await expect(worker.updateSettings({ logLevel: 'error' })).rejects.toThrow(
 		InvalidStateError
@@ -165,7 +167,7 @@ test('worker.dump() rejects with InvalidStateError if closed', async () => {
 
 	worker.close();
 
-	await new Promise<void>(resolve => worker.on('subprocessclose', resolve));
+	await enhancedOnce<WorkerEvents>(worker, 'subprocessclose');
 
 	await expect(worker.dump()).rejects.toThrow(InvalidStateError);
 }, 2000);
@@ -177,7 +179,7 @@ test('worker.getResourceUsage() succeeds', async () => {
 
 	worker.close();
 
-	await new Promise<void>(resolve => worker.on('subprocessclose', resolve));
+	await enhancedOnce<WorkerEvents>(worker, 'subprocessclose');
 }, 2000);
 
 test('worker.close() succeeds', async () => {
@@ -187,7 +189,7 @@ test('worker.close() succeeds', async () => {
 	worker.observer.once('close', onObserverClose);
 	worker.close();
 
-	await new Promise<void>(resolve => worker.on('subprocessclose', resolve));
+	await enhancedOnce<WorkerEvents>(worker, 'subprocessclose');
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(worker.closed).toBe(true);
@@ -224,7 +226,7 @@ test('Worker emits "died" if worker process died unexpectedly', async () => {
 	});
 
 	if (!worker1.subprocessClosed) {
-		await new Promise<void>(resolve => worker1.on('subprocessclose', resolve));
+		await enhancedOnce<WorkerEvents>(worker1, 'subprocessclose');
 	}
 
 	expect(onDied).toHaveBeenCalledTimes(1);
@@ -258,7 +260,7 @@ test('Worker emits "died" if worker process died unexpectedly', async () => {
 	});
 
 	if (!worker2.subprocessClosed) {
-		await new Promise<void>(resolve => worker2.on('subprocessclose', resolve));
+		await enhancedOnce<WorkerEvents>(worker2, 'subprocessclose');
 	}
 
 	expect(onDied).toHaveBeenCalledTimes(1);
@@ -292,7 +294,7 @@ test('Worker emits "died" if worker process died unexpectedly', async () => {
 	});
 
 	if (!worker3.subprocessClosed) {
-		await new Promise<void>(resolve => worker3.on('subprocessclose', resolve));
+		await enhancedOnce<WorkerEvents>(worker3, 'subprocessclose');
 	}
 
 	expect(onDied).toHaveBeenCalledTimes(1);

--- a/node/src/test/test-multiopus.ts
+++ b/node/src/test/test-multiopus.ts
@@ -1,4 +1,6 @@
 import * as mediasoup from '../';
+import { enhancedOnce } from '../enhancedEvents';
+import { WorkerEvents } from '../types';
 import { UnsupportedError } from '../errors';
 import * as utils from '../utils';
 
@@ -109,9 +111,7 @@ afterEach(async () => {
 	ctx.worker?.close();
 
 	if (ctx.worker?.subprocessClosed === false) {
-		await new Promise<void>(resolve =>
-			ctx.worker?.on('subprocessclose', resolve)
-		);
+		await enhancedOnce<WorkerEvents>(ctx.worker, 'subprocessclose');
 	}
 });
 


### PR DESCRIPTION
### Details

- Same as [events.once(emitter, eventName)](https://nodejs.org/api/events.html#eventsonceemitter-name-options) but with TypeScript typed events.
- Rename `EnhancedEventEmitter.ts` file to `enhancedEvents.ts` for consistency with the Node `events` module.