### PR TITLE
DepLibUring improvements

### DIFF
--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -18,6 +18,7 @@ jobs:
         ci:
           - os: ubuntu-20.04
           - os: ubuntu-22.04
+          - os: ubuntu-24.04
           - os: macos-12
           - os: macos-14
           - os: windows-2022

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         build:
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             cc: clang
             cxx: clang++
         build-type:

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -16,6 +16,7 @@ jobs:
           - os: ubuntu-24.04
             cc: clang
             cxx: clang++
+            pip-break-system-packages: true
         build-type:
           - Release
           - Debug
@@ -34,12 +35,12 @@ jobs:
         uses: actions/checkout@v4
 
       # We need to install pip invoke manually.
-      - if: runner.os != 'macOS'
+      - if: ${{ !matrix.build.pip-break-system-packages }}
         name: pip3 install invoke
         run: pip3 install invoke
 
-      # In macOS we need to specify this option.
-      - if: runner.os == 'macOS'
+      # In modern OSs we need to run pip with this option.
+      - if: ${{ matrix.build.pip-break-system-packages }}
         name: pip3 install --break-system-packages invoke
         run: pip3 install --break-system-packages invoke
 

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -19,6 +19,8 @@ jobs:
             cc: gcc
             cxx: g++
           # Worker prebuild for Linux with kernel version 6 Ubuntu (22.04).
+          # Let's not use Ubutu 24.04 to avoid same potential problem as described
+          # above.
           - os: ubuntu-22.04
             cc: gcc
             cxx: g++

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -31,6 +31,12 @@ jobs:
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
+          - os: ubuntu-24.04
+            cc: gcc
+            cxx: g++
+          - os: ubuntu-24.04
+            cc: clang
+            cxx: clang++
           - os: macos-12
             cc: gcc
             cxx: g++

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -34,15 +34,19 @@ jobs:
           - os: ubuntu-24.04
             cc: gcc
             cxx: g++
+            pip-break-system-packages: true
           - os: ubuntu-24.04
             cc: clang
             cxx: clang++
+            pip-break-system-packages: true
           - os: macos-12
             cc: gcc
             cxx: g++
+            pip-break-system-packages: true
           - os: macos-14
             cc: clang
             cxx: clang++
+            pip-break-system-packages: true
           - os: windows-2022
             cc: cl
             cxx: cl
@@ -81,12 +85,12 @@ jobs:
             ${{ matrix.build.os }}-node-${{matrix.build.cc}}-
 
       # We need to install pip invoke manually.
-      - if: runner.os != 'macOS'
+      - if: ${{ !matrix.build.pip-break-system-packages }}
         name: pip3 install invoke
         run: pip3 install invoke
 
-      # In macOS we need to specify this option.
-      - if: runner.os == 'macOS'
+      # In modern OSs we need to run pip with this option.
+      - if: ${{ matrix.build.pip-break-system-packages }}
         name: pip3 install --break-system-packages invoke
         run: pip3 install --break-system-packages invoke
 

--- a/worker/include/DepLibUring.hpp
+++ b/worker/include/DepLibUring.hpp
@@ -33,9 +33,10 @@ public:
 
 	using SendBuffer = uint8_t[SendBufferSize];
 
-	static bool IsRuntimeSupported();
 	static void ClassInit();
 	static void ClassDestroy();
+	static void CheckRuntimeSupport();
+	static bool IsRuntimeSupported();
 	static flatbuffers::Offset<FBS::LibUring::Dump> FillBuffer(flatbuffers::FlatBufferBuilder& builder);
 	static void StartPollingCQEs();
 	static void StopPollingCQEs();
@@ -51,8 +52,10 @@ public:
 	class LibUring;
 
 	thread_local static LibUring* liburing;
+	static bool runtimeSupported{ false };
 
-public:
+private:
+	// Private singleton.
 	class LibUring
 	{
 	public:
@@ -98,6 +101,10 @@ public:
 		}
 
 	private:
