### PR TITLE
RtpPacket: Make (almost) all methods remove payload padding if present

### DIFF
--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -549,14 +549,6 @@ namespace RTC
 		}
 
 		MS_ASSERT(ptr == this->payload, "wrong ptr calculation");
-
-		// TODO: Yes or not?
-		// If there is padding we have to ensure that last byte of it contains
-		// the number of bytes of padding.
-		// if (this->payloadPadding != 0u)
-		// {
-		// 	this->payload[this->payloadLength + this->payloadPadding - 1] = this->payloadPadding;
-		// }
 	}
 
 	void RtpPacket::UpdateMid(const std::string& mid)
@@ -668,7 +660,7 @@ namespace RTC
 		MS_TRACE();
 
 		this->size -= this->payloadLength;
-		this->payloadLength  = length;
+		this->payloadLength = length;
 		this->size += this->payloadLength;
 
 		// Remove padding if present.

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -550,12 +550,13 @@ namespace RTC
 
 		MS_ASSERT(ptr == this->payload, "wrong ptr calculation");
 
+		// TODO: Yes or not?
 		// If there is padding we have to ensure that last byte of it contains
 		// the number of bytes of padding.
-		if (this->payloadPadding != 0u)
-		{
-			this->payload[this->payloadLength + this->payloadPadding - 1] = this->payloadPadding;
-		}
+		// if (this->payloadPadding != 0u)
+		// {
+		// 	this->payload[this->payloadLength + this->payloadPadding - 1] = this->payloadPadding;
+		// }
 	}
 
 	void RtpPacket::UpdateMid(const std::string& mid)

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -1,6 +1,3 @@
-#define MS_CLASS "TestRtpPacket"
-#include "Logger.hpp"
-
 #include "common.hpp"
 #include "helpers.hpp"
 #include "RTC/RtpPacket.hpp"
@@ -698,6 +695,10 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00
 		};
 		// clang-format on
 
@@ -710,10 +711,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		{
 			FAIL("not a RTP packet");
 		}
-
-		MS_DUMP_STD("---- 1 [packet->GetPayloadLength():%zu, packet->GetPayloadPadding():%d]", packet->GetPayloadLength(), packet->GetPayloadPadding());
-		MS_DUMP_DATA_STD(packet->GetPayload(), packet->GetPayloadLength() + packet->GetPayloadPadding());
-		MS_DUMP_STD("····");
 
 		REQUIRE(packet->GetSize() == 28);
 		REQUIRE(packet->HasHeaderExtension() == false);
@@ -730,10 +727,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		extensions.clear();
 
 		packet->SetExtensions(2, extensions);
-
-		MS_DUMP_STD("---- 2 [packet->GetPayloadLength():%zu, packet->GetPayloadPadding():%d]", packet->GetPayloadLength(), packet->GetPayloadPadding());
-		MS_DUMP_DATA_STD(packet->GetPayload(), packet->GetPayloadLength() + packet->GetPayloadPadding());
-		MS_DUMP_STD("····");
 
 		REQUIRE(packet->GetSize() == 32);
 		REQUIRE(packet->HasHeaderExtension() == true);
@@ -774,10 +767,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		packet->SetExtensions(2, extensions);
 
-		MS_DUMP_STD("---- 3 [packet->GetPayloadLength():%zu, packet->GetPayloadPadding():%d]", packet->GetPayloadLength(), packet->GetPayloadPadding());
-		MS_DUMP_DATA_STD(packet->GetPayload(), packet->GetPayloadLength() + packet->GetPayloadPadding());
-		MS_DUMP_STD("····");
-
 		REQUIRE(packet->GetSize() == 52); // 51 + 1 byte for padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0b0001000000000000);
@@ -786,11 +775,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasTwoBytesExtensions() == true);
 		REQUIRE(packet->GetPayloadLength() == 12);
 		REQUIRE(packet->GetPayloadPadding() == 4);
-
-		MS_DUMP_STD("---- 4 [packet->GetPayloadLength():%zu, packet->GetPayloadPadding():%d]", packet->GetPayloadLength(), packet->GetPayloadPadding());
-		MS_DUMP_DATA_STD(packet->GetPayload(), packet->GetPayloadLength() + packet->GetPayloadPadding());
-		MS_DUMP_STD("····");
-
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -1,3 +1,6 @@
+#define MS_CLASS "TestRtpPacket"
+#include "Logger.hpp"
+
 #include "common.hpp"
 #include "helpers.hpp"
 #include "RTC/RtpPacket.hpp"
