### PR TITLE
Worker tests: use unique pointers when possible

### DIFF
--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -97,12 +97,10 @@ jobs:
         # TODO: Maybe fix this one day.
         if: runner.os != 'Windows'
 
-      # TODO: Uncomment once https://github.com/versatica/mediasoup/issues/1417
-      # is fixed.
-      # - name: invoke -r worker test-asan-address
-      #   run: invoke -r worker test-asan-address
-      #   # Address Sanitizer only works on Linux.
-      #   if: runner.os == 'Linux'
+      - name: invoke -r worker test-asan-address
+        run: invoke -r worker test-asan-address
+        # Address Sanitizer only works on Linux.
+        if: runner.os == 'Linux'
 
       # TODO: Uncomment once https://github.com/versatica/mediasoup/issues/1417
       # is fixed.

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -6,7 +6,7 @@ RUN set -x \
 	&& apt-get install --yes \
 		gcc g++ clang pkg-config bash-completion wget curl \
 		screen python3-pip python3-yaml pkg-config zlib1g-dev \
-		libgss-dev libssl-dev libxml2-dev
+		libgss-dev libssl-dev libxml2-dev gdb
 
 # Install node 20.
 RUN set -x \
@@ -20,6 +20,10 @@ RUN set -x \
 	> /etc/apt/sources.list.d/nodesource.list \
 	&& apt-get update \
 	&& apt-get install nodejs --yes
+
+# Enable core dumps.
+RUN set -x \
+	&& echo "mkdir -p /tmp/cores && chmod 777 /tmp/cores && echo \"/tmp/cores/core.%e.sig%s.%p\" > /proc/sys/kernel/core_pattern && ulimit -c unlimited" >> ~/.bashrc
 
 # Make CC and CXX point to clang/clang++ installed above.
 ENV LANG="C.UTF-8"

--- a/worker/test/src/RTC/Codecs/TestH264.cpp
+++ b/worker/test/src/RTC/Codecs/TestH264.cpp
@@ -21,10 +21,9 @@ SCENARIO("parse H264 payload descriptor", "[codecs][h264]")
 
 		std::memcpy(buffer, originalBuffer, sizeof(buffer));
 
-		const auto* payloadDescriptor = Codecs::H264::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<Codecs::H264::PayloadDescriptor> payloadDescriptor{ Codecs::H264::Parse(
+			buffer, sizeof(buffer)) };
 
 		REQUIRE(payloadDescriptor);
-
-		delete payloadDescriptor;
 	}
 }

--- a/worker/test/src/RTC/Codecs/TestH264_SVC.cpp
+++ b/worker/test/src/RTC/Codecs/TestH264_SVC.cpp
@@ -21,7 +21,9 @@ SCENARIO("parse H264_SVC payload descriptor", "[codecs][h264_svc]")
 
 		std::memcpy(buffer, originalBuffer, sizeof(buffer));
 
-		const auto* payloadDescriptor = Codecs::H264_SVC::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+			Codecs::H264_SVC::Parse(buffer, sizeof(buffer))
+		};
 
 		REQUIRE(payloadDescriptor);
 
@@ -31,8 +33,6 @@ SCENARIO("parse H264_SVC payload descriptor", "[codecs][h264_svc]")
 		REQUIRE(payloadDescriptor->isKeyFrame == true);
 		REQUIRE(payloadDescriptor->hasTlIndex == false);
 		REQUIRE(payloadDescriptor->hasSlIndex == false);
-
-		delete payloadDescriptor;
 	}
 
 	SECTION("parse payload descriptor for NALU 8")
@@ -49,7 +49,9 @@ SCENARIO("parse H264_SVC payload descriptor", "[codecs][h264_svc]")
 
 		std::memcpy(buffer, originalBuffer, sizeof(buffer));
 
-		const auto* payloadDescriptor = Codecs::H264_SVC::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+			Codecs::H264_SVC::Parse(buffer, sizeof(buffer))
+		};
 
 		REQUIRE(payloadDescriptor);
 
@@ -59,8 +61,6 @@ SCENARIO("parse H264_SVC payload descriptor", "[codecs][h264_svc]")
 		REQUIRE(payloadDescriptor->isKeyFrame == false);
 		REQUIRE(payloadDescriptor->hasTlIndex == false);
 		REQUIRE(payloadDescriptor->hasSlIndex == false);
-
-		delete payloadDescriptor;
 	}
 
 	SECTION("parse payload descriptor for NALU 1")
@@ -77,7 +77,9 @@ SCENARIO("parse H264_SVC payload descriptor", "[codecs][h264_svc]")
 
 		std::memcpy(buffer, originalBuffer, sizeof(buffer));
 
-		const auto* payloadDescriptor = Codecs::H264_SVC::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+			Codecs::H264_SVC::Parse(buffer, sizeof(buffer))
+		};
 
 		REQUIRE(payloadDescriptor);
 
@@ -87,8 +89,6 @@ SCENARIO("parse H264_SVC payload descriptor", "[codecs][h264_svc]")
 		REQUIRE(payloadDescriptor->isKeyFrame == false);
 		REQUIRE(payloadDescriptor->hasTlIndex == false);
 		REQUIRE(payloadDescriptor->hasSlIndex == false);
-
-		delete payloadDescriptor;
 	}
 
 	SECTION("parse payload descriptor for NALU 5")
@@ -105,7 +105,9 @@ SCENARIO("parse H264_SVC payload descriptor", "[codecs][h264_svc]")
 
 		std::memcpy(buffer, originalBuffer, sizeof(buffer));
 
-		const auto* payloadDescriptor = Codecs::H264_SVC::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+			Codecs::H264_SVC::Parse(buffer, sizeof(buffer))
+		};
 
 		REQUIRE(payloadDescriptor);
 
@@ -115,8 +117,6 @@ SCENARIO("parse H264_SVC payload descriptor", "[codecs][h264_svc]")
 		REQUIRE(payloadDescriptor->isKeyFrame == true);
 		REQUIRE(payloadDescriptor->hasTlIndex == false);
 		REQUIRE(payloadDescriptor->hasSlIndex == false);
-
-		delete payloadDescriptor;
 	}
 
 	SECTION("parse payload descriptor for NALU 14")
@@ -133,7 +133,9 @@ SCENARIO("parse H264_SVC payload descriptor", "[codecs][h264_svc]")
 
 		std::memcpy(buffer, originalBuffer, sizeof(buffer));
 
-		const auto* payloadDescriptor = Codecs::H264_SVC::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+			Codecs::H264_SVC::Parse(buffer, sizeof(buffer))
+		};
 
 		REQUIRE(payloadDescriptor);
 
@@ -145,8 +147,6 @@ SCENARIO("parse H264_SVC payload descriptor", "[codecs][h264_svc]")
 		REQUIRE(payloadDescriptor->isKeyFrame == false);
 		REQUIRE(payloadDescriptor->hasTlIndex == true);
 		REQUIRE(payloadDescriptor->hasSlIndex == true);
-
-		delete payloadDescriptor;
 	}
 
 	SECTION("parse payload descriptor for NALU 20")
@@ -163,7 +163,9 @@ SCENARIO("parse H264_SVC payload descriptor", "[codecs][h264_svc]")
 
 		std::memcpy(buffer, originalBuffer, sizeof(buffer));
 
-		const auto* payloadDescriptor = Codecs::H264_SVC::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+			Codecs::H264_SVC::Parse(buffer, sizeof(buffer))
+		};
 
 		REQUIRE(payloadDescriptor);
 
@@ -175,7 +177,5 @@ SCENARIO("parse H264_SVC payload descriptor", "[codecs][h264_svc]")
 		REQUIRE(payloadDescriptor->isKeyFrame == false);
 		REQUIRE(payloadDescriptor->hasTlIndex == true);
 		REQUIRE(payloadDescriptor->hasSlIndex == true);
-
-		delete payloadDescriptor;
 	}
 }

--- a/worker/test/src/RTC/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP8.cpp
@@ -38,7 +38,8 @@ SCENARIO("parse VP8 payload descriptor", "[codecs][vp8]")
 
 		std::memcpy(buffer, originalBuffer, sizeof(buffer));
 
-		const auto* payloadDescriptor = Codecs::VP8::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<Codecs::VP8::PayloadDescriptor> payloadDescriptor{ Codecs::VP8::Parse(
+			buffer, sizeof(buffer)) };
 
 		REQUIRE(payloadDescriptor);
 