+		void SetInactive()
+		{
+			this->active = false;
+		}
 		UserData* GetUserData();
 		bool IsDataInSendBuffers(const uint8_t* data) const
 		{

--- a/worker/include/DepLibUring.hpp
+++ b/worker/include/DepLibUring.hpp
@@ -51,9 +51,9 @@ public:
 
 	class LibUring;
 
-	thread_local static LibUring* liburing;
 	// Whether liburing is enabled or not after runtime checks.
-	static bool enabled{ false };
+	static bool enabled;
+	thread_local static LibUring* liburing;
 
 private:
 	// Private singleton.

--- a/worker/include/DepLibUring.hpp
+++ b/worker/include/DepLibUring.hpp
@@ -49,15 +49,14 @@ public:
 	static void SetActive();
 	static bool IsActive();
 
-	private:
-		class LibUring;
+	class LibUring;
 
 	// Whether liburing is enabled or not after runtime checks.
 	static bool enabled;
 	thread_local static LibUring* liburing;
 
-private:
-	// Private singleton.
+public:
+	// Singleton.
 	class LibUring
 	{
 	public:

--- a/worker/include/DepLibUring.hpp
+++ b/worker/include/DepLibUring.hpp
@@ -49,7 +49,8 @@ public:
 	static void SetActive();
 	static bool IsActive();
 
-	class LibUring;
+	private:
+		class LibUring;
 
 	// Whether liburing is enabled or not after runtime checks.
 	static bool enabled;

--- a/worker/include/DepLibUring.hpp
+++ b/worker/include/DepLibUring.hpp
@@ -36,7 +36,7 @@ public:
 	static void ClassInit();
 	static void ClassDestroy();
 	static void CheckRuntimeSupport();
-	static bool IsRuntimeSupported();
+	static bool IsEnabled();
 	static flatbuffers::Offset<FBS::LibUring::Dump> FillBuffer(flatbuffers::FlatBufferBuilder& builder);
 	static void StartPollingCQEs();
 	static void StopPollingCQEs();
@@ -52,7 +52,8 @@ public:
 	class LibUring;
 
 	thread_local static LibUring* liburing;
-	static bool runtimeSupported{ false };
+	// Whether liburing is enabled or not after runtime checks.
+	static bool enabled{ false };
 
 private:
 	// Private singleton.

--- a/worker/src/DepLibUring.cpp
+++ b/worker/src/DepLibUring.cpp
@@ -124,15 +124,15 @@ void DepLibUring::ClassInit()
 	// This must be called first.
 	DepLibUring::CheckRuntimeSupport();
 
-	if (DepLibUring::IsRuntimeSupported())
+	if (DepLibUring::IsEnabled())
 	{
 		DepLibUring::liburing = new LibUring();
 
-		MS_DEBUG_TAG(info, "liburing supported, enabled");
+		MS_DEBUG_TAG(info, "liburing enabled");
 	}
 	else
 	{
-		MS_DEBUG_TAG(info, "liburing not supported, not enabled");
+		MS_DEBUG_TAG(info, "liburing not enabled");
 	}
 }
 
@@ -163,22 +163,19 @@ void DepLibUring::CheckRuntimeSupport()
 
 	// liburing `sento` capabilities are supported for kernel versions greather
 	// than or equal to 6.
-	DepLibUring::runtimeSupported = kernelMayorLong >= 6;
+	DepLibUring::enabled = kernelMayorLong >= 6;
 }
 
-bool DepLibUring::IsRuntimeSupported()
+bool DepLibUring::IsEnabled()
 {
-	return DepLibUring::runtimeSupported;
+	return DepLibUring::enabled;
 }
 
 flatbuffers::Offset<FBS::LibUring::Dump> DepLibUring::FillBuffer(flatbuffers::FlatBufferBuilder& builder)
 {
 	MS_TRACE();
 
-	if (!DepLibUring::liburing)
-	{
-		return 0;
-	}
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
 
 	return DepLibUring::liburing->FillBuffer(builder);
 }
@@ -187,10 +184,7 @@ void DepLibUring::StartPollingCQEs()
 {
 	MS_TRACE();
 
-	if (!DepLibUring::liburing)
-	{
-		return;
-	}
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
 
 	DepLibUring::liburing->StartPollingCQEs();
 }
@@ -199,10 +193,7 @@ void DepLibUring::StopPollingCQEs()
 {
 	MS_TRACE();
 
-	if (!DepLibUring::liburing)
-	{
-		return;
-	}
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
 
 	DepLibUring::liburing->StopPollingCQEs();
 }
