### PR TITLE
WorkerSettings: Add disableLiburing option (enable_liburing in Rust)

### DIFF
--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -47,7 +47,7 @@ jobs:
         run: cargo clippy --all-targets -- -D warnings
 
       # NOTE: In Windows this will build and test libmediasoupworker in release
-      # mode twice since build.rs doesn't allow debug mode for Windows.
+      # mode twice since build.rs doesn't allow debug mode on Windows.
       - name: cargo test
         run: |
           cargo test --verbose

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - CI: Support Node 22 ([PR #1434](https://github.com/versatica/mediasoup/pull/1434)).
 - Update ESLint to version 9 ([PR #1435](https://github.com/versatica/mediasoup/pull/1435)).
+- `Worker`: Add `disableLiburing` boolean option (`false` by default) to disable `io_uring` even if it's supported by the prebuilt `mediasoup-worker` and by current host ([PR #1442](https://github.com/versatica/mediasoup/pull/1442)).
 
 ### 3.14.9
 
@@ -246,11 +247,11 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 ### 3.12.2
 
-- CI: Use `ubuntu-20.04` to build mediasoup-worker prebuilt on Linux ([PR #1092](https://github.com/versatica/mediasoup/pull/1092)).
+- CI: Use `ubuntu-20.04` to build `mediasoup-worker` prebuilt on Linux ([PR #1092](https://github.com/versatica/mediasoup/pull/1092)).
 
 ### 3.12.1
 
-- mediasoup-worker prebuild: Fallback to local building if fetched binary doesn't run on current host ([PR #1090](https://github.com/versatica/mediasoup/pull/1090)).
+- `mediasoup-worker` prebuild: Fallback to local building if fetched binary doesn't run on current host ([PR #1090](https://github.com/versatica/mediasoup/pull/1090)).
 
 ### 3.12.0
 
@@ -664,7 +665,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 - `Transport`: Implement new `setMaxOutgoingBitrate()` method ([PR #555](https://github.com/versatica/mediasoup/pull/555) by @t-mullen).
 - `SctpAssociation`: Don't warn if SCTP send buffer is full.
 - Rust: Update modules structure and other minor improvements for Rust version ([PR #558](https://github.com/versatica/mediasoup/pull/558)).
-- `mediasoup-worker`: Avoid duplicated basenames so that libmediasoup-worker is compilable on macOS ([PR #557](https://github.com/versatica/mediasoup/pull/557)).
+- `mediasoup-worker`: Avoid duplicated basenames so that `libmediasoup-worker` is compilable on macOS ([PR #557](https://github.com/versatica/mediasoup/pull/557)).
 
 ### 3.7.5
 
@@ -777,8 +778,8 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 ### 3.6.20
 
-- Remove `-fwrapv` when building mediasoup-worker in `Debug` mode (issue #460).
-- Add `MEDIASOUP_MAX_CORES` to limit `NUM_CORES` during mediasoup-worker build ([PR #462](https://github.com/versatica/mediasoup/pull/462)).
+- Remove `-fwrapv` when building `mediasoup-worker` in `Debug` mode (issue #460).
+- Add `MEDIASOUP_MAX_CORES` to limit `NUM_CORES` during `mediasoup-worker` build ([PR #462](https://github.com/versatica/mediasoup/pull/462)).
 
 ### 3.6.19
 
@@ -894,7 +895,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 - SCTP/DataChannel termination:
   - [PR #409](https://github.com/versatica/mediasoup/pull/409)
-  - Allow the Node application to directly send text/binary messages to mediasoup-worker C++ process so others can consume them using `DataConsumers`.
+  - Allow the Node application to directly send text/binary messages to `mediasoup-worker` C++ process so others can consume them using `DataConsumers`.
   - And vice-versa: allow the Node application to directly consume in Node messages send by `DataProducers`.
 - Add `WorkerLogTag` TypeScript enum and also add a new 'message' tag into it.
 
@@ -944,7 +945,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 ### 3.5.7
 
-- Fix crash in mediasoup-worker due to conversion from `uint64_t` to `int64_t` (used within `libwebrtc` code. Fixes #357.
+- Fix crash in `mediasoup-worker` due to conversion from `uint64_t` to `int64_t` (used within `libwebrtc` code. Fixes #357.
 - Update `usrsctp` library.
 - Update Node deps.
 
@@ -1058,7 +1059,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 ### 3.4.1
 
-- Improve mediasoup-worker build system by using `sh` instead of `bash` and default to 4 cores (thanks @smoke, [PR #349](https://github.com/versatica/mediasoup/pull/349)).
+- Improve `mediasoup-worker` build system by using `sh` instead of `bash` and default to 4 cores (thanks @smoke, [PR #349](https://github.com/versatica/mediasoup/pull/349)).
 
 ### 3.4.0
 
@@ -1133,7 +1134,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 ### 3.2.1
 
 - Add RTCP Extended Reports for RTT calculation on receiver RTP stream (thanks @yangjinechofor for initial pull request #314).
-- Make mediasoup-worker compile in Armbian Debian Buster (thanks @krishisola, fixes #321).
+- Make `mediasoup-worker` compile in Armbian Debian Buster (thanks @krishisola, fixes #321).
 
 ### 3.2.0
 
@@ -1255,7 +1256,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 ### 2.6.13
 
-- Make mediasoup-worker compile in Armbian Debian Buster (thanks @krishisola, fixes #321).
+- Make `mediasoup-worker` compile in Armbian Debian Buster (thanks @krishisola, fixes #321).
 - Update deps.
 
 ### 2.6.12
@@ -1281,7 +1282,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 ### 2.6.7
 
-- Fix wrong destruction of Transports in Router.cpp that generates 100% CPU usage in mediasoup-worker processes.
+- Fix wrong destruction of Transports in Router.cpp that generates 100% CPU usage in `mediasoup-worker` processes.
 
 ### 2.6.6
 

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -84,6 +84,11 @@ export type WorkerSettings<WorkerAppData extends AppData = AppData> = {
 	libwebrtcFieldTrials?: string;
 
 	/**
+	 * Disable liburing (io_uring) despite it's supported in current host.
+	 */
+	disableLiburing?: boolean;
+
+	/**
 	 * Custom application data.
 	 */
 	appData?: WorkerAppData;
@@ -287,6 +292,7 @@ export class Worker<
 		dtlsCertificateFile,
 		dtlsPrivateKeyFile,
 		libwebrtcFieldTrials,
+		disableLiburing,
 		appData,
 	}: WorkerSettings<WorkerAppData>) {
 		super();
@@ -336,6 +342,10 @@ export class Worker<
 
 		if (typeof libwebrtcFieldTrials === 'string' && libwebrtcFieldTrials) {
 			spawnArgs.push(`--libwebrtcFieldTrials=${libwebrtcFieldTrials}`);
+		}
+
+		if (disableLiburing) {
+			spawnArgs.push(`--disableLiburing`);
 		}
 
 		logger.debug(

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -345,7 +345,7 @@ export class Worker<
 		}
 
 		if (disableLiburing) {
-			spawnArgs.push(`--disableLiburing`);
+			spawnArgs.push(`--disableLiburing=true`);
 		}
 
 		logger.debug(

--- a/node/src/test/test-Worker.ts
+++ b/node/src/test/test-Worker.ts
@@ -63,6 +63,7 @@ test('createWorker() succeeds', async () => {
 		dtlsCertificateFile: path.join(__dirname, 'data', 'dtls-cert.pem'),
 		dtlsPrivateKeyFile: path.join(__dirname, 'data', 'dtls-key.pem'),
 		libwebrtcFieldTrials: 'WebRTC-Bwe-AlrLimitedBackoff/Disabled/',
+		disableLiburing: true,
 		appData: { foo: 456 },
 	});
 

--- a/node/src/test/test-node-sctp.ts
+++ b/node/src/test/test-node-sctp.ts
@@ -23,7 +23,7 @@ beforeEach(async () => {
 	// Set node-sctp default PMTU to 1200.
 	sctp.defaults({ PMTU: 1200 });
 
-	ctx.worker = await mediasoup.createWorker();
+	ctx.worker = await mediasoup.createWorker({ disableLiburing: true });
 	ctx.router = await ctx.worker.createRouter();
 	ctx.plainTransport = await ctx.router.createPlainTransport({
 		// https://github.com/nodejs/node/issues/14900.

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,6 +3,7 @@
 # NEXT
 
 - Update Rust toolchain channel to version 1.79.0 (PR #1409).
+- Updates from mediasoup TypeScript `3.14.7..=3.14.10`.
 
 # 0.17.0
 

--- a/rust/src/router/tests.rs
+++ b/rust/src/router/tests.rs
@@ -16,11 +16,10 @@ async fn init() -> Worker {
     let worker_manager = WorkerManager::new();
 
     worker_manager
-        // .create_worker(WorkerSettings {
-        //     enable_liburing: false,
-        //     ..WorkerSettings::default()
-        // })
-        .create_worker(WorkerSettings::default())
+        .create_worker(WorkerSettings {
+            enable_liburing: false,
+            ..WorkerSettings::default()
+        })
         .await
         .expect("Failed to create worker")
 }

--- a/rust/src/router/tests.rs
+++ b/rust/src/router/tests.rs
@@ -16,11 +16,9 @@ async fn init() -> Worker {
     let worker_manager = WorkerManager::new();
 
     worker_manager
-        .create_worker({
-            let mut settings = WorkerSettings::default();
-            settings.enable_liburing = false;
-
-            settings
+        .create_worker(WorkerSettings {
+            enable_liburing: false,
+            ..WorkerSettings::default()
         })
         .await
         .expect("Failed to create worker")

--- a/rust/src/router/tests.rs
+++ b/rust/src/router/tests.rs
@@ -16,10 +16,11 @@ async fn init() -> Worker {
     let worker_manager = WorkerManager::new();
 
     worker_manager
-        .create_worker(WorkerSettings {
-            enable_liburing: false,
-            ..WorkerSettings::default()
-        })
+        // .create_worker(WorkerSettings {
+        //     enable_liburing: false,
+        //     ..WorkerSettings::default()
+        // })
+        .create_worker(WorkerSettings::default())
         .await
         .expect("Failed to create worker")
 }

--- a/rust/src/router/tests.rs
+++ b/rust/src/router/tests.rs
@@ -16,7 +16,12 @@ async fn init() -> Worker {
     let worker_manager = WorkerManager::new();
 
     worker_manager
-        .create_worker(WorkerSettings::default())
+        .create_worker({
+            let mut settings = WorkerSettings::default();
+            settings.enable_liburing = false;
+
+            settings
+        })
         .await
         .expect("Failed to create worker")
 }
@@ -28,12 +33,6 @@ fn worker_close_event() {
 
         let router = worker
             .create_router(RouterOptions::default())
-            .create_worker({
-                let mut settings = WorkerSettings::default();
-                settings.enable_liburing = false;
-
-                settings
-            })
             .await
             .expect("Failed to create router");
 

--- a/rust/src/router/tests.rs
+++ b/rust/src/router/tests.rs
@@ -28,6 +28,12 @@ fn worker_close_event() {
 
         let router = worker
             .create_router(RouterOptions::default())
+            .create_worker({
+                let mut settings = WorkerSettings::default();
+                settings.enable_liburing = false;
+
+                settings
+            })
             .await
             .expect("Failed to create router");
 

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -413,7 +413,7 @@ impl Inner {
             ));
         }
 
-        if enable_liburing {
+        if !enable_liburing {
             spawn_args.push("--disable_liburing".to_string());
         }
 

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -192,6 +192,8 @@ pub struct WorkerSettings {
     /// "WebRTC-Bwe-AlrLimitedBackoff/Enabled/".
     #[doc(hidden)]
     pub libwebrtc_field_trials: Option<String>,
+    /// Disable liburing (io_uring) despite it's supported in current host.
+    pub disable_liburing: Option<bool>,
     /// Function that will be called under worker thread before worker starts, can be used for
     /// pinning worker threads to CPU cores.
     pub thread_initializer: Option<Arc<dyn Fn() + Send + Sync>>,
@@ -221,6 +223,7 @@ impl Default for WorkerSettings {
             rtc_port_range: 10000..=59999,
             dtls_files: None,
             libwebrtc_field_trials: None,
+            disable_liburing: None,
             thread_initializer: None,
             app_data: AppData::default(),
         }
@@ -235,6 +238,7 @@ impl fmt::Debug for WorkerSettings {
             rtc_port_range,
             dtls_files,
             libwebrtc_field_trials,
+            disable_liburing,
             thread_initializer,
             app_data,
         } = self;
@@ -245,6 +249,7 @@ impl fmt::Debug for WorkerSettings {
             .field("rtc_port_range", &rtc_port_range)
             .field("dtls_files", &dtls_files)
             .field("libwebrtc_field_trials", &libwebrtc_field_trials)
+            .field("disable_liburing", &disable_liburing)
             .field(
                 "thread_initializer",
                 &thread_initializer.as_ref().map(|_| "ThreadInitializer"),
@@ -356,6 +361,7 @@ impl Inner {
             rtc_port_range,
             dtls_files,
             libwebrtc_field_trials,
+            disable_liburing,
             thread_initializer,
             app_data,
         }: WorkerSettings,
@@ -402,6 +408,10 @@ impl Inner {
                 "--libwebrtcFieldTrials={}",
                 libwebrtc_field_trials.as_str()
             ));
+        }
+
+        if let Some(disable_liburing) = disable_liburing {
+            spawn_args.push(format!("--disable_liburing"));
         }
 
         let id = WorkerId::new();

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -414,7 +414,7 @@ impl Inner {
         }
 
         if !enable_liburing {
-            spawn_args.push("--disableLiburing".to_string());
+            spawn_args.push("--disableLiburing=true".to_string());
         }
 
         let id = WorkerId::new();

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -414,7 +414,7 @@ impl Inner {
         }
 
         if !enable_liburing {
-            spawn_args.push("--disable_liburing".to_string());
+            spawn_args.push("--disableLiburing".to_string());
         }
 
         let id = WorkerId::new();

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -192,8 +192,11 @@ pub struct WorkerSettings {
     /// "WebRTC-Bwe-AlrLimitedBackoff/Enabled/".
     #[doc(hidden)]
     pub libwebrtc_field_trials: Option<String>,
-    /// Disable liburing (io_uring) despite it's supported in current host.
-    pub disable_liburing: Option<bool>,
+    /// Enable liburing  This option is ignored if io_uring is not supported by
+    /// current host.
+    ///
+    /// Default `true`.
+    pub enable_liburing: bool,
     /// Function that will be called under worker thread before worker starts, can be used for
     /// pinning worker threads to CPU cores.
     pub thread_initializer: Option<Arc<dyn Fn() + Send + Sync>>,
@@ -223,7 +226,7 @@ impl Default for WorkerSettings {
             rtc_port_range: 10000..=59999,
             dtls_files: None,
             libwebrtc_field_trials: None,
-            disable_liburing: None,
+            enable_liburing: true,
             thread_initializer: None,
             app_data: AppData::default(),
         }
@@ -238,7 +241,7 @@ impl fmt::Debug for WorkerSettings {
             rtc_port_range,
             dtls_files,
             libwebrtc_field_trials,
-            disable_liburing,
+            enable_liburing,
             thread_initializer,
             app_data,
         } = self;
@@ -249,7 +252,7 @@ impl fmt::Debug for WorkerSettings {
             .field("rtc_port_range", &rtc_port_range)
             .field("dtls_files", &dtls_files)
             .field("libwebrtc_field_trials", &libwebrtc_field_trials)
-            .field("disable_liburing", &disable_liburing)
+            .field("enable_liburing", &enable_liburing)
             .field(
                 "thread_initializer",
                 &thread_initializer.as_ref().map(|_| "ThreadInitializer"),
@@ -361,7 +364,7 @@ impl Inner {
             rtc_port_range,
             dtls_files,
             libwebrtc_field_trials,
-            disable_liburing,
+            enable_liburing,
             thread_initializer,
             app_data,
         }: WorkerSettings,
@@ -410,8 +413,8 @@ impl Inner {
             ));
         }
 
-        if let Some(disable_liburing) = disable_liburing {
-            spawn_args.push(format!("--disable_liburing"));
+        if enable_liburing {
+            spawn_args.push("--disable_liburing".to_string());
         }
 
         let id = WorkerId::new();

--- a/worker/include/DepLibUring.hpp
+++ b/worker/include/DepLibUring.hpp
@@ -52,7 +52,7 @@ public:
 	class LibUring;
 
 	// Whether liburing is enabled or not after runtime checks.
-	static bool enabled;
+	thread_local static bool enabled;
 	thread_local static LibUring* liburing;
 
 public:

--- a/worker/include/Settings.hpp
+++ b/worker/include/Settings.hpp
@@ -39,6 +39,7 @@ public:
 		std::string dtlsCertificateFile;
 		std::string dtlsPrivateKeyFile;
 		std::string libwebrtcFieldTrials{ "WebRTC-Bwe-AlrLimitedBackoff/Enabled/" };
+		bool liburingDisabled{ false };
 	};
 
 public:

--- a/worker/src/DepLibUring.cpp
+++ b/worker/src/DepLibUring.cpp
@@ -4,6 +4,7 @@
 #include "DepLibUring.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
+#include "Settings.hpp"
 #include "Utils.hpp"
 #include <sys/eventfd.h>
 #include <sys/resource.h>
@@ -11,9 +12,9 @@
 
 /* Static variables. */
 bool DepLibUring::enabled{ false };
-/* liburing instance per thread. */
+// liburing instance per thread.
 thread_local DepLibUring::LibUring* DepLibUring::liburing{ nullptr };
-/* Completion queue entry array used to retrieve processes tasks. */
+// Completion queue entry array used to retrieve processes tasks.
 thread_local struct io_uring_cqe* cqes[DepLibUring::QueueDepth];
 
 /* Static methods for UV callbacks. */
@@ -120,6 +121,13 @@ void DepLibUring::ClassInit()
 	const auto minor = io_uring_minor_version();
 
 	MS_DEBUG_TAG(info, "liburing version: \"%i.%i\"", mayor, minor);
+
+	if (Settings::configuration.liburingDisabled)
+	{
+		MS_DEBUG_TAG(info, "liburing disabled by user settings");
+
+		return;
+	}
 
 	// This must be called first.
 	DepLibUring::CheckRuntimeSupport();

--- a/worker/src/DepLibUring.cpp
+++ b/worker/src/DepLibUring.cpp
@@ -11,7 +11,7 @@
 #include <sys/utsname.h>
 
 /* Static variables. */
-bool DepLibUring::enabled{ false };
+thread_local bool DepLibUring::enabled{ false };
 // liburing instance per thread.
 thread_local DepLibUring::LibUring* DepLibUring::liburing{ nullptr };
 // Completion queue entry array used to retrieve processes tasks.

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -79,7 +79,7 @@ void Settings::SetConfiguration(int argc, char* argv[])
 	{
 		if (!optarg)
 		{
-			MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
+			MS_THROW_TYPE_ERROR("missing value in command line argument in option '%c'", c);
 		}
 
 		switch (c)

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -81,6 +81,11 @@ void Settings::SetConfiguration(int argc, char* argv[])
 		{
 			case 'l':
 			{
+				if (!optarg)
+				{
+					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
+				}
+
 				stringValue = std::string(optarg);
 				SetLogLevel(stringValue);
 
@@ -89,6 +94,11 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 't':
 			{
+				if (!optarg)
+				{
+					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
+				}
+
 				stringValue = std::string(optarg);
 				logTags.push_back(stringValue);
 
@@ -97,6 +107,11 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'm':
 			{
+				if (!optarg)
+				{
+					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
+				}
+
 				try
 				{
 					Settings::configuration.rtcMinPort = static_cast<uint16_t>(std::stoi(optarg));
@@ -111,6 +126,11 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'M':
 			{
+				if (!optarg)
+				{
+					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
+				}
+
 				try
 				{
 					Settings::configuration.rtcMaxPort = static_cast<uint16_t>(std::stoi(optarg));
@@ -125,6 +145,11 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'c':
 			{
+				if (!optarg)
+				{
+					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
+				}
+
 				stringValue                                 = std::string(optarg);
 				Settings::configuration.dtlsCertificateFile = stringValue;
 
@@ -133,6 +158,11 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'p':
 			{
+				if (!optarg)
+				{
+					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
+				}
+
 				stringValue                                = std::string(optarg);
 				Settings::configuration.dtlsPrivateKeyFile = stringValue;
 
@@ -141,6 +171,11 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'W':
 			{
+				if (!optarg)
+				{
+					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
+				}
+
 				stringValue = std::string(optarg);
 
 				if (stringValue != Settings::configuration.libwebrtcFieldTrials)

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -60,7 +60,8 @@ void Settings::SetConfiguration(int argc, char* argv[])
 		{ "dtlsCertificateFile",  optional_argument, nullptr, 'c' },
 		{ "dtlsPrivateKeyFile",   optional_argument, nullptr, 'p' },
 		{ "libwebrtcFieldTrials", optional_argument, nullptr, 'W' },
-		{ nullptr, 0, nullptr, 0 }
+		{ "disableLiburing",      no_argument,       nullptr, 'd' },
+		{ nullptr,                0,                 nullptr,  0  }
 	};
 	// clang-format on
 	std::string stringValue;
@@ -73,13 +74,9 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 	optind = 1; // Set explicitly, otherwise subsequent runs will fail.
 	opterr = 0; // Don't allow getopt to print error messages.
+
 	while ((c = getopt_long_only(argc, argv, "", options, &optionIdx)) != -1)
 	{
-		if (!optarg)
-		{
-			MS_THROW_TYPE_ERROR("unknown configuration parameter: %s", optarg);
-		}
-
 		switch (c)
 		{
 			case 'l':
@@ -154,6 +151,13 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 					Settings::configuration.libwebrtcFieldTrials = stringValue;
 				}
+
+				break;
+			}
+
+			case 'd':
+			{
+				Settings::configuration.liburingDisabled = true;
 
 				break;
 			}

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -60,7 +60,7 @@ void Settings::SetConfiguration(int argc, char* argv[])
 		{ "dtlsCertificateFile",  optional_argument, nullptr, 'c' },
 		{ "dtlsPrivateKeyFile",   optional_argument, nullptr, 'p' },
 		{ "libwebrtcFieldTrials", optional_argument, nullptr, 'W' },
-		{ "disableLiburing",      no_argument,       nullptr, 'd' },
+		{ "disableLiburing",      optional_argument, nullptr, 'd' },
 		{ nullptr,                0,                 nullptr,  0  }
 	};
 	// clang-format on
@@ -77,15 +77,15 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 	while ((c = getopt_long_only(argc, argv, "", options, &optionIdx)) != -1)
 	{
+		if (!optarg)
+		{
+			MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
+		}
+
 		switch (c)
 		{
 			case 'l':
 			{
-				if (!optarg)
-				{
-					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
-				}
-
 				stringValue = std::string(optarg);
 				SetLogLevel(stringValue);
 
@@ -94,11 +94,6 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 't':
 			{
-				if (!optarg)
-				{
-					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
-				}
-
 				stringValue = std::string(optarg);
 				logTags.push_back(stringValue);
 
@@ -107,11 +102,6 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'm':
 			{
-				if (!optarg)
-				{
-					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
-				}
-
 				try
 				{
 					Settings::configuration.rtcMinPort = static_cast<uint16_t>(std::stoi(optarg));
@@ -126,11 +116,6 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'M':
 			{
-				if (!optarg)
-				{
-					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
-				}
-
 				try
 				{
 					Settings::configuration.rtcMaxPort = static_cast<uint16_t>(std::stoi(optarg));
@@ -145,11 +130,6 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'c':
 			{
-				if (!optarg)
-				{
-					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
-				}
-
 				stringValue                                 = std::string(optarg);
 				Settings::configuration.dtlsCertificateFile = stringValue;
 
@@ -158,11 +138,6 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'p':
 			{
-				if (!optarg)
-				{
-					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
-				}
-
 				stringValue                                = std::string(optarg);
 				Settings::configuration.dtlsPrivateKeyFile = stringValue;
 
@@ -171,11 +146,6 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'W':
 			{
-				if (!optarg)
-				{
-					MS_THROW_TYPE_ERROR("missing value in command line argument: %s", optarg);
-				}
-
 				stringValue = std::string(optarg);
 
 				if (stringValue != Settings::configuration.libwebrtcFieldTrials)
@@ -192,7 +162,12 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'd':
 			{
-				Settings::configuration.liburingDisabled = true;
+				stringValue = std::string(optarg);
+
+				if (stringValue == "true")
+				{
+					Settings::configuration.liburingDisabled = true;
+				}
 
 				break;
 			}


### PR DESCRIPTION
### Details

- Node: `createWorker({ disableLiburing: true })` disables liburing usage despite it's supported by the worker and current host.
- Rust: `create_worker({ enable_liburing: false })` disables liburing usage despite it's supported by the worker and current host.
- Related (still to be fixed) issue which brings lot of context: https://github.com/versatica/mediasoup/issues/1435