### PR TITLE
flatbuffer builder reuse

### DIFF
--- a/worker/include/Channel/ChannelNotifier.hpp
+++ b/worker/include/Channel/ChannelNotifier.hpp
@@ -34,7 +34,7 @@ namespace Channel
 
 			builder.FinishSizePrefixed(message);
 			this->channel->Send(builder.GetBufferPointer(), builder.GetSize());
-			builder.Reset();
+			builder.Clear();
 		}
 
 		void Emit(const std::string& targetId, FBS::Notification::Event event)
@@ -48,7 +48,7 @@ namespace Channel
 
 			builder.FinishSizePrefixed(message);
 			this->channel->Send(builder.GetBufferPointer(), builder.GetSize());
-			builder.Reset();
+			builder.Clear();
 		}
 
 	private:

--- a/worker/include/Channel/ChannelRequest.hpp
+++ b/worker/include/Channel/ChannelRequest.hpp
@@ -22,6 +22,7 @@ namespace Channel
 
 	public:
 		static absl::flat_hash_map<FBS::Request::Method, const char*> method2String;
+		thread_local static flatbuffers::FlatBufferBuilder bufferBuilder;
 
 	public:
 		ChannelRequest(Channel::ChannelSocket* channel, const FBS::Request::Request* request);
@@ -29,7 +30,7 @@ namespace Channel
 
 		flatbuffers::FlatBufferBuilder& GetBufferBuilder()
 		{
-			return this->bufferBuilder;
+			return ChannelRequest::bufferBuilder;
 		}
 		void Accept();
 		template<class Body>
@@ -39,7 +40,7 @@ namespace Channel
 
 			this->replied = true;
 
-			auto& builder = this->bufferBuilder;
+			auto& builder = ChannelRequest::bufferBuilder;
 			auto response = FBS::Response::CreateResponse(builder, this->id, true, type, body.Union());
 
 			auto message =
@@ -47,7 +48,7 @@ namespace Channel
 
 			builder.FinishSizePrefixed(message);
 			this->Send(builder.GetBufferPointer(), builder.GetSize());
-			builder.Reset();
+			builder.Clear();
 		}
 		void Error(const char* reason = nullptr);
 		void TypeError(const char* reason = nullptr);
@@ -61,7 +62,6 @@ namespace Channel
 		Channel::ChannelSocket* channel{ nullptr };
 		const FBS::Request::Request* data{ nullptr };
 		// Others.
-		flatbuffers::FlatBufferBuilder bufferBuilder{};
 		uint32_t id{ 0u };
 		Method method;
 		const char* methodCStr;

--- a/worker/src/Channel/ChannelRequest.cpp
+++ b/worker/src/Channel/ChannelRequest.cpp
@@ -83,7 +83,7 @@ namespace Channel
 		{ FBS::Request::Method::RTPOBSERVER_REMOVE_PRODUCER,                    "rtpObserver.removeProducer"                 },
 	};
 	// clang-format on
-
+	thread_local flatbuffers::FlatBufferBuilder ChannelRequest::bufferBuilder{};
 	/* Instance methods. */
 
 	/**
@@ -119,7 +119,7 @@ namespace Channel
 
 		this->replied = true;
 
-		auto& builder = this->bufferBuilder;
+		auto& builder = ChannelRequest::bufferBuilder;
 		auto response =
 		  FBS::Response::CreateResponse(builder, this->id, true, FBS::Response::Body::NONE, 0);
 
@@ -134,7 +134,7 @@ namespace Channel
 
 		this->replied = true;
 
-		auto& builder = this->bufferBuilder;
+		auto& builder = ChannelRequest::bufferBuilder;
 		auto response = FBS::Response::CreateResponseDirect(
 		  builder, this->id, false /*accepted*/, FBS::Response::Body::NONE, 0, "Error" /*Error*/, reason);
 
@@ -149,7 +149,7 @@ namespace Channel
 
 		this->replied = true;
 
-		auto& builder = this->bufferBuilder;
+		auto& builder = ChannelRequest::bufferBuilder;
 		auto response = FBS::Response::CreateResponseDirect(
 		  builder, this->id, false /*accepted*/, FBS::Response::Body::NONE, 0, "TypeError" /*Error*/, reason);
 
@@ -163,12 +163,12 @@ namespace Channel
 
 	void ChannelRequest::SendResponse(const flatbuffers::Offset<FBS::Response::Response>& response)
 	{
-		auto& builder = this->bufferBuilder;
+		auto& builder = ChannelRequest::bufferBuilder;
 		auto message =
 		  FBS::Message::CreateMessage(builder, FBS::Message::Body::Response, response.Union());
 
 		builder.FinishSizePrefixed(message);
 		this->Send(builder.GetBufferPointer(), builder.GetSize());
-		builder.Reset();
+		builder.Clear();
 	}
 } // namespace Channel

--- a/worker/src/Channel/ChannelRequest.cpp
+++ b/worker/src/Channel/ChannelRequest.cpp
@@ -9,7 +9,7 @@ namespace Channel
 {
 	/* Static variables. */
 
-	thread_local	flatbuffers::FlatBufferBuilder ChannelRequest::bufferBuilder{};
+	thread_local flatbuffers::FlatBufferBuilder ChannelRequest::bufferBuilder{};
 
 	/* Class variables. */
 
@@ -87,7 +87,7 @@ namespace Channel
 		{ FBS::Request::Method::RTPOBSERVER_REMOVE_PRODUCER,                    "rtpObserver.removeProducer"                 },
 	};
 	// clang-format on
-	
+
 	/* Instance methods. */
 
 	/**

--- a/worker/src/Channel/ChannelRequest.cpp
+++ b/worker/src/Channel/ChannelRequest.cpp
@@ -7,6 +7,10 @@
 
 namespace Channel
 {
+	/* Static variables. */
+
+	thread_local	flatbuffers::FlatBufferBuilder ChannelRequest::bufferBuilder{};
+
 	/* Class variables. */
 
 	// clang-format off
@@ -83,7 +87,7 @@ namespace Channel
 		{ FBS::Request::Method::RTPOBSERVER_REMOVE_PRODUCER,                    "rtpObserver.removeProducer"                 },
 	};
 	// clang-format on
-	thread_local flatbuffers::FlatBufferBuilder ChannelRequest::bufferBuilder{};
+	
 	/* Instance methods. */
 
 	/**

--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -162,7 +162,7 @@ namespace Channel
 
 		this->bufferBuilder.FinishSizePrefixed(message);
 		this->Send(this->bufferBuilder.GetBufferPointer(), this->bufferBuilder.GetSize());
-		this->bufferBuilder.Reset();
+		this->bufferBuilder.Clear();
 	}
 
 	bool ChannelSocket::CallbackRead()


### PR DESCRIPTION
use flatbuffer Builder Clear() , so it can reuse it's inner buf .  

```
void | Clear () // Reset all the state in this FlatBufferBuilder so it can be reused to construct another buffer.
```
`https://flatbuffers.dev/classflatbuffers_1_1_flat_buffer_builder.html#ae94b94ba71ea0aeb2d9a98c43b713412`