@@ -77,8 +78,6 @@ SCENARIO("parse VP8 payload descriptor", "[codecs][vp8]")
 				REQUIRE(std::memcmp(buffer, originalBuffer, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete payloadDescriptor;
 	}
 
 	SECTION("parse payload descriptor 2")
@@ -113,7 +112,8 @@ SCENARIO("parse VP8 payload descriptor", "[codecs][vp8]")
 		std::memcpy(buffer, originalBuffer, sizeof(buffer));
 
 		// Parse the buffer.
-		const auto* payloadDescriptor = Codecs::VP8::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<Codecs::VP8::PayloadDescriptor> payloadDescriptor{ Codecs::VP8::Parse(
+			buffer, sizeof(buffer)) };
 
 		REQUIRE(payloadDescriptor);
 
@@ -152,8 +152,6 @@ SCENARIO("parse VP8 payload descriptor", "[codecs][vp8]")
 				REQUIRE(std::memcmp(buffer, originalBuffer, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete payloadDescriptor;
 	};
 
 	SECTION("parse payload descriptor. I flag set but no space for pictureId")

--- a/worker/test/src/RTC/RTCP/TestBye.cpp
+++ b/worker/test/src/RTC/RTCP/TestBye.cpp
@@ -47,11 +47,11 @@ SCENARIO("RTCP BYE parsing", "[parser][rtcp][bye]")
 {
 	SECTION("parse BYE packet")
 	{
-		ByePacket* packet = ByePacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<ByePacket> packet{ ByePacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -64,8 +64,6 @@ SCENARIO("RTCP BYE parsing", "[parser][rtcp][bye]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create ByePacket")

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsAfb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsAfb.cpp
@@ -39,11 +39,11 @@ SCENARIO("RTCP Feedback PS AFB parsing", "[parser][rtcp][feedback-ps][afb]")
 	{
 		using namespace TestFeedbackPsAfb;
 
-		FeedbackPsAfbPacket* packet = FeedbackPsAfbPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackPsAfbPacket> packet{ FeedbackPsAfbPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -56,7 +56,5 @@ SCENARIO("RTCP Feedback PS AFB parsing", "[parser][rtcp][feedback-ps][afb]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 }

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsFir.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsFir.cpp
@@ -44,11 +44,11 @@ SCENARIO("RTCP Feedback PS FIR parsing", "[parser][rtcp][feedback-ps][fir]")
 
 	SECTION("parse FeedbackPsFirPacket")
 	{
-		FeedbackPsFirPacket* packet = FeedbackPsFirPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackPsFirPacket> packet{ FeedbackPsFirPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -61,8 +61,6 @@ SCENARIO("RTCP Feedback PS FIR parsing", "[parser][rtcp][feedback-ps][fir]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create FeedbackPsFirPacket")

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsLei.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsLei.cpp
@@ -41,11 +41,11 @@ SCENARIO("RTCP Feedback PS LEI parsing", "[parser][rtcp][feedback-ps][lei]")
 
 	SECTION("parse FeedbackPsLeiPacket")
 	{
-		FeedbackPsLeiPacket* packet = FeedbackPsLeiPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackPsLeiPacket> packet{ FeedbackPsLeiPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -58,8 +58,6 @@ SCENARIO("RTCP Feedback PS LEI parsing", "[parser][rtcp][feedback-ps][lei]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create FeedbackPsLeiPacket")

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsPli.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsPli.cpp
@@ -2,7 +2,6 @@
 #include "RTC/RTCP/FeedbackPsPli.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
-#include <memory>
 
 using namespace RTC::RTCP;
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsPli.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsPli.cpp
@@ -2,6 +2,7 @@
 #include "RTC/RTCP/FeedbackPsPli.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
+#include <memory>
 
 using namespace RTC::RTCP;
 
@@ -35,11 +36,11 @@ SCENARIO("RTCP Feeback RTP PLI parsing", "[parser][rtcp][feedback-ps][pli]")
 
 	SECTION("parse FeedbackPsPliPacket")
 	{
-		FeedbackPsPliPacket* packet = FeedbackPsPliPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackPsPliPacket> packet{ FeedbackPsPliPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -52,8 +53,6 @@ SCENARIO("RTCP Feeback RTP PLI parsing", "[parser][rtcp][feedback-ps][pli]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create FeedbackPsPliPacket")

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsRemb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsRemb.cpp
@@ -43,11 +43,11 @@ SCENARIO("RTCP Feedback PS parsing", "[parser][rtcp][feedback-ps][remb]")
 
 	SECTION("parse FeedbackPsRembPacket")
 	{
-		FeedbackPsRembPacket* packet = FeedbackPsRembPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackPsRembPacket> packet{ FeedbackPsRembPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -60,8 +60,6 @@ SCENARIO("RTCP Feedback PS parsing", "[parser][rtcp][feedback-ps][remb]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create FeedbackPsRembPacket")

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp
@@ -49,11 +49,11 @@ SCENARIO("RTCP Feedback PS RPSI parsing", "[parser][rtcp][feedback-ps][rpsi]")
 
 	SECTION("parse FeedbackPsRpsiPacket")
 	{
-		FeedbackPsRpsiPacket* packet = FeedbackPsRpsiPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackPsRpsiPacket> packet{ FeedbackPsRpsiPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -66,7 +66,5 @@ SCENARIO("RTCP Feedback PS RPSI parsing", "[parser][rtcp][feedback-ps][rpsi]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 }

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsSli.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsSli.cpp
@@ -46,11 +46,11 @@ SCENARIO("RTCP Feedback PS SLI parsing", "[parser][rtcp][feedback-ps][sli]")
 
 	SECTION("parse FeedbackPsSliPacket")
 	{
-		FeedbackPsSliPacket* packet = FeedbackPsSliPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackPsSliPacket> packet{ FeedbackPsSliPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -63,7 +63,5 @@ SCENARIO("RTCP Feedback PS SLI parsing", "[parser][rtcp][feedback-ps][sli]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 }

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsTst.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsTst.cpp
@@ -45,11 +45,11 @@ SCENARIO("RTCP Feedback PS TSTN parsing", "[parser][rtcp][feedback-ps][tstn]")
 
 	SECTION("parse FeedbackPsTstPacket")
 	{
-		FeedbackPsTstnPacket* packet = FeedbackPsTstnPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackPsTstnPacket> packet{ FeedbackPsTstnPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -62,8 +62,6 @@ SCENARIO("RTCP Feedback PS TSTN parsing", "[parser][rtcp][feedback-ps][tstn]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create FeedbackPsTstPacket")

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp
@@ -55,11 +55,11 @@ SCENARIO("RTCP Feedback PS VBCM parsing", "[parser][rtcp][feedback-ps][vbcm]")
 
 	SECTION("parse FeedbackPsVbcmPacket")
 	{
-		FeedbackPsVbcmPacket* packet = FeedbackPsVbcmPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackPsVbcmPacket> packet{ FeedbackPsVbcmPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -72,7 +72,5 @@ SCENARIO("RTCP Feedback PS VBCM parsing", "[parser][rtcp][feedback-ps][vbcm]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 }

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp
@@ -61,11 +61,11 @@ SCENARIO("RTCP Feeback RTP ECN parsing", "[parser][rtcp][feedback-rtp][ecn]")
 	{
 		using namespace TestFeedbackRtpEcn;
 
-		FeedbackRtpEcnPacket* packet = FeedbackRtpEcnPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackRtpEcnPacket> packet{ FeedbackRtpEcnPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -78,7 +78,5 @@ SCENARIO("RTCP Feeback RTP ECN parsing", "[parser][rtcp][feedback-rtp][ecn]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 }

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpNack.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpNack.cpp
@@ -45,11 +45,12 @@ SCENARIO("RTCP Feeback RTP NACK parsing", "[parser][rtcp][feedback-rtp][nack]")
 
 	SECTION("parse FeedbackRtpNackItem")
 	{
-		FeedbackRtpNackPacket* packet = FeedbackRtpNackPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackRtpNackPacket> packet{ FeedbackRtpNackPacket::Parse(
+			buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -62,8 +63,6 @@ SCENARIO("RTCP Feeback RTP NACK parsing", "[parser][rtcp][feedback-rtp][nack]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create FeedbackRtpNackPacket")

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpSrReq.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpSrReq.cpp
@@ -35,11 +35,12 @@ SCENARIO("RTCP Feeback RTP SR-REQ parsing", "[parser][rtcp][feedback-rtp][sr-req
 
 	SECTION("parse FeedbackRtpSrReqPacket")
 	{
-		FeedbackRtpSrReqPacket* packet = FeedbackRtpSrReqPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackRtpSrReqPacket> packet{ FeedbackRtpSrReqPacket::Parse(
+			buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -52,8 +53,6 @@ SCENARIO("RTCP Feeback RTP SR-REQ parsing", "[parser][rtcp][feedback-rtp][sr-req
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create FeedbackRtpSrReqPacket")

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp
@@ -45,11 +45,12 @@ SCENARIO("RTCP Feeback RTP TLLEI parsing", "[parser][rtcp][feedback-rtp][tllei]"
 	{
 		using namespace TestFeedbackRtpTllei;
 
-		FeedbackRtpTlleiPacket* packet = FeedbackRtpTlleiPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackRtpTlleiPacket> packet{ FeedbackRtpTlleiPacket::Parse(
+			buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -62,7 +63,5 @@ SCENARIO("RTCP Feeback RTP TLLEI parsing", "[parser][rtcp][feedback-rtp][tllei]"
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 }

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp
@@ -48,11 +48,12 @@ SCENARIO("RTCP Feeback RTP TMMBR parsing", "[parser][rtcp][feedback-rtp][tmmb]")
 
 	SECTION("parse FeedbackRtpTmmbrPacket")
 	{
-		FeedbackRtpTmmbrPacket* packet = FeedbackRtpTmmbrPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<FeedbackRtpTmmbrPacket> packet{ FeedbackRtpTmmbrPacket::Parse(
+			buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 
-		verify(packet);
+		verify(packet.get());
 
 		SECTION("serialize packet instance")
 		{
@@ -64,15 +65,12 @@ SCENARIO("RTCP Feeback RTP TMMBR parsing", "[parser][rtcp][feedback-rtp][tmmb]")
 			// represent the same content.
 			SECTION("create a packet out of the serialized buffer")
 			{
-				FeedbackRtpTmmbrPacket* packet = FeedbackRtpTmmbrPacket::Parse(buffer, sizeof(buffer));
+				std::unique_ptr<FeedbackRtpTmmbrPacket> packet{ FeedbackRtpTmmbrPacket::Parse(
+					buffer, sizeof(buffer)) };
 
-				verify(packet);
-
-				delete packet;
+				verify(packet.get());
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create FeedbackRtpTmmbrPacket")

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
@@ -3,6 +3,7 @@
 #include "RTC/RTCP/FeedbackRtpTransport.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
+#include <memory>
 
 using namespace RTC::RTCP;
 
@@ -69,7 +70,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 	SECTION(
 	  "create FeedbackRtpTransportPacket, small delta run length chunk and single large delta status packet")
 	{
-		auto* packet = new FeedbackRtpTransportPacket(senderSsrc, mediaSsrc);
+		auto packet = std::make_unique<FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
 
 		REQUIRE(packet);
 
@@ -141,7 +142,8 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 
 			SECTION("parse serialized buffer")
 			{
-				auto* packet2 = FeedbackRtpTransportPacket::Parse(buffer, len);
+				std::unique_ptr<FeedbackRtpTransportPacket> packet2{ FeedbackRtpTransportPacket::Parse(
+					buffer, len) };
 
 				REQUIRE(packet2);
 				REQUIRE(packet2->GetBaseSequenceNumber() == 1000);
@@ -155,17 +157,13 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 				REQUIRE(len == len2);
 				REQUIRE(std::memcmp(buffer, buffer2, len) == 0);
 				REQUIRE(packet2->GetSize() == len2);
-
-				delete packet2;
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create FeedbackRtpTransportPacket, run length chunk (2)")
 	{
-		auto* packet = new FeedbackRtpTransportPacket(senderSsrc, mediaSsrc);
+		auto packet = std::make_unique<FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
 
 		/* clang-format off */
 		std::vector<TestFeedbackRtpTransportInput> inputs =
@@ -209,7 +207,8 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 
 			SECTION("parse serialized buffer")
 			{
-				auto* packet2 = FeedbackRtpTransportPacket::Parse(buffer, len);
+				std::unique_ptr<FeedbackRtpTransportPacket> packet2{ FeedbackRtpTransportPacket::Parse(
+					buffer, len) };
 
 				REQUIRE(packet2);
 				REQUIRE(packet2->GetBaseSequenceNumber() == 1000);
@@ -223,12 +222,8 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 				REQUIRE(len == len2);
 				REQUIRE(std::memcmp(buffer, buffer2, len) == 0);
 				REQUIRE(packet2->GetSize() == len2);
-
-				delete packet2;
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create FeedbackRtpTransportPacket, mixed chunks")
@@ -246,7 +241,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		};
 		/* clang-format on */
 
-		auto* packet = new FeedbackRtpTransportPacket(senderSsrc, mediaSsrc);
+		auto packet = std::make_unique<FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
 
 		packet->SetFeedbackPacketCount(1);
 
@@ -281,7 +276,8 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 
 			SECTION("parse serialized buffer")
 			{
-				auto* packet2 = FeedbackRtpTransportPacket::Parse(buffer, len);
+				std::unique_ptr<FeedbackRtpTransportPacket> packet2{ FeedbackRtpTransportPacket::Parse(
+					buffer, len) };
 
 				REQUIRE(packet2);
 				REQUIRE(packet2->GetBaseSequenceNumber() == 1000);
@@ -295,12 +291,8 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 				REQUIRE(len == len2);
 				REQUIRE(std::memcmp(buffer, buffer2, len) == 0);
 				REQUIRE(packet2->GetSize() == len2);
-
-				delete packet2;
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create FeedbackRtpTransportPacket, incomplete two bit vector chunk")
@@ -311,7 +303,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 			{ 1001, 1000000700, RtcpMtu },
 		};
 
-		auto* packet = new FeedbackRtpTransportPacket(senderSsrc, mediaSsrc);
+		auto packet = std::make_unique<FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
 
 		packet->SetFeedbackPacketCount(1);
 
@@ -346,7 +338,8 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 
 			SECTION("parse serialized buffer")
 			{
-				auto* packet2 = FeedbackRtpTransportPacket::Parse(buffer, len);
+				std::unique_ptr<FeedbackRtpTransportPacket> packet2{ FeedbackRtpTransportPacket::Parse(
+					buffer, len) };
 
 				REQUIRE(packet2);
 				REQUIRE(packet2->GetBaseSequenceNumber() == 1000);
@@ -360,12 +353,8 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 				REQUIRE(len == len2);
 				REQUIRE(std::memcmp(buffer, buffer2, len) == 0);
 				REQUIRE(packet2->GetSize() == len2);
-
-				delete packet2;
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("create two sequential FeedbackRtpTransportPackets")
@@ -385,7 +374,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		};
 		/* clang-format on */
 
-		auto* packet = new FeedbackRtpTransportPacket(senderSsrc, mediaSsrc);
+		auto packet = std::make_unique<FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
 
 		packet->SetFeedbackPacketCount(1);
 
@@ -418,7 +407,8 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 
 		SECTION("parse serialized buffer")
 		{
-			auto* packet2 = FeedbackRtpTransportPacket::Parse(buffer, len);
+			std::unique_ptr<FeedbackRtpTransportPacket> packet2{ FeedbackRtpTransportPacket::Parse(
+				buffer, len) };
 
 			REQUIRE(packet2);
 			REQUIRE(packet2->GetBaseSequenceNumber() == 1000);
@@ -432,8 +422,6 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 			REQUIRE(len == len2);
 			REQUIRE(std::memcmp(buffer, buffer2, len) == 0);
 			REQUIRE(packet2->GetSize() == len2);
-
-			delete packet2;
 		}
 
 		auto latestWideSeqNumber = packet->GetLatestSequenceNumber();
@@ -453,7 +441,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		};
 		/* clang-format on */
 
-		auto* packet2 = new FeedbackRtpTransportPacket(senderSsrc, mediaSsrc);
+		auto packet2 = std::make_unique<FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
 
 		packet2->SetFeedbackPacketCount(2);
 
@@ -485,7 +473,8 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 
 		SECTION("parse serialized buffer")
 		{
-			auto* packet3 = FeedbackRtpTransportPacket::Parse(buffer, len);
+			std::unique_ptr<FeedbackRtpTransportPacket> packet3{ FeedbackRtpTransportPacket::Parse(
+				buffer, len) };
 
 			REQUIRE(packet3);
 			REQUIRE(packet3->GetBaseSequenceNumber() == 1008);
@@ -499,12 +488,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 			REQUIRE(len == len2);
 			REQUIRE(std::memcmp(buffer, buffer2, len) == 0);
 			REQUIRE(packet3->GetSize() == len2);
-
-			delete packet3;
 		}
-
-		delete packet2;
-		delete packet;
 	}
 
 	SECTION("parse FeedbackRtpTransportPacket, one bit vector chunk")
@@ -523,7 +507,8 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		};
 		// clang-format on
 
-		auto* packet = FeedbackRtpTransportPacket::Parse(data, sizeof(data));
+		std::unique_ptr<FeedbackRtpTransportPacket> packet{ FeedbackRtpTransportPacket::Parse(
+			data, sizeof(data)) };
 
 		REQUIRE(packet);
 		REQUIRE(packet->GetSize() == sizeof(data));
@@ -544,8 +529,6 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 			REQUIRE(len == sizeof(data));
 			REQUIRE(std::memcmp(data, buffer, len) == 0);
 		}
-
-		delete packet;
 	}
 
 	SECTION("parse FeedbackRtpTransportPacket with negative reference time")
@@ -561,7 +544,8 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		};
 		// clang-format on
 
-		auto* packet = FeedbackRtpTransportPacket::Parse(data, sizeof(data));
+		std::unique_ptr<FeedbackRtpTransportPacket> packet{ FeedbackRtpTransportPacket::Parse(
+			data, sizeof(data)) };
 
 		REQUIRE(packet);
 		REQUIRE(packet->GetSize() == sizeof(data));
@@ -582,8 +566,6 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 			REQUIRE(len == sizeof(data));
 			REQUIRE(std::memcmp(data, buffer, len) == 0);
 		}
-
-		delete packet;
 	}
 
 	SECTION("parse FeedbackRtpTransportPacket generated by Chrome")
@@ -600,7 +582,8 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		};
 		// clang-format on
 
-		auto* packet = FeedbackRtpTransportPacket::Parse(data, sizeof(data));
+		std::unique_ptr<FeedbackRtpTransportPacket> packet{ FeedbackRtpTransportPacket::Parse(
+			data, sizeof(data)) };
 
 		REQUIRE(packet);
 		REQUIRE(packet->GetSize() == sizeof(data));
@@ -622,8 +605,6 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 			REQUIRE(len == sizeof(data));
 			REQUIRE(std::memcmp(data, buffer, len) == 0);
 		}
-
-		delete packet;
 	}
 
 	SECTION("parse FeedbackRtpTransportPacket generated by Chrome with libwebrtc as a reference")
@@ -766,8 +747,10 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 
 		for (const auto& packetMeta : feedbackPacketsMeta)
 		{
-			auto buffer    = packetMeta.buffer;
-			auto* feedback = FeedbackRtpTransportPacket::Parse(buffer.data(), buffer.size());
+			auto buffer = packetMeta.buffer;
+
+			std::unique_ptr<FeedbackRtpTransportPacket> feedback{ FeedbackRtpTransportPacket::Parse(
+				buffer.data(), buffer.size()) };
 
 			REQUIRE(feedback->GetReferenceTime() == packetMeta.baseTimeRaw);
 			REQUIRE(feedback->GetReferenceTimestamp() == packetMeta.baseTimeMs);
@@ -783,7 +766,6 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 				REQUIRE(static_cast<int16_t>(resultDelta / 4) == delta);
 				deltasIt++;
 			}
-			delete feedback;
 		}
 	}
 
@@ -791,9 +773,9 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 	{
 		auto MaxBaseTime =
 		  FeedbackRtpTransportPacket::TimeWrapPeriod - FeedbackRtpTransportPacket::BaseTimeTick;
-		auto* packet1 = new FeedbackRtpTransportPacket(senderSsrc, mediaSsrc);
-		auto* packet2 = new FeedbackRtpTransportPacket(senderSsrc, mediaSsrc);
-		auto* packet3 = new FeedbackRtpTransportPacket(senderSsrc, mediaSsrc);
+		auto packet1 = std::make_unique<FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
+		auto packet2 = std::make_unique<FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
+		auto packet3 = std::make_unique<FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
 
 		packet1->SetReferenceTime(MaxBaseTime);
 		packet2->SetReferenceTime(MaxBaseTime + FeedbackRtpTransportPacket::BaseTimeTick);
@@ -813,9 +795,5 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		REQUIRE(packet2->GetBaseDelta(packet1->GetReferenceTimestamp()) == 64);
 		REQUIRE(packet3->GetBaseDelta(packet2->GetReferenceTimestamp()) == 64);
 		REQUIRE(packet3->GetBaseDelta(packet1->GetReferenceTimestamp()) == 128);
-
-		delete packet1;
-		delete packet2;
-		delete packet3;
 	}
 }

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
@@ -3,7 +3,6 @@
 #include "RTC/RTCP/FeedbackRtpTransport.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
-#include <memory>
 
 using namespace RTC::RTCP;
 

--- a/worker/test/src/RTC/RTCP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTCP/TestPacket.cpp
@@ -18,11 +18,9 @@ SCENARIO("RTCP parsing", "[parser][rtcp][packet]")
 
 	SECTION("a RTCP packet may only contain the RTCP common header")
 	{
-		Packet* packet = Packet::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<Packet> packet{ Packet::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
-
-		delete packet;
 	}
 
 	SECTION("a too small RTCP packet should fail")
@@ -30,11 +28,9 @@ SCENARIO("RTCP parsing", "[parser][rtcp][packet]")
 		// Provide a wrong packet length.
 		size_t length = sizeof(buffer) - 1;
 
-		Packet* packet = Packet::Parse(buffer, length);
+		std::unique_ptr<Packet> packet{ Packet::Parse(buffer, length) };
 
 		REQUIRE_FALSE(packet);
-
-		delete packet;
 	}
 
 	SECTION("a RTCP packet with incorrect version should fail")
@@ -42,11 +38,9 @@ SCENARIO("RTCP parsing", "[parser][rtcp][packet]")
 		// Set an incorrect version value (0).
 		buffer[0] &= 0b00111111;
 
-		Packet* packet = Packet::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<Packet> packet{ Packet::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE_FALSE(packet);
-
-		delete packet;
 	}
 
 	SECTION("a RTCP packet with incorrect length should fail")
@@ -54,11 +48,9 @@ SCENARIO("RTCP parsing", "[parser][rtcp][packet]")
 		// Set the packet length to zero.
 		buffer[3] = 1;
 
-		Packet* packet = Packet::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<Packet> packet{ Packet::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE_FALSE(packet);
-
-		delete packet;
 	}
 
 	SECTION("a RTCP packet with unknown type should fail")
@@ -66,10 +58,8 @@ SCENARIO("RTCP parsing", "[parser][rtcp][packet]")
 		// Set and unknown packet type (0).
 		buffer[1] = 0;
 
-		Packet* packet = Packet::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<Packet> packet{ Packet::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE_FALSE(packet);
-
-		delete packet;
 	}
 }

--- a/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
@@ -53,7 +53,7 @@ SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
 {
 	SECTION("parse RR packet with a single report")
 	{
-		ReceiverReportPacket* packet = ReceiverReportPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<ReceiverReportPacket> packet{ ReceiverReportPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet->GetCount() == 1);
 
@@ -67,7 +67,8 @@ SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
 
 			packet->Serialize(serialized);
 
-			ReceiverReportPacket* packet2 = ReceiverReportPacket::Parse(serialized, sizeof(buffer));
+			std::unique_ptr<ReceiverReportPacket> packet2{ ReceiverReportPacket::Parse(
+				serialized, sizeof(buffer)) };
 
 			REQUIRE(packet2->GetType() == Type::RR);
 			REQUIRE(packet2->GetCount() == 1);
@@ -81,26 +82,21 @@ SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
 
 			verify(report);
 
-			delete packet2;
-
 			SECTION("compare serialized packet with original buffer")
 			{
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("parse RR")
 	{
-		ReceiverReport* report = ReceiverReport::Parse(rrBuffer, ReceiverReport::HeaderSize);
+		std::unique_ptr<ReceiverReport> report{ ReceiverReport::Parse(
+			rrBuffer, ReceiverReport::HeaderSize) };
 
 		REQUIRE(report);
 
-		verify(report);
-
-		delete report;
+		verify(report.get());
 	}
 
 	SECTION("create RR packet with more than 31 reports")
@@ -132,7 +128,8 @@ SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
 		// Serialization must contain 2 RR packets since report count exceeds 31.
 		packet.Serialize(buffer);
 
-		auto* packet2 = static_cast<ReceiverReportPacket*>(Packet::Parse(buffer, sizeof(buffer)));
+		std::unique_ptr<ReceiverReportPacket> packet2{ static_cast<ReceiverReportPacket*>(
+			Packet::Parse(buffer, sizeof(buffer))) };
 
 		REQUIRE(packet2 != nullptr);
 		REQUIRE(packet2->GetCount() == 31);
@@ -172,7 +169,6 @@ SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
 			REQUIRE(report->GetDelaySinceLastSenderReport() == 31 + i);
 		}
 
-		delete packet2;
 		delete packet3;
 	}
 

--- a/worker/test/src/RTC/RTCP/TestSdes.cpp
+++ b/worker/test/src/RTC/RTCP/TestSdes.cpp
@@ -3,6 +3,7 @@
 #include "RTC/RTCP/Sdes.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
+#include <memory>
 #include <string>
 
 using namespace RTC::RTCP;
@@ -97,8 +98,8 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 {
 	SECTION("parse packet 1")
 	{
-		SdesPacket* packet = SdesPacket::Parse(buffer1, sizeof(buffer1));
-		auto* header       = reinterpret_cast<RTC::RTCP::Packet::CommonHeader*>(buffer1);
+		std::unique_ptr<SdesPacket> packet{ SdesPacket::Parse(buffer1, sizeof(buffer1)) };
+		auto* header = reinterpret_cast<RTC::RTCP::Packet::CommonHeader*>(buffer1);
 
 		REQUIRE(packet);
 		REQUIRE(ntohs(header->length) == 6);
@@ -164,14 +165,12 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 			REQUIRE(std::memcmp(chunk1Buffer, serialized1, 24) == 0);
 		}
-
-		delete packet;
 	}
 
 	SECTION("parse packet 2")
 	{
-		SdesPacket* packet = SdesPacket::Parse(buffer2, sizeof(buffer2));
-		auto* header       = reinterpret_cast<RTC::RTCP::Packet::CommonHeader*>(buffer2);
+		std::unique_ptr<SdesPacket> packet{ SdesPacket::Parse(buffer2, sizeof(buffer2)) };
+		auto* header = reinterpret_cast<RTC::RTCP::Packet::CommonHeader*>(buffer2);
 
 		REQUIRE(packet);
 		REQUIRE(ntohs(header->length) == 13);
@@ -292,14 +291,12 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 			REQUIRE(std::memcmp(chunk2Buffer, serialized2, 24) == 0);
 		}
-
-		delete packet;
 	}
 
 	SECTION("parse packet 3")
 	{
-		SdesPacket* packet = SdesPacket::Parse(buffer3, sizeof(buffer3));
-		auto* header       = reinterpret_cast<RTC::RTCP::Packet::CommonHeader*>(buffer3);
+		std::unique_ptr<SdesPacket> packet{ SdesPacket::Parse(buffer3, sizeof(buffer3)) };
+		auto* header = reinterpret_cast<RTC::RTCP::Packet::CommonHeader*>(buffer3);
 
 		REQUIRE(packet);
 		REQUIRE(ntohs(header->length) == 3);
@@ -364,8 +361,6 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 			REQUIRE(std::memcmp(chunk1Buffer, serialized1, 12) == 0);
 		}
-
-		delete packet;
 	}
 
 	SECTION("parsing a packet with missing null octects fails")
@@ -390,15 +385,13 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 		SdesPacket packet;
 		// Create a chunk and an item to obtain their size.
-		SdesChunk* chunk = new SdesChunk(1234 /*ssrc*/);
+		auto chunk = std::make_unique<SdesChunk>(1234 /*ssrc*/);
 		auto* item1 =
 		  new RTC::RTCP::SdesItem(SdesItem::Type::CNAME, item1Value.size(), item1Value.c_str());
 
 		chunk->AddItem(item1);
 
 		auto chunkSize = chunk->GetSize();
-
-		delete chunk;
 
 		for (auto i{ 1 }; i <= count; ++i)
 		{
@@ -422,7 +415,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 		// exceed 31.
 		packet.Serialize(buffer1);
 
-		auto* packet2 = static_cast<SdesPacket*>(Packet::Parse(buffer1, sizeof(buffer1)));
+		std::unique_ptr<SdesPacket> packet2{static_cast<SdesPacket*>(Packet::Parse(buffer1, sizeof(buffer1)))};
 
 		REQUIRE(packet2 != nullptr);
 		REQUIRE(packet2->GetCount() == count);
@@ -443,11 +436,10 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 			REQUIRE(std::string(item->GetValue()) == item1Value);
 		}
 
-		SdesPacket* packet3 = static_cast<SdesPacket*>(packet2->GetNext());
+		std::unique_ptr<SdesPacket> packet3{static_cast<SdesPacket*>(packet2->GetNext())};
 
 		REQUIRE(packet3 == nullptr);
 
-		delete packet3;
 	}
 
 	SECTION("create SDES packet with more than 31 chunks")
@@ -456,15 +448,13 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 		SdesPacket packet;
 		// Create a chunk and an item to obtain their size.
-		SdesChunk* chunk = new SdesChunk(1234 /*ssrc*/);
+		auto chunk = std::make_unique<SdesChunk>(1234 /*ssrc*/);
 		auto* item1 =
 		  new RTC::RTCP::SdesItem(SdesItem::Type::CNAME, item1Value.size(), item1Value.c_str());
 
 		chunk->AddItem(item1);
 
 		auto chunkSize = chunk->GetSize();
-
-		delete chunk;
 
 		for (auto i{ 1 }; i <= count; ++i)
 		{
@@ -487,7 +477,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 		// Serialization must contain 2 SDES packets since report count exceeds 31.
 		packet.Serialize(buffer1);
 
-		auto* packet2 = static_cast<SdesPacket*>(Packet::Parse(buffer1, sizeof(buffer1)));
+		std::unique_ptr<SdesPacket> packet2 {static_cast<SdesPacket*>(Packet::Parse(buffer1, sizeof(buffer1)))};
 
 		REQUIRE(packet2 != nullptr);
 		REQUIRE(packet2->GetCount() == 31);
@@ -529,7 +519,6 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 			REQUIRE(std::string(item->GetValue()) == item1Value);
 		}
 
-		delete packet2;
 		delete packet3;
 	}
 

--- a/worker/test/src/RTC/RTCP/TestSdes.cpp
+++ b/worker/test/src/RTC/RTCP/TestSdes.cpp
@@ -3,7 +3,6 @@
 #include "RTC/RTCP/Sdes.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
-#include <memory>
 #include <string>
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestSenderReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestSenderReport.cpp
@@ -2,6 +2,7 @@
 #include "RTC/RTCP/SenderReport.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
+#include <memory>
 
 using namespace RTC::RTCP;
 
@@ -50,7 +51,7 @@ SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 {
 	SECTION("parse SR packet")
 	{
-		SenderReportPacket* packet = SenderReportPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<SenderReportPacket> packet{ SenderReportPacket::Parse(buffer, sizeof(buffer)) };
 
 		auto* report = *(packet->Begin());
 
@@ -67,17 +68,15 @@ SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 				REQUIRE(std::memcmp(buffer, serialized, sizeof(buffer)) == 0);
 			}
 		}
-
-		delete packet;
 	}
 
 	SECTION("parse SR")
 	{
-		SenderReport* report = SenderReport::Parse(srBuffer, SenderReport::HeaderSize);
+		std::unique_ptr<SenderReport> report{ SenderReport::Parse(srBuffer, SenderReport::HeaderSize) };
 
 		REQUIRE(report);
 
-		verify(report);
+		verify(report.get());
 
 		SECTION("serialize SenderReport instance")
 		{
@@ -90,8 +89,6 @@ SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 				REQUIRE(std::memcmp(srBuffer, serialized, SenderReport::HeaderSize) == 0);
 			}
 		}
-
-		delete report;
 	}
 
 	SECTION("create SR packet multiple reports")
@@ -122,7 +119,8 @@ SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 
 		SenderReport* reports[count]{ nullptr };
 
-		auto* packet2 = static_cast<SenderReportPacket*>(Packet::Parse(buffer, sizeof(buffer)));
+		std::unique_ptr<SenderReportPacket> packet2{ static_cast<SenderReportPacket*>(
+			Packet::Parse(buffer, sizeof(buffer))) };
 
 		REQUIRE(packet2 != nullptr);
 
@@ -154,7 +152,6 @@ SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 			REQUIRE(report->GetOctetCount() == i);
 		}
 
-		delete packet2;
 		delete packet3;
 		delete packet4;
 	}

--- a/worker/test/src/RTC/RTCP/TestSenderReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestSenderReport.cpp
@@ -2,7 +2,6 @@
 #include "RTC/RTCP/SenderReport.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
-#include <memory>
 
 using namespace RTC::RTCP;
 

--- a/worker/test/src/RTC/RTCP/TestXr.cpp
+++ b/worker/test/src/RTC/RTCP/TestXr.cpp
@@ -4,7 +4,6 @@
 #include "RTC/RTCP/XrReceiverReferenceTime.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp(), std::memcpy()
-#include <memory>
 
 using namespace RTC::RTCP;
 

--- a/worker/test/src/RTC/RTCP/TestXr.cpp
+++ b/worker/test/src/RTC/RTCP/TestXr.cpp
@@ -3,8 +3,8 @@
 #include "RTC/RTCP/XrDelaySinceLastRr.hpp"
 #include "RTC/RTCP/XrReceiverReferenceTime.hpp"
 #include <catch2/catch_test_macros.hpp>
-#include <memory>
 #include <cstring> // std::memcmp(), std::memcpy()
+#include <memory>
 
 using namespace RTC::RTCP;
 
@@ -199,7 +199,7 @@ SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
 		// Create local report and check content.
 		// NOTE: We cannot use unique_ptr here since the instance lifecycle will be
 		// managed by the packet.
-		auto* report1   = new DelaySinceLastRr();
+		auto* report1 = new DelaySinceLastRr();
 		// NOTE: We cannot use unique_ptr here since the instance lifecycle will be
 		// managed by the report.
 		auto* ssrcInfo1 = new DelaySinceLastRr::SsrcInfo();

--- a/worker/test/src/RTC/RTCP/TestXr.cpp
+++ b/worker/test/src/RTC/RTCP/TestXr.cpp
@@ -3,6 +3,7 @@
 #include "RTC/RTCP/XrDelaySinceLastRr.hpp"
 #include "RTC/RTCP/XrReceiverReferenceTime.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <cstring> // std::memcmp(), std::memcpy()
 
 using namespace RTC::RTCP;

--- a/worker/test/src/RTC/RTCP/TestXr.cpp
+++ b/worker/test/src/RTC/RTCP/TestXr.cpp
@@ -131,7 +131,9 @@ SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
 	SECTION("create RRT")
 	{
 		// Create local report and check content.
-		std::unique_ptr<ReceiverReferenceTime> report1(new ReceiverReferenceTime());
+		// NOTE: We cannot use unique_ptr here since the instance lifecycle will be
+		// managed by the packet.
+		auto* report1 = new ReceiverReferenceTime();
 
 		report1->SetNtpSec(11111111);
 		report1->SetNtpFrac(22222222);
@@ -146,8 +148,9 @@ SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
 		report1->Serialize(bufferReport1);
 
 		// Create a new report out of the external buffer.
-		std::unique_ptr<ReceiverReferenceTime> report2(
-		  ReceiverReferenceTime::Parse(bufferReport1, report1->GetSize()));
+		// NOTE: We cannot use unique_ptr here since the instance lifecycle will be
+		// managed by the packet.
+		auto report2 = ReceiverReferenceTime::Parse(bufferReport1, report1->GetSize());
 
 		REQUIRE(report1->GetType() == report2->GetType());
 		REQUIRE(report1->GetNtpSec() == report2->GetNtpSec());
@@ -157,8 +160,8 @@ SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
 		std::unique_ptr<ExtendedReportPacket> packet1(new ExtendedReportPacket());
 
 		packet1->SetSsrc(2222);
-		packet1->AddReport(report1.get());
-		packet1->AddReport(report2.get());
+		packet1->AddReport(report1);
+		packet1->AddReport(report2);
 
 		REQUIRE(packet1->GetType() == Type::XR);
 		REQUIRE(packet1->GetCount() == 0);
@@ -194,8 +197,12 @@ SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
 	SECTION("create DLRR")
 	{
 		// Create local report and check content.
-		std::unique_ptr<DelaySinceLastRr> report1(new DelaySinceLastRr());
-		std::unique_ptr<DelaySinceLastRr::SsrcInfo> ssrcInfo1(new DelaySinceLastRr::SsrcInfo());
+		// NOTE: We cannot use unique_ptr here since the instance lifecycle will be
+		// managed by the packet.
+		auto* report1   = new DelaySinceLastRr();
+		// NOTE: We cannot use unique_ptr here since the instance lifecycle will be
+		// managed by the report.
+		auto* ssrcInfo1 = new DelaySinceLastRr::SsrcInfo();
 
 		ssrcInfo1->SetSsrc(1234);
 		ssrcInfo1->SetLastReceiverReport(11111111);
@@ -206,7 +213,7 @@ SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
 		REQUIRE(ssrcInfo1->GetDelaySinceLastReceiverReport() == 22222222);
 		REQUIRE(ssrcInfo1->GetSize() == sizeof(DelaySinceLastRr::SsrcInfo::Body));
 
-		report1->AddSsrcInfo(ssrcInfo1.get());
+		report1->AddSsrcInfo(ssrcInfo1);
 
 		// Serialize the report into an external buffer.
 		uint8_t bufferReport1[256]{ 0 };
@@ -214,8 +221,9 @@ SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
 		report1->Serialize(bufferReport1);
 
 		// Create a new report out of the external buffer.
-		std::unique_ptr<DelaySinceLastRr> report2(
-		  DelaySinceLastRr::Parse(bufferReport1, report1->GetSize()));
+		// NOTE: We cannot use unique_ptr here since the instance lifecycle will be
+		// managed by the packet.
+		auto report2 = DelaySinceLastRr::Parse(bufferReport1, report1->GetSize());
 
 		REQUIRE(report1->GetType() == report2->GetType());
 
@@ -232,8 +240,8 @@ SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
 		std::unique_ptr<ExtendedReportPacket> packet1(new ExtendedReportPacket());
 
 		packet1->SetSsrc(2222);
-		packet1->AddReport(report1.get());
-		packet1->AddReport(report2.get());
+		packet1->AddReport(report1);
+		packet1->AddReport(report2);
 
 		REQUIRE(packet1->GetType() == Type::XR);
 		REQUIRE(packet1->GetCount() == 0);

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -118,7 +118,7 @@ uint8_t rtpBuffer[] =
 // clang-format on
 
 // [pt:123, seq:21006, timestamp:1533790901]
-RtpPacket* packet = RtpPacket::Parse(rtpBuffer, sizeof(rtpBuffer));
+std::unique_ptr<RtpPacket> packet(RtpPacket::Parse(rtpBuffer, sizeof(rtpBuffer)));
 
 void validate(std::vector<TestNackGeneratorInput>& inputs)
 {
@@ -133,7 +133,7 @@ void validate(std::vector<TestNackGeneratorInput>& inputs)
 
 		packet->SetPayloadDescriptorHandler(tpdh);
 		packet->SetSequenceNumber(input.seq);
-		nackGenerator.ReceivePacket(packet, /*isRecovered*/ false);
+		nackGenerator.ReceivePacket(packet.get(), /*isRecovered*/ false);
 
 		listener.Check(nackGenerator);
 	}

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -24,7 +24,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			FAIL("cannot open file");
 		}
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, len) };
 
 		if (!packet)
 		{
@@ -50,8 +50,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(extenValue == nullptr);
 		REQUIRE(packet->ReadRid(rid) == false);
 		REQUIRE(rid == "");
-
-		delete packet;
 	}
 
 	SECTION("parse packet2.raw")
@@ -63,7 +61,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			FAIL("cannot open file");
 		}
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, len) };
 
 		if (!packet)
 		{
@@ -80,8 +78,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetHeaderExtensionLength() == 0);
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
-
-		delete packet;
 	}
 
 	SECTION("parse packet3.raw")
@@ -98,7 +94,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			FAIL("cannot open file");
 		}
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, len) };
 
 		if (!packet)
 		{
@@ -139,7 +135,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->ReadAbsSendTime(absSendTime) == true);
 		REQUIRE(absSendTime == 0x65341e);
 
-		auto* clonedPacket = packet->Clone();
+		std::unique_ptr<RtpPacket> clonedPacket{ packet->Clone() };
 
 		std::memset(buffer, '0', sizeof(buffer));
 
@@ -174,9 +170,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(extenValue[2] == 0x1e);
 		REQUIRE(clonedPacket->ReadAbsSendTime(absSendTime) == true);
 		REQUIRE(absSendTime == 0x65341e);
-
-		delete packet;
-		delete clonedPacket;
 	}
 
 	SECTION("create RtpPacket without header extension")
@@ -190,7 +183,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		};
 		// clang-format on
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
 
 		if (!packet)
 		{
@@ -205,8 +198,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetSsrc() == 5);
-
-		delete packet;
 	}
 
 	SECTION("create RtpPacket with One-Byte header extension")
@@ -224,7 +215,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		};
 		// clang-format on
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
 
 		if (!packet)
 		{
@@ -248,8 +239,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		REQUIRE(packet->GetPayloadLength() == 1000);
 		REQUIRE(packet->GetSize() == 1028);
-
-		delete packet;
 	}
 
 	SECTION("create RtpPacket with Two-Bytes header extension")
@@ -271,7 +260,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		uint8_t extenLen;
 		uint8_t* extenValue;
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
 
 		if (!packet)
 		{
@@ -316,8 +305,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasExtension(5) == false);
 		REQUIRE(extenValue == nullptr);
 		REQUIRE(extenLen == 0);
-
-		delete packet;
 	}
 
 	SECTION("rtx encryption-decryption")
@@ -340,7 +327,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		uint32_t rtxSsrc{ 6 };
 		uint16_t rtxSeq{ 80 };
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
 
 		if (!packet)
 		{
@@ -358,9 +345,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions());
 
-		auto* rtxPacket = packet->Clone();
-
-		delete packet;
+		std::unique_ptr<RtpPacket> rtxPacket{ packet->Clone() };
 
 		std::memset(buffer, '0', sizeof(buffer));
 
@@ -389,8 +374,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(rtxPacket->GetHeaderExtensionLength() == 12);
 		REQUIRE(rtxPacket->HasOneByteExtensions() == false);
 		REQUIRE(rtxPacket->HasTwoBytesExtensions());
-
-		delete rtxPacket;
 	}
 
 	SECTION("create RtpPacket and apply payload shift to it")
@@ -415,8 +398,8 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		};
 		// clang-format on
 
-		size_t len        = 40;
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		size_t len = 40;
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, len) };
 
 		if (!packet)
 		{
@@ -504,8 +487,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetPayloadLength() == 1000);
 		REQUIRE(packet->GetPayloadPadding() == 0);
 		REQUIRE(packet->GetSize() == 1028);
-
-		delete packet;
 	}
 
 	SECTION("set One-Byte header extensions")
@@ -530,7 +511,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		};
 		// clang-format on
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, 28);
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, 28) };
 		std::vector<RTC::RtpPacket::GenericExtension> extensions;
 		uint8_t extenLen;
 		uint8_t* extenValue;
@@ -675,8 +656,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(extenValue[1] == 0x02);
 		REQUIRE(extenValue[2] == 0x03);
 		REQUIRE(extenValue[3] == 0x00);
-
-		delete packet;
 	}
 
 	SECTION("set Two-Bytes header extensions")
@@ -703,7 +682,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		};
 		// clang-format on
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, 28);
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, 28) };
 		std::vector<RTC::RtpPacket::GenericExtension> extensions;
 		uint8_t extenLen;
 		uint8_t* extenValue;
@@ -830,8 +809,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetExtension(24, extenLen));
 		REQUIRE(packet->HasExtension(24) == true);
 		REQUIRE(extenLen == 4);
