### PR TITLE
Do not run test-asan-undefined in CI Linux GCC and upgrade abseil-cpp to 20240722.0 LTS

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -12,43 +12,67 @@ jobs:
   ci:
     strategy:
       matrix:
-        ci:
+        build:
           - os: ubuntu-20.04
             node: 18
+            cc: gcc
+            cxx: g++
           - os: ubuntu-22.04
             node: 20
+            cc: gcc
+            cxx: g++
           - os: ubuntu-22.04
             node: 22
+            cc: gcc
+            cxx: g++
           - os: ubuntu-24.04
             node: 22
+            cc: gcc
+            cxx: g++
             meson_args: '-Db_sanitize=address'
           - os: ubuntu-24.04
             node: 22
+            cc: clang
+            cxx: clang++
             meson_args: '-Db_sanitize=undefined'
           - os: ubuntu-24.04
             node: 22
+            cc: gcc
+            cxx: g++
             meson_args: '-Db_sanitize=thread'
           - os: macos-12
             node: 18
+            cc: clang
+            cxx: clang++
           - os: macos-14
             node: 20
+            cc: clang
+            cxx: clang++
           - os: macos-14
             node: 22
+            cc: clang
+            cxx: clang++
           - os: windows-2022
             node: 20
+            cc: cl
+            cxx: cl
           - os: windows-2022
+            cc: cl
+            cxx: cl
             node: 22
         build-type:
           - Release
           - Debug
 
-    runs-on: ${{ matrix.ci.os }}
+    runs-on: ${{ matrix.build.os }}
 
     env:
+      CC: ${{ matrix.build.cc }}
+      CXX: ${{ matrix.build.cxx }}
       MEDIASOUP_SKIP_WORKER_PREBUILT_DOWNLOAD: 'true'
       MEDIASOUP_LOCAL_DEV: 'true'
       MEDIASOUP_BUILDTYPE: ${{ matrix.build-type }}
-      MESON_ARGS: ${{ matrix.ci.meson_args }}
+      MESON_ARGS: ${{ matrix.build.meson_args }}
 
     steps:
       - name: Checkout
@@ -57,21 +81,22 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.ci.node }}
+          node-version: ${{ matrix.build.node }}
 
       - name: Configure cache
         uses: actions/cache@v3
         with:
           path: |
             ~/.npm
-          key: ${{ matrix.ci.os }}-node-${{ hashFiles('**/package.json') }}
+          key: ${{ matrix.build.os }}-node-${{ hashFiles('**/package.json') }}
           restore-keys: |
-            ${{ matrix.ci.os }}-node-
+            ${{ matrix.build.os }}-node-
 
       - name: npm ci
         run: npm ci --foreground-scripts
         env:
-          # Disable leak detection because it's detected by the tool flatc uses to build.
+          # Disable leak detection because it's detected by the tool flatc uses
+          # to build.
           ASAN_OPTIONS: 'detect_leaks=0'
 
       - name: npm run lint:node

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -15,7 +15,7 @@ jobs:
   ci:
     strategy:
       matrix:
-        ci:
+        build:
           - os: ubuntu-20.04
           - os: ubuntu-22.04
           - os: ubuntu-24.04
@@ -23,7 +23,7 @@ jobs:
           - os: macos-14
           - os: windows-2022
 
-    runs-on: ${{ matrix.ci.os }}
+    runs-on: ${{ matrix.build.os }}
 
     env:
       KEEP_BUILD_ARTIFACTS: '1'
