### PR TITLE
Add dependency-descriptor support

### DIFF
--- a/node/src/rtpParametersFbsUtils.ts
+++ b/node/src/rtpParametersFbsUtils.ts
@@ -473,7 +473,7 @@ export function rtpHeaderExtensionUriToFbs(
 		}
 
 		case 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension': {
-			return FbsRtpHeaderExtensionUri.DependencyDescriptor
+			return FbsRtpHeaderExtensionUri.DependencyDescriptor;
 		}
 
 		default: {

--- a/node/src/rtpParametersFbsUtils.ts
+++ b/node/src/rtpParametersFbsUtils.ts
@@ -413,6 +413,10 @@ export function rtpHeaderExtensionUriFromFbs(
 		case FbsRtpHeaderExtensionUri.PlayoutDelay: {
 			return 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay';
 		}
+
+		case FbsRtpHeaderExtensionUri.DependencyDescriptor: {
+			return 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension';
+		}
 	}
 }
 
@@ -466,6 +470,10 @@ export function rtpHeaderExtensionUriToFbs(
 
 		case 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay': {
 			return FbsRtpHeaderExtensionUri.PlayoutDelay;
+		}
+
+		case 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension': {
+			return FbsRtpHeaderExtensionUri.DependencyDescriptor
 		}
 
 		default: {

--- a/node/src/rtpParametersTypes.ts
+++ b/node/src/rtpParametersTypes.ts
@@ -302,7 +302,8 @@ export type RtpHeaderExtensionUri =
 	| 'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01'
 	| 'http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time'
 	| 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time'
-	| 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay';
+	| 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay'
+	| 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension';
 
 /**
  * Defines a RTP header extension within the RTP parameters. The list of RTP

--- a/node/src/supportedRtpCapabilities.ts
+++ b/node/src/supportedRtpCapabilities.ts
@@ -294,6 +294,13 @@ const supportedRtpCapabilities: RtpCapabilities = {
 			direction: 'sendrecv',
 		},
 		{
+			kind: 'video',
+			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+			preferredId: 8,
+			preferredEncrypt: false,
+			direction: 'recvonly',
+		},
+		{
 			kind: 'audio',
 			uri: 'urn:ietf:params:rtp-hdrext:ssrc-audio-level',
 			preferredId: 10,

--- a/node/src/supportedRtpCapabilities.ts
+++ b/node/src/supportedRtpCapabilities.ts
@@ -298,7 +298,7 @@ const supportedRtpCapabilities: RtpCapabilities = {
 			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
 			preferredId: 8,
 			preferredEncrypt: false,
-			direction: 'recvonly',
+			direction: 'sendrecv',
 		},
 		{
 			kind: 'audio',

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -382,6 +382,12 @@ test('router.pipeToRouter() succeeds with video', async () => {
 			parameters: {},
 		},
 		{
+			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+			id: 8,
+			encrypt: false,
+			parameters: {},
+		},
+		{
 			uri: 'urn:3gpp:video-orientation',
 			id: 11,
 			encrypt: false,
@@ -445,6 +451,12 @@ test('router.pipeToRouter() succeeds with video', async () => {
 		{
 			uri: 'urn:ietf:params:rtp-hdrext:framemarking',
 			id: 7,
+			encrypt: false,
+			parameters: {},
+		},
+		{
+			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+			id: 8,
 			encrypt: false,
 			parameters: {},
 		},
@@ -566,6 +578,12 @@ test('router.createPipeTransport() with enableRtx succeeds', async () => {
 		{
 			uri: 'urn:ietf:params:rtp-hdrext:framemarking',
 			id: 7,
+			encrypt: false,
+			parameters: {},
+		},
+		{
+			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+			id: 8,
 			encrypt: false,
 			parameters: {},
 		},

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -589,6 +589,12 @@ pub enum RtpHeaderExtensionUri {
     #[serde(rename = "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay")]
     PlayoutDelay,
 
+    /// <https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension>
+    #[serde(
+        rename = "https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension"
+    )]
+    DependencyDescriptor,
+
     #[doc(hidden)]
     #[serde(other, rename = "unsupported")]
     Unsupported,
@@ -627,6 +633,9 @@ impl RtpHeaderExtensionUri {
             RtpHeaderExtensionUri::PlayoutDelay => {
                 rtp_parameters::RtpHeaderExtensionUri::PlayoutDelay
             }
+            RtpHeaderExtensionUri::DependencyDescriptor => {
+                rtp_parameters::RtpHeaderExtensionUri::DependencyDescriptor
+            }
             RtpHeaderExtensionUri::Unsupported => panic!("Invalid RTP extension header URI"),
         }
     }
@@ -663,6 +672,9 @@ impl RtpHeaderExtensionUri {
             rtp_parameters::RtpHeaderExtensionUri::PlayoutDelay => {
                 RtpHeaderExtensionUri::PlayoutDelay
             }
+            rtp_parameters::RtpHeaderExtensionUri::DependencyDescriptor => {
+                RtpHeaderExtensionUri::DependencyDescriptor
+            }
         }
     }
 }
@@ -690,6 +702,7 @@ impl FromStr for RtpHeaderExtensionUri {
                 Ok(Self::AbsCaptureTime)
             }
             "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay" => Ok(Self::PlayoutDelay),
+            "https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension" => Ok(Self::DependencyDescriptor),
             _ => Err(RtpHeaderExtensionUriParseError::Unsupported),
         }
     }
@@ -723,6 +736,9 @@ impl RtpHeaderExtensionUri {
             }
             RtpHeaderExtensionUri::PlayoutDelay => {
                 "http://www.webrtc.org/experiments/rtp-hdrext/playout-delay"
+            }
+            RtpHeaderExtensionUri::DependencyDescriptor => {
+                "https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension"
             }
             RtpHeaderExtensionUri::Unsupported => "unsupported",
         }

--- a/rust/src/supported_rtp_capabilities.rs
+++ b/rust/src/supported_rtp_capabilities.rs
@@ -356,7 +356,7 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                 uri: RtpHeaderExtensionUri::DependencyDescriptor,
                 preferred_id: 8,
                 preferred_encrypt: false,
-                direction: RtpHeaderExtensionDirection::RecvOnly,
+                direction: RtpHeaderExtensionDirection::SendRecv,
             },
             RtpHeaderExtension {
                 kind: MediaKind::Audio,

--- a/rust/src/supported_rtp_capabilities.rs
+++ b/rust/src/supported_rtp_capabilities.rs
@@ -352,6 +352,13 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                 direction: RtpHeaderExtensionDirection::SendRecv,
             },
             RtpHeaderExtension {
+                kind: MediaKind::Video,
+                uri: RtpHeaderExtensionUri::DependencyDescriptor,
+                preferred_id: 8,
+                preferred_encrypt: false,
+                direction: RtpHeaderExtensionDirection::RecvOnly,
+            },
+            RtpHeaderExtension {
                 kind: MediaKind::Audio,
                 uri: RtpHeaderExtensionUri::AudioLevel,
                 preferred_id: 10,

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -109,6 +109,11 @@ fn video_producer_options() -> ProducerOptions {
             }],
             header_extensions: vec![
                 RtpHeaderExtensionParameters {
+                    uri: RtpHeaderExtensionUri::DependencyDescriptor,
+                    id: 8,
+                    encrypt: false,
+                },
+                RtpHeaderExtensionParameters {
                     uri: RtpHeaderExtensionUri::Mid,
                     id: 10,
                     encrypt: false,
@@ -495,6 +500,11 @@ fn pipe_to_router_succeeds_with_video() {
                     encrypt: false,
                 },
                 RtpHeaderExtensionParameters {
+                    uri: RtpHeaderExtensionUri::DependencyDescriptor,
+                    id: 8,
+                    encrypt: false,
+                },
+                RtpHeaderExtensionParameters {
                     uri: RtpHeaderExtensionUri::VideoOrientation,
                     id: 11,
                     encrypt: false,
@@ -554,6 +564,11 @@ fn pipe_to_router_succeeds_with_video() {
                 RtpHeaderExtensionParameters {
                     uri: RtpHeaderExtensionUri::FrameMarking,
                     id: 7,
+                    encrypt: false,
+                },
+                RtpHeaderExtensionParameters {
+                    uri: RtpHeaderExtensionUri::DependencyDescriptor,
+                    id: 8,
                     encrypt: false,
                 },
                 RtpHeaderExtensionParameters {
@@ -756,6 +771,11 @@ fn create_with_enable_rtx_succeeds() {
                 RtpHeaderExtensionParameters {
                     uri: RtpHeaderExtensionUri::FrameMarking,
                     id: 7,
+                    encrypt: false,
+                },
+                RtpHeaderExtensionParameters {
+                    uri: RtpHeaderExtensionUri::DependencyDescriptor,
+                    id: 8,
                     encrypt: false,
                 },
                 RtpHeaderExtensionParameters {

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -109,11 +109,6 @@ fn video_producer_options() -> ProducerOptions {
             }],
             header_extensions: vec![
                 RtpHeaderExtensionParameters {
-                    uri: RtpHeaderExtensionUri::DependencyDescriptor,
-                    id: 8,
-                    encrypt: false,
-                },
-                RtpHeaderExtensionParameters {
                     uri: RtpHeaderExtensionUri::Mid,
                     id: 10,
                     encrypt: false,

--- a/worker/deps/libwebrtc/libwebrtc/api/array_view.h
+++ b/worker/deps/libwebrtc/libwebrtc/api/array_view.h
@@ -1,0 +1,335 @@
+/*
+ *  Copyright 2015 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef API_ARRAY_VIEW_H_
+#define API_ARRAY_VIEW_H_
+
+#include <algorithm>
+#include <array>
+#include <cstddef>
+#include <iterator>
+#include <type_traits>
+
+// #include "rtc_base/checks.h"
+#include "rtc_base/type_traits.h"
+
+namespace rtc {
+
+// tl;dr: rtc::ArrayView is the same thing as gsl::span from the Guideline
+//        Support Library.
+//
+// Many functions read from or write to arrays. The obvious way to do this is
+// to use two arguments, a pointer to the first element and an element count:
+//
+//   bool Contains17(const int* arr, size_t size) {
+//     for (size_t i = 0; i < size; ++i) {
+//       if (arr[i] == 17)
+//         return true;
+//     }
+//     return false;
+//   }
+//
+// This is flexible, since it doesn't matter how the array is stored (C array,
+// std::vector, rtc::Buffer, ...), but it's error-prone because the caller has
+// to correctly specify the array length:
+//
+//   Contains17(arr, arraysize(arr));     // C array
+//   Contains17(arr.data(), arr.size());  // std::vector
+//   Contains17(arr, size);               // pointer + size
+//   ...
+//
+// It's also kind of messy to have two separate arguments for what is
+// conceptually a single thing.
+//
+// Enter rtc::ArrayView<T>. It contains a T pointer (to an array it doesn't
+// own) and a count, and supports the basic things you'd expect, such as
+// indexing and iteration. It allows us to write our function like this:
+//
+//   bool Contains17(rtc::ArrayView<const int> arr) {
+//     for (auto e : arr) {
+//       if (e == 17)
+//         return true;
+//     }
+//     return false;
+//   }
+//
+// And even better, because a bunch of things will implicitly convert to
+// ArrayView, we can call it like this:
+//
+//   Contains17(arr);                             // C array
+//   Contains17(arr);                             // std::vector
+//   Contains17(rtc::ArrayView<int>(arr, size));  // pointer + size
+//   Contains17(nullptr);                         // nullptr -> empty ArrayView
+//   ...
+//
+// ArrayView<T> stores both a pointer and a size, but you may also use
+// ArrayView<T, N>, which has a size that's fixed at compile time (which means
+// it only has to store the pointer).
+//
+// One important point is that ArrayView<T> and ArrayView<const T> are
+// different types, which allow and don't allow mutation of the array elements,
+// respectively. The implicit conversions work just like you'd hope, so that
+// e.g. vector<int> will convert to either ArrayView<int> or ArrayView<const
+// int>, but const vector<int> will convert only to ArrayView<const int>.
+// (ArrayView itself can be the source type in such conversions, so
+// ArrayView<int> will convert to ArrayView<const int>.)
+//
+// Note: ArrayView is tiny (just a pointer and a count if variable-sized, just
+// a pointer if fix-sized) and trivially copyable, so it's probably cheaper to
+// pass it by value than by const reference.
+
+namespace array_view_internal {
+
+// Magic constant for indicating that the size of an ArrayView is variable
+// instead of fixed.
+enum : std::ptrdiff_t { kArrayViewVarSize = -4711 };
+
+// Base class for ArrayViews of fixed nonzero size.
+template <typename T, std::ptrdiff_t Size>
+class ArrayViewBase {
+  static_assert(Size > 0, "ArrayView size must be variable or non-negative");
+
+ public:
+  ArrayViewBase(T* data, size_t /* size */) : data_(data) {}
+
+  static constexpr size_t size() { return Size; }
+  static constexpr bool empty() { return false; }
+  T* data() const { return data_; }
+
+ protected:
+  static constexpr bool fixed_size() { return true; }
+
+ private:
+  T* data_;
+};
+
+// Specialized base class for ArrayViews of fixed zero size.
+template <typename T>
+class ArrayViewBase<T, 0> {
+ public:
+  explicit ArrayViewBase(T* /* data */, size_t /* size */) {}
+
+  static constexpr size_t size() { return 0; }
+  static constexpr bool empty() { return true; }
+  T* data() const { return nullptr; }
+
+ protected:
+  static constexpr bool fixed_size() { return true; }
+};
+
+// Specialized base class for ArrayViews of variable size.
+template <typename T>
+class ArrayViewBase<T, array_view_internal::kArrayViewVarSize> {
+ public:
+  ArrayViewBase(T* data, size_t size)
+      : data_(size == 0 ? nullptr : data), size_(size) {}
+
+  size_t size() const { return size_; }
+  bool empty() const { return size_ == 0; }
+  T* data() const { return data_; }
+
+ protected:
+  static constexpr bool fixed_size() { return false; }
+
+ private:
+  T* data_;
+  size_t size_;
+};
+
+}  // namespace array_view_internal
+
+template <typename T,
+          std::ptrdiff_t Size = array_view_internal::kArrayViewVarSize>
+class ArrayView final : public array_view_internal::ArrayViewBase<T, Size> {
+ public:
+  using value_type = T;
+  using reference = value_type&;
+  using const_reference = const value_type&;
+  using pointer = value_type*;
+  using const_pointer = const value_type*;
+  using const_iterator = const T*;
+
+  // Construct an ArrayView from a pointer and a length.
+  template <typename U>
+  ArrayView(U* data, size_t size)
+      : array_view_internal::ArrayViewBase<T, Size>::ArrayViewBase(data, size) {
+    // RTC_DCHECK_EQ(size == 0 ? nullptr : data, this->data());
+    // RTC_DCHECK_EQ(size, this->size());
+    // RTC_DCHECK_EQ(!this->data(),
+    //               this->size() == 0);  // data is null iff size == 0.
+  }
+
+  // Construct an empty ArrayView. Note that fixed-size ArrayViews of size > 0
+  // cannot be empty.
+  ArrayView() : ArrayView(nullptr, 0) {}
+  ArrayView(std::nullptr_t)  // NOLINT
+      : ArrayView() {}
+  ArrayView(std::nullptr_t, size_t size)
+      : ArrayView(static_cast<T*>(nullptr), size) {
+    static_assert(Size == 0 || Size == array_view_internal::kArrayViewVarSize,
+                  "");
+    // RTC_DCHECK_EQ(0, size);
+  }
+
+  // Construct an ArrayView from a C-style array.
+  template <typename U, size_t N>
+  ArrayView(U (&array)[N])  // NOLINT
+      : ArrayView(array, N) {
+    static_assert(Size == N || Size == array_view_internal::kArrayViewVarSize,
+                  "Array size must match ArrayView size");
+  }
+
+  // (Only if size is fixed.) Construct a fixed size ArrayView<T, N> from a
+  // non-const std::array instance. For an ArrayView with variable size, the
+  // used ctor is ArrayView(U& u) instead.
+  template <typename U,
+            size_t N,
+            typename std::enable_if<
+                Size == static_cast<std::ptrdiff_t>(N)>::type* = nullptr>
+  ArrayView(std::array<U, N>& u)  // NOLINT
+      : ArrayView(u.data(), u.size()) {}
+
+  // (Only if size is fixed.) Construct a fixed size ArrayView<T, N> where T is
+  // const from a const(expr) std::array instance. For an ArrayView with
+  // variable size, the used ctor is ArrayView(U& u) instead.
+  template <typename U,
+            size_t N,
+            typename std::enable_if<
+                Size == static_cast<std::ptrdiff_t>(N)>::type* = nullptr>
+  ArrayView(const std::array<U, N>& u)  // NOLINT
+      : ArrayView(u.data(), u.size()) {}
+
+  // (Only if size is fixed.) Construct an ArrayView from any type U that has a
+  // static constexpr size() method whose return value is equal to Size, and a
+  // data() method whose return value converts implicitly to T*. In particular,
+  // this means we allow conversion from ArrayView<T, N> to ArrayView<const T,
+  // N>, but not the other way around. We also don't allow conversion from
+  // ArrayView<T> to ArrayView<T, N>, or from ArrayView<T, M> to ArrayView<T,
+  // N> when M != N.
+  template <
+      typename U,
+      typename std::enable_if<Size != array_view_internal::kArrayViewVarSize &&
+                              HasDataAndSize<U, T>::value>::type* = nullptr>
+  ArrayView(U& u)  // NOLINT
+      : ArrayView(u.data(), u.size()) {
+    static_assert(U::size() == Size, "Sizes must match exactly");
+  }
+  template <
+      typename U,
+      typename std::enable_if<Size != array_view_internal::kArrayViewVarSize &&
+                              HasDataAndSize<U, T>::value>::type* = nullptr>
+  ArrayView(const U& u)  // NOLINT(runtime/explicit)
+      : ArrayView(u.data(), u.size()) {
+    static_assert(U::size() == Size, "Sizes must match exactly");
+  }
+
+  // (Only if size is variable.) Construct an ArrayView from any type U that
+  // has a size() method whose return value converts implicitly to size_t, and
+  // a data() method whose return value converts implicitly to T*. In
+  // particular, this means we allow conversion from ArrayView<T> to
+  // ArrayView<const T>, but not the other way around. Other allowed
+  // conversions include
+  // ArrayView<T, N> to ArrayView<T> or ArrayView<const T>,
+  // std::vector<T> to ArrayView<T> or ArrayView<const T>,
+  // const std::vector<T> to ArrayView<const T>,
+  // rtc::Buffer to ArrayView<uint8_t> or ArrayView<const uint8_t>, and
+  // const rtc::Buffer to ArrayView<const uint8_t>.
+  template <
+      typename U,
+      typename std::enable_if<Size == array_view_internal::kArrayViewVarSize &&
+                              HasDataAndSize<U, T>::value>::type* = nullptr>
+  ArrayView(U& u)  // NOLINT
+      : ArrayView(u.data(), u.size()) {}
+  template <
+      typename U,
+      typename std::enable_if<Size == array_view_internal::kArrayViewVarSize &&
+                              HasDataAndSize<U, T>::value>::type* = nullptr>
+  ArrayView(const U& u)  // NOLINT(runtime/explicit)
+      : ArrayView(u.data(), u.size()) {}
+
+  // Indexing and iteration. These allow mutation even if the ArrayView is
+  // const, because the ArrayView doesn't own the array. (To prevent mutation,
+  // use a const element type.)
+  T& operator[](size_t idx) const {
+    RTC_DCHECK_LT(idx, this->size());
+    RTC_DCHECK(this->data());
+    return this->data()[idx];
+  }
+  T* begin() const { return this->data(); }
+  T* end() const { return this->data() + this->size(); }
+  const T* cbegin() const { return this->data(); }
+  const T* cend() const { return this->data() + this->size(); }
+  std::reverse_iterator<T*> rbegin() const {
+    return std::make_reverse_iterator(end());
+  }
+  std::reverse_iterator<T*> rend() const {
+    return std::make_reverse_iterator(begin());
+  }
+  std::reverse_iterator<const T*> crbegin() const {
+    return std::make_reverse_iterator(cend());
+  }
+  std::reverse_iterator<const T*> crend() const {
+    return std::make_reverse_iterator(cbegin());
+  }
+
+  ArrayView<T> subview(size_t offset, size_t size) const {
+    return offset < this->size()
+               ? ArrayView<T>(this->data() + offset,
+                              std::min(size, this->size() - offset))
+               : ArrayView<T>();
+  }
+  ArrayView<T> subview(size_t offset) const {
+    return subview(offset, this->size());
+  }
+};
+
+// Comparing two ArrayViews compares their (pointer,size) pairs; it does *not*
+// dereference the pointers.
+template <typename T, std::ptrdiff_t Size1, std::ptrdiff_t Size2>
+bool operator==(const ArrayView<T, Size1>& a, const ArrayView<T, Size2>& b) {
+  return a.data() == b.data() && a.size() == b.size();
+}
+template <typename T, std::ptrdiff_t Size1, std::ptrdiff_t Size2>
+bool operator!=(const ArrayView<T, Size1>& a, const ArrayView<T, Size2>& b) {
+  return !(a == b);
+}
+
+// Variable-size ArrayViews are the size of two pointers; fixed-size ArrayViews
+// are the size of one pointer. (And as a special case, fixed-size ArrayViews
+// of size 0 require no storage.)
+static_assert(sizeof(ArrayView<int>) == 2 * sizeof(int*), "");
+static_assert(sizeof(ArrayView<int, 17>) == sizeof(int*), "");
+static_assert(std::is_empty<ArrayView<int, 0>>::value, "");
+
+template <typename T>
+inline ArrayView<T> MakeArrayView(T* data, size_t size) {
+  return ArrayView<T>(data, size);
+}
+
+// Only for primitive types that have the same size and aligment.
+// Allow reinterpret cast of the array view to another primitive type of the
+// same size.
+// Template arguments order is (U, T, Size) to allow deduction of the template
+// arguments in client calls: reinterpret_array_view<target_type>(array_view).
+template <typename U, typename T, std::ptrdiff_t Size>
+inline ArrayView<U, Size> reinterpret_array_view(ArrayView<T, Size> view) {
+  static_assert(sizeof(U) == sizeof(T) && alignof(U) == alignof(T),
+                "ArrayView reinterpret_cast is only supported for casting "
+                "between views that represent the same chunk of memory.");
+  static_assert(
+      std::is_fundamental<T>::value && std::is_fundamental<U>::value,
+      "ArrayView reinterpret_cast is only supported for casting between "
+      "fundamental types.");
+  return ArrayView<U, Size>(reinterpret_cast<U*>(view.data()), view.size());
+}
+
+}  // namespace rtc
+
+#endif  // API_ARRAY_VIEW_H_

