### PR TITLE
Fix io_uring support detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- `Worker`: Fix `io_uring` support detection ([PR #1445](https://github.com/versatica/mediasoup/pull/1445)).
+
 ### 3.14.11
 
 - `Worker`: Fix `disableLiburing` option in `WorkerSettings` ([PR #1444](https://github.com/versatica/mediasoup/pull/1444)).

--- a/worker/include/DepLibUring.hpp
+++ b/worker/include/DepLibUring.hpp
@@ -35,7 +35,7 @@ public:
 
 	static void ClassInit();
 	static void ClassDestroy();
-	static void CheckRuntimeSupport();
+	static bool CheckRuntimeSupport();
 	static bool IsEnabled();
 	static flatbuffers::Offset<FBS::LibUring::Dump> FillBuffer(flatbuffers::FlatBufferBuilder& builder);
 	static void StartPollingCQEs();


### PR DESCRIPTION
- Fixes #1435

### Details

- Having Kernel >= 6 doesn't guarantee that `io_uring` is enabled. Some systems disable it at kernel layer.
- This PR checks if `io_uring` initialization works in launch time, otherwise `io_uring` is disabled.

### TODO

- This is another story, but we should rename `WorkerSettings.disableLiburing` to `WorkerSettings.disableIoUring`. That's what we are disabling and not the `io_uring` C wrapper library called `liburing`.