### PR TITLE
Fix VP9 out of order packets forwarding

### DIFF
--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -166,7 +166,7 @@ namespace RTC
 
 				this->currentTemporalLayer = temporalLayer;
 			}
-			int16_t GetCurrentSpatialLayer(uint16_t pictureId) const
+			int16_t GetSpatialLayerForPictureId(uint16_t pictureId) const
 			{
 				int16_t layer = this->spatialLayerPictureIdList.GetLayer(pictureId);
 				if (layer > -1)

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -155,7 +155,6 @@ namespace RTC
 				}
 
 				this->spatialLayerPictureIdList.Push(pictureId, spatialLayer);
-
 				this->currentSpatialLayer = spatialLayer;
 			}
 			void SetCurrentTemporalLayer(int16_t temporalLayer, uint16_t pictureId)

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -24,6 +24,7 @@ namespace RTC
 			explicit PictureIdList()
 			{
 			}
+
 			~PictureIdList()
 			{
 				this->list.clear();

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -182,6 +182,7 @@ namespace RTC
 			int16_t GetTemporalLayerForPictureId(uint16_t pictureId) const
 			{
 				int16_t layer = this->temporalLayerPictureIdList.GetLayer(pictureId);
+
 				if (layer > -1)
 				{
 					return layer;

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -60,7 +60,7 @@ namespace RTC
 					return -1;
 				}
 
-				for (auto it = std::next(this->list.begin()); it != this->list.end(); ++it)
+				for (auto it = std::next(this->layerChanges.begin()); it != this->layerChanges.end(); ++it)
 				{
 					if (RTC::SeqManager<uint16_t, 15>::IsSeqHigherThan(it->first, pictureId))
 					{

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -48,6 +48,7 @@ namespace RTC
 						break;
 					}
 				}
+
 				this->list.push_back({ pictureId, layer });
 			}
 

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -55,18 +55,18 @@ namespace RTC
 
 			int16_t GetLayer(uint16_t pictureId) const
 			{
-				if (this->list.size() > 1)
+				if (this->list.empty())
 				{
-					for (auto it = std::next(this->list.begin()); it != this->list.end(); ++it)
-					{
-						if (RTC::SeqManager<uint16_t, 15>::IsSeqHigherThan(it->first, pictureId))
-						{
-							return std::prev(it)->second;
-						}
-					}
+					return -1;
 				}
 
-				return -1;
+				for (auto it = std::next(this->list.begin()); it != this->list.end(); ++it)
+				{
+					if (RTC::SeqManager<uint16_t, 15>::IsSeqHigherThan(it->first, pictureId))
+					{
+						return std::prev(it)->second;
+					}
+				}
 			}
 
 		private:

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -27,12 +27,12 @@ namespace RTC
 
 			~PictureIdList()
 			{
-				this->list.clear();
+				this->layerChanges.clear();
 			}
 
 			void Push(uint16_t pictureId, int16_t layer)
 			{
-				for (const auto& it : this->list)
+				for (const auto& it : this->layerChanges)
 				{
 					// Layers can be changed only with ordered pictureId values.
 					// If pictureId is lower than the previous one, then it has rolled over the max value.
@@ -42,7 +42,7 @@ namespace RTC
 
 					if (diff > MaxCurrentLayerPictureIdNum)
 					{
-						this->list.pop_front();
+						this->layerChanges.pop_front();
 					}
 					else
 					{
@@ -50,12 +50,12 @@ namespace RTC
 					}
 				}
 
-				this->list.push_back({ pictureId, layer });
+				this->layerChanges.push_back({ pictureId, layer });
 			}
 
 			int16_t GetLayer(uint16_t pictureId) const
 			{
-				if (this->list.size() <= 1)
+				if (this->layerChanges.size() <= 1)
 				{
 					return -1;
 				}
@@ -72,7 +72,9 @@ namespace RTC
 			}
 
 		private:
-			std::deque<std::pair<uint16_t, int16_t>> list;
+			// List populated with the spatial/temporal layer changes
+			// indexed by the corresponding pictureId.
+			std::deque<std::pair<uint16_t, int16_t>> layerChanges;
 		};
 
 		// Encoding context used by PayloadDescriptorHandler to properly rewrite the