--- a/worker/deps/libwebrtc/libwebrtc/api/transport/rtp/dependency_descriptor.cc
+++ b/worker/deps/libwebrtc/libwebrtc/api/transport/rtp/dependency_descriptor.cc
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2020 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "api/transport/rtp/dependency_descriptor.h"
+
+#include "absl/container/inlined_vector.h"
+#include "absl/strings/string_view.h"
+// #include "rtc_base/checks.h"
+
+namespace webrtc {
+
+constexpr int DependencyDescriptor::kMaxSpatialIds;
+constexpr int DependencyDescriptor::kMaxTemporalIds;
+constexpr int DependencyDescriptor::kMaxTemplates;
+constexpr int DependencyDescriptor::kMaxDecodeTargets;
+
+namespace webrtc_impl {
+
+absl::InlinedVector<DecodeTargetIndication, 10> StringToDecodeTargetIndications(
+    absl::string_view symbols) {
+  absl::InlinedVector<DecodeTargetIndication, 10> dtis;
+  dtis.reserve(symbols.size());
+  for (char symbol : symbols) {
+    DecodeTargetIndication indication;
+    switch (symbol) {
+      case '-':
+        indication = DecodeTargetIndication::kNotPresent;
+        break;
+      case 'D':
+        indication = DecodeTargetIndication::kDiscardable;
+        break;
+      case 'R':
+        indication = DecodeTargetIndication::kRequired;
+        break;
+      case 'S':
+        indication = DecodeTargetIndication::kSwitch;
+        break;
+      default:
+        // RTC_DCHECK_NOTREACHED();
+    }
+    dtis.push_back(indication);
+  }
+  return dtis;
+}
+
+}  // namespace webrtc_impl
+}  // namespace webrtc

