### PR TITLE
Node: Expose `Index` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Node: Expose `Index` interface in `types.indexTypes` or via `import { Index as MediasoupIndex } from 'mediasoup/lib/indexTypes'` ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 3.15.2
 
 - `Worker`: Fix crash when using colliding `portRange` values in different transports ([PR #1469](https://github.com/versatica/mediasoup/pull/1469)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Node: Expose `Index` interface in `types.indexTypes` or via `import { Index as MediasoupIndex } from 'mediasoup/lib/indexTypes'` ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Node: Expose `Index` interface in `types.indexTypes` or via `import { Index as MediasoupIndex } from 'mediasoup/lib/indexTypes'` ([PR #1485](https://github.com/versatica/mediasoup/pull/1485)).
 
 ### 3.15.2
 

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -1,28 +1,29 @@
 import { Logger, LoggerEmitter } from './Logger';
 import { EnhancedEventEmitter } from './enhancedEvents';
+import type {
+	Observer,
+	ObserverEvents,
+	LogEventListeners,
+	Index,
+} from './indexTypes';
 import type { Worker, WorkerSettings } from './WorkerTypes';
 import { WorkerImpl, workerBin } from './Worker';
 import { supportedRtpCapabilities } from './supportedRtpCapabilities';
 import type { RtpCapabilities } from './rtpParametersTypes';
-import type * as types from './types';
+import { parseScalabilityMode } from './scalabilityModesUtils';
+import type { AppData } from './types';
 import * as utils from './utils';
 
 /**
  * Expose all types.
  */
-export { types };
+export type * as types from './types';
 
 /**
  * Expose mediasoup version.
  */
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 export const version: string = require('../../package.json').version;
-
-export type Observer = EnhancedEventEmitter<ObserverEvents>;
-
-export type ObserverEvents = {
-	newworker: [Worker];
-};
 
 const observer: Observer = new EnhancedEventEmitter<ObserverEvents>();
 
@@ -59,9 +60,7 @@ const logger = new Logger();
  * });
  * ```
  */
-export function setLogEventListeners(
-	listeners?: types.LogEventListeners
-): void {
+export function setLogEventListeners(listeners?: LogEventListeners): void {
 	logger.debug('setLogEventListeners()');
 
 	let debugLogEmitter: LoggerEmitter | undefined;
@@ -92,9 +91,7 @@ export function setLogEventListeners(
 /**
  * Create a Worker.
  */
-export async function createWorker<
-	WorkerAppData extends types.AppData = types.AppData,
->({
+export async function createWorker<WorkerAppData extends AppData = AppData>({
 	logLevel = 'error',
 	logTags,
 	rtcMinPort = 10000,
@@ -145,9 +142,24 @@ export function getSupportedRtpCapabilities(): RtpCapabilities {
 /**
  * Expose parseScalabilityMode() function.
  */
-export { parseScalabilityMode } from './scalabilityModesUtils';
+export { parseScalabilityMode };
 
 /**
  * Expose extras module.
  */
 export * as extras from './extras';
+
+// NOTE: This constant of type Index is created just to check at TypeScript
+// level that everything exported here (all but TS types) matches the Index
+// interface exposed by indexTypes.ts.
+//
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const indexImpl: Index = {
+	version,
+	observer,
+	workerBin,
+	setLogEventListeners,
+	createWorker,
+	getSupportedRtpCapabilities,
+	parseScalabilityMode,
+};

--- a/node/src/indexTypes.ts
+++ b/node/src/indexTypes.ts
@@ -1,0 +1,32 @@
+import type { EnhancedEventEmitter } from './enhancedEvents';
+import type { Worker, WorkerSettings } from './WorkerTypes';
+import type { RtpCapabilities } from './rtpParametersTypes';
+import type { parseScalabilityMode } from './scalabilityModesUtils';
+import type { AppData } from './types';
+
+export type ObserverEvents = {
+	newworker: [Worker];
+};
+
+export type Observer = EnhancedEventEmitter<ObserverEvents>;
+
+/**
+ * Event listeners for mediasoup generated logs.
+ */
+export type LogEventListeners = {
+	ondebug?: (namespace: string, log: string) => void;
+	onwarn?: (namespace: string, log: string) => void;
+	onerror?: (namespace: string, log: string, error?: Error) => void;
+};
+
+export interface Index {
+	version: string;
+	observer: EnhancedEventEmitter<ObserverEvents>;
+	workerBin: string;
+	setLogEventListeners: (listeners?: LogEventListeners) => void;
+	createWorker: <WorkerAppData extends AppData = AppData>(
+		options?: WorkerSettings<WorkerAppData>
+	) => Promise<Worker<WorkerAppData>>;
+	getSupportedRtpCapabilities: () => RtpCapabilities;
+	parseScalabilityMode: typeof parseScalabilityMode;
+}

--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -1,4 +1,4 @@
-export type { Observer, ObserverEvents } from './index';
+export type * from './indexTypes';
 export type * from './WorkerTypes';
 export type * from './WebRtcServerTypes';
 export type * from './RouterTypes';
@@ -31,13 +31,4 @@ export type Either<T, U> = Only<T, U> | Only<U, T>;
 
 export type AppData = {
 	[key: string]: unknown;
-};
-
-/**
- * Event listeners for mediasoup generated logs.
- */
-export type LogEventListeners = {
-	ondebug?: (namespace: string, log: string) => void;
-	onwarn?: (namespace: string, log: string) => void;
-	onerror?: (namespace: string, log: string, error?: Error) => void;
 };


### PR DESCRIPTION
## Details

- Fixes #1476
- Expose `types.indexTypes` or via `import { Index as MediasoupIndex } from 'mediasoup/lib/indexTypes'` ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).