-
-		delete packet;
 	}
 
 	SECTION("read frame-marking extension")
@@ -848,7 +825,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		};
 		// clang-format on
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
 
 		if (!packet)
 		{
@@ -882,7 +859,5 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(frameMarking->tid == 3);
 		REQUIRE(frameMarking->lid == 1);
 		REQUIRE(frameMarking->tl0picidx == 5);
-
-		delete packet;
 	}
 }

--- a/worker/test/src/RTC/TestRtpPacketH264Svc.cpp
+++ b/worker/test/src/RTC/TestRtpPacketH264Svc.cpp
@@ -26,7 +26,7 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 			FAIL("cannot open file");
 		}
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, len) };
 
 		if (!packet)
 		{
@@ -59,8 +59,9 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 		// Read frame-marking.
 		packet->ReadFrameMarking(&frameMarking, frameMarkingLen);
 
-		const auto* payloadDescriptor =
-		  Codecs::H264_SVC::Parse(payload, sizeof(payload), frameMarking, frameMarkingLen);
+		std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+			Codecs::H264_SVC::Parse(payload, sizeof(payload), frameMarking, frameMarkingLen)
+		};
 
 		REQUIRE(payloadDescriptor);
 
@@ -73,10 +74,6 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 		REQUIRE(payloadDescriptor->tlIndex == 0);
 		REQUIRE(payloadDescriptor->hasSlIndex == false);
 		REQUIRE(payloadDescriptor->isKeyFrame == true);