@@ -211,7 +202,7 @@ uint8_t* DepLibUring::GetSendBuffer()
 {
 	MS_TRACE();
 
-	MS_ASSERT(DepLibUring::liburing, "DepLibUring::liburing is not set");
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
 
 	return DepLibUring::liburing->GetSendBuffer();
 }
@@ -221,7 +212,7 @@ bool DepLibUring::PrepareSend(
 {
 	MS_TRACE();
 
-	MS_ASSERT(DepLibUring::liburing, "DepLibUring::liburing is not set");
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
 
 	return DepLibUring::liburing->PrepareSend(sockfd, data, len, addr, cb);
 }
@@ -231,7 +222,7 @@ bool DepLibUring::PrepareWrite(
 {
 	MS_TRACE();
 
-	MS_ASSERT(DepLibUring::liburing, "DepLibUring::liburing is not set");
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
 
 	return DepLibUring::liburing->PrepareWrite(sockfd, data1, len1, data2, len2, cb);
 }
@@ -240,10 +231,7 @@ void DepLibUring::Submit()
 {
 	MS_TRACE();
 
-	if (!DepLibUring::liburing)
-	{
-		return;
-	}
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
 
 	DepLibUring::liburing->Submit();
 }
@@ -252,10 +240,7 @@ void DepLibUring::SetActive()
 {
 	MS_TRACE();
 
-	if (!DepLibUring::liburing)
-	{
-		return;
-	}
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
 
 	DepLibUring::liburing->SetActive();
 }
@@ -264,10 +249,7 @@ bool DepLibUring::IsActive()
 {
 	MS_TRACE();
 
-	if (!DepLibUring::liburing)
-	{
-		return false;
-	}
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
 
 	return DepLibUring::liburing->IsActive();
 }

--- a/worker/src/DepLibUring.cpp
+++ b/worker/src/DepLibUring.cpp
@@ -175,7 +175,7 @@ flatbuffers::Offset<FBS::LibUring::Dump> DepLibUring::FillBuffer(flatbuffers::Fl
 {
 	MS_TRACE();
 
-	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not enabled");
 
 	return DepLibUring::liburing->FillBuffer(builder);
 }
@@ -184,7 +184,7 @@ void DepLibUring::StartPollingCQEs()
 {
 	MS_TRACE();
 
-	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not enabled");
 
 	DepLibUring::liburing->StartPollingCQEs();
 }
@@ -193,7 +193,7 @@ void DepLibUring::StopPollingCQEs()
 {
 	MS_TRACE();
 
-	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not enabled");
 
 	DepLibUring::liburing->StopPollingCQEs();
 }
@@ -202,7 +202,7 @@ uint8_t* DepLibUring::GetSendBuffer()
 {
 	MS_TRACE();
 
-	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not enabled");
 
 	return DepLibUring::liburing->GetSendBuffer();
 }
@@ -212,7 +212,7 @@ bool DepLibUring::PrepareSend(
 {
 	MS_TRACE();
 
-	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not enabled");
 
 	return DepLibUring::liburing->PrepareSend(sockfd, data, len, addr, cb);
 }
@@ -222,7 +222,7 @@ bool DepLibUring::PrepareWrite(
 {
 	MS_TRACE();
 
-	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not enabled");
 
 	return DepLibUring::liburing->PrepareWrite(sockfd, data1, len1, data2, len2, cb);
 }
@@ -231,7 +231,7 @@ void DepLibUring::Submit()
 {
 	MS_TRACE();
 
-	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not enabled");
 
 	DepLibUring::liburing->Submit();
 }
@@ -240,7 +240,7 @@ void DepLibUring::SetActive()
 {
 	MS_TRACE();
 
-	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not enabled");
 
 	DepLibUring::liburing->SetActive();
 }
@@ -249,7 +249,7 @@ bool DepLibUring::IsActive()
 {
 	MS_TRACE();
 
-	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
+	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not enabled");
 
 	return DepLibUring::liburing->IsActive();
 }

--- a/worker/src/DepLibUring.cpp
+++ b/worker/src/DepLibUring.cpp
@@ -186,7 +186,6 @@ void DepLibUring::StartPollingCQEs()
 
 	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
 
-
 	DepLibUring::liburing->StartPollingCQEs();
 }
 

--- a/worker/src/DepLibUring.cpp
+++ b/worker/src/DepLibUring.cpp
@@ -10,7 +10,7 @@
 #include <sys/utsname.h>
 
 /* Static variables. */
-
+bool DepLibUring::enabled{ false };
 /* liburing instance per thread. */
 thread_local DepLibUring::LibUring* DepLibUring::liburing{ nullptr };
 /* Completion queue entry array used to retrieve processes tasks. */
@@ -185,6 +185,7 @@ void DepLibUring::StartPollingCQEs()
 	MS_TRACE();
 
 	MS_ASSERT(DepLibUring::enabled, "DepLibUring::liburing not supported");
+
 
 	DepLibUring::liburing->StartPollingCQEs();
 }

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -251,12 +251,15 @@ void DepUsrSCTP::Checker::OnTimer(TimerHandle* /*timer*/)
 	const int elapsedMs = this->lastCalledAtMs ? static_cast<int>(nowMs - this->lastCalledAtMs) : 0;
 
 #ifdef MS_LIBURING_SUPPORTED
-	// Activate liburing usage.
-	// 'usrsctp_handle_timers()' will synchronously call the send/recv
-	// callbacks for the pending data. If there are multiple messages to be
-	// sent over the network then we will send those messages within a single
-	// system call.
-	DepLibUring::SetActive();
+	if (DepLibUring::IsEnabled())
+	{
+		// Activate liburing usage.
+		// 'usrsctp_handle_timers()' will synchronously call the send/recv
+		// callbacks for the pending data. If there are multiple messages to be
+		// sent over the network then we will send those messages within a single
+		// system call.
+		DepLibUring::SetActive();
+	}
 #endif
 
 	usrsctp_handle_timers(elapsedMs);

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -265,8 +265,11 @@ void DepUsrSCTP::Checker::OnTimer(TimerHandle* /*timer*/)
 	usrsctp_handle_timers(elapsedMs);
 
 #ifdef MS_LIBURING_SUPPORTED
-	// Submit all prepared submission entries.
-	DepLibUring::Submit();
+	if (DepLibUring::IsEnabled())
+	{
+		// Submit all prepared submission entries.
+		DepLibUring::Submit();
+	}
 #endif
 
 	this->lastCalledAtMs = nowMs;

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -665,8 +665,11 @@ namespace RTC
 			std::shared_ptr<RTC::RtpPacket> sharedPacket;
 
 #ifdef MS_LIBURING_SUPPORTED
-			// Activate liburing usage.
-			DepLibUring::SetActive();
+			if (DepLibUring::IsEnabled())
+			{
+				// Activate liburing usage.
+				DepLibUring::SetActive();
+			}
 #endif
 
 			for (auto* consumer : consumers)
@@ -683,8 +686,11 @@ namespace RTC
 			}
 
 #ifdef MS_LIBURING_SUPPORTED
-			// Submit all prepared submission entries.
-			DepLibUring::Submit();
+			if (DepLibUring::IsEnabled())
+			{
+				// Submit all prepared submission entries.
+				DepLibUring::Submit();
+			}
 #endif
 		}
 
@@ -925,10 +931,13 @@ namespace RTC
 		if (!dataConsumers.empty())
 		{
 #ifdef MS_LIBURING_SUPPORTED
-			// Activate liburing usage.
-			// The effective sending could be synchronous, thus we would send those
-			// messages within a single system call.
-			DepLibUring::SetActive();
+			if (DepLibUring::IsEnabled())
+			{
+				// Activate liburing usage.
+				// The effective sending could be synchronous, thus we would send those
+				// messages within a single system call.
+				DepLibUring::SetActive();
+			}
 #endif
 
 			for (auto* dataConsumer : dataConsumers)
@@ -937,8 +946,11 @@ namespace RTC
 			}
 
 #ifdef MS_LIBURING_SUPPORTED
-			// Submit all prepared submission entries.
-			DepLibUring::Submit();
+			if (DepLibUring::IsEnabled())
+			{
+				// Submit all prepared submission entries.
+				DepLibUring::Submit();
+			}
 #endif
 		}
 	}

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -128,8 +128,11 @@ namespace RTC
 		this->nackCount++;
 
 #ifdef MS_LIBURING_SUPPORTED
