### PR TITLE
Sign self generated DTLS certificate with SHA256

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Sign self generated DTLS certificate with SHA256 ([PR #1450](https://github.com/versatica/mediasoup/pull/1450)).
+
 ### 3.14.13
 
 - Node: Fix regression in exported `mediasoup.types` (classes are now exported as classes instead of types).

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -415,7 +415,7 @@ namespace RTC
 		}
 
 		// Sign the certificate with its own private key.
-		ret = X509_sign(DtlsTransport::certificate, DtlsTransport::privateKey, EVP_sha1());
+		ret = X509_sign(DtlsTransport::certificate, DtlsTransport::privateKey, EVP_sha256());
 
 		if (ret == 0)
 		{


### PR DESCRIPTION
Fixes #1447

### Details

- Sign self generated DTLS certificates with SHA256 instead of deprecated SHA1.