@@ -553,17 +556,17 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		extensions.clear();
 
-		// NOTE: This will remove padding.
 		packet->SetExtensions(1, extensions);
 
-		REQUIRE(packet->GetSize() == 28);
+		REQUIRE(packet->GetSize() == 32);
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
 		REQUIRE(packet->GetHeaderExtensionLength() == 0);
 		REQUIRE(packet->HasOneByteExtensions() == true);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
-		REQUIRE(packet->GetPayloadPadding() == 0);
+		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 
@@ -608,14 +611,15 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		packet->SetExtensions(1, extensions);
 
-		REQUIRE(packet->GetSize() == 48); // 49 + 3 bytes for padding in header extension.
+		REQUIRE(packet->GetSize() == 52); // 49 + 3 bytes for padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
 		REQUIRE(packet->GetHeaderExtensionLength() == 20); // 17 + 3 bytes for padding.
 		REQUIRE(packet->HasOneByteExtensions() == true);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
-		REQUIRE(packet->GetPayloadPadding() == 0);
+		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 		REQUIRE(packet->GetExtension(0, extenLen) == nullptr);
@@ -643,14 +647,15 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		packet->SetExtensions(1, extensions);
 
-		REQUIRE(packet->GetSize() == 36);
+		REQUIRE(packet->GetSize() == 40);
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
 		REQUIRE(packet->GetHeaderExtensionLength() == 8); // 5 + 3 bytes for padding.
 		REQUIRE(packet->HasOneByteExtensions() == true);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
-		REQUIRE(packet->GetPayloadPadding() == 0);
+		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 		REQUIRE(packet->GetExtension(1, extenLen) == nullptr);
@@ -706,6 +711,10 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			FAIL("not a RTP packet");
 		}
 
+		MS_DUMP_STD("---- 1 [packet->GetPayloadLength():%zu, packet->GetPayloadPadding():%d]", packet->GetPayloadLength(), packet->GetPayloadPadding());
+		MS_DUMP_DATA_STD(packet->GetPayload(), packet->GetPayloadLength() + packet->GetPayloadPadding());
+		MS_DUMP_STD("····");
+
 		REQUIRE(packet->GetSize() == 28);
 		REQUIRE(packet->HasHeaderExtension() == false);
 		REQUIRE(packet->GetHeaderExtensionId() == 0);
@@ -720,17 +729,21 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		extensions.clear();
 
-		// NOTE: This will remove padding.
 		packet->SetExtensions(2, extensions);
 
-		REQUIRE(packet->GetSize() == 28);
+		MS_DUMP_STD("---- 2 [packet->GetPayloadLength():%zu, packet->GetPayloadPadding():%d]", packet->GetPayloadLength(), packet->GetPayloadPadding());
+		MS_DUMP_DATA_STD(packet->GetPayload(), packet->GetPayloadLength() + packet->GetPayloadPadding());
+		MS_DUMP_STD("····");
+
+		REQUIRE(packet->GetSize() == 32);
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0b0001000000000000);
 		REQUIRE(packet->GetHeaderExtensionLength() == 0);
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == true);
 		REQUIRE(packet->GetPayloadLength() == 12);
-		REQUIRE(packet->GetPayloadPadding() == 0);
+		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 
@@ -759,17 +772,26 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value2 // value
 		);
 
-		// NOTE: This will remove padding.
 		packet->SetExtensions(2, extensions);
 
-		REQUIRE(packet->GetSize() == 48); // 51 + 1 byte for padding in header extension.
+		MS_DUMP_STD("---- 3 [packet->GetPayloadLength():%zu, packet->GetPayloadPadding():%d]", packet->GetPayloadLength(), packet->GetPayloadPadding());
+		MS_DUMP_DATA_STD(packet->GetPayload(), packet->GetPayloadLength() + packet->GetPayloadPadding());
+		MS_DUMP_STD("····");
+
+		REQUIRE(packet->GetSize() == 52); // 51 + 1 byte for padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0b0001000000000000);
 		REQUIRE(packet->GetHeaderExtensionLength() == 20); // 19 + 1 byte for padding.
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == true);
 		REQUIRE(packet->GetPayloadLength() == 12);
