### PR TITLE
Fix crash when two transports use colliding port ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- `Worker`: Fix crash when using colliding `portRange` values in different transports ([PR #](https://github.com/versatica/mediasoup/pull/)).
+- `Worker`: Fix crash when using colliding `portRange` values in different transports ([PR #1469](https://github.com/versatica/mediasoup/pull/1469)).
 
 ### 3.15.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- `Worker`: Fix crash when using colliding `portRange` values in different transports ([PR #](https://github.com/versatica/mediasoup/pull/)).
+
 ### 3.15.1
 
 - Expose `extras` namespace which exports `EnhancedEventEmitter` and `enhancedOnce()` for now ([PR #1464](https://github.com/versatica/mediasoup/pull/1464)).

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,25 +20,25 @@
 				"tar": "^7.4.3"
 			},
 			"devDependencies": {
-				"@eslint/js": "^9.14.0",
+				"@eslint/js": "^9.15.0",
 				"@octokit/rest": "^21.0.2",
 				"@types/debug": "^4.1.12",
 				"@types/jest": "^29.5.14",
-				"@types/node": "^22.9.0",
-				"eslint": "^9.14.0",
+				"@types/node": "^22.9.1",
+				"eslint": "^9.15.0",
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-jest": "^28.9.0",
 				"eslint-plugin-prettier": "^5.2.1",
 				"globals": "^15.12.0",
 				"jest": "^29.7.0",
-				"marked": "^15.0.0",
+				"marked": "^15.0.2",
 				"open-cli": "^8.0.0",
 				"pick-port": "^2.1.0",
 				"prettier": "^3.3.3",
 				"sctp": "^1.0.0",
 				"ts-jest": "^29.2.5",
 				"typescript": "^5.6.3",
-				"typescript-eslint": "^8.14.0"
+				"typescript-eslint": "^8.15.0"
 			},
 			"engines": {
 				"node": ">=18"
@@ -749,10 +749,11 @@
 			}
 		},
 		"node_modules/@eslint/config-array": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-			"integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
+			"integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/object-schema": "^2.1.4",
 				"debug": "^4.3.1",
@@ -763,9 +764,9 @@
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
-			"integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
+			"integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -773,10 +774,11 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-			"integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+			"integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"ajv": "^6.12.4",
 				"debug": "^4.3.2",
@@ -800,6 +802,7 @@
 			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
 			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			},
@@ -808,9 +811,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.14.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
-			"integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
+			"version": "9.15.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
+			"integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -822,15 +825,17 @@
 			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.4.tgz",
 			"integrity": "sha512-BsWiH1yFGjXXS2yvrf5LyuoSIIbPrGUWob917o+BTKuZ7qJdxX8aJLRxs1fS9n6r7vESrq1OUqb68dANcFXuQQ==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			}
 		},
 		"node_modules/@eslint/plugin-kit": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-			"integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+			"integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
 			"dev": true,
+			"license": "Apache-2.0",
 			"dependencies": {
 				"levn": "^0.4.1"
 			},
@@ -1923,9 +1928,9 @@
 			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
 		},
 		"node_modules/@types/node": {
-			"version": "22.9.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-			"integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+			"version": "22.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.1.tgz",
+			"integrity": "sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1954,17 +1959,17 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.14.0.tgz",
-			"integrity": "sha512-tqp8H7UWFaZj0yNO6bycd5YjMwxa6wIHOLZvWPkidwbgLCsBMetQoGj7DPuAlWa2yGO3H48xmPwjhsSPPCGU5w==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.15.0.tgz",
+			"integrity": "sha512-+zkm9AR1Ds9uLWN3fkoeXgFppaQ+uEVtfOV62dDmsy9QCNqlRHWNEck4yarvRNrvRcHQLGfqBNui3cimoz8XAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.14.0",
-				"@typescript-eslint/type-utils": "8.14.0",
-				"@typescript-eslint/utils": "8.14.0",
-				"@typescript-eslint/visitor-keys": "8.14.0",
+				"@typescript-eslint/scope-manager": "8.15.0",
+				"@typescript-eslint/type-utils": "8.15.0",
+				"@typescript-eslint/utils": "8.15.0",
+				"@typescript-eslint/visitor-keys": "8.15.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
@@ -1988,16 +1993,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.14.0.tgz",
-			"integrity": "sha512-2p82Yn9juUJq0XynBXtFCyrBDb6/dJombnz6vbo6mgQEtWHfvHbQuEa9kAOVIt1c9YFwi7H6WxtPj1kg+80+RA==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.15.0.tgz",
+			"integrity": "sha512-7n59qFpghG4uazrF9qtGKBZXn7Oz4sOMm8dwNWDQY96Xlm2oX67eipqcblDj+oY1lLCbf1oltMZFpUso66Kl1A==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.14.0",
-				"@typescript-eslint/types": "8.14.0",
-				"@typescript-eslint/typescript-estree": "8.14.0",
-				"@typescript-eslint/visitor-keys": "8.14.0",
+				"@typescript-eslint/scope-manager": "8.15.0",
+				"@typescript-eslint/types": "8.15.0",
+				"@typescript-eslint/typescript-estree": "8.15.0",
+				"@typescript-eslint/visitor-keys": "8.15.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -2017,14 +2022,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.14.0.tgz",
-			"integrity": "sha512-aBbBrnW9ARIDn92Zbo7rguLnqQ/pOrUguVpbUwzOhkFg2npFDwTgPGqFqE0H5feXcOoJOfX3SxlJaKEVtq54dw==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.15.0.tgz",
+			"integrity": "sha512-QRGy8ADi4J7ii95xz4UoiymmmMd/zuy9azCaamnZ3FM8T5fZcex8UfJcjkiEZjJSztKfEBe3dZ5T/5RHAmw2mA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.14.0",
-				"@typescript-eslint/visitor-keys": "8.14.0"
+				"@typescript-eslint/types": "8.15.0",
+				"@typescript-eslint/visitor-keys": "8.15.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2035,14 +2040,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.14.0.tgz",
-			"integrity": "sha512-Xcz9qOtZuGusVOH5Uk07NGs39wrKkf3AxlkK79RBK6aJC1l03CobXjJbwBPSidetAOV+5rEVuiT1VSBUOAsanQ==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.15.0.tgz",
+			"integrity": "sha512-UU6uwXDoI3JGSXmcdnP5d8Fffa2KayOhUUqr/AiBnG1Gl7+7ut/oyagVeSkh7bxQ0zSXV9ptRh/4N15nkCqnpw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.14.0",
-				"@typescript-eslint/utils": "8.14.0",
+				"@typescript-eslint/typescript-estree": "8.15.0",
+				"@typescript-eslint/utils": "8.15.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.3.0"
 			},
@@ -2053,6 +2058,9 @@
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
 			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0"
+			},
 			"peerDependenciesMeta": {
 				"typescript": {
 					"optional": true
@@ -2060,9 +2068,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.14.0.tgz",
-			"integrity": "sha512-yjeB9fnO/opvLJFAsPNYlKPnEM8+z4og09Pk504dkqonT02AyL5Z9SSqlE0XqezS93v6CXn49VHvB2G7XSsl0g==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.15.0.tgz",
+			"integrity": "sha512-n3Gt8Y/KyJNe0S3yDCD2RVKrHBC4gTUcLTebVBXacPy091E6tNspFLKRXlk3hwT4G55nfr1n2AdFqi/XMxzmPQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2074,14 +2082,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.14.0.tgz",
-			"integrity": "sha512-OPXPLYKGZi9XS/49rdaCbR5j/S14HazviBlUQFvSKz3npr3NikF+mrgK7CFVur6XEt95DZp/cmke9d5i3vtVnQ==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.15.0.tgz",
+			"integrity": "sha512-1eMp2JgNec/niZsR7ioFBlsh/Fk0oJbhaqO0jRyQBMgkz7RrFfkqF9lYYmBoGBaSiLnu8TAPQTwoTUiSTUW9dg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
-				"@typescript-eslint/types": "8.14.0",
-				"@typescript-eslint/visitor-keys": "8.14.0",
+				"@typescript-eslint/types": "8.15.0",
+				"@typescript-eslint/visitor-keys": "8.15.0",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -2129,16 +2137,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.14.0.tgz",
-			"integrity": "sha512-OGqj6uB8THhrHj0Fk27DcHPojW7zKwKkPmHXHvQ58pLYp4hy8CSUdTKykKeh+5vFqTTVmjz0zCOOPKRovdsgHA==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.15.0.tgz",
+			"integrity": "sha512-k82RI9yGhr0QM3Dnq+egEpz9qB6Un+WLYhmoNcvl8ltMEededhh7otBVVIDDsEEttauwdY/hQoSsOv13lxrFzQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.14.0",
-				"@typescript-eslint/types": "8.14.0",
-				"@typescript-eslint/typescript-estree": "8.14.0"
+				"@typescript-eslint/scope-manager": "8.15.0",
+				"@typescript-eslint/types": "8.15.0",
+				"@typescript-eslint/typescript-estree": "8.15.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2149,17 +2157,22 @@
 			},
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0"
+			},
+			"peerDependenciesMeta": {
+				"typescript": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.14.0.tgz",
-			"integrity": "sha512-vG0XZo8AdTH9OE6VFRwAZldNc7qtJ/6NLGWak+BtENuEUXGZgFpihILPiBvKXvJ2nFu27XNGC6rKiwuaoMbYzQ==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.15.0.tgz",
+			"integrity": "sha512-h8vYOulWec9LhpwfAdZf2bjr8xIp0KNKnpgqSz0qqYYKAW/QZKw3ktRndbiAtUz4acH4QLQavwZBYCc0wulA/Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.14.0",
-				"eslint-visitor-keys": "^3.4.3"
+				"@typescript-eslint/types": "8.15.0",
+				"eslint-visitor-keys": "^4.2.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2167,6 +2180,19 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
+			}
+		},
+		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+			"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/acorn": {
@@ -2187,6 +2213,7 @@
 			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
+			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
 			}