-
-		delete payloadDescriptor;
-
-		delete packet;
 	}
 
 	SECTION("parse I0-8.bin")
@@ -90,7 +87,7 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 			FAIL("cannot open file");
 		}
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, len) };
 
 		if (!packet)
 		{
@@ -123,8 +120,9 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 		// Read frame-marking.
 		packet->ReadFrameMarking(&frameMarking, frameMarkingLen);
 
-		const auto* payloadDescriptor =
-		  Codecs::H264_SVC::Parse(payload, sizeof(payload), frameMarking, frameMarkingLen);
+		std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+			Codecs::H264_SVC::Parse(payload, sizeof(payload), frameMarking, frameMarkingLen)
+		};
 
 		REQUIRE(payloadDescriptor);
 
@@ -137,10 +135,6 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 		REQUIRE(payloadDescriptor->tlIndex == 0);
 		REQUIRE(payloadDescriptor->hasSlIndex == false);
 		REQUIRE(payloadDescriptor->isKeyFrame == false);
-
-		delete payloadDescriptor;
-
-		delete packet;
 	}
 
 	SECTION("parse I0-5.bin")
@@ -154,7 +148,7 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 			FAIL("cannot open file");
 		}
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, len) };
 
 		if (!packet)
 		{
@@ -187,8 +181,9 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 		// Read frame-marking.
 		packet->ReadFrameMarking(&frameMarking, frameMarkingLen);
 
-		const auto* payloadDescriptor =
-		  Codecs::H264_SVC::Parse(payload, sizeof(payload), frameMarking, frameMarkingLen);
+		std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+			Codecs::H264_SVC::Parse(payload, sizeof(payload), frameMarking, frameMarkingLen)
+		};
 
 		REQUIRE(payloadDescriptor);
 
