### PR TITLE
Fix Worker crash when closing WebRtcServer with active WebRtcTransports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - Worker: Fix memory leak when using `WebRtcServer` with TCP enabled ([PR #1389](https://github.com/versatica/mediasoup/pull/1389)).
+- Worker: Fix crash when closing `WebRtcServer` with active `WebRtcTransports` ([PR #1390](https://github.com/versatica/mediasoup/pull/1390)).
 
 ### 3.14.4
 

--- a/worker/src/RTC/WebRtcServer.cpp
+++ b/worker/src/RTC/WebRtcServer.cpp
@@ -236,6 +236,15 @@ namespace RTC
 
 		this->shared->channelMessageRegistrator->UnregisterHandler(this->id);
 
+		// NOTE: We need to close WebRtcTransports first since they may need to
+		// send DTLS Close Alert so UDP sockets and TCP connections must remain
+		// open.
+		for (auto* webRtcTransport : this->webRtcTransports)
+		{
+			webRtcTransport->ListenServerClosed();
+		}
+		this->webRtcTransports.clear();
+
 		for (auto& item : this->udpSocketOrTcpServers)
 		{
 			delete item.udpSocket;
@@ -245,12 +254,6 @@ namespace RTC
 			item.tcpServer = nullptr;
 		}
 		this->udpSocketOrTcpServers.clear();
-
-		for (auto* webRtcTransport : this->webRtcTransports)
-		{
-			webRtcTransport->ListenServerClosed();
-		}
-		this->webRtcTransports.clear();
 	}
 
 	flatbuffers::Offset<FBS::WebRtcServer::DumpResponse> WebRtcServer::FillBuffer(


### PR DESCRIPTION
Fixes #1388

### Details

- `WebRtcServer` destructor must first close its `WebRtcTransports` and then the UDP sockets and TCP servers (so also its TCP connections). Otherwise those `WebRtcTransports` will try to send DTLS Close Alert on an already closed/freed `UdpSocketHandle` or `TcpConnectionHandle`.

### Steps to verify

1. Have `WebRtcServer` running and a client connected.
2. In server side call `webRtcServer.close()`.
3. It should not crash anymore.