-		// Activate liburing usage.
-		DepLibUring::SetActive();
+		if (DepLibUring::IsEnabled())
+		{
+			// Activate liburing usage.
+			DepLibUring::SetActive();
+		}
 #endif
 
 		for (auto it = nackPacket->Begin(); it != nackPacket->End(); ++it)
@@ -173,8 +176,11 @@ namespace RTC
 		}
 
 #ifdef MS_LIBURING_SUPPORTED
-		// Submit all prepared submission entries.
-		DepLibUring::Submit();
+		if (DepLibUring::IsEnabled())
+		{
+			// Submit all prepared submission entries.
+			DepLibUring::Submit();
+		}
 #endif
 	}
 

--- a/worker/src/RTC/SrtpSession.cpp
+++ b/worker/src/RTC/SrtpSession.cpp
@@ -204,6 +204,7 @@ namespace RTC
 		uint8_t* encryptBuffer = EncryptBuffer;
 
 #ifdef MS_LIBURING_SUPPORTED
+		if (DepLibUring::IsEnabled())
 		{
 			if (!DepLibUring::IsActive())
 			{

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2158,8 +2158,11 @@ namespace RTC
 		std::unique_ptr<RTC::RTCP::CompoundPacket> packet{ new RTC::RTCP::CompoundPacket() };
 
 #ifdef MS_LIBURING_SUPPORTED
-		// Activate liburing usage.
-		DepLibUring::SetActive();
+		if (DepLibUring::IsEnabled())
+		{
+			// Activate liburing usage.
+			DepLibUring::SetActive();
+		}
 #endif
 
 		for (auto& kv : this->mapConsumers)
@@ -2207,8 +2210,11 @@ namespace RTC
 		}
 
 #ifdef MS_LIBURING_SUPPORTED
-		// Submit all prepared submission entries.
-		DepLibUring::Submit();
+		if (DepLibUring::IsEnabled())
+		{
+			// Submit all prepared submission entries.
+			DepLibUring::Submit();
+		}
 #endif
 	}
 

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -44,8 +44,11 @@ Worker::Worker(::Channel::ChannelSocket* channel) : channel(channel)
 	DepUsrSCTP::CreateChecker();
 
 #ifdef MS_LIBURING_SUPPORTED
