### PR TITLE
fix: panic with normal errors in Rust

### DIFF
--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -1020,9 +1020,9 @@ impl Consumer {
             .inner
             .channel
             .request(self.id(), ConsumerGetStatsRequest {})
-            .await;
+            .await?;
 
-        if let Ok(response::Body::ConsumerGetStatsResponse(data)) = response {
+        if let response::Body::ConsumerGetStatsResponse(data) = response {
             match data.stats.len() {
                 0 => panic!("Empty stats response from worker"),
                 1 => {

--- a/rust/src/router/producer.rs
+++ b/rust/src/router/producer.rs
@@ -899,9 +899,9 @@ impl Producer {
             .inner()
             .channel
             .request(self.id(), ProducerGetStatsRequest {})
-            .await;
+            .await?;
 
-        if let Ok(response::Body::ProducerGetStatsResponse(data)) = response {
+        if let response::Body::ProducerGetStatsResponse(data) = response {
             Ok(data.stats.iter().map(ProducerStat::from_fbs).collect())
         } else {
             panic!("Wrong message from worker");


### PR DESCRIPTION
Returns an error when an error can be returned