-		REQUIRE(packet->GetPayloadPadding() == 0);
+		REQUIRE(packet->GetPayloadPadding() == 4);
+
+		MS_DUMP_STD("---- 4 [packet->GetPayloadLength():%zu, packet->GetPayloadPadding():%d]", packet->GetPayloadLength(), packet->GetPayloadPadding());
+		MS_DUMP_DATA_STD(packet->GetPayload(), packet->GetPayloadLength() + packet->GetPayloadPadding());
+		MS_DUMP_STD("····");
+
+		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 		REQUIRE(packet->GetExtension(0, extenLen) == nullptr);
@@ -805,14 +827,15 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		packet->SetExtensions(2, extensions);
 
-		REQUIRE(packet->GetSize() == 36);
+		REQUIRE(packet->GetSize() == 40);
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0b0001000000000000);
 		REQUIRE(packet->GetHeaderExtensionLength() == 8);
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == true);
 		REQUIRE(packet->GetPayloadLength() == 12);
-		REQUIRE(packet->GetPayloadPadding() == 0);
+		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 		REQUIRE(packet->GetExtension(1, extenLen) == nullptr);

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -435,6 +435,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 8);
 		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetSize() == 40);
 
 		auto* payload = packet->GetPayload();
@@ -448,11 +449,12 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(payload[6] == 0x06);
 		REQUIRE(payload[7] == 0x07);
 
+		// NOTE: This will remove padding.
 		packet->ShiftPayload(0, 2, true);
 
 		REQUIRE(packet->GetPayloadLength() == 10);
-		REQUIRE(packet->GetPayloadPadding() == 4);
-		REQUIRE(packet->GetSize() == 42);
+		REQUIRE(packet->GetPayloadPadding() == 0);
+		REQUIRE(packet->GetSize() == 38);
 		REQUIRE(payload[2] == 0x00);
 		REQUIRE(payload[3] == 0x01);
 		REQUIRE(payload[4] == 0x02);
@@ -465,8 +467,8 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		packet->ShiftPayload(0, 2, false);
 
 		REQUIRE(packet->GetPayloadLength() == 8);
-		REQUIRE(packet->GetPayloadPadding() == 4);
-		REQUIRE(packet->GetSize() == 40);
+		REQUIRE(packet->GetPayloadPadding() == 0);
+		REQUIRE(packet->GetSize() == 36);
 		REQUIRE(payload[0] == 0x00);
 		REQUIRE(payload[1] == 0x01);
 		REQUIRE(payload[2] == 0x02);
@@ -476,18 +478,18 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(payload[6] == 0x06);
 		REQUIRE(payload[7] == 0x07);
 
-		// NOTE: This will require padding to 2 bytes.
+		// NOTE: This will remove padding.
 		packet->SetPayloadLength(14);
 
 		REQUIRE(packet->GetPayloadLength() == 14);
-		REQUIRE(packet->GetPayloadPadding() == 2);
-		REQUIRE(packet->GetSize() == 44);
+		REQUIRE(packet->GetPayloadPadding() == 0);
+		REQUIRE(packet->GetSize() == 42);
 
 		packet->ShiftPayload(4, 4, true);
 
 		REQUIRE(packet->GetPayloadLength() == 18);
-		REQUIRE(packet->GetPayloadPadding() == 2);
-		REQUIRE(packet->GetSize() == 48);
+		REQUIRE(packet->GetPayloadPadding() == 0);
+		REQUIRE(packet->GetSize() == 46);
 		REQUIRE(payload[0] == 0x00);
 		REQUIRE(payload[1] == 0x01);
 		REQUIRE(payload[2] == 0x02);
@@ -545,21 +547,23 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
 		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 
 		extensions.clear();
 
+		// NOTE: This will remove padding.
 		packet->SetExtensions(1, extensions);
 
-		REQUIRE(packet->GetSize() == 32);
+		REQUIRE(packet->GetSize() == 28);
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
 		REQUIRE(packet->GetHeaderExtensionLength() == 0);
 		REQUIRE(packet->HasOneByteExtensions() == true);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
-		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayloadPadding() == 0);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 
@@ -604,14 +608,14 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		packet->SetExtensions(1, extensions);
 
