### PR TITLE
Update Meson to 1.5.0

### DIFF
--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -93,10 +93,10 @@ jobs:
       - name: invoke -r worker mediasoup-worker
         run: invoke -r worker mediasoup-worker
 
-      - name: invoke -r worker test
-        run: invoke -r worker test
-        # TODO: Maybe fix this one day.
-        if: runner.os != 'Windows'
+      # - name: invoke -r worker test
+      #   run: invoke -r worker test
+      #   # TODO: Maybe fix this one day.
+      #   if: runner.os != 'Windows'
 
       - name: invoke -r worker test-asan-address
         run: invoke -r worker test-asan-address

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -11,6 +11,7 @@ concurrency:
 jobs:
   ci:
     strategy:
+      # Here we want to see all errors, not just the first one.
       fail-fast: false
       matrix:
         build:
@@ -48,7 +49,7 @@ jobs:
       CC: ${{ matrix.build.cc }}
       CXX: ${{ matrix.build.cxx }}
       MEDIASOUP_SKIP_WORKER_PREBUILT_DOWNLOAD: 'true'
-      MEDIASOUP_LOCAL_DEV: 'true'
+      MEDIASOUP_LOCAL_DEV: 'false'
       MEDIASOUP_BUILDTYPE: ${{ matrix.build-type }}
 
     steps:
@@ -90,16 +91,28 @@ jobs:
         # TODO: Maybe fix this one day.
         if: runner.os != 'Windows'
 
-      # - name: invoke -r worker mediasoup-worker
-      #   run: invoke -r worker mediasoup-worker
+      - name: invoke -r worker mediasoup-worker
+        run: invoke -r worker mediasoup-worker
 
-      # - name: invoke -r worker test
-      #   run: invoke -r worker test
-      #   # TODO: Maybe fix this one day.
-      #   if: runner.os != 'Windows'
+      - name: invoke -r worker test
+        run: invoke -r worker test
+        # TODO: Maybe fix this one day.
+        if: runner.os != 'Windows'
+
+      # Let's clean everything before rebuilding worker tests with ASAN.
+      - name: invoke -r worker clean-all
+        run: invoke -r worker clean-all
+        # Address Sanitizer only works on Linux.
+        if: runner.os == 'Linux'
 
       - name: invoke -r worker test-asan-address
         run: invoke -r worker test-asan-address
+        # Address Sanitizer only works on Linux.
+        if: runner.os == 'Linux'
+
+      # Let's clean everything before rebuilding worker tests with ASAN.
+      - name: invoke -r worker clean-all
+        run: invoke -r worker clean-all
         # Address Sanitizer only works on Linux.
         if: runner.os == 'Linux'
 
@@ -109,6 +122,12 @@ jobs:
       #   run: invoke -r worker test-asan-undefined
       #   # Address Sanitizer only works on Linux.
       #   if: runner.os == 'Linux'
+
+      # Let's clean everything before rebuilding worker tests with ASAN.
+      - name: invoke -r worker clean-all
+        run: invoke -r worker clean-all
+        # Address Sanitizer only works on Linux.
+        if: runner.os == 'Linux'
 
       # TODO: Uncomment once https://github.com/versatica/mediasoup/issues/1417
       # is fixed.

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -90,8 +90,8 @@ jobs:
         # TODO: Maybe fix this one day.
         if: runner.os != 'Windows'
 
-      - name: invoke -r worker mediasoup-worker
-        run: invoke -r worker mediasoup-worker
+      # - name: invoke -r worker mediasoup-worker
+      #   run: invoke -r worker mediasoup-worker
 
       # - name: invoke -r worker test
       #   run: invoke -r worker test

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -11,6 +11,8 @@ concurrency:
 jobs:
   ci:
     strategy:
+      # TMP for debugging
+      fail-fast: false
       matrix:
         build:
           - os: ubuntu-20.04

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -111,10 +111,10 @@ jobs:
         if: runner.os == 'Linux'
 
       # Let's clean everything before rebuilding worker tests with ASAN.
-      - name: invoke -r worker clean-all
-        run: invoke -r worker clean-all
-        # Address Sanitizer only works on Linux.
-        if: runner.os == 'Linux'
+      # - name: invoke -r worker clean-all
+      #   run: invoke -r worker clean-all
+      #   # Address Sanitizer only works on Linux.
+      #   if: runner.os == 'Linux'
 
       # TODO: Uncomment once https://github.com/versatica/mediasoup/issues/1417
       # is fixed.
@@ -124,10 +124,10 @@ jobs:
       #   if: runner.os == 'Linux'
 
       # Let's clean everything before rebuilding worker tests with ASAN.
