### PR TITLE
Bring back RTP and RTCP notifications

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,7 +1354,7 @@ checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 
 [[package]]
 name = "mediasoup"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "actix",
  "actix-web",
@@ -1391,7 +1391,7 @@ dependencies = [
 
 [[package]]
 name = "mediasoup-sys"
-version = "0.9.0"
+version = "0.9.1"
 dependencies = [
  "planus",
  "planus-codegen",


### PR DESCRIPTION
Looks like they were forgotten during conversion, should fix https://github.com/versatica/mediasoup/issues/1454 (though I didn't test it).

@sw-vish LMK if it does what you expect it to do.

P.S. Lock file was not committed after last change, so I had to include it.