@@ -200,10 +195,6 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 		REQUIRE(payloadDescriptor->isKeyFrame == true);
 		REQUIRE(payloadDescriptor->hasSlIndex == false);
 		REQUIRE(payloadDescriptor->hasTlIndex == false);
-
-		delete payloadDescriptor;
-
-		delete packet;
 	}
 
 	SECTION("parse I1-15.bin")
@@ -217,7 +208,7 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 			FAIL("cannot open file");
 		}
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, len) };
 
 		if (!packet)
 		{
@@ -250,8 +241,9 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 		// Read frame-marking.
 		packet->ReadFrameMarking(&frameMarking, frameMarkingLen);
 
-		const auto* payloadDescriptor =
-		  Codecs::H264_SVC::Parse(payload, sizeof(payload), frameMarking, frameMarkingLen);
+		std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+			Codecs::H264_SVC::Parse(payload, sizeof(payload), frameMarking, frameMarkingLen)
+		};
 
 		REQUIRE(payloadDescriptor);
 
@@ -264,10 +256,6 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 		REQUIRE(payloadDescriptor->tlIndex == 0);
 		REQUIRE(payloadDescriptor->hasSlIndex == false);
 		REQUIRE(payloadDescriptor->isKeyFrame == false);
-
-		delete payloadDescriptor;
-
-		delete packet;
 	}
 
 	SECTION("parse I0-14.bin")