--- a/worker/deps/libwebrtc/libwebrtc/api/transport/rtp/dependency_descriptor.cc
+++ b/worker/deps/libwebrtc/libwebrtc/api/transport/rtp/dependency_descriptor.cc
@@ -42,8 +42,8 @@ absl::InlinedVector<DecodeTargetIndication, 10> StringToDecodeTargetIndications(
       case 'S':
         indication = DecodeTargetIndication::kSwitch;
         break;
-      default:
-        // RTC_DCHECK_NOTREACHED();
+      // default:
+      //  RTC_DCHECK_NOTREACHED();
     }
     dtis.push_back(indication);
   }

--- a/worker/deps/libwebrtc/libwebrtc/api/transport/rtp/dependency_descriptor.h
+++ b/worker/deps/libwebrtc/libwebrtc/api/transport/rtp/dependency_descriptor.h
@@ -1,0 +1,150 @@
+/*
+ *  Copyright (c) 2020 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef API_TRANSPORT_RTP_DEPENDENCY_DESCRIPTOR_H_
+#define API_TRANSPORT_RTP_DEPENDENCY_DESCRIPTOR_H_
+
+#include <stdint.h>
+
+#include <initializer_list>
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "absl/container/inlined_vector.h"
+#include "absl/strings/string_view.h"
+#include "api/video/render_resolution.h"
+
+namespace webrtc {
+// Structures to build and parse dependency descriptor as described in
+// https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension
+
+// Relationship of a frame to a Decode target.
+enum class DecodeTargetIndication {
+  kNotPresent = 0,   // DecodeTargetInfo symbol '-'
+  kDiscardable = 1,  // DecodeTargetInfo symbol 'D'
+  kSwitch = 2,       // DecodeTargetInfo symbol 'S'
+  kRequired = 3      // DecodeTargetInfo symbol 'R'
+};
+
+struct FrameDependencyTemplate {
+  // Setters are named briefly to chain them when building the template.
+  FrameDependencyTemplate& S(int spatial_layer);
+  FrameDependencyTemplate& T(int temporal_layer);
+  FrameDependencyTemplate& Dtis(absl::string_view dtis);
+  FrameDependencyTemplate& FrameDiffs(std::initializer_list<int> diffs);
+  FrameDependencyTemplate& ChainDiffs(std::initializer_list<int> diffs);
+
+  friend bool operator==(const FrameDependencyTemplate& lhs,
+                         const FrameDependencyTemplate& rhs) {
+    return lhs.spatial_id == rhs.spatial_id &&
+           lhs.temporal_id == rhs.temporal_id &&
+           lhs.decode_target_indications == rhs.decode_target_indications &&
+           lhs.frame_diffs == rhs.frame_diffs &&
+           lhs.chain_diffs == rhs.chain_diffs;
+  }
+
+  int spatial_id = 0;
+  int temporal_id = 0;
+  absl::InlinedVector<DecodeTargetIndication, 10> decode_target_indications;
+  absl::InlinedVector<int, 4> frame_diffs;
+  absl::InlinedVector<int, 4> chain_diffs;
+};
+
+struct FrameDependencyStructure {
+  friend bool operator==(const FrameDependencyStructure& lhs,
+                         const FrameDependencyStructure& rhs) {
+    return lhs.num_decode_targets == rhs.num_decode_targets &&
+           lhs.num_chains == rhs.num_chains &&
+           lhs.decode_target_protected_by_chain ==
+               rhs.decode_target_protected_by_chain &&
+           lhs.resolutions == rhs.resolutions && lhs.templates == rhs.templates;
+  }
+
+  int structure_id = 0;
+  int num_decode_targets = 0;
+  int num_chains = 0;
+  // If chains are used (num_chains > 0), maps decode target index into index of
+  // the chain protecting that target.
+  absl::InlinedVector<int, 10> decode_target_protected_by_chain;
+  absl::InlinedVector<RenderResolution, 4> resolutions;
+  std::vector<FrameDependencyTemplate> templates;
+};
+
+class DependencyDescriptorMandatory {
+ public:
+  void set_frame_number(int frame_number) { frame_number_ = frame_number; }
+  int frame_number() const { return frame_number_; }
+
+  void set_template_id(int template_id) { template_id_ = template_id; }
+  int template_id() const { return template_id_; }
+
+  void set_first_packet_in_frame(bool first) { first_packet_in_frame_ = first; }
+  bool first_packet_in_frame() const { return first_packet_in_frame_; }
+
+  void set_last_packet_in_frame(bool last) { last_packet_in_frame_ = last; }
+  bool last_packet_in_frame() const { return last_packet_in_frame_; }
+
+ private:
+  int frame_number_;
+  int template_id_;
+  bool first_packet_in_frame_;
+  bool last_packet_in_frame_;
+};
+
+struct DependencyDescriptor {
+  static constexpr int kMaxSpatialIds = 4;
+  static constexpr int kMaxTemporalIds = 8;
+  static constexpr int kMaxDecodeTargets = 32;
+  static constexpr int kMaxTemplates = 64;
+
+  bool first_packet_in_frame = true;
+  bool last_packet_in_frame = true;
+  int frame_number = 0;
+  FrameDependencyTemplate frame_dependencies;
+  std::optional<RenderResolution> resolution;
+  std::optional<uint32_t> active_decode_targets_bitmask;
+  std::unique_ptr<FrameDependencyStructure> attached_structure;
+};
+
+// Below are implementation details.
+namespace webrtc_impl {
+absl::InlinedVector<DecodeTargetIndication, 10> StringToDecodeTargetIndications(
+    absl::string_view indication_symbols);
+}  // namespace webrtc_impl
+
+inline FrameDependencyTemplate& FrameDependencyTemplate::S(int spatial_layer) {
+  this->spatial_id = spatial_layer;
+  return *this;
+}
+inline FrameDependencyTemplate& FrameDependencyTemplate::T(int temporal_layer) {
+  this->temporal_id = temporal_layer;
+  return *this;
+}
+inline FrameDependencyTemplate& FrameDependencyTemplate::Dtis(
+    absl::string_view dtis) {
+  this->decode_target_indications =
+      webrtc_impl::StringToDecodeTargetIndications(dtis);
+  return *this;
+}
+inline FrameDependencyTemplate& FrameDependencyTemplate::FrameDiffs(
+    std::initializer_list<int> diffs) {
+  this->frame_diffs.assign(diffs.begin(), diffs.end());
+  return *this;
+}
+inline FrameDependencyTemplate& FrameDependencyTemplate::ChainDiffs(
+    std::initializer_list<int> diffs) {
+  this->chain_diffs.assign(diffs.begin(), diffs.end());
+  return *this;
+}
+
+}  // namespace webrtc
+
+#endif  // API_TRANSPORT_RTP_DEPENDENCY_DESCRIPTOR_H_

--- a/worker/deps/libwebrtc/libwebrtc/api/video/render_resolution.h
+++ b/worker/deps/libwebrtc/libwebrtc/api/video/render_resolution.h
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2021 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef API_VIDEO_RENDER_RESOLUTION_H_
+#define API_VIDEO_RENDER_RESOLUTION_H_
+
+namespace webrtc {
+
+// TODO(bugs.webrtc.org/12114) : remove in favor of Resolution.
+class RenderResolution {
+ public:
+  constexpr RenderResolution() = default;
+  constexpr RenderResolution(int width, int height)
+      : width_(width), height_(height) {}
+  RenderResolution(const RenderResolution&) = default;
+  RenderResolution& operator=(const RenderResolution&) = default;
+
+  friend bool operator==(const RenderResolution& lhs,
+                         const RenderResolution& rhs) {
+    return lhs.width_ == rhs.width_ && lhs.height_ == rhs.height_;
+  }
+  friend bool operator!=(const RenderResolution& lhs,
+                         const RenderResolution& rhs) {
+    return !(lhs == rhs);
+  }
+
+  constexpr bool Valid() const { return width_ > 0 && height_ > 0; }
+
+  constexpr int Width() const { return width_; }
+  constexpr int Height() const { return height_; }
+
+ private:
+  int width_ = 0;
+  int height_ = 0;
+};
+
+}  // namespace webrtc
+
+#endif  // API_VIDEO_RENDER_RESOLUTION_H_

--- a/worker/deps/libwebrtc/libwebrtc/modules/rtp_rtcp/source/rtp_dependency_descriptor_reader.cc
+++ b/worker/deps/libwebrtc/libwebrtc/modules/rtp_rtcp/source/rtp_dependency_descriptor_reader.cc
@@ -1,0 +1,239 @@
+/*
+ *  Copyright (c) 2019 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+#include "modules/rtp_rtcp/source/rtp_dependency_descriptor_reader.h"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include "api/transport/rtp/dependency_descriptor.h"
+#include "rtc_base/bitstream_reader.h"
+// #include "rtc_base/checks.h"
+
+namespace webrtc {
+
+RtpDependencyDescriptorReader::RtpDependencyDescriptorReader(
+    rtc::ArrayView<const uint8_t> raw_data,
+    const FrameDependencyStructure* structure,
+    DependencyDescriptor* descriptor)
+    : descriptor_(descriptor), buffer_(raw_data) {
+  // RTC_DCHECK(descriptor);
+
+  ReadMandatoryFields();
+  if (raw_data.size() > 3)
+    ReadExtendedFields();
+
+  structure_ = descriptor->attached_structure
+                   ? descriptor->attached_structure.get()
+                   : structure;
+  if (structure_ == nullptr) {
+    buffer_.Invalidate();
+    return;
+  }
+  if (active_decode_targets_present_flag_) {
+    descriptor->active_decode_targets_bitmask =
+        buffer_.ReadBits(structure_->num_decode_targets);
+  }
+
+  ReadFrameDependencyDefinition();
+}
+
+void RtpDependencyDescriptorReader::ReadTemplateDependencyStructure() {
+  descriptor_->attached_structure =
+      std::make_unique<FrameDependencyStructure>();
+  descriptor_->attached_structure->structure_id = buffer_.ReadBits(6);
+  descriptor_->attached_structure->num_decode_targets = buffer_.ReadBits(5) + 1;
+
+  ReadTemplateLayers();
+  ReadTemplateDtis();
+  ReadTemplateFdiffs();
+  ReadTemplateChains();
+
+  if (buffer_.Read<bool>())
+    ReadResolutions();
+}
+
+void RtpDependencyDescriptorReader::ReadTemplateLayers() {
+  enum NextLayerIdc {
+    kSameLayer = 0,
+    kNextTemporalLayer = 1,
+    kNextSpatialLayer = 2,
+    kNoMoreTemplates = 3,
+  };
+  std::vector<FrameDependencyTemplate> templates;
+
+  int temporal_id = 0;
+  int spatial_id = 0;
+  NextLayerIdc next_layer_idc;
+  do {
+    if (templates.size() == DependencyDescriptor::kMaxTemplates) {
+      buffer_.Invalidate();
+      break;
+    }
+    templates.emplace_back();
+    FrameDependencyTemplate& last_template = templates.back();
+    last_template.temporal_id = temporal_id;
+    last_template.spatial_id = spatial_id;
+
+    next_layer_idc = static_cast<NextLayerIdc>(buffer_.ReadBits(2));
+    if (next_layer_idc == kNextTemporalLayer) {
+      temporal_id++;
+      if (temporal_id >= DependencyDescriptor::kMaxTemporalIds) {
+        buffer_.Invalidate();
+        break;
+      }
+    } else if (next_layer_idc == kNextSpatialLayer) {
+      temporal_id = 0;
+      spatial_id++;
+      if (spatial_id >= DependencyDescriptor::kMaxSpatialIds) {
+        buffer_.Invalidate();
+        break;
+      }
+    }
+  } while (next_layer_idc != kNoMoreTemplates && buffer_.Ok());
+
+  descriptor_->attached_structure->templates = std::move(templates);
+}
+
+void RtpDependencyDescriptorReader::ReadTemplateDtis() {
+  FrameDependencyStructure* structure = descriptor_->attached_structure.get();
+  for (FrameDependencyTemplate& current_template : structure->templates) {
+    current_template.decode_target_indications.resize(
+        structure->num_decode_targets);
+    for (int i = 0; i < structure->num_decode_targets; ++i) {
+      current_template.decode_target_indications[i] =
+          static_cast<DecodeTargetIndication>(buffer_.ReadBits(2));
+    }
+  }
+}
+
+void RtpDependencyDescriptorReader::ReadTemplateFdiffs() {
+  for (FrameDependencyTemplate& current_template :
+       descriptor_->attached_structure->templates) {
+    for (bool fdiff_follows = buffer_.Read<bool>(); fdiff_follows;
+         fdiff_follows = buffer_.Read<bool>()) {
+      uint64_t fdiff_minus_one = buffer_.ReadBits(4);
+      current_template.frame_diffs.push_back(fdiff_minus_one + 1);
+    }
+  }
+}
+
+void RtpDependencyDescriptorReader::ReadTemplateChains() {
+  FrameDependencyStructure* structure = descriptor_->attached_structure.get();
+  structure->num_chains =
+      buffer_.ReadNonSymmetric(structure->num_decode_targets + 1);
+  if (structure->num_chains == 0)
+    return;
+  for (int i = 0; i < structure->num_decode_targets; ++i) {
+    uint32_t protected_by_chain =
+        buffer_.ReadNonSymmetric(structure->num_chains);
+    structure->decode_target_protected_by_chain.push_back(protected_by_chain);
+  }
+  for (FrameDependencyTemplate& frame_template : structure->templates) {
+    for (int chain_id = 0; chain_id < structure->num_chains; ++chain_id) {
+      frame_template.chain_diffs.push_back(buffer_.ReadBits(4));
+    }
+  }
+}
+
+void RtpDependencyDescriptorReader::ReadResolutions() {
+  FrameDependencyStructure* structure = descriptor_->attached_structure.get();
+  // The way templates are bitpacked, they are always ordered by spatial_id.
+  int spatial_layers = structure->templates.back().spatial_id + 1;
+  structure->resolutions.reserve(spatial_layers);
+  for (int sid = 0; sid < spatial_layers; ++sid) {
+    uint16_t width_minus_1 = buffer_.Read<uint16_t>();
+    uint16_t height_minus_1 = buffer_.Read<uint16_t>();
+    structure->resolutions.emplace_back(width_minus_1 + 1, height_minus_1 + 1);
+  }
+}
+
+void RtpDependencyDescriptorReader::ReadMandatoryFields() {
+  descriptor_->first_packet_in_frame = buffer_.Read<bool>();
+  descriptor_->last_packet_in_frame = buffer_.Read<bool>();
+  frame_dependency_template_id_ = buffer_.ReadBits(6);
+  descriptor_->frame_number = buffer_.Read<uint16_t>();
+}
+
+void RtpDependencyDescriptorReader::ReadExtendedFields() {
+  bool template_dependency_structure_present_flag = buffer_.Read<bool>();
+  active_decode_targets_present_flag_ = buffer_.Read<bool>();
+  custom_dtis_flag_ = buffer_.Read<bool>();
+  custom_fdiffs_flag_ = buffer_.Read<bool>();
+  custom_chains_flag_ = buffer_.Read<bool>();
+  if (template_dependency_structure_present_flag) {
+    ReadTemplateDependencyStructure();
+    // RTC_DCHECK(descriptor_->attached_structure);
+    descriptor_->active_decode_targets_bitmask =
+        (uint64_t{1} << descriptor_->attached_structure->num_decode_targets) -
+        1;
+  }
+}
+
+void RtpDependencyDescriptorReader::ReadFrameDependencyDefinition() {
+  size_t template_index =
+      (frame_dependency_template_id_ + DependencyDescriptor::kMaxTemplates -
+       structure_->structure_id) %
+      DependencyDescriptor::kMaxTemplates;
+
+  if (template_index >= structure_->templates.size()) {
+    buffer_.Invalidate();
+    return;
+  }
+
+  // Copy all the fields from the matching template
+  descriptor_->frame_dependencies = structure_->templates[template_index];
+
+  if (custom_dtis_flag_)
+    ReadFrameDtis();
+  if (custom_fdiffs_flag_)
+    ReadFrameFdiffs();
+  if (custom_chains_flag_)
+    ReadFrameChains();
+
+  if (structure_->resolutions.empty()) {
+    descriptor_->resolution = std::nullopt;
+  } else {
+    // Format guarantees that if there were resolutions in the last structure,
+    // then each spatial layer got one.
+    // RTC_DCHECK_LE(descriptor_->frame_dependencies.spatial_id,
+    //               structure_->resolutions.size());
+    descriptor_->resolution =
+        structure_->resolutions[descriptor_->frame_dependencies.spatial_id];
+  }
+}
+
+void RtpDependencyDescriptorReader::ReadFrameDtis() {
+  // RTC_DCHECK_EQ(
+  //     descriptor_->frame_dependencies.decode_target_indications.size(),
+  //     structure_->num_decode_targets);
+  for (auto& dti : descriptor_->frame_dependencies.decode_target_indications) {
+    dti = static_cast<DecodeTargetIndication>(buffer_.ReadBits(2));
+  }
+}
+
+void RtpDependencyDescriptorReader::ReadFrameFdiffs() {
+  descriptor_->frame_dependencies.frame_diffs.clear();
+  for (uint64_t next_fdiff_size = buffer_.ReadBits(2); next_fdiff_size > 0;
+       next_fdiff_size = buffer_.ReadBits(2)) {
+    uint64_t fdiff_minus_one = buffer_.ReadBits(4 * next_fdiff_size);
+    descriptor_->frame_dependencies.frame_diffs.push_back(fdiff_minus_one + 1);
+  }
+}
+
+void RtpDependencyDescriptorReader::ReadFrameChains() {
+  // RTC_DCHECK_EQ(descriptor_->frame_dependencies.chain_diffs.size(),
+  //               structure_->num_chains);
+  for (auto& chain_diff : descriptor_->frame_dependencies.chain_diffs) {
+    chain_diff = buffer_.Read<uint8_t>();
+  }
+}
+
+}  // namespace webrtc

--- a/worker/deps/libwebrtc/libwebrtc/modules/rtp_rtcp/source/rtp_dependency_descriptor_reader.h
+++ b/worker/deps/libwebrtc/libwebrtc/modules/rtp_rtcp/source/rtp_dependency_descriptor_reader.h
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2019 The WebRTC project authors. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+#ifndef MODULES_RTP_RTCP_SOURCE_RTP_DEPENDENCY_DESCRIPTOR_READER_H_
+#define MODULES_RTP_RTCP_SOURCE_RTP_DEPENDENCY_DESCRIPTOR_READER_H_
+
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "api/array_view.h"
+#include "api/transport/rtp/dependency_descriptor.h"
+#include "rtc_base/bitstream_reader.h"
+
+namespace webrtc {
+// Deserializes DependencyDescriptor rtp header extension.
+class RtpDependencyDescriptorReader {
+ public:
+  // Parses the dependency descriptor.
+  RtpDependencyDescriptorReader(rtc::ArrayView<const uint8_t> raw_data,
+                                const FrameDependencyStructure* structure,
+                                DependencyDescriptor* descriptor);
+  RtpDependencyDescriptorReader(const RtpDependencyDescriptorReader&) = delete;
+  RtpDependencyDescriptorReader& operator=(
+      const RtpDependencyDescriptorReader&) = delete;
+
+  // Returns true if parse was successful.
+  bool ParseSuccessful() { return buffer_.Ok(); }
+
+ private:
+  // Functions to read template dependency structure.
+  void ReadTemplateDependencyStructure();
+  void ReadTemplateLayers();
+  void ReadTemplateDtis();
+  void ReadTemplateFdiffs();
+  void ReadTemplateChains();
+  void ReadResolutions();
+
+  // Function to read details for the current frame.
+  void ReadMandatoryFields();
+  void ReadExtendedFields();
+  void ReadFrameDependencyDefinition();
+
+  void ReadFrameDtis();
+  void ReadFrameFdiffs();
+  void ReadFrameChains();
+
+  // Output.
+  DependencyDescriptor* const descriptor_;
+  // Values that are needed while reading the descriptor, but can be discarded
+  // when reading is complete.
+  BitstreamReader buffer_;
+  int frame_dependency_template_id_ = 0;
+  bool active_decode_targets_present_flag_ = false;
+  bool custom_dtis_flag_ = false;
+  bool custom_fdiffs_flag_ = false;
+  bool custom_chains_flag_ = false;
+  const FrameDependencyStructure* structure_ = nullptr;
+};
+
+}  // namespace webrtc
+
+#endif  // MODULES_RTP_RTCP_SOURCE_RTP_DEPENDENCY_DESCRIPTOR_READER_H_

--- a/worker/deps/libwebrtc/libwebrtc/rtc_base/bitstream_reader.cc
+++ b/worker/deps/libwebrtc/libwebrtc/rtc_base/bitstream_reader.cc
@@ -1,0 +1,168 @@
+/*
+ *  Copyright 2021 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#include "rtc_base/bitstream_reader.h"
+
+#include <stdint.h>
+
+#include <limits>
+
+#include "absl/numeric/bits.h"
+// #include "rtc_base/checks.h"
+#include "rtc_base/numerics/safe_conversions.h"
+
+namespace webrtc {
+
+uint64_t BitstreamReader::ReadBits(int bits) {
+  // RTC_DCHECK_GE(bits, 0);
+  // RTC_DCHECK_LE(bits, 64);
+  set_last_read_is_verified(false);
+
+  if (remaining_bits_ < bits) {
+    Invalidate();
+    return 0;
+  }
+
+  int remaining_bits_in_first_byte = remaining_bits_ % 8;
+  remaining_bits_ -= bits;
+  if (bits < remaining_bits_in_first_byte) {
+    // Reading fewer bits than what's left in the current byte, just
+    // return the portion of this byte that is needed.
+    int offset = (remaining_bits_in_first_byte - bits);
+    return ((*bytes_) >> offset) & ((1 << bits) - 1);
+  }
+
+  uint64_t result = 0;
+  if (remaining_bits_in_first_byte > 0) {
+    // Read all bits that were left in the current byte and consume that byte.
+    bits -= remaining_bits_in_first_byte;
+    uint8_t mask = (1 << remaining_bits_in_first_byte) - 1;
+    result = static_cast<uint64_t>(*bytes_ & mask) << bits;
+    ++bytes_;
+  }
+
+  // Read as many full bytes as we can.
+  while (bits >= 8) {
+    bits -= 8;
+    result |= uint64_t{*bytes_} << bits;
+    ++bytes_;
+  }
+  // Whatever is left to read is smaller than a byte, so grab just the needed
+  // bits and shift them into the lowest bits.
+  if (bits > 0) {
+    result |= (*bytes_ >> (8 - bits));
+  }
+  return result;
+}
+
+int BitstreamReader::ReadBit() {
+  set_last_read_is_verified(false);
+  if (remaining_bits_ <= 0) {
+    Invalidate();
+    return 0;
+  }
+  --remaining_bits_;
+
+  int bit_position = remaining_bits_ % 8;
+  if (bit_position == 0) {
+    // Read the last bit from current byte and move to the next byte.
+    return (*bytes_++) & 0x01;
+  }
+
+  return (*bytes_ >> bit_position) & 0x01;
+}
+
+void BitstreamReader::ConsumeBits(int bits) {
+  // RTC_DCHECK_GE(bits, 0);
+  set_last_read_is_verified(false);
+  if (remaining_bits_ < bits) {
+    Invalidate();
+    return;
+  }
+
+  int remaining_bytes = (remaining_bits_ + 7) / 8;
+  remaining_bits_ -= bits;
+  int new_remaining_bytes = (remaining_bits_ + 7) / 8;
+  bytes_ += (remaining_bytes - new_remaining_bytes);
+}
+
+uint32_t BitstreamReader::ReadNonSymmetric(uint32_t num_values) {
+  // RTC_DCHECK_GT(num_values, 0);
+  // RTC_DCHECK_LE(num_values, uint32_t{1} << 31);
+
+  int width = absl::bit_width(num_values);
+  uint32_t num_min_bits_values = (uint32_t{1} << width) - num_values;
+
+  uint64_t val = ReadBits(width - 1);
+  if (val < num_min_bits_values) {
+    return val;
+  }
+  return (val << 1) + ReadBit() - num_min_bits_values;
+}
+
+uint32_t BitstreamReader::ReadExponentialGolomb() {
+  // Count the number of leading 0.
+  int zero_bit_count = 0;
+  while (ReadBit() == 0) {
+    if (++zero_bit_count >= 32) {
+      // Golob value won't fit into 32 bits of the return value. Fail the parse.
+      Invalidate();
+      return 0;
+    }
+  }
+
+  // The bit count of the value is the number of zeros + 1.
+  // However the first '1' was already read above.
+  return (uint32_t{1} << zero_bit_count) +
+         rtc::dchecked_cast<uint32_t>(ReadBits(zero_bit_count)) - 1;
+}
+
+int BitstreamReader::ReadSignedExponentialGolomb() {
+  uint32_t unsigned_val = ReadExponentialGolomb();
+  if ((unsigned_val & 1) == 0) {
+    return -static_cast<int>(unsigned_val / 2);
+  } else {
+    return (unsigned_val + 1) / 2;
+  }
+}
+
+uint64_t BitstreamReader::ReadLeb128() {
+  uint64_t decoded = 0;
+  size_t i = 0;
+  uint8_t byte;
+  // A LEB128 value can in theory be arbitrarily large, but for convenience sake
+  // consider it invalid if it can't fit in an uint64_t.
+  do {
+    byte = Read<uint8_t>();
+    decoded +=
+        (static_cast<uint64_t>(byte & 0x7f) << static_cast<uint64_t>(7 * i));
+    ++i;
+  } while (i < 10 && (byte & 0x80));
+
+  // The first 9 bytes represent the first 63 bits. The tenth byte can therefore
+  // not be larger than 1 as it would overflow an uint64_t.
+  if (i == 10 && byte > 1) {
+    Invalidate();
+  }
+
+  return Ok() ? decoded : 0;
+}
+
+std::string BitstreamReader::ReadString(int num_bytes) {
+  std::string res;
+  res.reserve(num_bytes);
+  for (int i = 0; i < num_bytes; ++i) {
+    res += Read<uint8_t>();
+  }
+
+  return Ok() ? res : std::string();
+}
+
+}  // namespace webrtc

--- a/worker/deps/libwebrtc/libwebrtc/rtc_base/bitstream_reader.h
+++ b/worker/deps/libwebrtc/libwebrtc/rtc_base/bitstream_reader.h
@@ -1,0 +1,152 @@
+/*
+ *  Copyright 2021 The WebRTC Project Authors. All rights reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license
+ *  that can be found in the LICENSE file in the root of the source
+ *  tree. An additional intellectual property rights grant can be found
+ *  in the file PATENTS.  All contributing project authors may
+ *  be found in the AUTHORS file in the root of the source tree.
+ */
+
+#ifndef RTC_BASE_BITSTREAM_READER_H_
+#define RTC_BASE_BITSTREAM_READER_H_
+
+#include <stdint.h>
+
+#include "absl/base/attributes.h"
+#include "absl/strings/string_view.h"
+#include "api/array_view.h"
+// #include "rtc_base/checks.h"
+#include "rtc_base/numerics/safe_conversions.h"
+
+namespace webrtc {
+
+// A class to parse sequence of bits. Byte order is assumed big-endian/network.
+// This class is optimized for successful parsing and binary size.
+// Individual calls to `Read` and `ConsumeBits` never fail. Instead they may
+// change the class state into 'failure state'. User of this class should verify
+// parsing by checking if class is in that 'failure state' by calling `Ok`.
+// That verification can be done once after multiple reads.
+class BitstreamReader {
+ public:
+  explicit BitstreamReader(
+      rtc::ArrayView<const uint8_t> bytes ABSL_ATTRIBUTE_LIFETIME_BOUND);
+  explicit BitstreamReader(
+      absl::string_view bytes ABSL_ATTRIBUTE_LIFETIME_BOUND);
+  BitstreamReader(const BitstreamReader&) = default;
+  BitstreamReader& operator=(const BitstreamReader&) = default;
+  ~BitstreamReader();
+
+  // Return number of unread bits in the buffer, or negative number if there
+  // was a reading error.
+  int RemainingBitCount() const;
+
+  // Returns `true` iff all calls to `Read` and `ConsumeBits` were successful.
+  bool Ok() const { return RemainingBitCount() >= 0; }
+
+  // Sets `BitstreamReader` into the failure state.
+  void Invalidate() { remaining_bits_ = -1; }
+
+  // Moves current read position forward. `bits` must be non-negative.
+  void ConsumeBits(int bits);
+
+  // Reads single bit. Returns 0 or 1.
+  ABSL_MUST_USE_RESULT int ReadBit();
+
+  // Reads `bits` from the bitstream. `bits` must be in range [0, 64].
+  // Returns an unsigned integer in range [0, 2^bits - 1].
+  // On failure sets `BitstreamReader` into the failure state and returns 0.
+  ABSL_MUST_USE_RESULT uint64_t ReadBits(int bits);
+
+  // Reads unsigned integer of fixed width.
+  template <typename T,
+            typename std::enable_if<std::is_unsigned<T>::value &&
+                                    !std::is_same<T, bool>::value &&
+                                    sizeof(T) <= 8>::type* = nullptr>
+  ABSL_MUST_USE_RESULT T Read() {
+    return rtc::dchecked_cast<T>(ReadBits(sizeof(T) * 8));
+  }
+
+  // Reads single bit as boolean.
+  template <
+      typename T,
+      typename std::enable_if<std::is_same<T, bool>::value>::type* = nullptr>
+  ABSL_MUST_USE_RESULT bool Read() {
+    return ReadBit() != 0;
+  }
+
+  // Reads value in range [0, `num_values` - 1].
+  // This encoding is similar to ReadBits(val, Ceil(Log2(num_values)),
+  // but reduces wastage incurred when encoding non-power of two value ranges
+  // Non symmetric values are encoded as:
+  // 1) n = bit_width(num_values)
+  // 2) k = (1 << n) - num_values
+  // Value v in range [0, k - 1] is encoded in (n-1) bits.
+  // Value v in range [k, num_values - 1] is encoded as (v+k) in n bits.
+  // https://aomediacodec.github.io/av1-spec/#nsn
+  uint32_t ReadNonSymmetric(uint32_t num_values);
+
+  // Reads exponential golomb encoded value.
+  // On failure sets `BitstreamReader` into the failure state and returns
+  // unspecified value.
+  // Exponential golomb values are encoded as:
+  // 1) x = source val + 1
+  // 2) In binary, write [bit_width(x) - 1] 0s, then x
+  // To decode, we count the number of leading 0 bits, read that many + 1 bits,
+  // and increment the result by 1.
+  // Fails the parsing if the value wouldn't fit in a uint32_t.
+  uint32_t ReadExponentialGolomb();
+
+  // Reads signed exponential golomb values at the current offset. Signed
+  // exponential golomb values are just the unsigned values mapped to the
+  // sequence 0, 1, -1, 2, -2, etc. in order.
+  // On failure sets `BitstreamReader` into the failure state and returns
+  // unspecified value.
+  int ReadSignedExponentialGolomb();
+
+  // Reads a LEB128 encoded value. The value will be considered invalid if it
+  // can't fit into a uint64_t.
+  uint64_t ReadLeb128();
+
+  std::string ReadString(int num_bytes);
+
+ private:
+  void set_last_read_is_verified(bool value) const;
+
+  // Next byte with at least one unread bit.
+  const uint8_t* bytes_;
+
+  // Number of bits remained to read.
+  int remaining_bits_;
+
+  // Unused in release mode.
+  mutable bool last_read_is_verified_ = true;
+};
+
+inline BitstreamReader::BitstreamReader(rtc::ArrayView<const uint8_t> bytes)
+    : bytes_(bytes.data()),
+      remaining_bits_(rtc::checked_cast<int>(bytes.size() * 8)) {}
+
+inline BitstreamReader::BitstreamReader(absl::string_view bytes)
+    : bytes_(reinterpret_cast<const uint8_t*>(bytes.data())),
+      remaining_bits_(rtc::checked_cast<int>(bytes.size() * 8)) {}
+
+inline BitstreamReader::~BitstreamReader() {
+  // RTC_DCHECK(last_read_is_verified_) << "Latest calls to Read or ConsumeBit "
+  //                                       "were not checked with Ok function.";
+}
+
+inline void BitstreamReader::set_last_read_is_verified(bool value) const {
+#ifdef RTC_DCHECK_IS_ON
+  last_read_is_verified_ = value;
+#endif
+}
+
+inline int BitstreamReader::RemainingBitCount() const {
+  set_last_read_is_verified(true);
+  return remaining_bits_;
+}
+
+}  // namespace webrtc
+
+#endif  // RTC_BASE_BITSTREAM_READER_H_