@@ -199,6 +201,7 @@ namespace RTC
 			bool ignoreDtx{ false };
 
 		private:
+			// List of spatial/temporal layer changes indexed by the corresponding pictureId.
 			PictureIdList spatialLayerPictureIdList;
 			PictureIdList temporalLayerPictureIdList;
 		};

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -171,6 +171,7 @@ namespace RTC
 			int16_t GetSpatialLayerForPictureId(uint16_t pictureId) const
 			{
 				int16_t layer = this->spatialLayerPictureIdList.GetLayer(pictureId);
+
 				if (layer > -1)
 				{
 					return layer;

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -147,7 +147,6 @@ namespace RTC
 				this->ignoreDtx = ignoreDtx;
 			}
 			virtual void SyncRequired() = 0;
-
 			void SetCurrentSpatialLayer(int16_t spatialLayer, uint16_t pictureId)
 			{
 				if (this->currentSpatialLayer == spatialLayer)

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -165,7 +165,6 @@ namespace RTC
 				}
 
 				this->temporalLayerPictureIdList.Push(pictureId, temporalLayer);
-
 				this->currentTemporalLayer = temporalLayer;
 			}
 			int16_t GetSpatialLayerForPictureId(uint16_t pictureId) const

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -55,7 +55,7 @@ namespace RTC
 
 			int16_t GetLayer(uint16_t pictureId) const
 			{
-				if (this->list.empty())
+				if (this->list.size() <= 1)
 				{
 					return -1;
 				}

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -67,6 +67,8 @@ namespace RTC
 						return std::prev(it)->second;
 					}
 				}
+
+				return -1;
 			}
 
 		private:

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -176,7 +176,7 @@ namespace RTC
 
 				return this->currentSpatialLayer;
 			}
