### PR TITLE
add unit test for mapping packets with lower sequence number than the first mapped packet

### DIFF
--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -1400,4 +1400,19 @@ SCENARIO("SeqManager", "[rtc][SeqMananger]")
 		SeqManager<uint16_t> seqManager(/*initialOutput*/ 1000);
 		validate(seqManager, inputs);
 	}
+
+	SECTION("map packets prior to first mapped packet")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{  4,  4, false, false },
+			{  3,  3, false, false },
+			{  65535,  65535, false, false },
+		};
+		// clang-format on
+
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
 }


### PR DESCRIPTION
see #1437 and #1438. Works but why not have a test