--- a/worker/deps/libwebrtc/meson.build
+++ b/worker/deps/libwebrtc/meson.build
@@ -6,11 +6,13 @@ libwebrtc_sources = [
   'libwebrtc/rtc_base/experiments/field_trial_units.cc',
   'libwebrtc/rtc_base/experiments/rate_control_settings.cc',
   'libwebrtc/rtc_base/network/sent_packet.cc',
+  'libwebrtc/rtc_base/bitstream_reader.cc',
   'libwebrtc/call/rtp_transport_controller_send.cc',
   'libwebrtc/api/transport/bitrate_settings.cc',
   'libwebrtc/api/transport/field_trial_based_config.cc',
   'libwebrtc/api/transport/network_types.cc',
   'libwebrtc/api/transport/goog_cc_factory.cc',
+  'libwebrtc/api/transport/rtp/dependency_descriptor.cc',
   'libwebrtc/api/units/timestamp.cc',
   'libwebrtc/api/units/time_delta.cc',
   'libwebrtc/api/units/data_rate.cc',
@@ -43,6 +45,7 @@ libwebrtc_sources = [
   'libwebrtc/modules/congestion_controller/rtp/send_time_history.cc',
   'libwebrtc/modules/congestion_controller/rtp/transport_feedback_adapter.cc',
   'libwebrtc/modules/congestion_controller/rtp/control_handler.cc',
+  'libwebrtc/modules/rtp_rtcp/source/rtp_dependency_descriptor_reader.cc',
 ]
 
 abseil_cpp_proj = subproject(

--- a/worker/fbs/rtpParameters.fbs
+++ b/worker/fbs/rtpParameters.fbs
@@ -74,6 +74,7 @@ enum RtpHeaderExtensionUri: uint8 {
     AbsSendTime,
     AbsCaptureTime,
     PlayoutDelay,
+    DependencyDescriptor,
 }
 
 table RtpHeaderExtensionParameters {

--- a/worker/include/RTC/Codecs/H264.hpp
+++ b/worker/include/RTC/Codecs/H264.hpp
@@ -4,6 +4,7 @@
 #include "common.hpp"
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
 #include "RTC/RtpPacket.hpp"
+#include <libwebrtc/api/transport/rtp/dependency_descriptor.h>
 
 namespace RTC
 {
@@ -19,30 +20,24 @@ namespace RTC
 
 				void Dump() const override;
 
-				// Fields in frame-marking extension.
-				uint8_t s : 1;          // Start of Frame.
-				uint8_t e : 1;          // End of Frame.
-				uint8_t i : 1;          // Independent Frame.
-				uint8_t d : 1;          // Discardable Frame.
-				uint8_t b : 1;          // Base Layer Sync.
-				uint8_t tid{ 0 };       // Temporal layer id.
-				uint8_t lid{ 0 };       // Spatial layer id.
-				uint8_t tl0picidx{ 0 }; // TL0PICIDX
+				// Fields in dependency descriptor.
+				bool s{ false };  // Start bit.
+				bool e{ false };  // End bit.
+				uint8_t tid{ 0 }; // Temporal layer id.
+				uint8_t lid{ 0 }; // Spatial layer id.
 
 				// Parsed values.
 				bool hasLid{ false };
 				bool hasTid{ false };
-				bool hasTl0picidx{ false };
 				bool isKeyFrame{ false };
 			};
 
 		public:
 			static H264::PayloadDescriptor* Parse(
-			  const uint8_t* data,
-			  size_t len,
-			  RTC::RtpPacket::FrameMarking* frameMarking = nullptr,
-			  uint8_t frameMarkingLen                    = 0);
-			static void ProcessRtpPacket(RTC::RtpPacket* packet);
+			  const uint8_t* data, size_t len, webrtc::DependencyDescriptor* descriptor = nullptr);
+			static void ProcessRtpPacket(
+			  RTC::RtpPacket* packet,
+			  std::unique_ptr<webrtc::FrameDependencyStructure>& frameDependencyStructure);
 
 		public:
 			class EncodingContext : public RTC::Codecs::EncodingContext

--- a/worker/include/RTC/Codecs/Tools.hpp
+++ b/worker/include/RTC/Codecs/Tools.hpp
@@ -10,6 +10,7 @@
 #include "RTC/Codecs/VP9.hpp"
 #include "RTC/RtpDictionaries.hpp"
 #include "RTC/RtpPacket.hpp"
+#include <libwebrtc/api/transport/rtp/dependency_descriptor.h>
 
 namespace RTC
 {
@@ -43,7 +44,10 @@ namespace RTC
 				}
 			}
 
-			static void ProcessRtpPacket(RTC::RtpPacket* packet, const RTC::RtpCodecMimeType& mimeType)
+			static void ProcessRtpPacket(
+			  RTC::RtpPacket* packet,
+			  const RTC::RtpCodecMimeType& mimeType,
+			  std::unique_ptr<webrtc::FrameDependencyStructure>& frameDependencyStructure)
 			{
 				switch (mimeType.type)
 				{
@@ -67,7 +71,7 @@ namespace RTC
 
 							case RTC::RtpCodecMimeType::Subtype::H264:
 							{
-								RTC::Codecs::H264::ProcessRtpPacket(packet);
+								RTC::Codecs::H264::ProcessRtpPacket(packet, frameDependencyStructure);
 
 								break;
 							}

--- a/worker/include/RTC/RtpDictionaries.hpp
+++ b/worker/include/RTC/RtpDictionaries.hpp
@@ -123,6 +123,7 @@ namespace RTC
 			TRANSPORT_WIDE_CC_01   = 5,
 			FRAME_MARKING_07       = 6, // NOTE: Remove once RFC.
 			FRAME_MARKING          = 7,
+			DEPENDENCY_DESCRIPTOR  = 8,
 			SSRC_AUDIO_LEVEL       = 10,
 			VIDEO_ORIENTATION      = 11,
 			TOFFSET                = 12,

--- a/worker/include/RTC/RtpHeaderExtensionIds.hpp
+++ b/worker/include/RTC/RtpHeaderExtensionIds.hpp
@@ -20,6 +20,7 @@ namespace RTC
 		uint8_t toffset{ 0u };
 		uint8_t absCaptureTime{ 0u };
 		uint8_t playoutDelay{ 0u };
+		uint8_t dependencyDescriptor{ 0u };
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RtpStreamRecv.hpp
@@ -6,6 +6,7 @@
 #include "RTC/RateCalculator.hpp"
 #include "RTC/RtpStream.hpp"
 #include "handles/TimerHandle.hpp"
+#include <libwebrtc/api/transport/rtp/dependency_descriptor.h>
 #include <vector>
 
 namespace RTC
@@ -131,6 +132,8 @@ namespace RTC
 		TransmissionCounter transmissionCounter;
 		// Just valid media.
 		RTC::RtpDataCounter mediaTransmissionCounter;
+
+		std::unique_ptr<webrtc::FrameDependencyStructure> frameDependencyStructure;
 	};
 } // namespace RTC
 

--- a/worker/src/RTC/Consumer.cpp
+++ b/worker/src/RTC/Consumer.cpp
@@ -114,6 +114,13 @@ namespace RTC
 			{
 				this->rtpHeaderExtensionIds.rrid = exten.id;
 			}
+
+			if (
+			  this->rtpHeaderExtensionIds.dependencyDescriptor == 0u &&
+			  exten.type == RTC::RtpHeaderExtensionUri::Type::DEPENDENCY_DESCRIPTOR)
+			{
+				this->rtpHeaderExtensionIds.dependencyDescriptor = exten.id;
+			}
 		}
 
 		// paused is set to false by default.