@@ -38,7 +38,7 @@ jobs:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-          key: ${{ matrix.ci.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ matrix.build.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
 
       - name: cargo fmt
         run: cargo fmt --all -- --check

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -21,35 +21,67 @@ jobs:
             # Workaround for this issue in Ubunt 20.04:
             # https://github.com/versatica/mediasoup/actions/runs/9992113733/job/27616379442?pr=1427
             workaround-ubuntu-20-04: true
+            run-test-asan-address: true
+            # Skip test-asan-undefined in Linux with GCC due to a bug in GCC
+            # that affects abseil-cpp:
+            # https://github.com/abseil/abseil-cpp/issues/1634
+            run-test-asan-undefined: false
+            run-test-asan-thread: true
           - os: ubuntu-20.04
             cc: clang
             cxx: clang++
             workaround-ubuntu-20-04: true
+            run-test-asan-address: true
+            run-test-asan-undefined: true
+            run-test-asan-thread: true
           - os: ubuntu-22.04
             cc: gcc
             cxx: g++
+            run-test-asan-address: true
+            run-test-asan-undefined: false
+            run-test-asan-thread: true
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
+            run-test-asan-address: true
+            run-test-asan-undefined: true
+            run-test-asan-thread: true
           - os: ubuntu-24.04
             cc: gcc
             cxx: g++
             pip-break-system-packages: true
+            run-test-asan-address: true
+            run-test-asan-undefined: false
+            run-test-asan-thread: true
           - os: ubuntu-24.04
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
+            run-test-asan-address: true
+            run-test-asan-undefined: true
+            run-test-asan-thread: true
           - os: macos-12
             cc: gcc
             cxx: g++
             pip-break-system-packages: true
+            # Address Sanitizer does not work on MacOS.
+            run-test-asan-address: false
+            run-test-asan-undefined: false
+            run-test-asan-thread: false
           - os: macos-14
             cc: clang
             cxx: clang++
+            run-test-asan-address: false
+            run-test-asan-undefined: false
+            run-test-asan-thread: false
             pip-break-system-packages: true
           - os: windows-2022
             cc: cl
             cxx: cl
+            # Address Sanitizer does not work on Windows.
+            run-test-asan-address: false
+            run-test-asan-undefined: false
+            run-test-asan-thread: false
         # A single Node.js version should be fine for C++.
         node:
           - 22
@@ -118,20 +150,17 @@ jobs:
         name: invoke -r worker test
         run: invoke -r worker test
 
-      # Address Sanitizer only works on Linux.
       # Let's clean everything before rebuilding worker tests with ASAN.
-      - if: runner.os == 'Linux'
+      - if: ${{ matrix.build.run-test-asan-address }}
         name: invoke -r worker test-asan-address
         run: invoke -r worker clean-all && invoke -r worker test-asan-address
 
-      # Address Sanitizer only works on Linux.
       # Let's clean everything before rebuilding worker tests with ASAN.
-      - if: runner.os == 'Linux'
+      - if: ${{ matrix.build.run-test-asan-undefined }}
         name: invoke -r worker test-asan-undefined
         run: invoke -r worker clean-all && invoke -r worker test-asan-undefined
 
-      # Address Sanitizer only works on Linux.
       # Let's clean everything before rebuilding worker tests with ASAN.
-      - if: runner.os == 'Linux'
+      - if: ${{ matrix.build.run-test-asan-thread }}
         name: invoke -r worker test-asan-thread
         run: invoke -r worker clean-all && invoke -r worker test-asan-thread

--- a/worker/subprojects/abseil-cpp.wrap
+++ b/worker/subprojects/abseil-cpp.wrap
@@ -1,6 +1,6 @@
 [wrap-file]
 directory = abseil-cpp-20240722.0
-source_url = https://github.com/abseil/abseil-cpp/archive/abseil-cpp-20240722.0.tar.gz
+source_url = https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz
 source_filename = abseil-cpp-20240722.0.tar.gz
 source_hash = f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3
 patch_filename = abseil-cpp_20240722.0-1_patch.zip

--- a/worker/subprojects/abseil-cpp.wrap
+++ b/worker/subprojects/abseil-cpp.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = abseil-cpp-20230802.1
-source_url = https://github.com/abseil/abseil-cpp/archive/20230802.1.tar.gz
-source_filename = abseil-cpp-20230802.1.tar.gz
-source_hash = 987ce98f02eefbaf930d6e38ab16aa05737234d7afbab2d5c4ea7adbe50c28ed
-patch_filename = abseil-cpp_20230802.1-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20230802.1-2/get_patch
-patch_hash = f6ceb55ca4b0995d826cbdefc0a37e0f8b6202d3e7ecb3436298f54d3a23942b
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20230802.1-2/abseil-cpp-20230802.1.tar.gz
-wrapdb_version = 20230802.1-2
+directory = abseil-cpp-20240722.0
+source_url = https://github.com/abseil/abseil-cpp/archive/abseil-cpp-20240722.0.tar.gz
+source_filename = abseil-cpp-20240722.0.tar.gz
+source_hash = f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3
+patch_filename = abseil-cpp_20240722.0-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20240722.0-1/get_patch
+patch_hash = 692bbbc39cacaba4dc4b0c8b2fbbe32736c9cde6377acfa0d52088797af14ded
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20240722.0-1/abseil-cpp-20240722.0.tar.gz
+wrapdb_version = 20240722.0-1
 
 [provide]
 absl_base = absl_base_dep


### PR DESCRIPTION
## Details

- Skip `test-asan-undefined` in Linux with GCC due to a bug in GCC that affects abseil-cpp: https://github.com/abseil/abseil-cpp/issues/1634
- Unblock PR https://github.com/versatica/mediasoup/pull/1456 written by @garrettboone.