@@ -2196,6 +2223,7 @@
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -2273,7 +2301,8 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-			"dev": true
+			"dev": true,
+			"license": "Python-2.0"
 		},
 		"node_modules/async": {
 			"version": "3.2.5",
@@ -2890,27 +2919,27 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.14.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
-			"integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
+			"version": "9.15.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.15.0.tgz",
+			"integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.18.0",
-				"@eslint/core": "^0.7.0",
-				"@eslint/eslintrc": "^3.1.0",
-				"@eslint/js": "9.14.0",
-				"@eslint/plugin-kit": "^0.2.0",
+				"@eslint/config-array": "^0.19.0",
+				"@eslint/core": "^0.9.0",
+				"@eslint/eslintrc": "^3.2.0",
+				"@eslint/js": "9.15.0",
+				"@eslint/plugin-kit": "^0.2.3",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
-				"@humanwhocodes/retry": "^0.4.0",
+				"@humanwhocodes/retry": "^0.4.1",
 				"@types/estree": "^1.0.6",
 				"@types/json-schema": "^7.0.15",
 				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
-				"cross-spawn": "^7.0.2",
+				"cross-spawn": "^7.0.5",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
 				"eslint-scope": "^8.2.0",
@@ -2929,8 +2958,7 @@
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.3",
-				"text-table": "^0.2.0"
+				"optionator": "^0.9.3"
 			},
 			"bin": {
 				"eslint": "bin/eslint.js"
@@ -3199,7 +3227,8 @@
 			"version": "3.1.3",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/fast-diff": {
 			"version": "1.3.0",
@@ -3658,6 +3687,7 @@
 			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"parent-module": "^1.0.0",
 				"resolve-from": "^4.0.0"
@@ -4563,6 +4593,7 @@
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
 			},