@@ -281,7 +269,7 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 			FAIL("cannot open file");
 		}
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, len) };
 
 		if (!packet)
 		{
@@ -314,8 +302,9 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 		// Read frame-marking.
 		packet->ReadFrameMarking(&frameMarking, frameMarkingLen);
 
-		const auto* payloadDescriptor =
-		  Codecs::H264_SVC::Parse(payload, sizeof(payload), frameMarking, frameMarkingLen);
+		std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+			Codecs::H264_SVC::Parse(payload, sizeof(payload), frameMarking, frameMarkingLen)
+		};
 
 		REQUIRE(payloadDescriptor);
 
@@ -328,10 +317,6 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 		REQUIRE(payloadDescriptor->tlIndex == 0);
 		REQUIRE(payloadDescriptor->hasSlIndex == false);
 		REQUIRE(payloadDescriptor->isKeyFrame == true);
-
-		delete payloadDescriptor;
-
-		delete packet;
 	}
 
 	SECTION("parse 2SL-I14.bin")
@@ -345,7 +330,7 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 			FAIL("cannot open file");
 		}
 
-		RtpPacket* packet = RtpPacket::Parse(buffer, len);
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, len) };
 
 		if (!packet)
 		{
@@ -378,8 +363,9 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 		// Read frame-marking.
 		packet->ReadFrameMarking(&frameMarking, frameMarkingLen);
 
-		const auto* payloadDescriptor =
-		  Codecs::H264_SVC::Parse(payload, sizeof(payload), frameMarking, frameMarkingLen);
+		std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+			Codecs::H264_SVC::Parse(payload, sizeof(payload), frameMarking, frameMarkingLen)
+		};
 
 		REQUIRE(payloadDescriptor);
 