-			int16_t GetCurrentTemporalLayer(uint16_t pictureId) const
+			int16_t GetTemporalLayerForPictureId(uint16_t pictureId) const
 			{
 				int16_t layer = this->temporalLayerPictureIdList.GetLayer(pictureId);
 				if (layer > -1)

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -243,19 +243,18 @@ namespace RTC
 
 			if (!isOldPacket)
 			{
-                                 // Upgrade current spatial layer if needed.
+				// Upgrade current spatial layer if needed.
 				if (context->GetTargetSpatialLayer() > context->GetCurrentSpatialLayer())
 				{
 					if (this->payloadDescriptor->isKeyFrame)
 					{
 						MS_DEBUG_DEV(
 						  "upgrading tmpSpatialLayer from %" PRIu16 " to %" PRIu16 " (packet:%" PRIu8 ":%" PRIu8
-						  ") old:%d",
+						  ")",
 						  context->GetCurrentSpatialLayer(),
 						  context->GetTargetSpatialLayer(),
 						  packetSpatialLayer,
-						  packetTemporalLayer,
-						  isOldPacket);
+						  packetTemporalLayer);
 
 						tmpSpatialLayer  = context->GetTargetSpatialLayer();
 						tmpTemporalLayer = 0; // Just in case.

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -376,7 +376,7 @@ namespace RTC
 			}
 
 			// Filter temporal layers higher than current one.
-			uint16_t tmpTemporalLayerCheck =
+			uint16_t temporalLayerForPictureId =
 			  isOldPacket ? context->GetCurrentTemporalLayer(this->payloadDescriptor->pictureId)
 			              : tmpTemporalLayer;
 			if (packetTemporalLayer > tmpTemporalLayerCheck)

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -311,12 +311,12 @@ namespace RTC
 			// * different than the current one when KSVC is enabled and this is not a keyframe
 			// (interframe p bit = 1)
 			uint16_t spatialLayerForPictureId =
-			  isOldPacket ? context->GetCurrentSpatialLayer(this->payloadDescriptor->pictureId)
+			  isOldPacket ? context->GetSpatialLayerForPictureId(this->payloadDescriptor->pictureId)
 			              : tmpSpatialLayer;
 			// clang-format off
 			if (
-				packetSpatialLayer > tmpSpatialLayerCheck ||
-				(context->IsKSvc() && this->payloadDescriptor->p && packetSpatialLayer != tmpSpatialLayerCheck)
+				packetSpatialLayer > spatialLayerForPictureId ||
+				(context->IsKSvc() && this->payloadDescriptor->p && packetSpatialLayer != spatialLayerForPictureId)
 			)
 			// clang-format on
 			{
@@ -376,9 +376,9 @@ namespace RTC
 
 			// Filter temporal layers higher than current one.
 			uint16_t temporalLayerForPictureId =
-			  isOldPacket ? context->GetCurrentTemporalLayer(this->payloadDescriptor->pictureId)
+			  isOldPacket ? context->GetTemporalLayerForPictureId(this->payloadDescriptor->pictureId)
 			              : tmpTemporalLayer;
-			if (packetTemporalLayer > tmpTemporalLayerCheck)
+			if (packetTemporalLayer > temporalLayerForPictureId)
 			{
 				return false;
 			}

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -379,6 +379,7 @@ namespace RTC
 			uint16_t temporalLayerForPictureId =
 			  isOldPacket ? context->GetTemporalLayerForPictureId(this->payloadDescriptor->pictureId)
 			              : tmpTemporalLayer;
+
 			if (packetTemporalLayer > temporalLayerForPictureId)
 			{
 				return false;

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -241,7 +241,6 @@ namespace RTC
 			);
 			// clang-format on
 
-			// Upgrade current spatial layer if needed.
 			if (!isOldPacket)
 			{
                                  // Upgrade current spatial layer if needed.

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -311,7 +311,7 @@ namespace RTC
 			// * higher than current one
 			// * different than the current one when KSVC is enabled and this is not a keyframe
 			// (interframe p bit = 1)
-			uint16_t tmpSpatialLayerCheck =
+			uint16_t spatialLayerForPictureId =
 			  isOldPacket ? context->GetCurrentSpatialLayer(this->payloadDescriptor->pictureId)
 			              : tmpSpatialLayer;
 			// clang-format off

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -244,6 +244,7 @@ namespace RTC
 			// Upgrade current spatial layer if needed.
 			if (!isOldPacket)
 			{
+                                 // Upgrade current spatial layer if needed.
 				if (context->GetTargetSpatialLayer() > context->GetCurrentSpatialLayer())
 				{
 					if (this->payloadDescriptor->isKeyFrame)

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -313,6 +313,7 @@ namespace RTC
 			uint16_t spatialLayerForPictureId =
 			  isOldPacket ? context->GetSpatialLayerForPictureId(this->payloadDescriptor->pictureId)
 			              : tmpSpatialLayer;
+
 			// clang-format off
 			if (
 				packetSpatialLayer > spatialLayerForPictureId ||

--- a/worker/test/src/RTC/Codecs/TestVP9.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP9.cpp
@@ -10,11 +10,11 @@ constexpr uint16_t MaxPictureId = (1 << 15) - 1;
 Codecs::VP9::PayloadDescriptor* CreateVP9Packet(
   uint8_t* buffer, size_t bufferLen, uint16_t pictureId, uint8_t tlIndex)
 {
-	buffer[0]             = 0xAD; // I and L bits
+	buffer[0]             = 0xAD; // I, L, B, E bits
 	uint16_t netPictureId = htons(pictureId);
 	std::memcpy(buffer + 1, &netPictureId, 2);
 	buffer[1] |= 0x80;
-	buffer[3] = tlIndex << 6;
+	buffer[3] = (tlIndex << 5) | (1 << 4); // tlIndex, switchingUpPoint
 
 	auto* payloadDescriptor = Codecs::VP9::Parse(buffer, bufferLen);
 
@@ -74,5 +74,111 @@ SCENARIO("process VP9 payload descriptor", "[codecs][vp9]")
 		// Frame 3.
 		forwarded = ProcessVP9Packet(context, 1, 1);
 		REQUIRE_FALSE(forwarded);
+	}
+
+	SECTION("test PayloadDescriptorHandler")
+	{
+		RTC::Codecs::EncodingContext::Params params;
+		params.spatialLayers  = 1;
+		params.temporalLayers = 3;
+
+		Codecs::VP9::EncodingContext context(params);
+
+		uint16_t start = MaxPictureId - 2000;
+
+		context.SetCurrentTemporalLayer(0, start + 0);
+		context.SetCurrentTemporalLayer(1, start + 1);
+		context.SetCurrentTemporalLayer(2, start + 5);
+		context.SetCurrentTemporalLayer(0, start + 6);
+
+		REQUIRE(context.GetCurrentTemporalLayer(start + 0) == 0);
+		REQUIRE(context.GetCurrentTemporalLayer(start + 1) == 1);
+		REQUIRE(context.GetCurrentTemporalLayer(start + 2) == 1);
+		REQUIRE(context.GetCurrentTemporalLayer(start + 5) == 2);
+		REQUIRE(context.GetCurrentTemporalLayer(start + 6) == 0);
+
+		context.SetCurrentTemporalLayer(1, start + 1000);
+		context.SetCurrentTemporalLayer(2, start + 1001); // This will drop the first item.
+
+		REQUIRE(context.GetCurrentTemporalLayer(start + 1000) == 1);
+		REQUIRE(context.GetCurrentTemporalLayer(start + 0) == 1); // It will get the item at start+1.
+
+		context.SetCurrentTemporalLayer(0, 0); // This will drop items from start to start+999.
+
+		REQUIRE(context.GetCurrentTemporalLayer(0) == 0);
+		REQUIRE(context.GetCurrentTemporalLayer(start + 0) == 1); // It will get the item at start+1000.
+	}
+
+	SECTION("drop packets that belong to other temporal layers with unordered pictureID")
+	{
+		RTC::Codecs::EncodingContext::Params params;
+		params.spatialLayers  = 1;
+		params.temporalLayers = 3;
+
+		Codecs::VP9::EncodingContext context(params);
+		context.SyncRequired();
+		context.SetCurrentSpatialLayer(0, 0);
+		context.SetTargetSpatialLayer(0);
+
+		uint16_t start                                                     = MaxPictureId - 20;
+		std::vector<std::tuple<uint16_t, uint16_t, int16_t, bool>> packets = {
+			// targetTemporalLayer=0
+			{ start, 0, 0, true },
+			{ start, 1, -1, false },
+			{ start + 1, 0, -1, true },
+			{ start + 1, 1, -1, false },
+			{ start + 2, 0, -1, true },
+			{ start + 2, 1, -1, false },
+			// targetTemporalLayer=1
+			{ start + 10, 0, 1, true },
+			{ start + 10, 1, -1, true },
+			{ start + 11, 0, -1, true },
+			{ start + 11, 1, -1, true },
+
+			{ start + 3, 0, -1, true }, // old packet
+			{ start + 3, 1, -1, false },
+			{ start + 12, 0, -1, true },
+			{ start + 12, 1, -1, true },
+			// targetTemporalLayer=0
+			{ start + 14, 0, 0, true },
+			{ start + 14, 1, -1, false },
+			{ start + 13, 0, -1, true }, // old packet
+			{ start + 13, 1, -1, true },
+			// targetTemporalLayer=1
+			{ start + 15, 0, 1, true },
+			{ start + 15, 1, -1, true },
+			// targetTemporalLayer=0
+			{ 0, 0, 0, true },
+			{ 0, 1, -1, false },
+			{ 1, 0, -1, true },
+			{ 1, 1, -1, false },
+			{ start + 16, 0, -1, true }, // old packet
+			{ start + 16, 1, -1, true },
+		};
+
+		for (const auto& packet : packets)
+		{
+			auto pictureId           = std::get<0>(packet);
+			auto tlIndex             = std::get<1>(packet);
+			auto targetTemporalLayer = std::get<2>(packet);
+			auto shouldForward       = std::get<3>(packet);
+
+			if (targetTemporalLayer >= 0)
+			{
+				context.SetTargetTemporalLayer(targetTemporalLayer);
+			}
+
+			auto forwarded = ProcessVP9Packet(context, pictureId, tlIndex);
+
+			if (shouldForward)
+			{
+				REQUIRE(forwarded);
+				REQUIRE(forwarded->pictureId == pictureId);
+			}
+			else
+			{
+				REQUIRE_FALSE(forwarded);
+			}
+		}
 	}
 }

--- a/worker/test/src/RTC/Codecs/TestVP9.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP9.cpp
@@ -135,7 +135,6 @@ SCENARIO("process VP9 payload descriptor", "[codecs][vp9]")
 			{ start + 10, 1, -1, true },
 			{ start + 11, 0, -1, true },
 			{ start + 11, 1, -1, true },
-
 			{ start + 3, 0, -1, true }, // old packet
 			{ start + 3, 1, -1, false },
 			{ start + 12, 0, -1, true },

--- a/worker/test/src/RTC/Codecs/TestVP9.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP9.cpp
@@ -91,22 +91,23 @@ SCENARIO("process VP9 payload descriptor", "[codecs][vp9]")
 		context.SetCurrentTemporalLayer(2, start + 5);
 		context.SetCurrentTemporalLayer(0, start + 6);
 
-		REQUIRE(context.GetCurrentTemporalLayer(start + 0) == 0);
-		REQUIRE(context.GetCurrentTemporalLayer(start + 1) == 1);
-		REQUIRE(context.GetCurrentTemporalLayer(start + 2) == 1);
-		REQUIRE(context.GetCurrentTemporalLayer(start + 5) == 2);
-		REQUIRE(context.GetCurrentTemporalLayer(start + 6) == 0);
+		REQUIRE(context.GetTemporalLayerForPictureId(start + 0) == 0);
+		REQUIRE(context.GetTemporalLayerForPictureId(start + 1) == 1);
+		REQUIRE(context.GetTemporalLayerForPictureId(start + 2) == 1);
+		REQUIRE(context.GetTemporalLayerForPictureId(start + 5) == 2);
+		REQUIRE(context.GetTemporalLayerForPictureId(start + 6) == 0);
 
 		context.SetCurrentTemporalLayer(1, start + 1000);
 		context.SetCurrentTemporalLayer(2, start + 1001); // This will drop the first item.
 
-		REQUIRE(context.GetCurrentTemporalLayer(start + 1000) == 1);
-		REQUIRE(context.GetCurrentTemporalLayer(start + 0) == 1); // It will get the item at start+1.
+		REQUIRE(context.GetTemporalLayerForPictureId(start + 1000) == 1);
+		REQUIRE(context.GetTemporalLayerForPictureId(start + 0) == 1); // It will get the item at start+1.
 
 		context.SetCurrentTemporalLayer(0, 0); // This will drop items from start to start+999.
 
-		REQUIRE(context.GetCurrentTemporalLayer(0) == 0);
-		REQUIRE(context.GetCurrentTemporalLayer(start + 0) == 1); // It will get the item at start+1000.
+		REQUIRE(context.GetTemporalLayerForPictureId(0) == 0);
+		REQUIRE(
+		  context.GetTemporalLayerForPictureId(start + 0) == 1); // It will get the item at start+1000.
 	}
 
 	SECTION("drop packets that belong to other temporal layers with unordered pictureID")


### PR DESCRIPTION
Hi :wave: 
When I run different tests with 1 VP9 video publisher with network packet loss (10-15%) and delay (100-500ms) at sender side, I always measure a low video framerate (~3-4fps at average) at receiver side.

Looking at the VP9 Process method, I see that when we receive an out-of-order packet, we forward it without checking if it satisfies the current spatial and temporal layer values. As opposite, dropping those out of order packets in some cases improves the measured fps at receiver side.

This PR tries uses an intermediate approach, saving the spatial/temporal and pictureID relation in a list when the current layers change. When an old packet arrives, we search for the spatial/temporal layer for the packets pictureID (getting the layer that was active for the given pictureID) and drop the packet if its layer is greater than that. This way we are sure that we forward the packet only if it would have been forwarded did it arrive in order.
This prevents forwarding packets that would later be discarded by the decoder, and that would potentially generate over-processing, overflowing the jitter buffer and hence discarding legitimate packets, etc.

Tests results in the same conditions show an increase of the measured fps from ~3-4 to 7-8fps.

Ref:
similar PR for VP8: https://github.com/versatica/mediasoup/pull/1009