### PR TITLE
Expose extras namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Expose `extras` namespace which exports `EnhancedEventEmitter`, `Events` and `enhancedOnce()` for now ([PR #1464](https://github.com/versatica/mediasoup/pull/1464)).
+- Expose `extras` namespace which exports `EnhancedEventEmitter` and `enhancedOnce()` for now ([PR #1464](https://github.com/versatica/mediasoup/pull/1464)).
 
 ### 3.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Expose `extras` namespace which exports `EnhancedEventEmitter`, `Events` and `enhancedOnce()` for now ([PR #1464](https://github.com/versatica/mediasoup/pull/1464)).
+
 ### 3.15.0
 
 - Node: Add TypeScript interfaces for all exported classes ([PR #1463](https://github.com/versatica/mediasoup/pull/1463)).

--- a/node/src/RtpObserver.ts
+++ b/node/src/RtpObserver.ts
@@ -53,7 +53,7 @@ export abstract class RtpObserverImpl<
 	// Observer instance.
 	readonly #observer: Observer;
 
-	constructor(
+	protected constructor(
 		{
 			internal,
 			channel,

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -175,7 +175,7 @@ export abstract class TransportImpl<
 	// Observer instance.
 	readonly #observer: Observer;
 
-	constructor(
+	protected constructor(
 		{
 			internal,
 			data,

--- a/node/src/enhancedEvents.ts
+++ b/node/src/enhancedEvents.ts
@@ -1,6 +1,6 @@
 import { EventEmitter, once } from 'node:events';
 
-export type Events = Record<string, any[]>;
+type Events = Record<string, any[]>;
 
 export class EnhancedEventEmitter<
 	E extends Events = Events,

--- a/node/src/enhancedEvents.ts
+++ b/node/src/enhancedEvents.ts
@@ -1,6 +1,6 @@
 import { EventEmitter, once } from 'node:events';
 
-type Events = Record<string, any[]>;
+export type Events = Record<string, any[]>;
 
 export class EnhancedEventEmitter<
 	E extends Events = Events,

--- a/node/src/extras.ts
+++ b/node/src/extras.ts
@@ -1,0 +1,1 @@
+export { EnhancedEventEmitter, Events, enhancedOnce } from './enhancedEvents';

--- a/node/src/extras.ts
+++ b/node/src/extras.ts
@@ -1,1 +1,1 @@
-export { EnhancedEventEmitter, Events, enhancedOnce } from './enhancedEvents';
+export { EnhancedEventEmitter, enhancedOnce } from './enhancedEvents';

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -146,3 +146,8 @@ export function getSupportedRtpCapabilities(): RtpCapabilities {
  * Expose parseScalabilityMode() function.
  */
 export { parseScalabilityMode } from './scalabilityModesUtils';
+
+/**
+ * Expose extras module.
+ */
+export * as extras from './extras';


### PR DESCRIPTION
## Details

- Expose `mediasoup.extras` which (for now) exports `EnhancedEventEmitter` and `enhancedOnce()`.
- Useful when writing mocks implementing mediasoup TS interfaces.