@@ -393,10 +379,6 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 		REQUIRE(payloadDescriptor->hasSlIndex);
 		REQUIRE(payloadDescriptor->slIndex == 0);
 		REQUIRE(payloadDescriptor->isKeyFrame == true);
-
-		delete payloadDescriptor;
-
-		delete packet;
 	}
 
 	SECTION("create and test RTP files")
@@ -453,7 +435,7 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 					FAIL("Failed to write RTP packet!\n");
 				}
 
-				RtpPacket* packet = RtpPacket::Parse(buffer2, len);
+				std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer2, len) };
 
 				if (!packet)
 				{
@@ -469,8 +451,9 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 				// Read frame-marking.
 				packet->ReadFrameMarking(&frameMarking, frameMarkingLen);
 
-				const auto* payloadDescriptor = Codecs::H264_SVC::Parse(
-				  payload, packet->GetPayloadLength(), frameMarking, frameMarkingLen);
+				std::unique_ptr<RTC::Codecs::H264_SVC::PayloadDescriptor> payloadDescriptor{
+					Codecs::H264_SVC::Parse(payload, packet->GetPayloadLength(), frameMarking, frameMarkingLen)
+				};
 
 				REQUIRE(payloadDescriptor);
 
@@ -478,9 +461,6 @@ SCENARIO("parse RTP packets with H264 SVC", "[parser][rtp]")
 
 				pos += bytes;
 				rows++;
-
-				delete payloadDescriptor;
-				delete packet;
 			}
 
 			nf.close();

--- a/worker/test/src/RTC/TestRtpRetransmissionBuffer.cpp
+++ b/worker/test/src/RTC/TestRtpRetransmissionBuffer.cpp
@@ -36,14 +36,14 @@ public:
 		};
 		// clang-format on
 
-		auto* packet = RtpPacket::Parse(rtpBuffer, sizeof(rtpBuffer));
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(rtpBuffer, sizeof(rtpBuffer)) };
 
 		packet->SetSequenceNumber(seq);
 		packet->SetTimestamp(timestamp);
 
 		std::shared_ptr<RtpPacket> sharedPacket;
 
-		RtpRetransmissionBuffer::Insert(packet, sharedPacket);
+		RtpRetransmissionBuffer::Insert(packet.get(), sharedPacket);
 	}
 
 	void AssertBuffer(std::vector<VerificationItem> verificationBuffer)

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -4,20 +4,22 @@
 #include "RTC/RtpStream.hpp"
 #include "RTC/RtpStreamSend.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <memory>
 #include <vector>
 
 // #define PERFORMANCE_TEST 1
 
 using namespace RTC;
 
-static RtpPacket* CreateRtpPacket(uint8_t* buffer, size_t len, uint16_t seq, uint32_t timestamp)
+static std::unique_ptr<RtpPacket> CreateRtpPacket(
+  uint8_t* buffer, size_t len, uint16_t seq, uint32_t timestamp)
 {
 	auto* packet = RtpPacket::Parse(buffer, len);
 
 	packet->SetSequenceNumber(seq);
 	packet->SetTimestamp(timestamp);
 
-	return packet;
+	return std::unique_ptr<RtpPacket>(packet);
 }
 
 static void SendRtpPacket(std::vector<std::pair<RtpStreamSend*, uint32_t>> streams, RtpPacket* packet)
@@ -78,20 +80,15 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 	SECTION("receive NACK and get retransmitted packets")
 	{
 		// packet1 [pt:123, seq:21006, timestamp:1533790901]
-		std::unique_ptr<RtpPacket> packet1(
-		  CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
+		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
 		// packet2 [pt:123, seq:21007, timestamp:1533790901]
-		std::unique_ptr<RtpPacket> packet2(
-		  CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
+		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
 		// packet3 [pt:123, seq:21008, timestamp:1533793871]
-		std::unique_ptr<RtpPacket> packet3(
-		  CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871));
+		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871));
 		// packet4 [pt:123, seq:21009, timestamp:1533793871]
-		std::unique_ptr<RtpPacket> packet4(
-		  CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871));
+		auto packet4(CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871));
 		// packet5 [pt:123, seq:21010, timestamp:1533796931]
-		std::unique_ptr<RtpPacket> packet5(
-		  CreateRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931));
+		auto packet5(CreateRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931));
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -104,7 +101,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
 
 		std::string mid;
-		std::unique_ptr<RtpStreamSend> stream(new RtpStreamSend(&testRtpStreamListener, params, mid));
+		auto stream = std::make_unique<RtpStreamSend>(&testRtpStreamListener, params, mid);
 
 		// Receive all the packets (some of them not in order and/or duplicated).
 		SendRtpPacket({ { stream.get(), params.ssrc } }, packet1.get());
@@ -146,20 +143,15 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 	SECTION("receive NACK and get zero retransmitted packets if useNack is not set")
 	{
 		// packet1 [pt:123, seq:21006, timestamp:1533790901]
-		std::unique_ptr<RtpPacket> packet1(
-		  CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
+		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
 		// packet2 [pt:123, seq:21007, timestamp:1533790901]
-		std::unique_ptr<RtpPacket> packet2(
-		  CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
+		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
 		// packet3 [pt:123, seq:21008, timestamp:1533793871]
-		std::unique_ptr<RtpPacket> packet3(
-		  CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871));
+		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871));
 		// packet4 [pt:123, seq:21009, timestamp:1533793871]
-		std::unique_ptr<RtpPacket> packet4(
-		  CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871));
+		auto packet4(CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871));
 		// packet5 [pt:123, seq:21010, timestamp:1533796931]