-	// Start polling CQEs, which will create a uv_pool_t handle.
-	DepLibUring::StartPollingCQEs();
+	if (DepLibUring::IsEnabled())
+	{
+		// Start polling CQEs, which will create a uv_pool_t handle.
+		DepLibUring::StartPollingCQEs();
+	}
 #endif
 
 	// Tell the Node process that we are running.
@@ -106,8 +109,11 @@ void Worker::Close()
 	DepUsrSCTP::CloseChecker();
 
 #ifdef MS_LIBURING_SUPPORTED
-	// Stop polling CQEs, which will close the uv_pool_t handle.
-	DepLibUring::StopPollingCQEs();
+	if (DepLibUring::IsEnabled())
+	{
+		// Stop polling CQEs, which will close the uv_pool_t handle.
+		DepLibUring::StopPollingCQEs();
+	}
 #endif
 
 	// Close the Channel.

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -156,7 +156,7 @@ flatbuffers::Offset<FBS::Worker::DumpResponse> Worker::FillBuffer(
 	  channelMessageHandlers
 #ifdef MS_LIBURING_SUPPORTED
 	  ,
-	  DepLibUring::FillBuffer(builder)
+	  DepLibUring::IsEnabled() ? DepLibUring::FillBuffer(builder) : nullptr
 #endif
 	);
 }

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -148,17 +148,26 @@ flatbuffers::Offset<FBS::Worker::DumpResponse> Worker::FillBuffer(
 	// Add channelMessageHandlers.
 	auto channelMessageHandlers = this->shared->channelMessageRegistrator->FillBuffer(builder);
 
-	return FBS::Worker::CreateDumpResponseDirect(
-	  builder,
-	  Logger::Pid,
-	  &webRtcServerIds,
-	  &routerIds,
-	  channelMessageHandlers
 #ifdef MS_LIBURING_SUPPORTED
-	  ,
-	  DepLibUring::IsEnabled() ? DepLibUring::FillBuffer(builder) : nullptr
+	if (DepLibUring::IsEnabled())
+	{
+		return FBS::Worker::CreateDumpResponseDirect(
+		  builder,
+		  Logger::Pid,
+		  &webRtcServerIds,
+		  &routerIds,
+		  channelMessageHandlers,
+		  DepLibUring::FillBuffer(builder));
+	}
+	else
+	{
+		return FBS::Worker::CreateDumpResponseDirect(
+		  builder, Logger::Pid, &webRtcServerIds, &routerIds, channelMessageHandlers, );
+	}
+#else
+	return FBS::Worker::CreateDumpResponseDirect(
+	  builder, Logger::Pid, &webRtcServerIds, &routerIds, channelMessageHandlers, );
 #endif
-	);
 }
 
 flatbuffers::Offset<FBS::Worker::ResourceUsageResponse> Worker::FillBufferResourceUsage(

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -162,11 +162,11 @@ flatbuffers::Offset<FBS::Worker::DumpResponse> Worker::FillBuffer(
 	else
 	{
 		return FBS::Worker::CreateDumpResponseDirect(
-		  builder, Logger::Pid, &webRtcServerIds, &routerIds, channelMessageHandlers, );
+		  builder, Logger::Pid, &webRtcServerIds, &routerIds, channelMessageHandlers);
 	}
 #else
 	return FBS::Worker::CreateDumpResponseDirect(
-	  builder, Logger::Pid, &webRtcServerIds, &routerIds, channelMessageHandlers, );
+	  builder, Logger::Pid, &webRtcServerIds, &routerIds, channelMessageHandlers);
 #endif
 }
 

