### PR TITLE
Fix TS Observers type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Worker: Test, fix buffer overflow ([PR #1419](https://github.com/versatica/mediasoup/pull/1419)).
 - Bump up Meson from 1.3.0 to 1.5.0 ([PR #1424](https://github.com/versatica/mediasoup/pull/1424)).
+- Node: Export new `WorkerObserver`, `ProducerObserver`, etc. TypeScript types ([PR #1430](https://github.com/versatica/mediasoup/pull/1430)).
 
 ### 3.14.8
 

--- a/node/src/ActiveSpeakerObserver.ts
+++ b/node/src/ActiveSpeakerObserver.ts
@@ -33,6 +33,9 @@ export type ActiveSpeakerObserverEvents = RtpObserverEvents & {
 	dominantspeaker: [ActiveSpeakerObserverDominantSpeaker];
 };
 
+export type ActiveSpeakerObserverObserver =
+	EnhancedEventEmitter<ActiveSpeakerObserverObserverEvents>;
+
 export type ActiveSpeakerObserverObserverEvents = RtpObserverObserverEvents & {
 	dominantspeaker: [ActiveSpeakerObserverDominantSpeaker];
 };
@@ -46,7 +49,8 @@ export class ActiveSpeakerObserver<
 	ActiveSpeakerObserverAppData extends AppData = AppData,
 > extends RtpObserver<
 	ActiveSpeakerObserverAppData,
-	ActiveSpeakerObserverEvents
+	ActiveSpeakerObserverEvents,
+	ActiveSpeakerObserverObserver
 > {
 	/**
 	 * @private
@@ -54,15 +58,20 @@ export class ActiveSpeakerObserver<
 	constructor(
 		options: RtpObserverObserverConstructorOptions<ActiveSpeakerObserverAppData>
 	) {
-		super(options);
+		const observer: ActiveSpeakerObserverObserver =
+			new EnhancedEventEmitter<ActiveSpeakerObserverObserverEvents>();
+
+		super(options, observer);
 
 		this.handleWorkerNotifications();
 	}
 
 	/**
 	 * Observer.
+	 *
+	 * @override
 	 */
-	get observer(): EnhancedEventEmitter<ActiveSpeakerObserverObserverEvents> {
+	get observer(): ActiveSpeakerObserverObserver {
 		return super.observer;
 	}
 

--- a/node/src/AudioLevelObserver.ts
+++ b/node/src/AudioLevelObserver.ts
@@ -55,6 +55,9 @@ export type AudioLevelObserverEvents = RtpObserverEvents & {
 	silence: [];
 };
 
+export type AudioLevelObserverObserver =
+	EnhancedEventEmitter<AudioLevelObserverObserverEvents>;
+
 export type AudioLevelObserverObserverEvents = RtpObserverObserverEvents & {
 	volumes: [AudioLevelObserverVolume[]];
 	silence: [];
@@ -67,22 +70,31 @@ const logger = new Logger('AudioLevelObserver');
 
 export class AudioLevelObserver<
 	AudioLevelObserverAppData extends AppData = AppData,
-> extends RtpObserver<AudioLevelObserverAppData, AudioLevelObserverEvents> {
+> extends RtpObserver<
+	AudioLevelObserverAppData,
+	AudioLevelObserverEvents,
+	AudioLevelObserverObserver
+> {
 	/**
 	 * @private
 	 */
 	constructor(
 		options: AudioLevelObserverConstructorOptions<AudioLevelObserverAppData>
 	) {
-		super(options);
+		const observer: AudioLevelObserverObserver =
+			new EnhancedEventEmitter<AudioLevelObserverObserverEvents>();
+
+		super(options, observer);
 
 		this.handleWorkerNotifications();
 	}
 
 	/**
 	 * Observer.
+	 *
+	 * @override
 	 */
-	get observer(): EnhancedEventEmitter<AudioLevelObserverObserverEvents> {
+	get observer(): AudioLevelObserverObserver {
 		return super.observer;
 	}
 

--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -179,6 +179,8 @@ export type ConsumerEvents = {
 	'@producerclose': [];
 };
 
+export type ConsumerObserver = EnhancedEventEmitter<ConsumerObserverEvents>;
+
 export type ConsumerObserverEvents = {
 	close: [];
 	pause: [];
@@ -318,7 +320,8 @@ export class Consumer<
 	#currentLayers?: ConsumerLayers;
 
 	// Observer instance.
-	readonly #observer = new EnhancedEventEmitter<ConsumerObserverEvents>();
+	readonly #observer: ConsumerObserver =
+		new EnhancedEventEmitter<ConsumerObserverEvents>();
 
 	/**
 	 * @private
@@ -459,7 +462,7 @@ export class Consumer<
 	/**
 	 * Observer.
 	 */
-	get observer(): EnhancedEventEmitter<ConsumerObserverEvents> {
+	get observer(): ConsumerObserver {
 		return this.#observer;
 	}
 

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -92,6 +92,9 @@ export type DataConsumerEvents = {
 	'@dataproducerclose': [];
 };
 
+export type DataConsumerObserver =
+	EnhancedEventEmitter<DataConsumerObserverEvents>;
+
 export type DataConsumerObserverEvents = {
 	close: [];
 	pause: [];
@@ -148,7 +151,8 @@ export class DataConsumer<
 	#appData: DataConsumerAppData;
 
 	// Observer instance.
-	readonly #observer = new EnhancedEventEmitter<DataConsumerObserverEvents>();
+	readonly #observer: DataConsumerObserver =
+		new EnhancedEventEmitter<DataConsumerObserverEvents>();
 
 	/**
 	 * @private
@@ -272,7 +276,7 @@ export class DataConsumer<
 	/**
 	 * Observer.
 	 */
-	get observer(): EnhancedEventEmitter<DataConsumerObserverEvents> {
+	get observer(): DataConsumerObserver {
 		return this.#observer;
 	}
 

--- a/node/src/DataProducer.ts
+++ b/node/src/DataProducer.ts
@@ -67,6 +67,9 @@ export type DataProducerEvents = {
 	'@close': [];
 };
 
+export type DataProducerObserver =
+	EnhancedEventEmitter<DataProducerObserverEvents>;
+
 export type DataProducerObserverEvents = {
 	close: [];
 	pause: [];
@@ -113,7 +116,8 @@ export class DataProducer<
 	#appData: DataProducerAppData;
 
 	// Observer instance.
-	readonly #observer = new EnhancedEventEmitter<DataProducerObserverEvents>();
+	readonly #observer: DataProducerObserver =
+		new EnhancedEventEmitter<DataProducerObserverEvents>();
 
 	/**
 	 * @private
@@ -210,7 +214,7 @@ export class DataProducer<
 	/**
 	 * Observer.
 	 */
-	get observer(): EnhancedEventEmitter<DataProducerObserverEvents> {
+	get observer(): DataProducerObserver {
 		return this.#observer;
 	}
 

--- a/node/src/DirectTransport.ts
+++ b/node/src/DirectTransport.ts
@@ -1,4 +1,5 @@
 import { Logger } from './Logger';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import { UnsupportedError } from './errors';
 import {
 	BaseTransportDump,
@@ -44,6 +45,9 @@ export type DirectTransportEvents = TransportEvents & {
 	rtcp: [Buffer];
 };
 
+export type DirectTransportObserver =
+	EnhancedEventEmitter<DirectTransportObserverEvents>;
+
 export type DirectTransportObserverEvents = TransportObserverEvents & {
 	rtcp: [Buffer];
 };
@@ -64,7 +68,7 @@ export class DirectTransport<
 > extends Transport<
 	DirectTransportAppData,
 	DirectTransportEvents,
-	DirectTransportObserverEvents
+	DirectTransportObserver
 > {
 	// DirectTransport data.
 	readonly #data: DirectTransportData;
@@ -75,7 +79,10 @@ export class DirectTransport<
 	constructor(
 		options: DirectTransportConstructorOptions<DirectTransportAppData>
 	) {
-		super(options);
+		const observer: DirectTransportObserver =
+			new EnhancedEventEmitter<DirectTransportObserverEvents>();
+
+		super(options, observer);
 
 		logger.debug('constructor()');
 
@@ -84,6 +91,15 @@ export class DirectTransport<
 		};
 
 		this.handleWorkerNotifications();
+	}
+
+	/**
+	 * Observer.
+	 *
+	 * @override
+	 */
+	get observer(): DirectTransportObserver {
+		return super.observer;
 	}
 
 	/**

--- a/node/src/PipeTransport.ts
+++ b/node/src/PipeTransport.ts
@@ -1,5 +1,6 @@
 import * as flatbuffers from 'flatbuffers';
 import { Logger } from './Logger';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import * as ortc from './ortc';
 import {
 	BaseTransportDump,
@@ -131,6 +132,9 @@ export type PipeTransportEvents = TransportEvents & {
 	sctpstatechange: [SctpState];
 };
 
+export type PipeTransportObserver =
+	EnhancedEventEmitter<PipeTransportObserverEvents>;
+
 export type PipeTransportObserverEvents = TransportObserverEvents & {
 	sctpstatechange: [SctpState];
 };
@@ -161,7 +165,7 @@ export class PipeTransport<
 > extends Transport<
 	PipeTransportAppData,
 	PipeTransportEvents,
-	PipeTransportObserverEvents
+	PipeTransportObserver
 > {
 	// PipeTransport data.
 	readonly #data: PipeTransportData;
@@ -170,7 +174,10 @@ export class PipeTransport<
 	 * @private
 	 */
 	constructor(options: PipeTransportConstructorOptions<PipeTransportAppData>) {
-		super(options);
+		const observer: PipeTransportObserver =
+			new EnhancedEventEmitter<PipeTransportObserverEvents>();
+
+		super(options, observer);
 
 		logger.debug('constructor()');
 
@@ -185,6 +192,15 @@ export class PipeTransport<
 		};
 
 		this.handleWorkerNotifications();
+	}
+
+	/**
+	 * Observer.
+	 *
+	 * @override
+	 */
+	get observer(): PipeTransportObserver {
+		return super.observer;
 	}
 
 	/**

--- a/node/src/PlainTransport.ts
+++ b/node/src/PlainTransport.ts
@@ -1,5 +1,6 @@
 import * as flatbuffers from 'flatbuffers';
 import { Logger } from './Logger';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import {
 	parseSctpState,
 	BaseTransportDump,
@@ -130,6 +131,9 @@ export type PlainTransportEvents = TransportEvents & {
 	sctpstatechange: [SctpState];
 };
 
+export type PlainTransportObserver =
+	EnhancedEventEmitter<PlainTransportObserverEvents>;
+
 export type PlainTransportObserverEvents = TransportObserverEvents & {
 	tuple: [TransportTuple];
 	rtcptuple: [TransportTuple];
@@ -166,7 +170,7 @@ export class PlainTransport<
 > extends Transport<
 	PlainTransportAppData,
 	PlainTransportEvents,
-	PlainTransportObserverEvents
+	PlainTransportObserver
 > {
 	// PlainTransport data.
 	readonly #data: PlainTransportData;
@@ -177,7 +181,10 @@ export class PlainTransport<
 	constructor(
 		options: PlainTransportConstructorOptions<PlainTransportAppData>
 	) {
-		super(options);
+		const observer: PlainTransportObserver =
+			new EnhancedEventEmitter<PlainTransportObserverEvents>();
+
+		super(options, observer);
 
 		logger.debug('constructor()');
 
@@ -194,6 +201,15 @@ export class PlainTransport<
 		};
 
 		this.handleWorkerNotifications();
+	}
+
+	/**
+	 * Observer.
+	 *
+	 * @override
+	 */
+	get observer(): PlainTransportObserver {
+		return super.observer;
 	}
 
 	/**

--- a/node/src/Producer.ts
+++ b/node/src/Producer.ts
@@ -140,6 +140,8 @@ export type ProducerEvents = {
 	'@close': [];
 };
 
+export type ProducerObserver = EnhancedEventEmitter<ProducerObserverEvents>;
+
 export type ProducerObserverEvents = {
 	close: [];
 	pause: [];
@@ -198,7 +200,8 @@ export class Producer<
 	#score: ProducerScore[] = [];
 
 	// Observer instance.
-	readonly #observer = new EnhancedEventEmitter<ProducerObserverEvents>();
+	readonly #observer: ProducerObserver =
+		new EnhancedEventEmitter<ProducerObserverEvents>();
 
 	/**
 	 * @private
@@ -304,7 +307,7 @@ export class Producer<
 	/**
 	 * Observer.
 	 */
-	get observer(): EnhancedEventEmitter<ProducerObserverEvents> {
+	get observer(): ProducerObserver {
 		return this.#observer;
 	}
 

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -198,6 +198,8 @@ export type RouterEvents = {
 	'@close': [];
 };
 
+export type RouterObserver = EnhancedEventEmitter<RouterObserverEvents>;
+
 export type RouterObserverEvents = {
 	close: [];
 	newtransport: [Transport];
@@ -252,7 +254,8 @@ export class Router<
 	> = new Map();
 
 	// Observer instance.
-	readonly #observer = new EnhancedEventEmitter<RouterObserverEvents>();
+	readonly #observer: RouterObserver =
+		new EnhancedEventEmitter<RouterObserverEvents>();
 
 	/**
 	 * @private
@@ -316,7 +319,7 @@ export class Router<
 	/**
 	 * Observer.
 	 */
-	get observer(): EnhancedEventEmitter<RouterObserverEvents> {
+	get observer(): RouterObserver {
 		return this.#observer;
 	}
 

--- a/node/src/RtpObserver.ts
+++ b/node/src/RtpObserver.ts
@@ -15,6 +15,9 @@ export type RtpObserverEvents = {
 	'@close': [];
 };
 
+export type RtpObserverObserver =
+	EnhancedEventEmitter<RtpObserverObserverEvents>;
+
 export type RtpObserverObserverEvents = {
 	close: [];
 	pause: [];
@@ -43,9 +46,10 @@ export type RtpObserverAddRemoveProducerOptions = {
 	producerId: string;
 };
 
-export class RtpObserver<
+export abstract class RtpObserver<
 	RtpObserverAppData extends AppData = AppData,
 	Events extends RtpObserverEvents = RtpObserverEvents,
+	Observer extends RtpObserverObserver = RtpObserverObserver,
 > extends EnhancedEventEmitter<Events> {
 	// Internal data.
 	protected readonly internal: RtpObserverObserverInternal;
@@ -68,18 +72,21 @@ export class RtpObserver<
 	) => Producer | undefined;
 
 	// Observer instance.
-	readonly #observer = new EnhancedEventEmitter<RtpObserverObserverEvents>();
+	readonly #observer: Observer;
 
 	/**
 	 * @private
 	 * @interface
 	 */
-	constructor({
-		internal,
-		channel,
-		appData,
-		getProducerById,
-	}: RtpObserverConstructorOptions<RtpObserverAppData>) {
+	constructor(
+		{
+			internal,
+			channel,
+			appData,
+			getProducerById,
+		}: RtpObserverConstructorOptions<RtpObserverAppData>,
+		observer: Observer
+	) {
 		super();
 
 		logger.debug('constructor()');
@@ -88,6 +95,7 @@ export class RtpObserver<
 		this.channel = channel;
 		this.#appData = appData || ({} as RtpObserverAppData);
 		this.getProducerById = getProducerById;
+		this.#observer = observer;
 	}
 
 	/**
@@ -128,7 +136,7 @@ export class RtpObserver<
 	/**
 	 * Observer.
 	 */
-	get observer(): EnhancedEventEmitter<RtpObserverObserverEvents> {
+	get observer(): Observer {
 		return this.#observer;
 	}
 

--- a/node/src/WebRtcServer.ts
+++ b/node/src/WebRtcServer.ts
@@ -34,6 +34,9 @@ export type WebRtcServerEvents = {
 	'@close': [];
 };
 
+export type WebRtcServerObserver =
+	EnhancedEventEmitter<WebRtcServerObserverEvents>;
+
 export type WebRtcServerObserverEvents = {
 	close: [];
 	webrtctransporthandled: [WebRtcTransport];
@@ -89,7 +92,8 @@ export class WebRtcServer<
 	readonly #webRtcTransports: Map<string, WebRtcTransport> = new Map();
 
 	// Observer instance.
-	readonly #observer = new EnhancedEventEmitter<WebRtcServerObserverEvents>();
+	readonly #observer: WebRtcServerObserver =
+		new EnhancedEventEmitter<WebRtcServerObserverEvents>();
 
 	/**
 	 * @private
@@ -143,7 +147,7 @@ export class WebRtcServer<
 	/**
 	 * Observer.
 	 */
-	get observer(): EnhancedEventEmitter<WebRtcServerObserverEvents> {
+	get observer(): WebRtcServerObserver {
 		return this.#observer;
 	}
 

--- a/node/src/WebRtcTransport.ts
+++ b/node/src/WebRtcTransport.ts
@@ -1,5 +1,6 @@
 import * as flatbuffers from 'flatbuffers';
 import { Logger } from './Logger';
+import { EnhancedEventEmitter } from './enhancedEvents';
 import {
 	parseSctpState,
 	parseBaseTransportDump,
@@ -215,6 +216,9 @@ export type WebRtcTransportEvents = TransportEvents & {
 	sctpstatechange: [SctpState];
 };
 
+export type WebRtcTransportObserver =
+	EnhancedEventEmitter<WebRtcTransportObserverEvents>;
+
 export type WebRtcTransportObserverEvents = TransportObserverEvents & {
 	icestatechange: [IceState];
 	iceselectedtuplechange: [TransportTuple];
@@ -258,7 +262,7 @@ export class WebRtcTransport<
 > extends Transport<
 	WebRtcTransportAppData,
 	WebRtcTransportEvents,
-	WebRtcTransportObserverEvents
+	WebRtcTransportObserver
 > {
 	// WebRtcTransport data.
 	readonly #data: WebRtcTransportData;
@@ -269,7 +273,10 @@ export class WebRtcTransport<
 	constructor(
 		options: WebRtcTransportConstructorOptions<WebRtcTransportAppData>
 	) {
-		super(options);
+		const observer: WebRtcTransportObserver =
+			new EnhancedEventEmitter<WebRtcTransportObserverEvents>();
+
+		super(options, observer);
 
 		logger.debug('constructor()');
 
@@ -289,6 +296,15 @@ export class WebRtcTransport<
 		};
 
 		this.handleWorkerNotifications();
+	}
+
+	/**
+	 * Observer.
+	 *
+	 * @override
+	 */
+	get observer(): WebRtcTransportObserver {
+		return super.observer;
 	}
 
 	/**

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -210,6 +210,8 @@ export type WorkerEvents = {
 	'@failure': [Error];
 };
 
+export type WorkerObserver = EnhancedEventEmitter<WorkerObserverEvents>;
+
 export type WorkerObserverEvents = {
 	close: [];
 	newwebrtcserver: [WebRtcServer];
@@ -275,7 +277,8 @@ export class Worker<
 	readonly #routers: Set<Router> = new Set();
 
 	// Observer instance.
-	readonly #observer = new EnhancedEventEmitter<WorkerObserverEvents>();
+	readonly #observer: WorkerObserver =
+		new EnhancedEventEmitter<WorkerObserverEvents>();
 
 	/**
 	 * @private
@@ -545,7 +548,7 @@ export class Worker<
 	/**
 	 * Observer.
 	 */
-	get observer(): EnhancedEventEmitter<WorkerObserverEvents> {
+	get observer(): WorkerObserver {
 		return this.#observer;
 	}
 

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -22,11 +22,13 @@ export const version: string = require('../../package.json').version;
  */
 export { parse as parseScalabilityMode } from './scalabilityModes';
 
+export type Observer = EnhancedEventEmitter<ObserverEvents>;
+
 export type ObserverEvents = {
 	newworker: [Worker];
 };
 
-const observer = new EnhancedEventEmitter<ObserverEvents>();
+const observer: Observer = new EnhancedEventEmitter<ObserverEvents>();
 
 /**
  * Observer.


### PR DESCRIPTION
### Details

- Export `WorkerObserver`, `ProducerObserver` types.
- Many changes done because things were wrong at TS level despite it didn't show up (things showed up to me while doing this).