### PR TITLE
Use @versatica/sctp fork to fix npm audit vulnerability

### DIFF
--- a/node/src/test/test-node-sctp.ts
+++ b/node/src/test/test-node-sctp.ts
@@ -1,6 +1,6 @@
 import * as dgram from 'node:dgram';
 // @ts-expect-error -- sctp library doesn't have TS types.
-import * as sctp from 'sctp';
+import * as sctp from '@versatica/sctp';
 import * as mediasoup from '../';
 import { enhancedOnce } from '../enhancedEvents';
 import type { WorkerEvents } from '../types';

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
 				"@types/debug": "^4.1.12",
 				"@types/jest": "^29.5.14",
 				"@types/node": "^22.10.2",
+				"@versatica/sctp": "^1.1.0",
 				"eslint": "^9.17.0",
 				"eslint-config-prettier": "^9.1.0",
 				"eslint-plugin-jest": "^28.9.0",
@@ -35,7 +36,6 @@
 				"open-cli": "^8.0.0",
 				"pick-port": "^2.1.0",
 				"prettier": "^3.4.2",
-				"sctp": "^1.0.0",
 				"ts-jest": "^29.2.5",
 				"typescript": "^5.7.2",
 				"typescript-eslint": "^8.18.1"
@@ -2177,6 +2177,28 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
+		"node_modules/@versatica/ip": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@versatica/ip/-/ip-3.0.0.tgz",
+			"integrity": "sha512-ZRXnoa2oKQDQiFNXzDv2WtE+nQQfhUIwLHE0aXgVWMeatMAxGvA9qLpg8BoxtF6rny+ooZN05zY+xQQU9Ykf9Q==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@versatica/sctp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@versatica/sctp/-/sctp-1.1.0.tgz",
+			"integrity": "sha512-My2bu/HV8+TGpq5RimjoglRtPctk5dhKNGkiSgaWrLWIHinEz+7agFPDYAe2iOf1M8EGKvXZuNebo6lYMmbdcg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@versatica/ip": "^3.0.0",
+				"debug": "^4.4.0",
+				"polycrc": "^1.1.1"
+			},
+			"engines": {
+				"node": ">=6.0.0"
+			}
+		},
 		"node_modules/acorn": {
 			"version": "8.14.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -3733,12 +3755,6 @@
 			"engines": {
 				"node": "^18.17.0 || >=20.5.0"
 			}
-		},
-		"node_modules/ip": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-			"integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
-			"dev": true
 		},
 		"node_modules/is-arrayish": {
 			"version": "0.2.1",
@@ -5307,10 +5323,11 @@
 			}
 		},
 		"node_modules/polycrc": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/polycrc/-/polycrc-0.1.0.tgz",
-			"integrity": "sha512-pBjdz8Gj0ixRkR80acjWl6bxiHf23MTI6chIKbQqphF2SrXXtYSPlftCSL31bD3veSWJCaTsM1QhT6zlIebqlg==",
-			"dev": true
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/polycrc/-/polycrc-1.1.1.tgz",
+			"integrity": "sha512-bfvt5BA/1e3e5RhBmmYVYED3PRddGN0j+lAed5PmnLWrVCkYEsltsfZLuKgtmUz1OEvPBAZlgWfoEpUTN/po6Q==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
@@ -5603,20 +5620,6 @@
 					"url": "https://feross.org/support"
 				}
 			]
-		},
-		"node_modules/sctp": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/sctp/-/sctp-1.0.0.tgz",
-			"integrity": "sha512-wceaBrz55a0dbYG3c2zfJ1adUASLJhntQYZNVZKlGfKH1ExMckZB0sOxroWgpJLflcAB/k6wMOAPOrmylsRU4A==",
-			"dev": true,
-			"dependencies": {
-				"debug": "^4.1.1",
-				"ip": "^1.1.5",
-				"polycrc": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
 		},
 		"node_modules/semver": {
 			"version": "7.6.3",
@@ -7958,6 +7961,23 @@
 				}
 			}
 		},