--- a/worker/src/handles/TcpConnectionHandle.cpp
+++ b/worker/src/handles/TcpConnectionHandle.cpp
@@ -168,11 +168,14 @@ void TcpConnectionHandle::Start()
 	}
 
 #ifdef MS_LIBURING_SUPPORTED
-	err = uv_fileno(reinterpret_cast<uv_handle_t*>(this->uvHandle), std::addressof(this->fd));
-
-	if (err != 0)
+	if (DepLibUring::IsEnabled())
 	{
-		MS_THROW_ERROR("uv_fileno() failed: %s", uv_strerror(err));
+		err = uv_fileno(reinterpret_cast<uv_handle_t*>(this->uvHandle), std::addressof(this->fd));
+
+		if (err != 0)
+		{
+			MS_THROW_ERROR("uv_fileno() failed: %s", uv_strerror(err));
+		}
 	}
 #endif
 }
@@ -209,6 +212,7 @@ void TcpConnectionHandle::Write(
 	}
 
 #ifdef MS_LIBURING_SUPPORTED
+	if (DepLibUring::IsEnabled())
 	{
 		if (!DepLibUring::IsActive())
 		{

--- a/worker/src/handles/UdpSocketHandle.cpp
+++ b/worker/src/handles/UdpSocketHandle.cpp
@@ -88,11 +88,14 @@ UdpSocketHandle::UdpSocketHandle(uv_udp_t* uvHandle) : uvHandle(uvHandle)
 	}
 
 #ifdef MS_LIBURING_SUPPORTED
-	err = uv_fileno(reinterpret_cast<uv_handle_t*>(this->uvHandle), std::addressof(this->fd));
-
-	if (err != 0)
+	if (DepLibUring::IsEnabled())
 	{
-		MS_THROW_ERROR("uv_fileno() failed: %s", uv_strerror(err));
+		err = uv_fileno(reinterpret_cast<uv_handle_t*>(this->uvHandle), std::addressof(this->fd));
+
+		if (err != 0)
+		{
+			MS_THROW_ERROR("uv_fileno() failed: %s", uv_strerror(err));
+		}
 	}
 #endif
 }
@@ -144,6 +147,7 @@ void UdpSocketHandle::Send(
 	}
 
 #ifdef MS_LIBURING_SUPPORTED
+	if (DepLibUring::IsEnabled())
 	{
 		if (!DepLibUring::IsActive())
 		{


### PR DESCRIPTION
### Details

- Be explicit. Always check if liburing is enabled in runtime before calling any method in `DepLibUring`.  This is cosmetic but helps when reading the whole code.
- So basically, always check the new `DepLibUring::IsEnabled()` method before making any call to `DepLibUring::xxxx()`. This doesn't apply to `DepLibUring::ClassInit()/Destroy()`.
- This PR is intended to help (but not fix) this important issue: https://github.com/versatica/mediasoup/issues/1435#issuecomment-2277687011
- Bonus track: Fixes #1441.