--- a/worker/src/RTC/RtpDictionaries/RtpHeaderExtensionUri.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpHeaderExtensionUri.cpp
@@ -72,6 +72,11 @@ namespace RTC
 			{
 				return RtpHeaderExtensionUri::Type::ABS_CAPTURE_TIME;
 			}
+
+			case FBS::RtpParameters::RtpHeaderExtensionUri::DependencyDescriptor:
+			{
+				return RtpHeaderExtensionUri::Type::DEPENDENCY_DESCRIPTOR;
+			}
 		}
 	}
 
@@ -138,6 +143,11 @@ namespace RTC
 			case RtpHeaderExtensionUri::Type::ABS_CAPTURE_TIME:
 			{
 				return FBS::RtpParameters::RtpHeaderExtensionUri::AbsCaptureTime;
+			}
+
+			case RtpHeaderExtensionUri::Type::DEPENDENCY_DESCRIPTOR:
+			{
+				return FBS::RtpParameters::RtpHeaderExtensionUri::DependencyDescriptor;
 			}
 		}
 	}

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -392,16 +392,17 @@ namespace RTC
 		MS_ASSERT(type == 1u || type == 2u, "type must be 1 or 2");
 
 		// Reset extension ids.
-		this->midExtensionId               = 0u;
-		this->ridExtensionId               = 0u;
-		this->rridExtensionId              = 0u;
-		this->absSendTimeExtensionId       = 0u;
-		this->transportWideCc01ExtensionId = 0u;
-		this->frameMarking07ExtensionId    = 0u;
-		this->frameMarkingExtensionId      = 0u;
-		this->ssrcAudioLevelExtensionId    = 0u;
-		this->videoOrientationExtensionId  = 0u;
-		this->playoutDelayExtensionId      = 0u;
+		this->midExtensionId                  = 0u;
+		this->ridExtensionId                  = 0u;
+		this->rridExtensionId                 = 0u;
+		this->absSendTimeExtensionId          = 0u;
+		this->transportWideCc01ExtensionId    = 0u;
+		this->frameMarking07ExtensionId       = 0u;
+		this->frameMarkingExtensionId         = 0u;
+		this->ssrcAudioLevelExtensionId       = 0u;
+		this->videoOrientationExtensionId     = 0u;
+		this->playoutDelayExtensionId         = 0u;
+		this->dependencyDescriptorExtensionId = 0u;
 
 		// Clear the One-Byte and Two-Bytes extension elements maps.
 		std::fill(std::begin(this->oneByteExtensions), std::end(this->oneByteExtensions), nullptr);