-      - name: invoke -r worker clean-all
-        run: invoke -r worker clean-all
-        # Address Sanitizer only works on Linux.
-        if: runner.os == 'Linux'
+      # - name: invoke -r worker clean-all
+      #   run: invoke -r worker clean-all
+      #   # Address Sanitizer only works on Linux.
+      #   if: runner.os == 'Linux'
 
       # TODO: Uncomment once https://github.com/versatica/mediasoup/issues/1417
       # is fixed.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### NEXT
 
 - Worker: Test, fix buffer overflow ([PR #1419](https://github.com/versatica/mediasoup/pull/1419)).
-- Bump up Meson from 1.3.0 to 1.4.1.
+- Bump up Meson from 1.3.0 to 1.5.0 ([PR #1424](https://github.com/versatica/mediasoup/pull/1424)).
 
 ### 3.14.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - Worker: Test, fix buffer overflow ([PR #1419](https://github.com/versatica/mediasoup/pull/1419)).
+- Bump up Meson from 1.3.0 to 1.4.1.
 
 ### 3.14.8
 
@@ -434,7 +435,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 ### 3.10.2
 
-- Fix release contents by including meson_options.txt ([PR #863](https://github.com/versatica/mediasoup/pull/863)).
+- Fix release contents by including `meson_options.txt` ([PR #863](https://github.com/versatica/mediasoup/pull/863)).
 
 ### 3.10.1
 

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -13,6 +13,9 @@ cpp_args = [
   host_machine.endian() == 'little' ? '-DMS_LITTLE_ENDIAN' : '-DMS_BIG_ENDIAN',
 ]
 
+add_global_arguments('-fsanitize=address', language: 'cpp')
+add_global_link_arguments('-fsanitize=address', language: 'cpp')
+
 if host_machine.system() == 'windows'
   cpp_args += [
     '-DNOMINMAX', # Don't define min and max macros (windows.h)

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -13,9 +13,6 @@ cpp_args = [
   host_machine.endian() == 'little' ? '-DMS_LITTLE_ENDIAN' : '-DMS_BIG_ENDIAN',
 ]
 
-add_global_arguments('-fsanitize=address', language: 'cpp')
-add_global_link_arguments('-fsanitize=address', language: 'cpp')
-
 if host_machine.system() == 'windows'
   cpp_args += [
     '-DNOMINMAX', # Don't define min and max macros (windows.h)

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -50,7 +50,7 @@ PIP_PYLINT_DIR = f'{MEDIASOUP_OUT_DIR}/pip_pylint';
 NUM_CORES = len(os.sched_getaffinity(0)) if hasattr(os, 'sched_getaffinity') else os.cpu_count();
 PYTHON = os.getenv('PYTHON') or sys.executable;
 MESON = os.getenv('MESON') or f'{PIP_MESON_NINJA_DIR}/bin/meson';
-MESON_VERSION = os.getenv('MESON_VERSION') or '1.4.2';
+MESON_VERSION = os.getenv('MESON_VERSION') or '1.5.0';
 # MESON_ARGS can be used to provide extra configuration parameters to meson,
 # such as adding defines or changing optimization options. For instance, use
 # `MESON_ARGS="-Dms_log_trace=true -Dms_log_file_line=true" npm i` to compile

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -50,7 +50,7 @@ PIP_PYLINT_DIR = f'{MEDIASOUP_OUT_DIR}/pip_pylint';
 NUM_CORES = len(os.sched_getaffinity(0)) if hasattr(os, 'sched_getaffinity') else os.cpu_count();
 PYTHON = os.getenv('PYTHON') or sys.executable;
 MESON = os.getenv('MESON') or f'{PIP_MESON_NINJA_DIR}/bin/meson';
-MESON_VERSION = os.getenv('MESON_VERSION') or '1.4.0';
+MESON_VERSION = os.getenv('MESON_VERSION') or '1.4.2';
 # MESON_ARGS can be used to provide extra configuration parameters to meson,
 # such as adding defines or changing optimization options. For instance, use
 # `MESON_ARGS="-Dms_log_trace=true -Dms_log_file_line=true" npm i` to compile

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -50,7 +50,7 @@ PIP_PYLINT_DIR = f'{MEDIASOUP_OUT_DIR}/pip_pylint';
 NUM_CORES = len(os.sched_getaffinity(0)) if hasattr(os, 'sched_getaffinity') else os.cpu_count();
 PYTHON = os.getenv('PYTHON') or sys.executable;
 MESON = os.getenv('MESON') or f'{PIP_MESON_NINJA_DIR}/bin/meson';
-MESON_VERSION = os.getenv('MESON_VERSION') or '1.4.1';
+MESON_VERSION = os.getenv('MESON_VERSION') or '1.3.1';
 # MESON_ARGS can be used to provide extra configuration parameters to meson,
 # such as adding defines or changing optimization options. For instance, use
 # `MESON_ARGS="-Dms_log_trace=true -Dms_log_file_line=true" npm i` to compile

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -50,7 +50,7 @@ PIP_PYLINT_DIR = f'{MEDIASOUP_OUT_DIR}/pip_pylint';
 NUM_CORES = len(os.sched_getaffinity(0)) if hasattr(os, 'sched_getaffinity') else os.cpu_count();
 PYTHON = os.getenv('PYTHON') or sys.executable;
 MESON = os.getenv('MESON') or f'{PIP_MESON_NINJA_DIR}/bin/meson';
-MESON_VERSION = os.getenv('MESON_VERSION') or '1.3.0';
+MESON_VERSION = os.getenv('MESON_VERSION') or '1.4.1';
 # MESON_ARGS can be used to provide extra configuration parameters to meson,
 # such as adding defines or changing optimization options. For instance, use
 # `MESON_ARGS="-Dms_log_trace=true -Dms_log_file_line=true" npm i` to compile

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -61,7 +61,6 @@ MESON_ARGS = os.getenv('MESON_ARGS') if os.getenv('MESON_ARGS') else '--vsenv' i
 # Let's use a specific version of ninja to avoid buggy version 1.11.1:
 # https://mediasoup.discourse.group/t/partly-solved-could-not-detect-ninja-v1-8-2-or-newer/
 # https://github.com/ninja-build/ninja/issues/2211
-# https://github.com/ninja-build/ninja/issues/2212
 NINJA_VERSION = os.getenv('NINJA_VERSION') or '1.10.2.4';
 PYLINT_VERSION = os.getenv('PYLINT_VERSION') or '3.0.2';
 NPM = os.getenv('NPM') or 'npm';

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -388,7 +388,7 @@ def test(ctx):
         );
 
 
-@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Db_sanitize=address'), flatc])
+@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Db_sanitize=address -Db_lundef=false'), flatc])
 def test_asan_address(ctx):
     """
     Run worker test with Address Sanitizer with '-fsanitize=address'
@@ -419,7 +419,7 @@ def test_asan_address(ctx):
         );
 
 
-@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Db_sanitize=undefined'), flatc])
+@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Db_sanitize=undefined -Db_lundef=false'), flatc])
 def test_asan_undefined(ctx):
     """
     Run worker test with undefined Sanitizer with -fsanitize=undefined
@@ -450,7 +450,7 @@ def test_asan_undefined(ctx):
         );
 
 
-@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Db_sanitize=thread'), flatc])
+@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Db_sanitize=thread -Db_lundef=false'), flatc])
 def test_asan_thread(ctx):
     """
     Run worker test with thread Sanitizer with -fsanitize=thread
@@ -510,7 +510,7 @@ def tidy(ctx):
         );
 
 
-@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Db_sanitize=address'), flatc])
+@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Db_sanitize=address -Db_lundef=false'), flatc])
 def fuzzer(ctx):
     """
     Build the mediasoup-worker-fuzzer binary (which uses libFuzzer)

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -50,7 +50,7 @@ PIP_PYLINT_DIR = f'{MEDIASOUP_OUT_DIR}/pip_pylint';
 NUM_CORES = len(os.sched_getaffinity(0)) if hasattr(os, 'sched_getaffinity') else os.cpu_count();
 PYTHON = os.getenv('PYTHON') or sys.executable;
 MESON = os.getenv('MESON') or f'{PIP_MESON_NINJA_DIR}/bin/meson';
-MESON_VERSION = os.getenv('MESON_VERSION') or '1.3.1';
+MESON_VERSION = os.getenv('MESON_VERSION') or '1.3.2';
 # MESON_ARGS can be used to provide extra configuration parameters to meson,
 # such as adding defines or changing optimization options. For instance, use
 # `MESON_ARGS="-Dms_log_trace=true -Dms_log_file_line=true" npm i` to compile

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -50,7 +50,7 @@ PIP_PYLINT_DIR = f'{MEDIASOUP_OUT_DIR}/pip_pylint';
 NUM_CORES = len(os.sched_getaffinity(0)) if hasattr(os, 'sched_getaffinity') else os.cpu_count();
 PYTHON = os.getenv('PYTHON') or sys.executable;
 MESON = os.getenv('MESON') or f'{PIP_MESON_NINJA_DIR}/bin/meson';
-MESON_VERSION = os.getenv('MESON_VERSION') or '1.3.2';
+MESON_VERSION = os.getenv('MESON_VERSION') or '1.4.0';
 # MESON_ARGS can be used to provide extra configuration parameters to meson,
 # such as adding defines or changing optimization options. For instance, use
 # `MESON_ARGS="-Dms_log_trace=true -Dms_log_file_line=true" npm i` to compile


### PR DESCRIPTION
I've seen some `-undefined not supported` error when trying to build worker tests with Address Sanitizer in macOS (which is not supported anyway) and it went away after updating Meson.