-		std::unique_ptr<RtpPacket> packet5(
-		  CreateRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931));
+		auto packet5(CreateRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931));
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -172,7 +164,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
 
 		std::string mid;
-		std::unique_ptr<RtpStreamSend> stream(new RtpStreamSend(&testRtpStreamListener, params, mid));
+		auto stream = std::make_unique<RtpStreamSend>(&testRtpStreamListener, params, mid);
 
 		// Receive all the packets (some of them not in order and/or duplicated).
 		SendRtpPacket({ { stream.get(), params.ssrc } }, packet1.get());
@@ -202,20 +194,15 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 	SECTION("receive NACK and get zero retransmitted packets for audio")
 	{
 		// packet1 [pt:123, seq:21006, timestamp:1533790901]
-		std::unique_ptr<RtpPacket> packet1(
-		  CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
+		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
 		// packet2 [pt:123, seq:21007, timestamp:1533790901]
-		std::unique_ptr<RtpPacket> packet2(
-		  CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
+		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
 		// packet3 [pt:123, seq:21008, timestamp:1533793871]
-		std::unique_ptr<RtpPacket> packet3(
-		  CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871));
+		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871));
 		// packet4 [pt:123, seq:21009, timestamp:1533793871]
-		std::unique_ptr<RtpPacket> packet4(
-		  CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871));
+		auto packet4(CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871));
 		// packet5 [pt:123, seq:21010, timestamp:1533796931]
-		std::unique_ptr<RtpPacket> packet5(
-		  CreateRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931));
+		auto packet5(CreateRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931));
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -228,7 +215,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params.mimeType.type = RTC::RtpCodecMimeType::Type::AUDIO;
 
 		std::string mid;
-		std::unique_ptr<RtpStreamSend> stream(new RtpStreamSend(&testRtpStreamListener, params, mid));
+		auto stream = std::make_unique<RtpStreamSend>(&testRtpStreamListener, params, mid);
 
 		// Receive all the packets (some of them not in order and/or duplicated).
 		SendRtpPacket({ { stream.get(), params.ssrc } }, packet1.get());
@@ -258,11 +245,9 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 	SECTION("receive NACK in different RtpStreamSend instances and get retransmitted packets")
 	{
 		// packet1 [pt:123, seq:21006, timestamp:1533790901]
-		std::unique_ptr<RtpPacket> packet1(
-		  CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
+		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
 		// packet2 [pt:123, seq:21007, timestamp:1533790901]
-		std::unique_ptr<RtpPacket> packet2(
-		  CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
+		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
 
 		// Create two RtpStreamSend instances.
 		TestRtpStreamListener testRtpStreamListener1;
@@ -334,10 +319,8 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		uint32_t diffTs    = RtpStreamSend::MaxRetransmissionDelayForVideoMs * clockRate / 1000;
 		uint32_t secondTs  = firstTs + diffTs;
 
-		std::unique_ptr<RtpPacket> packet1(
-		  CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, firstTs));
-		std::unique_ptr<RtpPacket> packet2(
-		  CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, secondTs - 1));
+		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, firstTs));
+		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, secondTs - 1));
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -350,7 +333,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params1.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
 
 		std::string mid;
-		std::unique_ptr<RtpStreamSend> stream(new RtpStreamSend(&testRtpStreamListener, params1, mid));
+		auto stream = std::make_unique<RtpStreamSend>(&testRtpStreamListener, params1, mid);
 
 		// Receive all the packets.
 		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet1.get());
@@ -389,12 +372,9 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		// Send a third packet so it will clean old packets from the buffer.
 		uint32_t thirdTs = firstTs + (2 * diffTs);
 
-		std::unique_ptr<RtpPacket> packet1(
-		  CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, firstTs));
-		std::unique_ptr<RtpPacket> packet2(
-		  CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, secondTs));
-		std::unique_ptr<RtpPacket> packet3(
-		  CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, thirdTs));
+		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, firstTs));
+		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, secondTs));
+		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, thirdTs));
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -407,7 +387,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params1.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
 
 		std::string mid;
-		std::unique_ptr<RtpStreamSend> stream(new RtpStreamSend(&testRtpStreamListener, params1, mid));
+		auto stream = std::make_unique<RtpStreamSend>(&testRtpStreamListener, params1, mid);
 
 		// Receive all the packets.
 		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet1.get());
@@ -439,18 +419,14 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 	{
 		// This scenario reproduce the "too bad sequence number" and "bad sequence
 		// number" scenarios in RtpStream::UpdateSeq().
-		std::unique_ptr<RtpPacket> packet1(
-		  CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 50001, 1000001));
-		std::unique_ptr<RtpPacket> packet2(
-		  CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 50002, 1000002));
+		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 50001, 1000001));
+		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 50002, 1000002));
 		// Third packet has bad sequence number (its seq is more than MaxDropout=3000
 		// older than current max seq) and will be dropped.
-		std::unique_ptr<RtpPacket> packet3(
-		  CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 40003, 1000003));
+		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 40003, 1000003));
 		// Forth packet has seq=badSeq+1 so will be accepted and will trigger a
 		// stream reset.
-		std::unique_ptr<RtpPacket> packet4(
-		  CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 40004, 1000004));
+		auto packet4(CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 40004, 1000004));
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -463,7 +439,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params1.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
 
 		std::string mid;
-		std::unique_ptr<RtpStreamSend> stream(new RtpStreamSend(&testRtpStreamListener, params1, mid));
+		auto stream = std::make_unique<RtpStreamSend>(&testRtpStreamListener, params1, mid);
 
 		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet1.get());
 		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet2.get());

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -496,8 +496,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		params.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
 
 		std::string mid;
-		std::unique_ptr<RtpStreamSend> sharedStream1(
-		  new RtpStreamSend(&testRtpStreamListener, params, mid));
+		std::unique_ptr<RtpStreamSend> stream1(new RtpStreamSend(&testRtpStreamListener, params, mid));
 
 		size_t iterations = 10000000;
 
@@ -509,33 +508,32 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 			auto* packet = RtpPacket::Parse(rtpBuffer1, 1500);
 			packet->SetSsrc(1111);
 
-			std::unique_ptr<RtpPacket> sharedPacket(packet);
+			std::shared_ptr<RtpPacket> sharedPacket(packet);
 
-			sharedStream1->ReceivePacket(packet, sharedPacket);
+			stream1->ReceivePacket(packet, sharedPacket);
 		}
 
 		std::chrono::duration<double> dur = std::chrono::system_clock::now() - start;
-		std::cout << "nullptr && initialized unique_ptr: \t" << dur.count() << " seconds" << std::endl;
+		std::cout << "nullptr && initialized shared_ptr: \t" << dur.count() << " seconds" << std::endl;
 
 		params.mimeType.type = RTC::RtpCodecMimeType::Type::AUDIO;
-		std::unique_ptr<RtpStreamSend> sharedStream2(
-		  new RtpStreamSend(&testRtpStreamListener, params, mid));
+		std::unique_ptr<RtpStreamSend> stream2(new RtpStreamSend(&testRtpStreamListener, params, mid));
 
 		start = std::chrono::system_clock::now();
 
 		for (size_t i = 0; i < iterations; i++)
 		{
-			std::unique_ptr<RtpPacket> sharedPacket;
+			std::shared_ptr<RtpPacket> sharedPacket;
 
 			// Create packet.
 			auto* packet = RtpPacket::Parse(rtpBuffer1, 1500);
 			packet->SetSsrc(1111);
 
-			sharedStream2->ReceivePacket(packet, sharedPacket);
+			stream2->ReceivePacket(packet, sharedPacket);
 		}
 
 		dur = std::chrono::system_clock::now() - start;
-		std::cout << "raw && empty unique_ptr duration: \t" << dur.count() << " seconds" << std::endl;
+		std::cout << "raw && empty shared_ptr duration: \t" << dur.count() << " seconds" << std::endl;
 	}
 #endif
 }

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -4,7 +4,6 @@
 #include "RTC/RtpStream.hpp"
 #include "RTC/RtpStreamSend.hpp"
 #include <catch2/catch_test_macros.hpp>
-#include <memory>
 #include <vector>
 
 // #define PERFORMANCE_TEST 1

--- a/worker/test/src/RTC/TestTransportCongestionControlServer.cpp
+++ b/worker/test/src/RTC/TestTransportCongestionControlServer.cpp
@@ -93,7 +93,7 @@ void validate(std::vector<TestTransportCongestionControlServerInput>& inputs, Te
 	tccServer.SetMaxIncomingBitrate(150000);
 	tccServer.TransportConnected();
 
-	RtpPacket* packet = RtpPacket::Parse(buffer, sizeof(buffer));
+	std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
 
 	packet->SetTransportWideCc01ExtensionId(5);
 	packet->SetSequenceNumber(1);
@@ -116,7 +116,7 @@ void validate(std::vector<TestTransportCongestionControlServerInput>& inputs, Te
 		}
 
 		packet->UpdateTransportWideCc01(input.wideSeqNumber);
-		tccServer.IncomingPacket(input.nowMs, packet);
+		tccServer.IncomingPacket(input.nowMs, packet.get());
 	}
 
 	tccServer.FillAndSendTransportCcFeedback();


### PR DESCRIPTION
(WIP)

### Details

- Avoid having allocated pointers outside `unique_ptr` pointers.
- So caution with all those mediasoup `Parse()` static methods that return an allocated pointer.
- `TestRtpStreamSend.cpp`: Use `unique_ptr` instead of `shared_ptr`.