@@ -754,16 +755,17 @@ namespace RTC
 		  newHeader, newHeaderExtension, newPayload, this->payloadLength, this->payloadPadding, this->size);
 
 		// Keep already set extension ids.
-		packet->midExtensionId               = this->midExtensionId;
-		packet->ridExtensionId               = this->ridExtensionId;
-		packet->rridExtensionId              = this->rridExtensionId;
-		packet->absSendTimeExtensionId       = this->absSendTimeExtensionId;
-		packet->transportWideCc01ExtensionId = this->transportWideCc01ExtensionId;
-		packet->frameMarking07ExtensionId    = this->frameMarking07ExtensionId; // Remove once RFC.
-		packet->frameMarkingExtensionId      = this->frameMarkingExtensionId;
-		packet->ssrcAudioLevelExtensionId    = this->ssrcAudioLevelExtensionId;
-		packet->videoOrientationExtensionId  = this->videoOrientationExtensionId;
-		packet->playoutDelayExtensionId      = this->playoutDelayExtensionId;
+		packet->midExtensionId                  = this->midExtensionId;
+		packet->ridExtensionId                  = this->ridExtensionId;
+		packet->rridExtensionId                 = this->rridExtensionId;
+		packet->absSendTimeExtensionId          = this->absSendTimeExtensionId;
+		packet->transportWideCc01ExtensionId    = this->transportWideCc01ExtensionId;
+		packet->frameMarking07ExtensionId       = this->frameMarking07ExtensionId; // Remove once RFC.
+		packet->frameMarkingExtensionId         = this->frameMarkingExtensionId;
+		packet->ssrcAudioLevelExtensionId       = this->ssrcAudioLevelExtensionId;
+		packet->videoOrientationExtensionId     = this->videoOrientationExtensionId;
+		packet->playoutDelayExtensionId         = this->playoutDelayExtensionId;
+		packet->dependencyDescriptorExtensionId = this->dependencyDescriptorExtensionId;
 		// Assign the payload descriptor handler.
 		packet->payloadDescriptorHandler = this->payloadDescriptorHandler;
 		// Store allocated buffer.

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -279,7 +279,7 @@ namespace RTC
 		// Process the packet at codec level.
 		if (packet->GetPayloadType() == GetPayloadType())
 		{
-			RTC::Codecs::Tools::ProcessRtpPacket(packet, GetMimeType());
+			RTC::Codecs::Tools::ProcessRtpPacket(packet, GetMimeType(), this->frameDependencyStructure);
 		}
 
 		// Pass the packet to the NackGenerator.
@@ -410,7 +410,7 @@ namespace RTC
 		// Process the packet at codec level.
 		if (packet->GetPayloadType() == GetPayloadType())
 		{
-			RTC::Codecs::Tools::ProcessRtpPacket(packet, GetMimeType());
+			RTC::Codecs::Tools::ProcessRtpPacket(packet, GetMimeType(), this->frameDependencyStructure);
 		}
 
 		// Mark the packet as retransmitted.


### PR DESCRIPTION
Add dependency-descriptor extension support. Tested on mediasoup-demo.
Note: Now mediasoup-client can't get dd extension showup by default , so I have hardcode for testing. See :https://github.com/Lynnworld/mediasoup-client/blob/5e8ff720bfae116e62989eae984ad3ccf2b11cd9/src/handlers/ortc/utils.ts#L25

<img width="1901" alt="image" src="https://github.com/user-attachments/assets/e12b121f-e9ba-4ed5-bb12-2d19df632d04" />