+		"@versatica/ip": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@versatica/ip/-/ip-3.0.0.tgz",
+			"integrity": "sha512-ZRXnoa2oKQDQiFNXzDv2WtE+nQQfhUIwLHE0aXgVWMeatMAxGvA9qLpg8BoxtF6rny+ooZN05zY+xQQU9Ykf9Q==",
+			"dev": true
+		},
+		"@versatica/sctp": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/@versatica/sctp/-/sctp-1.1.0.tgz",
+			"integrity": "sha512-My2bu/HV8+TGpq5RimjoglRtPctk5dhKNGkiSgaWrLWIHinEz+7agFPDYAe2iOf1M8EGKvXZuNebo6lYMmbdcg==",
+			"dev": true,
+			"requires": {
+				"@versatica/ip": "^3.0.0",
+				"debug": "^4.4.0",
+				"polycrc": "^1.1.1"
+			}
+		},
 		"acorn": {
 			"version": "8.14.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
@@ -9019,12 +9039,6 @@
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-5.0.0.tgz",
 			"integrity": "sha512-+N0ngpO3e7cRUWOJAS7qw0IZIVc6XPrW4MlFBdD066F2L4k1L6ker3hLqSq7iXxU5tgS4WGkIUElWn5vogAEnw=="
-		},
-		"ip": {
-			"version": "1.1.9",
-			"resolved": "https://registry.npmjs.org/ip/-/ip-1.1.9.tgz",
-			"integrity": "sha512-cyRxvOEpNHNtchU3Ln9KC/auJgup87llfQpQ+t5ghoC/UhL16SWzbueiCsdTnWmqAWl7LadfuwhlqmtOaqMHdQ==",
-			"dev": true
 		},
 		"is-arrayish": {
 			"version": "0.2.1",
@@ -10152,9 +10166,9 @@
 			}
 		},
 		"polycrc": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/polycrc/-/polycrc-0.1.0.tgz",
-			"integrity": "sha512-pBjdz8Gj0ixRkR80acjWl6bxiHf23MTI6chIKbQqphF2SrXXtYSPlftCSL31bD3veSWJCaTsM1QhT6zlIebqlg==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/polycrc/-/polycrc-1.1.1.tgz",
+			"integrity": "sha512-bfvt5BA/1e3e5RhBmmYVYED3PRddGN0j+lAed5PmnLWrVCkYEsltsfZLuKgtmUz1OEvPBAZlgWfoEpUTN/po6Q==",
 			"dev": true
 		},
 		"prelude-ls": {
@@ -10323,17 +10337,6 @@
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
 			"dev": true
-		},
-		"sctp": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/sctp/-/sctp-1.0.0.tgz",
-			"integrity": "sha512-wceaBrz55a0dbYG3c2zfJ1adUASLJhntQYZNVZKlGfKH1ExMckZB0sOxroWgpJLflcAB/k6wMOAPOrmylsRU4A==",
-			"dev": true,
-			"requires": {
-				"debug": "^4.1.1",
-				"ip": "^1.1.5",
-				"polycrc": "^0.1.0"
-			}
 		},
 		"semver": {
 			"version": "7.6.3",

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
 		"@types/debug": "^4.1.12",
 		"@types/jest": "^29.5.14",
 		"@types/node": "^22.10.2",
+		"@versatica/sctp": "^1.1.0",
 		"eslint": "^9.17.0",
 		"eslint-config-prettier": "^9.1.0",
 		"eslint-plugin-jest": "^28.9.0",
@@ -124,7 +125,6 @@
 		"open-cli": "^8.0.0",
 		"pick-port": "^2.1.0",
 		"prettier": "^3.4.2",
-		"sctp": "^1.0.0",
 		"ts-jest": "^29.2.5",
 		"typescript": "^5.7.2",
 		"typescript-eslint": "^8.18.1"


### PR DESCRIPTION
## Details

- I've forked NPM `ip` package (see https://github.com/versatica/node-ip), removed public API affected by the [vulnerability](https://github.com/advisories/GHSA-2p57-rm9w-gvfp) and published version 3.0.0 under `@versatica` NPM organization.
- I've forked NPM `sctp` package(see https://github.com/versatica/node-sctp), updated deps and (of course) replace `ip` with `@versativa/ip` dependency, and published version 1.1.0 under `@versatica` NPM organization.
- And of course I've replaced `sctp` with `@versativa/sctp` in mediasoup, so now `npm audit` is ok.

### Before

```
$ npm install mediasoup

[...]

added 2 packages, removed 2 packages, changed 1 package, and audited 500 packages in 4s

106 packages are looking for funding
  run `npm fund` for details

2 high severity vulnerabilities

Some issues need review, and may require choosing
a different dependency.

Run `npm audit` for details.
```

### After

```
$ npm install mediasoup

[...]

up to date, audited 500 packages in 4s

106 packages are looking for funding
  run `npm fund` for details

found 0 vulnerabilities
```