@@ -4598,7 +4629,8 @@
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
@@ -4722,9 +4754,9 @@
 			}
 		},
 		"node_modules/marked": {
-			"version": "15.0.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.0.tgz",
-			"integrity": "sha512-0mouKmBROJv/WSHJBPZZyYofUgawMChnD5je/g+aOBXsHDjb/IsnTQj7mnhQZu+qPJmRQ0ecX3mLGEUm3BgwYA==",
+			"version": "15.0.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.2.tgz",
+			"integrity": "sha512-85RUkoYKIVB21PbMKrnD6aCl9ws+XKEyhJNMbLn206NyD3jbBo7Ec7Wi4Jrsn4dV1a2ng7K/jfkmIN0DNoS41w==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -5094,6 +5126,7 @@
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"callsites": "^3.0.0"
 			},
@@ -5376,6 +5409,7 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=6"
 			}
@@ -5505,6 +5539,7 @@
 			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=4"
 			}
@@ -5944,12 +5979,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/text-table": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true
-		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -6096,15 +6125,15 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.14.0.tgz",
-			"integrity": "sha512-K8fBJHxVL3kxMmwByvz8hNdBJ8a0YqKzKDX6jRlrjMuNXyd5T2V02HIq37+OiWXvUUOXgOOGiSSOh26Mh8pC3w==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.15.0.tgz",
+			"integrity": "sha512-wY4FRGl0ZI+ZU4Jo/yjdBu0lVTSML58pu6PgGtJmCufvzfV565pUF6iACQt092uFOd49iLOTX/sEVmHtbSrS+w==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.14.0",
-				"@typescript-eslint/parser": "8.14.0",
-				"@typescript-eslint/utils": "8.14.0"
+				"@typescript-eslint/eslint-plugin": "8.15.0",
+				"@typescript-eslint/parser": "8.15.0",
+				"@typescript-eslint/utils": "8.15.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -6112,6 +6141,9 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
+			},
+			"peerDependencies": {
+				"eslint": "^8.57.0 || ^9.0.0"
 			},
 			"peerDependenciesMeta": {
 				"typescript": {
@@ -6178,6 +6210,7 @@
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
+			"license": "BSD-2-Clause",
 			"dependencies": {
 				"punycode": "^2.1.0"
 			}
@@ -6876,9 +6909,9 @@
 			"dev": true
 		},
 		"@eslint/config-array": {
-			"version": "0.18.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.18.0.tgz",
-			"integrity": "sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==",
+			"version": "0.19.0",
+			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.0.tgz",
+			"integrity": "sha512-zdHg2FPIFNKPdcHWtiNT+jEFCHYVplAXRDlQDyqy0zGx/q2parwh7brGJSiTxRk/TSMkbM//zt/f5CHgyTyaSQ==",
 			"dev": true,
 			"requires": {
 				"@eslint/object-schema": "^2.1.4",
@@ -6887,15 +6920,15 @@
 			}
 		},
 		"@eslint/core": {
-			"version": "0.7.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.7.0.tgz",
-			"integrity": "sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==",
+			"version": "0.9.0",
+			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.0.tgz",
+			"integrity": "sha512-7ATR9F0e4W85D/0w7cU0SNj7qkAexMG+bAHEZOjo9akvGuhHE2m7umzWzfnpa0XAg5Kxc1BWmtPMV67jJ+9VUg==",
 			"dev": true
 		},
 		"@eslint/eslintrc": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.1.0.tgz",
-			"integrity": "sha512-4Bfj15dVJdoy3RfZmmo86RK1Fwzn6SstsvK9JS+BaVKqC6QQQQyXekNaC+g+LKNgkQ+2VhGAzm6hO40AhMR3zQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+			"integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
 			"dev": true,
 			"requires": {
 				"ajv": "^6.12.4",
@@ -6918,9 +6951,9 @@
 			}
 		},
 		"@eslint/js": {
-			"version": "9.14.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.14.0.tgz",
-			"integrity": "sha512-pFoEtFWCPyDOl+C6Ift+wC7Ro89otjigCf5vcuWqWgqNSQbRrpjSvdeE6ofLz4dHmyxD5f7gIdGT4+p36L6Twg==",
+			"version": "9.15.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.15.0.tgz",
+			"integrity": "sha512-tMTqrY+EzbXmKJR5ToI8lxu7jaN5EdmrBFJpQk5JmSlyLsx6o4t27r883K5xsLuCYCpfKBCGswMSWXsM+jB7lg==",
 			"dev": true
 		},
 		"@eslint/object-schema": {
@@ -6930,9 +6963,9 @@
 			"dev": true
 		},
 		"@eslint/plugin-kit": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-			"integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+			"version": "0.2.3",
