### PR TITLE
TestRtpStreamSend: ASAN, fix buffer overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### NEXT
+
+- Worker: Test, fix buffer overflow ([PR #1419](https://github.com/versatica/mediasoup/pull/1419)).
+
 ### 3.14.8
 
 - Add support for 'playout-delay' RTP extension ([PR #1412](https://github.com/versatica/mediasoup/pull/1412) by @DavidNegro).

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -10,9 +10,9 @@
 
 using namespace RTC;
 
-static RtpPacket* CreateRtpPacket(uint8_t* buffer, uint16_t seq, uint32_t timestamp)
+static RtpPacket* CreateRtpPacket(uint8_t* buffer, size_t len, uint16_t seq, uint32_t timestamp)
 {
-	auto* packet = RtpPacket::Parse(buffer, 1500);
+	auto* packet = RtpPacket::Parse(buffer, len);
 
 	packet->SetSequenceNumber(seq);
 	packet->SetTimestamp(timestamp);
@@ -78,15 +78,15 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 	SECTION("receive NACK and get retransmitted packets")
 	{
 		// packet1 [pt:123, seq:21006, timestamp:1533790901]
-		auto* packet1 = CreateRtpPacket(rtpBuffer1, 21006, 1533790901);
+		auto* packet1 = CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901);
 		// packet2 [pt:123, seq:21007, timestamp:1533790901]
-		auto* packet2 = CreateRtpPacket(rtpBuffer2, 21007, 1533790901);
+		auto* packet2 = CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901);
 		// packet3 [pt:123, seq:21008, timestamp:1533793871]
-		auto* packet3 = CreateRtpPacket(rtpBuffer3, 21008, 1533793871);
+		auto* packet3 = CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871);
 		// packet4 [pt:123, seq:21009, timestamp:1533793871]
-		auto* packet4 = CreateRtpPacket(rtpBuffer4, 21009, 1533793871);
+		auto* packet4 = CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871);
 		// packet5 [pt:123, seq:21010, timestamp:1533796931]
-		auto* packet5 = CreateRtpPacket(rtpBuffer5, 21010, 1533796931);
+		auto* packet5 = CreateRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931);
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -143,15 +143,15 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 	SECTION("receive NACK and get zero retransmitted packets if useNack is not set")
 	{
 		// packet1 [pt:123, seq:21006, timestamp:1533790901]
-		auto* packet1 = CreateRtpPacket(rtpBuffer1, 21006, 1533790901);
+		auto* packet1 = CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901);
 		// packet2 [pt:123, seq:21007, timestamp:1533790901]
-		auto* packet2 = CreateRtpPacket(rtpBuffer2, 21007, 1533790901);
+		auto* packet2 = CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901);
 		// packet3 [pt:123, seq:21008, timestamp:1533793871]
-		auto* packet3 = CreateRtpPacket(rtpBuffer3, 21008, 1533793871);
+		auto* packet3 = CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871);
 		// packet4 [pt:123, seq:21009, timestamp:1533793871]
-		auto* packet4 = CreateRtpPacket(rtpBuffer4, 21009, 1533793871);
+		auto* packet4 = CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871);
 		// packet5 [pt:123, seq:21010, timestamp:1533796931]
-		auto* packet5 = CreateRtpPacket(rtpBuffer5, 21010, 1533796931);
+		auto* packet5 = CreateRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931);
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -196,15 +196,15 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 	SECTION("receive NACK and get zero retransmitted packets for audio")
 	{
 		// packet1 [pt:123, seq:21006, timestamp:1533790901]
-		auto* packet1 = CreateRtpPacket(rtpBuffer1, 21006, 1533790901);
+		auto* packet1 = CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901);
 		// packet2 [pt:123, seq:21007, timestamp:1533790901]
-		auto* packet2 = CreateRtpPacket(rtpBuffer2, 21007, 1533790901);
+		auto* packet2 = CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901);
 		// packet3 [pt:123, seq:21008, timestamp:1533793871]
-		auto* packet3 = CreateRtpPacket(rtpBuffer3, 21008, 1533793871);
+		auto* packet3 = CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871);
 		// packet4 [pt:123, seq:21009, timestamp:1533793871]
-		auto* packet4 = CreateRtpPacket(rtpBuffer4, 21009, 1533793871);
+		auto* packet4 = CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871);
 		// packet5 [pt:123, seq:21010, timestamp:1533796931]
-		auto* packet5 = CreateRtpPacket(rtpBuffer5, 21010, 1533796931);
+		auto* packet5 = CreateRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931);
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -249,9 +249,9 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 	SECTION("receive NACK in different RtpStreamSend instances and get retransmitted packets")
 	{
 		// packet1 [pt:123, seq:21006, timestamp:1533790901]
-		auto* packet1 = CreateRtpPacket(rtpBuffer1, 21006, 1533790901);
+		auto* packet1 = CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901);
 		// packet2 [pt:123, seq:21007, timestamp:1533790901]
-		auto* packet2 = CreateRtpPacket(rtpBuffer2, 21007, 1533790901);
+		auto* packet2 = CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901);
 
 		// Create two RtpStreamSend instances.
 		TestRtpStreamListener testRtpStreamListener1;
@@ -326,8 +326,8 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		uint32_t diffTs    = RtpStreamSend::MaxRetransmissionDelayForVideoMs * clockRate / 1000;
 		uint32_t secondTs  = firstTs + diffTs;
 
-		auto* packet1 = CreateRtpPacket(rtpBuffer1, 21006, firstTs);
-		auto* packet2 = CreateRtpPacket(rtpBuffer2, 21007, secondTs - 1);
+		auto* packet1 = CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, firstTs);
+		auto* packet2 = CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, secondTs - 1);
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -381,9 +381,9 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		// Send a third packet so it will clean old packets from the buffer.
 		uint32_t thirdTs = firstTs + (2 * diffTs);
 
-		auto* packet1 = CreateRtpPacket(rtpBuffer1, 21006, firstTs);
-		auto* packet2 = CreateRtpPacket(rtpBuffer2, 21007, secondTs);
-		auto* packet3 = CreateRtpPacket(rtpBuffer3, 21008, thirdTs);
+		auto* packet1 = CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, firstTs);
+		auto* packet2 = CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, secondTs);
+		auto* packet3 = CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, thirdTs);
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -430,14 +430,14 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 	{
 		// This scenario reproduce the "too bad sequence number" and "bad sequence
 		// number" scenarios in RtpStream::UpdateSeq().
-		auto* packet1 = CreateRtpPacket(rtpBuffer1, 50001, 1000001);
-		auto* packet2 = CreateRtpPacket(rtpBuffer2, 50002, 1000002);
+		auto* packet1 = CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 50001, 1000001);
+		auto* packet2 = CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 50002, 1000002);
 		// Third packet has bad sequence number (its seq is more than MaxDropout=3000
 		// older than current max seq) and will be dropped.
-		auto* packet3 = CreateRtpPacket(rtpBuffer3, 40003, 1000003);
+		auto* packet3 = CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 40003, 1000003);
 		// Forth packet has seq=badSeq+1 so will be accepted and will trigger a
 		// stream reset.
-		auto* packet4 = CreateRtpPacket(rtpBuffer4, 40004, 1000004);
+		auto* packet4 = CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 40004, 1000004);
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;


### PR DESCRIPTION
Do not use a hardcoded length value when parsing a RTP packet

Fixes **TODO 1** in https://github.com/versatica/mediasoup/issues/1417#issuecomment-2199943723