### PR TITLE
Node: Fix types in mediasoup.types are empty/undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### NEXT
 
 - Sign self generated DTLS certificate with SHA256 ([PR #1450](https://github.com/versatica/mediasoup/pull/1450)).
-- Node: Fix `mediasoup.types` exported types are empty.
+- Node: Fix `mediasoup.types` exported types are empty ([PR #1453](https://github.com/versatica/mediasoup/pull/1453)).
 
 ### 3.14.13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - Sign self generated DTLS certificate with SHA256 ([PR #1450](https://github.com/versatica/mediasoup/pull/1450)).
+- Node: Fix `mediasoup.types` exported types are empty.
 
 ### 3.14.13
 

--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -1,4 +1,4 @@
-export type * from './index';
+export type { Observer, ObserverEvents, LogEventListeners } from './index';
 export type * from './RtpParameters';
 export type * from './SctpParameters';
 export type * from './SrtpParameters';


### PR DESCRIPTION
Fixes #1451

### Details

- If `index.ts` exports `types.ts` and vice-versa.... problems.