+			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+			"integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
 			"dev": true,
 			"requires": {
 				"levn": "^0.4.1"
@@ -7791,9 +7824,9 @@
 			"integrity": "sha512-iiUgKzV9AuaEkZqkOLDIvlQiL6ltuZd9tGcW3gwpnX8JbuiuhFlEGmmFXEXkN50Cvq7Os88IY2v0dkDqXYWVgA=="
 		},
 		"@types/node": {
-			"version": "22.9.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-			"integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
+			"version": "22.9.1",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.1.tgz",
+			"integrity": "sha512-p8Yy/8sw1caA8CdRIQBG5tiLHmxtQKObCijiAa9Ez+d4+PRffM4054xbju0msf+cvhJpnFEeNjxmVT/0ipktrg==",
 			"dev": true,
 			"requires": {
 				"undici-types": "~6.19.8"
@@ -7821,16 +7854,16 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.14.0.tgz",
-			"integrity": "sha512-tqp8H7UWFaZj0yNO6bycd5YjMwxa6wIHOLZvWPkidwbgLCsBMetQoGj7DPuAlWa2yGO3H48xmPwjhsSPPCGU5w==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.15.0.tgz",
+			"integrity": "sha512-+zkm9AR1Ds9uLWN3fkoeXgFppaQ+uEVtfOV62dDmsy9QCNqlRHWNEck4yarvRNrvRcHQLGfqBNui3cimoz8XAg==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.14.0",
-				"@typescript-eslint/type-utils": "8.14.0",
-				"@typescript-eslint/utils": "8.14.0",
-				"@typescript-eslint/visitor-keys": "8.14.0",
+				"@typescript-eslint/scope-manager": "8.15.0",
+				"@typescript-eslint/type-utils": "8.15.0",
+				"@typescript-eslint/utils": "8.15.0",
+				"@typescript-eslint/visitor-keys": "8.15.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^5.3.1",
 				"natural-compare": "^1.4.0",
@@ -7838,54 +7871,54 @@
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.14.0.tgz",
-			"integrity": "sha512-2p82Yn9juUJq0XynBXtFCyrBDb6/dJombnz6vbo6mgQEtWHfvHbQuEa9kAOVIt1c9YFwi7H6WxtPj1kg+80+RA==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.15.0.tgz",
+			"integrity": "sha512-7n59qFpghG4uazrF9qtGKBZXn7Oz4sOMm8dwNWDQY96Xlm2oX67eipqcblDj+oY1lLCbf1oltMZFpUso66Kl1A==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "8.14.0",
-				"@typescript-eslint/types": "8.14.0",
-				"@typescript-eslint/typescript-estree": "8.14.0",
-				"@typescript-eslint/visitor-keys": "8.14.0",
+				"@typescript-eslint/scope-manager": "8.15.0",
+				"@typescript-eslint/types": "8.15.0",
+				"@typescript-eslint/typescript-estree": "8.15.0",
+				"@typescript-eslint/visitor-keys": "8.15.0",
 				"debug": "^4.3.4"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.14.0.tgz",
-			"integrity": "sha512-aBbBrnW9ARIDn92Zbo7rguLnqQ/pOrUguVpbUwzOhkFg2npFDwTgPGqFqE0H5feXcOoJOfX3SxlJaKEVtq54dw==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.15.0.tgz",
+			"integrity": "sha512-QRGy8ADi4J7ii95xz4UoiymmmMd/zuy9azCaamnZ3FM8T5fZcex8UfJcjkiEZjJSztKfEBe3dZ5T/5RHAmw2mA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.14.0",
-				"@typescript-eslint/visitor-keys": "8.14.0"
+				"@typescript-eslint/types": "8.15.0",
+				"@typescript-eslint/visitor-keys": "8.15.0"
 			}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.14.0.tgz",
-			"integrity": "sha512-Xcz9qOtZuGusVOH5Uk07NGs39wrKkf3AxlkK79RBK6aJC1l03CobXjJbwBPSidetAOV+5rEVuiT1VSBUOAsanQ==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.15.0.tgz",
+			"integrity": "sha512-UU6uwXDoI3JGSXmcdnP5d8Fffa2KayOhUUqr/AiBnG1Gl7+7ut/oyagVeSkh7bxQ0zSXV9ptRh/4N15nkCqnpw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/typescript-estree": "8.14.0",
-				"@typescript-eslint/utils": "8.14.0",
+				"@typescript-eslint/typescript-estree": "8.15.0",
+				"@typescript-eslint/utils": "8.15.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.3.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.14.0.tgz",
-			"integrity": "sha512-yjeB9fnO/opvLJFAsPNYlKPnEM8+z4og09Pk504dkqonT02AyL5Z9SSqlE0XqezS93v6CXn49VHvB2G7XSsl0g==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.15.0.tgz",
+			"integrity": "sha512-n3Gt8Y/KyJNe0S3yDCD2RVKrHBC4gTUcLTebVBXacPy091E6tNspFLKRXlk3hwT4G55nfr1n2AdFqi/XMxzmPQ==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.14.0.tgz",
-			"integrity": "sha512-OPXPLYKGZi9XS/49rdaCbR5j/S14HazviBlUQFvSKz3npr3NikF+mrgK7CFVur6XEt95DZp/cmke9d5i3vtVnQ==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.15.0.tgz",
+			"integrity": "sha512-1eMp2JgNec/niZsR7ioFBlsh/Fk0oJbhaqO0jRyQBMgkz7RrFfkqF9lYYmBoGBaSiLnu8TAPQTwoTUiSTUW9dg==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.14.0",
-				"@typescript-eslint/visitor-keys": "8.14.0",
+				"@typescript-eslint/types": "8.15.0",
+				"@typescript-eslint/visitor-keys": "8.15.0",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -7915,25 +7948,33 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.14.0.tgz",
-			"integrity": "sha512-OGqj6uB8THhrHj0Fk27DcHPojW7zKwKkPmHXHvQ58pLYp4hy8CSUdTKykKeh+5vFqTTVmjz0zCOOPKRovdsgHA==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.15.0.tgz",
+			"integrity": "sha512-k82RI9yGhr0QM3Dnq+egEpz9qB6Un+WLYhmoNcvl8ltMEededhh7otBVVIDDsEEttauwdY/hQoSsOv13lxrFzQ==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.4.0",
-				"@typescript-eslint/scope-manager": "8.14.0",
-				"@typescript-eslint/types": "8.14.0",
-				"@typescript-eslint/typescript-estree": "8.14.0"
+				"@typescript-eslint/scope-manager": "8.15.0",
+				"@typescript-eslint/types": "8.15.0",
+				"@typescript-eslint/typescript-estree": "8.15.0"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.14.0.tgz",
-			"integrity": "sha512-vG0XZo8AdTH9OE6VFRwAZldNc7qtJ/6NLGWak+BtENuEUXGZgFpihILPiBvKXvJ2nFu27XNGC6rKiwuaoMbYzQ==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.15.0.tgz",
+			"integrity": "sha512-h8vYOulWec9LhpwfAdZf2bjr8xIp0KNKnpgqSz0qqYYKAW/QZKw3ktRndbiAtUz4acH4QLQavwZBYCc0wulA/Q==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.14.0",
-				"eslint-visitor-keys": "^3.4.3"
+				"@typescript-eslint/types": "8.15.0",
+				"eslint-visitor-keys": "^4.2.0"
+			},
+			"dependencies": {
+				"eslint-visitor-keys": {
+					"version": "4.2.0",
+					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+					"integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+					"dev": true
+				}
 			}
 		},
 		"acorn": {
@@ -8443,26 +8484,26 @@
 			"dev": true
 		},
 		"eslint": {
-			"version": "9.14.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.14.0.tgz",
-			"integrity": "sha512-c2FHsVBr87lnUtjP4Yhvk4yEhKrQavGafRA/Se1ouse8PfbfC/Qh9Mxa00yWsZRlqeUB9raXip0aiiUZkgnr9g==",
+			"version": "9.15.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.15.0.tgz",
+			"integrity": "sha512-7CrWySmIibCgT1Os28lUU6upBshZ+GxybLOrmRzi08kS8MBuO8QA7pXEgYgY5W8vK3e74xv0lpjo9DbaGU9Rkw==",
 			"dev": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
-				"@eslint/config-array": "^0.18.0",
-				"@eslint/core": "^0.7.0",
-				"@eslint/eslintrc": "^3.1.0",
-				"@eslint/js": "9.14.0",
-				"@eslint/plugin-kit": "^0.2.0",
+				"@eslint/config-array": "^0.19.0",
+				"@eslint/core": "^0.9.0",
+				"@eslint/eslintrc": "^3.2.0",
+				"@eslint/js": "9.15.0",
+				"@eslint/plugin-kit": "^0.2.3",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
-				"@humanwhocodes/retry": "^0.4.0",
+				"@humanwhocodes/retry": "^0.4.1",
 				"@types/estree": "^1.0.6",
 				"@types/json-schema": "^7.0.15",
 				"ajv": "^6.12.4",
 				"chalk": "^4.0.0",
-				"cross-spawn": "^7.0.2",
+				"cross-spawn": "^7.0.5",
 				"debug": "^4.3.2",
 				"escape-string-regexp": "^4.0.0",
 				"eslint-scope": "^8.2.0",
@@ -8481,8 +8522,7 @@
 				"lodash.merge": "^4.6.2",
 				"minimatch": "^3.1.2",
 				"natural-compare": "^1.4.0",
-				"optionator": "^0.9.3",
-				"text-table": "^0.2.0"
+				"optionator": "^0.9.3"
 			},
 			"dependencies": {
 				"eslint-visitor-keys": {
@@ -9750,9 +9790,9 @@
 			}
 		},
 		"marked": {
-			"version": "15.0.0",
-			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.0.tgz",
-			"integrity": "sha512-0mouKmBROJv/WSHJBPZZyYofUgawMChnD5je/g+aOBXsHDjb/IsnTQj7mnhQZu+qPJmRQ0ecX3mLGEUm3BgwYA==",
+			"version": "15.0.2",
+			"resolved": "https://registry.npmjs.org/marked/-/marked-15.0.2.tgz",
+			"integrity": "sha512-85RUkoYKIVB21PbMKrnD6aCl9ws+XKEyhJNMbLn206NyD3jbBo7Ec7Wi4Jrsn4dV1a2ng7K/jfkmIN0DNoS41w==",
 			"dev": true
 		},
 		"meow": {
@@ -10557,12 +10597,6 @@
 				"minimatch": "^3.0.4"
 			}
 		},
