### PR TITLE
fix Simulcast IncreaseLayer bug when producer score is zero

### DIFF
--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -476,6 +476,12 @@ namespace RTC
 				continue;
 			}
 
+			// Ignore spatial layers for Producer stream score 0.
+			if (producerRtpStream->GetScore() == 0)
+			{
+				continue;
+			}
+
 			// If the stream has not been active time enough and we have an active one
 			// already, move to the next spatial layer.
 			// clang-format off


### PR DESCRIPTION
when producer stop index 0 , consumer won't switch to index 1
log show ` RTC::SimulcastConsumer::IncreaseLayer() | testing layers 0:0 [virtual bitrate:2446120, required bitrate:0]`