-		REQUIRE(packet->GetSize() == 52); // 49 + 3 bytes for padding in header extension.
+		REQUIRE(packet->GetSize() == 48); // 49 + 3 bytes for padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
 		REQUIRE(packet->GetHeaderExtensionLength() == 20); // 17 + 3 bytes for padding.
 		REQUIRE(packet->HasOneByteExtensions() == true);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
-		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayloadPadding() == 0);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 		REQUIRE(packet->GetExtension(0, extenLen) == nullptr);
@@ -639,14 +643,14 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		packet->SetExtensions(1, extensions);
 
-		REQUIRE(packet->GetSize() == 40);
+		REQUIRE(packet->GetSize() == 36);
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
 		REQUIRE(packet->GetHeaderExtensionLength() == 8); // 5 + 3 bytes for padding.
 		REQUIRE(packet->HasOneByteExtensions() == true);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
-		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayloadPadding() == 0);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 		REQUIRE(packet->GetExtension(1, extenLen) == nullptr);
@@ -710,21 +714,23 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
 		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 
 		extensions.clear();
 
+		// NOTE: This will remove padding.
 		packet->SetExtensions(2, extensions);
 
-		REQUIRE(packet->GetSize() == 32);
+		REQUIRE(packet->GetSize() == 28);
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0b0001000000000000);
 		REQUIRE(packet->GetHeaderExtensionLength() == 0);
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == true);
 		REQUIRE(packet->GetPayloadLength() == 12);
-		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayloadPadding() == 0);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 
@@ -753,16 +759,17 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value2 // value
 		);
 
+		// NOTE: This will remove padding.
 		packet->SetExtensions(2, extensions);
 
-		REQUIRE(packet->GetSize() == 52); // 51 + 1 byte for padding in header extension.
+		REQUIRE(packet->GetSize() == 48); // 51 + 1 byte for padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0b0001000000000000);
 		REQUIRE(packet->GetHeaderExtensionLength() == 20); // 19 + 1 byte for padding.
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == true);
 		REQUIRE(packet->GetPayloadLength() == 12);
-		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayloadPadding() == 0);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 		REQUIRE(packet->GetExtension(0, extenLen) == nullptr);
@@ -798,14 +805,14 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		packet->SetExtensions(2, extensions);
 
-		REQUIRE(packet->GetSize() == 40);
+		REQUIRE(packet->GetSize() == 36);
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0b0001000000000000);
 		REQUIRE(packet->GetHeaderExtensionLength() == 8);
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == true);
 		REQUIRE(packet->GetPayloadLength() == 12);
-		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayloadPadding() == 0);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 		REQUIRE(packet->GetExtension(1, extenLen) == nullptr);

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -476,17 +476,17 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(payload[6] == 0x06);
 		REQUIRE(payload[7] == 0x07);
 
-		// NOTE: This will require padding to 4 bytes.
+		// NOTE: This will require padding to 2 bytes.
 		packet->SetPayloadLength(14);
 
-		REQUIRE(packet->GetPayloadLength() == 16);
-		REQUIRE(packet->GetPayloadPadding() == 0);
+		REQUIRE(packet->GetPayloadLength() == 14);
+		REQUIRE(packet->GetPayloadPadding() == 2);
 		REQUIRE(packet->GetSize() == 44);
 
 		packet->ShiftPayload(4, 4, true);
 
-		REQUIRE(packet->GetPayloadLength() == 20);
-		REQUIRE(packet->GetPayloadPadding() == 0);
+		REQUIRE(packet->GetPayloadLength() == 18);
+		REQUIRE(packet->GetPayloadPadding() == 2);
 		REQUIRE(packet->GetSize() == 48);
 		REQUIRE(payload[0] == 0x00);
 		REQUIRE(payload[1] == 0x01);


### PR DESCRIPTION
Fixes #1379

### Details

Before this PR:

- We have inconsistent behavior: some methods in `RtpPacket` keep existing payload padding after mangling the payload others don't.
- Those methods that keep existing payload do it wrong (real bug here) since they do NOT write the number of padding bytes in the last byte of the padding.

After this PR:

- All methods (but `clone()`) remove payload padding if present. Period.
- There is no real need to keep padding (AKA be padded to 4 bytes). That's just for super legazy plain RTP engines.
- "And why don't we keep existing padding instead?". See section above "Before this PR". Lot of work for little/null benefit. I don't want to waste much energy on this topic given that (when time comes in) I'd like to focus on task https://github.com/versatica/mediasoup/issues/1233 instead.