-		"text-table": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-			"dev": true
-		},
 		"tmpl": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -10646,14 +10680,14 @@
 			"dev": true
 		},
 		"typescript-eslint": {
-			"version": "8.14.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.14.0.tgz",
-			"integrity": "sha512-K8fBJHxVL3kxMmwByvz8hNdBJ8a0YqKzKDX6jRlrjMuNXyd5T2V02HIq37+OiWXvUUOXgOOGiSSOh26Mh8pC3w==",
+			"version": "8.15.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.15.0.tgz",
+			"integrity": "sha512-wY4FRGl0ZI+ZU4Jo/yjdBu0lVTSML58pu6PgGtJmCufvzfV565pUF6iACQt092uFOd49iLOTX/sEVmHtbSrS+w==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/eslint-plugin": "8.14.0",
-				"@typescript-eslint/parser": "8.14.0",
-				"@typescript-eslint/utils": "8.14.0"
+				"@typescript-eslint/eslint-plugin": "8.15.0",
+				"@typescript-eslint/parser": "8.15.0",
+				"@typescript-eslint/utils": "8.15.0"
 			}
 		},
 		"undici-types": {

--- a/package.json
+++ b/package.json
@@ -109,24 +109,24 @@
 		"tar": "^7.4.3"
 	},
 	"devDependencies": {
-		"@eslint/js": "^9.14.0",
+		"@eslint/js": "^9.15.0",
 		"@octokit/rest": "^21.0.2",
 		"@types/debug": "^4.1.12",
 		"@types/jest": "^29.5.14",
-		"@types/node": "^22.9.0",
-		"eslint": "^9.14.0",
+		"@types/node": "^22.9.1",
+		"eslint": "^9.15.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-jest": "^28.9.0",
 		"eslint-plugin-prettier": "^5.2.1",
 		"globals": "^15.12.0",
 		"jest": "^29.7.0",
-		"marked": "^15.0.0",
+		"marked": "^15.0.2",
 		"open-cli": "^8.0.0",
 		"pick-port": "^2.1.0",
 		"prettier": "^3.3.3",
 		"sctp": "^1.0.0",
 		"ts-jest": "^29.2.5",
 		"typescript": "^5.6.3",
-		"typescript-eslint": "^8.14.0"
+		"typescript-eslint": "^8.15.0"
 	}
 }

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -678,8 +678,8 @@ namespace RTC
 				// We want it in network order.
 				const uint64_t address = bindAddrIn->sin_addr.s_addr;
 
-				hash = static_cast<uint64_t>(minPort) << 48;
-				hash = static_cast<uint64_t>(maxPort) << 32;
+				hash |= static_cast<uint64_t>(minPort) << 48;
+				hash |= static_cast<uint64_t>(maxPort) << 32;
 				hash |= (address >> 2) << 2;
 				hash |= 0x0000; // AF_INET.
 
@@ -693,8 +693,8 @@ namespace RTC
 
 				const auto address = a[0] ^ a[1] ^ a[2] ^ a[3];
 
-				hash = static_cast<uint64_t>(minPort) << 48;
-				hash = static_cast<uint64_t>(maxPort) << 32;
+				hash |= static_cast<uint64_t>(minPort) << 48;
+				hash |= static_cast<uint64_t>(maxPort) << 32;
 				hash |= static_cast<uint64_t>(address) << 16;
 				hash |= (static_cast<uint64_t>(address) >> 2) << 2;
 				hash |= 0x0002; // AF_INET6.


### PR DESCRIPTION
Fixes #1466

We where NOT taking into account `minPort` when generating the `hash` of the `PortRange` (due to a typo) so different inputs where obtaining same `hash`.