### PR TITLE
refactor: make `hex_as_bytes` DRY

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.72.0"
+channel = "1.79.0"
 components = ["rustfmt", "clippy"]

--- a/rust/src/data_structures.rs
+++ b/rust/src/data_structures.rs
@@ -569,35 +569,35 @@ impl DtlsFingerprint {
         match fingerprint.algorithm {
             web_rtc_transport::FingerprintAlgorithm::Sha1 => {
                 let value_result = hex_as_bytes::<20>(fingerprint.value.as_str());
-                
+
                 DtlsFingerprint::Sha1 {
                     value: value_result,
                 }
             }
             web_rtc_transport::FingerprintAlgorithm::Sha224 => {
                 let value_result = hex_as_bytes::<28>(fingerprint.value.as_str());
-                
+
                 DtlsFingerprint::Sha224 {
                     value: value_result,
                 }
             }
             web_rtc_transport::FingerprintAlgorithm::Sha256 => {
                 let value_result = hex_as_bytes::<32>(fingerprint.value.as_str());
-                
+
                 DtlsFingerprint::Sha256 {
                     value: value_result,
                 }
             }
             web_rtc_transport::FingerprintAlgorithm::Sha384 => {
                 let value_result = hex_as_bytes::<48>(fingerprint.value.as_str());
-                
+
                 DtlsFingerprint::Sha384 {
                     value: value_result,
                 }
             }
             web_rtc_transport::FingerprintAlgorithm::Sha512 => {
                 let value_result = hex_as_bytes::<64>(fingerprint.value.as_str());
-                
+
                 DtlsFingerprint::Sha512 {
                     value: value_result,
                 }

--- a/rust/src/data_structures.rs
+++ b/rust/src/data_structures.rs
@@ -528,12 +528,15 @@ pub enum DtlsFingerprint {
     },
 }
 
-fn hex_as_bytes(input: &str, output: &mut [u8]) {
+fn hex_as_bytes<const N: usize>(input: &str) -> [u8; N] {
+    let mut output = [0_u8; N];
     for (i, o) in input.split(':').zip(&mut output.iter_mut()) {
         *o = u8::from_str_radix(i, 16).unwrap_or_else(|error| {
             panic!("Failed to parse value {i} as series of hex bytes: {error}")
         });
     }
+
+    output
 }
 
 impl DtlsFingerprint {
@@ -565,46 +568,36 @@ impl DtlsFingerprint {
     pub(crate) fn from_fbs(fingerprint: &web_rtc_transport::Fingerprint) -> DtlsFingerprint {
         match fingerprint.algorithm {
             web_rtc_transport::FingerprintAlgorithm::Sha1 => {
-                let mut value_result = [0_u8; 20];
-
-                hex_as_bytes(fingerprint.value.as_str(), &mut value_result);
-
+                let value_result = hex_as_bytes::<20>(fingerprint.value.as_str());
+                
                 DtlsFingerprint::Sha1 {
                     value: value_result,
                 }
             }
             web_rtc_transport::FingerprintAlgorithm::Sha224 => {
-                let mut value_result = [0_u8; 28];
-
-                hex_as_bytes(fingerprint.value.as_str(), &mut value_result);
-
+                let value_result = hex_as_bytes::<28>(fingerprint.value.as_str());
+                
                 DtlsFingerprint::Sha224 {
                     value: value_result,
                 }
             }
             web_rtc_transport::FingerprintAlgorithm::Sha256 => {
-                let mut value_result = [0_u8; 32];
-
-                hex_as_bytes(fingerprint.value.as_str(), &mut value_result);
-
+                let value_result = hex_as_bytes::<32>(fingerprint.value.as_str());
+                
                 DtlsFingerprint::Sha256 {
                     value: value_result,
                 }
             }
             web_rtc_transport::FingerprintAlgorithm::Sha384 => {
-                let mut value_result = [0_u8; 48];
-
-                hex_as_bytes(fingerprint.value.as_str(), &mut value_result);
-
+                let value_result = hex_as_bytes::<48>(fingerprint.value.as_str());
+                
                 DtlsFingerprint::Sha384 {
                     value: value_result,
                 }
             }
             web_rtc_transport::FingerprintAlgorithm::Sha512 => {
-                let mut value_result = [0_u8; 64];
-
-                hex_as_bytes(fingerprint.value.as_str(), &mut value_result);
-
+                let value_result = hex_as_bytes::<64>(fingerprint.value.as_str());
+                
                 DtlsFingerprint::Sha512 {
                     value: value_result,
                 }

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -681,15 +681,14 @@ pub(crate) fn can_consume(
         if caps
             .codecs
             .iter()
-            .any(|cap_codec| match_codecs(cap_codec.deref().into(), codec.into(), true).is_ok())
+            .any(|cap_codec| match_codecs(cap_codec.into(), codec.into(), true).is_ok())
         {
             matching_codecs.push(codec);
         }
     }
 
     // Ensure there is at least one media codec.
-    Ok(matching_codecs
-        .get(0)
+    Ok(matching_codecs.first()
         .map(|codec| !codec.is_rtx())
         .unwrap_or_default())
 }
@@ -840,8 +839,7 @@ pub(crate) fn get_consumer_rtp_parameters(
         // If any of the consumable_rtp_parameters.encodings has scalability_mode, process it
         // (assume all encodings have the same value).
         let mut scalability_mode = consumable_rtp_parameters
-            .encodings
-            .get(0)
+            .encodings.first()
             .map(|encoding| encoding.scalability_mode.clone())
             .unwrap_or_default();
 

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -688,7 +688,8 @@ pub(crate) fn can_consume(
     }
 
     // Ensure there is at least one media codec.
-    Ok(matching_codecs.first()
+    Ok(matching_codecs
+        .first()
         .map(|codec| !codec.is_rtx())
         .unwrap_or_default())
 }
@@ -839,7 +840,8 @@ pub(crate) fn get_consumer_rtp_parameters(
         // If any of the consumable_rtp_parameters.encodings has scalability_mode, process it
         // (assume all encodings have the same value).
         let mut scalability_mode = consumable_rtp_parameters
-            .encodings.first()
+            .encodings
+            .first()
             .map(|encoding| encoding.scalability_mode.clone())
             .unwrap_or_default();
 

--- a/rust/src/ortc/tests.rs
+++ b/rust/src/ortc/tests.rs
@@ -255,8 +255,8 @@ fn get_producer_rtp_parameters_mapping_get_consumable_rtp_parameters_get_consume
         ]
     );
 
-    assert_eq!(rtp_mapping.encodings.get(0).unwrap().ssrc, Some(11111111));
-    assert_eq!(rtp_mapping.encodings.get(0).unwrap().rid, None);
+    assert_eq!(rtp_mapping.encodings.first().unwrap().ssrc, Some(11111111));
+    assert_eq!(rtp_mapping.encodings.first().unwrap().rid, None);
     assert_eq!(rtp_mapping.encodings.get(1).unwrap().ssrc, Some(21111111));
     assert_eq!(rtp_mapping.encodings.get(1).unwrap().rid, None);
     assert_eq!(rtp_mapping.encodings.get(2).unwrap().ssrc, None);
@@ -303,13 +303,13 @@ fn get_producer_rtp_parameters_mapping_get_consumable_rtp_parameters_get_consume
     );
 
     assert_eq!(
-        consumable_rtp_parameters.encodings.get(0).unwrap().ssrc,
-        Some(rtp_mapping.encodings.get(0).unwrap().mapped_ssrc),
+        consumable_rtp_parameters.encodings.first().unwrap().ssrc,
+        Some(rtp_mapping.encodings.first().unwrap().mapped_ssrc),
     );
     assert_eq!(
         consumable_rtp_parameters
             .encodings
-            .get(0)
+            .first()
             .unwrap()
             .max_bitrate,
         Some(111111),
@@ -317,7 +317,7 @@ fn get_producer_rtp_parameters_mapping_get_consumable_rtp_parameters_get_consume
     assert_eq!(
         consumable_rtp_parameters
             .encodings
-            .get(0)
+            .first()
             .unwrap()
             .scalability_mode,
         ScalabilityMode::L1T3,
@@ -489,20 +489,20 @@ fn get_producer_rtp_parameters_mapping_get_consumable_rtp_parameters_get_consume
     assert_eq!(consumer_rtp_parameters.encodings.len(), 1);
     assert!(consumer_rtp_parameters
         .encodings
-        .get(0)
+        .first()
         .unwrap()
         .ssrc
         .is_some());
     assert!(consumer_rtp_parameters
         .encodings
-        .get(0)
+        .first()
         .unwrap()
         .rtx
         .is_some());
     assert_eq!(
         consumer_rtp_parameters
             .encodings
-            .get(0)
+            .first()
             .unwrap()
             .scalability_mode,
         ScalabilityMode::L3T3,
@@ -510,7 +510,7 @@ fn get_producer_rtp_parameters_mapping_get_consumable_rtp_parameters_get_consume
     assert_eq!(
         consumer_rtp_parameters
             .encodings
-            .get(0)
+            .first()
             .unwrap()
             .max_bitrate,
         Some(333333),
@@ -566,26 +566,26 @@ fn get_producer_rtp_parameters_mapping_get_consumable_rtp_parameters_get_consume
     assert_eq!(pipe_consumer_rtp_parameters.encodings.len(), 3);
     assert!(pipe_consumer_rtp_parameters
         .encodings
-        .get(0)
+        .first()
         .unwrap()
         .ssrc
         .is_some());
     assert!(pipe_consumer_rtp_parameters
         .encodings
-        .get(0)
+        .first()
         .unwrap()
         .rtx
         .is_none());
     assert!(pipe_consumer_rtp_parameters
         .encodings
-        .get(0)
+        .first()
         .unwrap()
         .max_bitrate
         .is_some());
     assert_eq!(
         pipe_consumer_rtp_parameters
             .encodings
-            .get(0)
+            .first()
             .unwrap()
             .scalability_mode,
         ScalabilityMode::L1T3,

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -1303,8 +1303,12 @@ impl Router {
                     // We've created `DataConsumer` with SCTP above, so this should never panic
                     pipe_data_consumer.sctp_stream_parameters().unwrap(),
                 );
-                producer_options.label = pipe_data_consumer.label().clone();
-                producer_options.protocol = pipe_data_consumer.protocol().clone();
+                producer_options
+                    .label
+                    .clone_from(pipe_data_consumer.label());
+                producer_options
+                    .protocol
+                    .clone_from(pipe_data_consumer.protocol());
                 producer_options.app_data = data_producer.app_data().clone();
 
                 producer_options

--- a/rust/src/router/producer.rs
+++ b/rust/src/router/producer.rs
@@ -759,7 +759,7 @@ impl Producer {
                 match Notification::from_fbs(notification) {
                     Ok(notification) => match notification {
                         Notification::Score(scores) => {
-                            *score.lock() = scores.clone();
+                            score.lock().clone_from(&scores);
                             handlers.score.call(|callback| {
                                 callback(&scores);
                             });

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -905,7 +905,6 @@ impl RtpParameters {
         })
     }
 
-    #[allow(dead_code)]
     pub(crate) fn into_fbs(self) -> rtp_parameters::RtpParameters {
         rtp_parameters::RtpParameters {
             mid: self.mid,

--- a/rust/src/scalability_modes.rs
+++ b/rust/src/scalability_modes.rs
@@ -184,9 +184,9 @@ impl FromStr for ScalabilityMode {
     }
 }
 
-impl ToString for ScalabilityMode {
-    fn to_string(&self) -> String {
-        self.as_str().to_string()
+impl std::fmt::Display for ScalabilityMode {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.as_str())
     }
 }
 

--- a/rust/src/worker/common.rs
+++ b/rust/src/worker/common.rs
@@ -35,9 +35,7 @@ impl<F: Sized + Send + Sync + 'static> EventHandlers<F> {
         let index;
         {
             let mut event_handlers = self.handlers.lock();
-            let list = event_handlers
-                .entry(target_id.clone())
-                .or_default();
+            let list = event_handlers.entry(target_id.clone()).or_default();
             index = list.index;
             list.index += 1;
             list.callbacks.insert(index, callback);

--- a/rust/src/worker/common.rs
+++ b/rust/src/worker/common.rs
@@ -37,7 +37,7 @@ impl<F: Sized + Send + Sync + 'static> EventHandlers<F> {
             let mut event_handlers = self.handlers.lock();
             let list = event_handlers
                 .entry(target_id.clone())
-                .or_insert_with(EventHandlersList::default);
+                .or_default();
             index = list.index;
             list.index += 1;
             list.callbacks.insert(index, callback);

--- a/rust/src/worker/utils/channel_read_fn.rs
+++ b/rust/src/worker/utils/channel_read_fn.rs
@@ -9,6 +9,7 @@ unsafe extern "C" fn free_vec(message: *mut u8, message_len: u32, message_capaci
 }
 
 pub(super) struct ChannelReadCallback {
+    // Silence clippy warnings
     _callback: Box<dyn (FnMut(UvAsyncT) -> Option<Vec<u8>>) + Send + 'static>,
 }
 

--- a/rust/src/worker/utils/channel_read_fn.rs
+++ b/rust/src/worker/utils/channel_read_fn.rs
@@ -8,6 +8,7 @@ unsafe extern "C" fn free_vec(message: *mut u8, message_len: u32, message_capaci
     Vec::from_raw_parts(message, message_len as usize, message_capacity);
 }
 
+#[allow(dead_code)]
 pub(super) struct ChannelReadCallback(
     Box<dyn (FnMut(UvAsyncT) -> Option<Vec<u8>>) + Send + 'static>,
 );

--- a/rust/src/worker/utils/channel_read_fn.rs
+++ b/rust/src/worker/utils/channel_read_fn.rs
@@ -8,10 +8,17 @@ unsafe extern "C" fn free_vec(message: *mut u8, message_len: u32, message_capaci
     Vec::from_raw_parts(message, message_len as usize, message_capacity);
 }
 
-#[allow(dead_code)]
-pub(super) struct ChannelReadCallback(
-    Box<dyn (FnMut(UvAsyncT) -> Option<Vec<u8>>) + Send + 'static>,
-);
+pub(super) struct ChannelReadCallback {
+    _callback: Box<dyn (FnMut(UvAsyncT) -> Option<Vec<u8>>) + Send + 'static>,
+}
+
+impl ChannelReadCallback {
+    pub(super) fn new(
+        _callback: Box<dyn (FnMut(UvAsyncT) -> Option<Vec<u8>>) + Send + 'static>,
+    ) -> Self {
+        Self { _callback }
+    }
+}
 
 pub(crate) struct PreparedChannelRead {
     channel_read_fn: ChannelReadFn,
@@ -72,6 +79,6 @@ where
     PreparedChannelRead {
         channel_read_fn: wrapper::<F>,
         channel_read_ctx: ChannelReadCtx(read_callback.as_ref() as *const F as *const c_void),
-        write_callback: ChannelReadCallback(read_callback),
+        write_callback: ChannelReadCallback::new(read_callback),
     }
 }

--- a/rust/src/worker/utils/channel_write_fn.rs
+++ b/rust/src/worker/utils/channel_write_fn.rs
@@ -3,6 +3,7 @@ use std::os::raw::c_void;
 use std::slice;
 
 #[allow(clippy::type_complexity)]
+#[allow(dead_code)]
 pub(super) struct ChannelReadCallback(Box<dyn FnMut(&[u8]) + Send + 'static>);
 
 pub(crate) struct PreparedChannelWrite {

--- a/rust/src/worker/utils/channel_write_fn.rs
+++ b/rust/src/worker/utils/channel_write_fn.rs
@@ -2,9 +2,19 @@ pub(super) use mediasoup_sys::{ChannelWriteCtx, ChannelWriteFn};
 use std::os::raw::c_void;
 use std::slice;
 
+/// TypeAlias to silience clippy::type_complexity warnings
+type CallbackType = Box<dyn FnMut(&[u8]) + Send + 'static>;
+
 #[allow(clippy::type_complexity)]
-#[allow(dead_code)]
-pub(super) struct ChannelReadCallback(Box<dyn FnMut(&[u8]) + Send + 'static>);
+pub(super) struct ChannelReadCallback {
+    _callback: CallbackType,
+}
+
+impl ChannelReadCallback {
+    pub(super) fn new(_callback: CallbackType) -> Self {
+        Self { _callback }
+    }
+}
 
 pub(crate) struct PreparedChannelWrite {
     channel_write_fn: ChannelWriteFn,
@@ -55,6 +65,6 @@ where
     PreparedChannelWrite {
         channel_write_fn: wrapper::<F>,
         channel_write_ctx: ChannelWriteCtx(read_callback.as_ref() as *const F as *const c_void),
-        read_callback: ChannelReadCallback(read_callback),
+        read_callback: ChannelReadCallback::new(read_callback),
     }
 }

--- a/rust/src/worker/utils/channel_write_fn.rs
+++ b/rust/src/worker/utils/channel_write_fn.rs
@@ -5,8 +5,8 @@ use std::slice;
 /// TypeAlias to silience clippy::type_complexity warnings
 type CallbackType = Box<dyn FnMut(&[u8]) + Send + 'static>;
 
-#[allow(clippy::type_complexity)]
 pub(super) struct ChannelReadCallback {
+    // Silence clippy warnings
     _callback: CallbackType,
 }
 

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -291,6 +291,7 @@ fn consumer_device_capabilities() -> RtpCapabilities {
 }
 
 // Keeps executor threads running until dropped
+#[allow(dead_code)]
 struct ExecutorGuard(Vec<async_oneshot::Sender<()>>);
 
 fn create_executor() -> (ExecutorGuard, Arc<Executor<'static>>) {
@@ -977,7 +978,7 @@ fn dump_succeeds() {
                     ssrc: audio_consumer
                         .rtp_parameters()
                         .encodings
-                        .get(0)
+                        .first()
                         .unwrap()
                         .ssrc,
                     rid: None,
@@ -1086,13 +1087,13 @@ fn dump_succeeds() {
                     ssrc: video_consumer
                         .rtp_parameters()
                         .encodings
-                        .get(0)
+                        .first()
                         .unwrap()
                         .ssrc,
                     rtx: video_consumer
                         .rtp_parameters()
                         .encodings
-                        .get(0)
+                        .first()
                         .unwrap()
                         .rtx,
                     dtx: None,
@@ -1165,7 +1166,7 @@ fn get_stats_succeeds() {
                 audio_consumer
                     .rtp_parameters()
                     .encodings
-                    .get(0)
+                    .first()
                     .unwrap()
                     .ssrc
                     .unwrap()
@@ -1214,7 +1215,7 @@ fn get_stats_succeeds() {
                 video_consumer
                     .rtp_parameters()
                     .encodings
-                    .get(0)
+                    .first()
                     .unwrap()
                     .ssrc
                     .unwrap()

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -292,6 +292,7 @@ fn consumer_device_capabilities() -> RtpCapabilities {
 
 // Keeps executor threads running until dropped
 struct ExecutorGuard {
+    // Silence clippy warnings
     _senders: Vec<async_oneshot::Sender<()>>,
 }
 

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -291,8 +291,15 @@ fn consumer_device_capabilities() -> RtpCapabilities {
 }
 
 // Keeps executor threads running until dropped
-#[allow(dead_code)]
-struct ExecutorGuard(Vec<async_oneshot::Sender<()>>);
+struct ExecutorGuard {
+    _senders: Vec<async_oneshot::Sender<()>>,
+}
+
+impl ExecutorGuard {
+    fn new(_senders: Vec<async_oneshot::Sender<()>>) -> Self {
+        Self { _senders }
+    }
+}
 
 fn create_executor() -> (ExecutorGuard, Arc<Executor<'static>>) {
     let executor = Arc::new(Executor::new());
@@ -319,7 +326,7 @@ fn create_executor() -> (ExecutorGuard, Arc<Executor<'static>>) {
         })
         .collect();
 
-    (ExecutorGuard(senders), executor)
+    (ExecutorGuard::new(senders), executor)
 }
 
 async fn init() -> (

--- a/rust/tests/integration/webrtc_server.rs
+++ b/rust/tests/integration/webrtc_server.rs
@@ -10,6 +10,11 @@ use std::net::{IpAddr, Ipv4Addr};
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 
+#[derive(Debug, PartialEq)]
+struct CustomAppData {
+    foo: u32,
+}
+
 async fn init() -> (Worker, Worker) {
     {
         let mut builder = env_logger::builder();
@@ -51,11 +56,6 @@ fn create_webrtc_server_succeeds() {
                 }
             })
             .detach();
-
-        #[derive(Debug, PartialEq)]
-        struct CustomAppData {
-            foo: u32,
-        }
 
         let webrtc_server = worker1
             .create_webrtc_server({
@@ -150,11 +150,6 @@ fn create_webrtc_server_without_specifying_port_succeeds() {
             })
             .detach();
 
-        #[derive(Debug, PartialEq)]
-        struct CustomAppData {
-            foo: u32,
-        }
-
         let webrtc_server = worker1
             .create_webrtc_server({
                 let listen_infos = WebRtcServerListenInfos::new(ListenInfo {
@@ -232,11 +227,6 @@ fn unavailable_infos_fails() {
                 }
             })
             .detach();
-
-        // #[derive(Debug, PartialEq)]
-        // struct CustomAppData {
-        //     foo: u32,
-        // }
 
         // Using an unavailable listen IP.
         {

--- a/rust/tests/integration/webrtc_server.rs
+++ b/rust/tests/integration/webrtc_server.rs
@@ -233,10 +233,10 @@ fn unavailable_infos_fails() {
             })
             .detach();
 
-        #[derive(Debug, PartialEq)]
-        struct CustomAppData {
-            foo: u32,
-        }
+        // #[derive(Debug, PartialEq)]
+        // struct CustomAppData {
+        //     foo: u32,
+        // }
 
         // Using an unavailable listen IP.
         {

--- a/rust/tests/integration/webrtc_transport.rs
+++ b/rust/tests/integration/webrtc_transport.rs
@@ -280,7 +280,7 @@ fn create_with_fixed_port_succeeds() {
             .await
             .expect("Failed to create WebRTC transport");
 
-        assert_eq!(transport.ice_candidates().get(0).unwrap().port, port);
+        assert_eq!(transport.ice_candidates().first().unwrap().port, port);
     });
 }
 
@@ -306,7 +306,7 @@ fn create_with_port_range_succeeds() {
             .await
             .expect("Failed to create WebRTC transport");
 
-        let port1 = transport1.ice_candidates().get(0).unwrap().port;
+        let port1 = transport1.ice_candidates().first().unwrap().port;
         assert!(port1 >= *port_range.start() && port1 <= *port_range.end());
 
         let transport2 = router
@@ -325,7 +325,7 @@ fn create_with_port_range_succeeds() {
             .await
             .expect("Failed to create WebRTC transport");
 
-        let port2 = transport2.ice_candidates().get(0).unwrap().port;
+        let port2 = transport2.ice_candidates().first().unwrap().port;
         assert!(port2 >= *port_range.start() && port2 <= *port_range.end());
 
         assert!(matches!(

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -33,14 +33,12 @@ fn main() {
     )
     .expect("Failed to translate flatbuffers files");
 
-    let planus_content = planus_codegen::generate_rust(&flatbuffers_declarations)
-        .expect("Failed to generate Rust code from flatbuffers");
-
-    let planus_content =
-        planus_content.replace("mod root {", "mod root {\n    #![allow(clippy::all)]");
-    fs::write(format!("{out_dir}/fbs.rs"), planus_content)
-        .expect("Failed to write generated Rust flatbuffers into fbs.rs");
-
+    fs::write(
+        format!("{out_dir}/fbs.rs"),
+        planus_codegen::generate_rust(&flatbuffers_declarations)
+            .expect("Failed to generate Rust code from flatbuffers"),
+    )
+    .expect("Failed to write generated Rust flatbuffers into fbs.rs");
     if env::var("DOCS_RS").is_ok() {
         // Skip everything when building docs on docs.rs
         return;

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -33,12 +33,13 @@ fn main() {
     )
     .expect("Failed to translate flatbuffers files");
 
-    fs::write(
-        format!("{out_dir}/fbs.rs"),
-        planus_codegen::generate_rust(&flatbuffers_declarations)
-            .expect("Failed to generate Rust code from flatbuffers"),
-    )
-    .expect("Failed to write generated Rust flatbuffers into fbs.rs");
+    let planus_content = planus_codegen::generate_rust(&flatbuffers_declarations)
+        .expect("Failed to generate Rust code from flatbuffers");
+
+    let planus_content =
+        planus_content.replace("mod root {", "mod root {\n    #![allow(clippy::all)]");
+    fs::write(format!("{out_dir}/fbs.rs"), planus_content)
+        .expect("Failed to write generated Rust flatbuffers into fbs.rs");
 
     if env::var("DOCS_RS").is_ok() {
         // Skip everything when building docs on docs.rs

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -1,6 +1,11 @@
 use std::os::raw::{c_char, c_int, c_void};
 
-include!(concat!(env!("OUT_DIR"), "/fbs.rs"));
+pub use planus_codegen::*;
+
+mod planus_codegen {
+    #![allow(clippy::all)]
+    include!(concat!(env!("OUT_DIR"), "/fbs.rs"));
+}
 
 #[repr(transparent)]
 #[derive(Copy, Clone)]


### PR DESCRIPTION
- Modify `hex_as_bytes` function to return an array of bytes based on input length
- Remove mutable `output` parameter in `hex_as_bytes` function
- Update usage of `hex_as_bytes` function to use generic type and constant size