### PR TITLE
CI: Remove deprecated macos12 runner and add macos13 and macos15

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -57,9 +57,9 @@ jobs:
             cc: cl
             cxx: cl
           - os: windows-2022
+            node: 22
             cc: cl
             cxx: cl
-            node: 22
         build-type:
           - Release
           - Debug

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -40,7 +40,7 @@ jobs:
             cc: gcc
             cxx: g++
             meson_args: '-Db_sanitize=thread'
-          - os: macos-12
+          - os: macos-13
             node: 18
             cc: clang
             cxx: clang++
@@ -48,7 +48,7 @@ jobs:
             node: 20
             cc: clang
             cxx: clang++
-          - os: macos-14
+          - os: macos-15
             node: 22
             cc: clang
             cxx: clang++

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -19,8 +19,9 @@ jobs:
           - os: ubuntu-20.04
           - os: ubuntu-22.04
           - os: ubuntu-24.04
-          - os: macos-12
+          - os: macos-13
           - os: macos-14
+          - os: macos-15
           - os: windows-2022
 
     runs-on: ${{ matrix.build.os }}

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -24,10 +24,13 @@ jobs:
           - os: ubuntu-22.04
             cc: gcc
             cxx: g++
-          - os: macos-12
+          - os: macos-13
             cc: clang
             cxx: clang++
           - os: macos-14
+            cc: clang
+            cxx: clang++
+          - os: macos-15
             cc: clang
             cxx: clang++
           - os: windows-2022

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -60,7 +60,7 @@ jobs:
             run-test-asan-address: true
             run-test-asan-undefined: true
             run-test-asan-thread: true
-          - os: macos-12
+          - os: macos-13
             cc: gcc
             cxx: g++
             pip-break-system-packages: true
@@ -69,6 +69,13 @@ jobs:
             run-test-asan-undefined: false
             run-test-asan-thread: false
           - os: macos-14
+            cc: clang
+            cxx: clang++
+            run-test-asan-address: false
+            run-test-asan-undefined: false
+            run-test-asan-thread: false
+            pip-break-system-packages: true
+          - os: macos-15
             cc: clang
             cxx: clang++
             run-test-asan-address: false


### PR DESCRIPTION
## Details

In the GitHub announcement:

> The macOS 12 runner image will be removed by December 3rd, 2024. To raise awareness of the upcoming removal, jobs using macOS 12 will temporarily fail during scheduled time periods defined below:
>
> - November 4, 9:00 AM - 7:00 PM EST
> - November 11, 9:00 AM - 7:00 PM EST
> - November 18, 9:00 AM - 7:00 PM EST
> - November 25, 9:00 AM - 7:00 PM EST
>
> **What you need to do**
>
> Jobs using the macos-12 YAML workflow label should be updated to macos-15, macos-14, macos-13, or macos-latest.