### PR TITLE
Add RTC/Consts.hpp file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - `Worker`: Drop VP8 packets with a higher temporal layer than the current one ([PR #1009](https://github.com/versatica/mediasoup/pull/1009)).
+- Fix the problem of the TCC package being omitted from being sent ([PR #1492](https://github.com/versatica/mediasoup/pull/1492) by @penguinol).
 
 ### 3.15.3
 

--- a/worker/fuzzer/src/RTC/FuzzerRateCalculator.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerRateCalculator.cpp
@@ -2,7 +2,7 @@
 #include "DepLibUV.hpp"
 #include "Utils.hpp"
 #include "RTC/RateCalculator.hpp"
-#include "RTC/RtpPacket.hpp" // RTC::MtuSize
+#include "RTC/Consts.hpp"
 
 static ::RTC::RateCalculator rateCalculator;
 static uint64_t nowMs;
@@ -26,7 +26,7 @@ void Fuzzer::RTC::RateCalculator::Fuzz(const uint8_t* data, size_t len)
 	}
 
 	auto size =
-	  static_cast<size_t>(Utils::Crypto::GetRandomUInt(0u, static_cast<uint32_t>(::RTC::MtuSize)));
+	  static_cast<size_t>(Utils::Crypto::GetRandomUInt(0u, static_cast<uint32_t>(::RTC::Consts::MtuSize)));
 
 	nowMs += Utils::Crypto::GetRandomUInt(0u, 1000u);
 

--- a/worker/fuzzer/src/RTC/FuzzerRateCalculator.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerRateCalculator.cpp
@@ -1,8 +1,8 @@
 #include "RTC/FuzzerRateCalculator.hpp"
 #include "DepLibUV.hpp"
 #include "Utils.hpp"
-#include "RTC/RateCalculator.hpp"
 #include "RTC/Consts.hpp"
+#include "RTC/RateCalculator.hpp"
 
 static ::RTC::RateCalculator rateCalculator;
 static uint64_t nowMs;
@@ -25,8 +25,8 @@ void Fuzzer::RTC::RateCalculator::Fuzz(const uint8_t* data, size_t len)
 		return;
 	}
 
-	auto size =
-	  static_cast<size_t>(Utils::Crypto::GetRandomUInt(0u, static_cast<uint32_t>(::RTC::Consts::MtuSize)));
+	auto size = static_cast<size_t>(
+	  Utils::Crypto::GetRandomUInt(0u, static_cast<uint32_t>(::RTC::Consts::MtuSize)));
 
 	nowMs += Utils::Crypto::GetRandomUInt(0u, 1000u);
 

--- a/worker/include/RTC/Consts.hpp
+++ b/worker/include/RTC/Consts.hpp
@@ -1,0 +1,32 @@
+#ifndef MS_RTC_CONSTS_HPP
+#define MS_RTC_CONSTS_HPP
+
+namespace RTC
+{
+	namespace Consts
+	{
+		/**
+		 * Max MTU size.
+		 */
+		constexpr size_t MtuSize{ 1500u };
+
+		/**
+		 * Maximum size for a RTCP compound packet.
+		 * IPv4|Ipv6 header size: 20|40 bytes. IPv6 considered.
+		 * UDP|TCP header size:   8|20  bytes. TCP considered.
+		 * SRTP Encryption: 148 bytes.
+		     SRTP_MAX_TRAILER_LEN+4 is the maximum number of octects that will be
+		     added to an RTCP packet by srtp_protect_rtcp().
+		     srtp.h: SRTP_MAX_TRAILER_LEN (SRTP_MAX_TAG_LEN + SRTP_MAX_MKI_LEN).
+		 */
+		constexpr size_t RtcpPacketMaxSize{ MtuSize - 40 - 20 - 148u };
+
+		/**
+		 * MID RTP header extension max length (just used when setting/updating MID
+		 * extension).
+		 */
+		constexpr uint8_t MidRtpExtensionMaxLength{ 8u };
+	} // namespace Consts
+} // namespace RTC
+
+#endif

--- a/worker/include/RTC/Consts.hpp
+++ b/worker/include/RTC/Consts.hpp
@@ -19,7 +19,7 @@ namespace RTC
 		     added to an RTCP packet by srtp_protect_rtcp().
 		     srtp.h: SRTP_MAX_TRAILER_LEN (SRTP_MAX_TAG_LEN + SRTP_MAX_MKI_LEN).
 		 */
-		constexpr size_t RtcpPacketMaxSize{ MtuSize - 40 - 20 - 148u };
+		constexpr size_t RtcpPacketMaxSize{ RTC::Consts::MtuSize - 40 - 20 - 148u };
 
 		/**
 		 * MID RTP header extension max length (just used when setting/updating MID

--- a/worker/include/RTC/RTCP/CompoundPacket.hpp
+++ b/worker/include/RTC/RTCP/CompoundPacket.hpp
@@ -7,7 +7,6 @@
 #include "RTC/RTCP/SenderReport.hpp"
 #include "RTC/RTCP/XrDelaySinceLastRr.hpp"
 #include "RTC/RTCP/XrReceiverReferenceTime.hpp"
-#include "RTC/RtpPacket.hpp" // MaxPacketSize.
 #include <vector>
 
 namespace RTC

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -18,17 +18,6 @@ namespace RTC
 {
 	// Max MTU size.
 	constexpr size_t MtuSize{ 1500u };
-	// Maximum size for a CompundPacket.
-	// * IPv4|Ipv6 header size: 20|40 bytes. IPv6 considered.
-	// * UDP|TCP header size:   8|20  bytes. TCP considered.
-	// * SRTP Encryption: 148 bytes.
-	//    SRTP_MAX_TRAILER_LEN+4 is the maximum number of octects that will be
-	//    added to an RTCP packet by srtp_protect_rtcp().
-	//    srtp.h: SRTP_MAX_TRAILER_LEN (SRTP_MAX_TAG_LEN + SRTP_MAX_MKI_LEN)
-	constexpr size_t MaxPacketSize{ RTC::MtuSize - 40 - 20 - 148u };
-	// MID header extension max length (just used when setting/updating MID
-	// extension).
-	constexpr uint8_t MidMaxLength{ 8u };
 
 	class RtpPacket
 	{

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -16,9 +16,6 @@
 
 namespace RTC
 {
-	// Max MTU size.
-	constexpr size_t MtuSize{ 1500u };
-
 	class RtpPacket
 	{
 	public:

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -3,6 +3,7 @@
 
 #include "RTC/DirectTransport.hpp"
 #include "Logger.hpp"
+#include "RTC/Consts.hpp"
 
 namespace RTC
 {
@@ -102,7 +103,7 @@ namespace RTC
 				// Increase receive transmission.
 				RTC::Transport::DataReceived(len);
 
-				if (len > RTC::MtuSize + 100)
+				if (len > RTC::Consts::MtuSize + 100)
 				{
 					MS_WARN_TAG(rtp, "given RTCP packet exceeds maximum size [len:%i]", len);
 

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -7,6 +7,7 @@
 #include "MediaSoupErrors.hpp"
 #include "Utils.hpp"
 #include "RTC/Codecs/Tools.hpp"
+#include "RTC/Consts.hpp"
 #include "RTC/RTCP/Feedback.hpp"
 #include "RTC/RTCP/XrReceiverReferenceTime.hpp"
 #include <absl/container/inlined_vector.h>
@@ -1246,7 +1247,7 @@ namespace RTC
 
 			// Add urn:ietf:params:rtp-hdrext:sdes:mid.
 			{
-				extenLen = RTC::MidMaxLength;
+				extenLen = RTC::Consts::MidRtpExtensionMaxLength;
 
 				extensions.emplace_back(
 				  static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::MID), extenLen, bufferPtr);

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -525,7 +525,7 @@ namespace RTC
 				// Increase receive transmission.
 				this->listener->OnProducerReceiveData(this, len);
 
-				if (len > RTC::MtuSize + 100)
+				if (len > RTC::Consts::MtuSize + 100)
 				{
 					MS_WARN_TAG(rtp, "given RTP packet exceeds maximum size [len:%i]", len);
 
@@ -536,7 +536,7 @@ namespace RTC
 				// receiving buffer now.
 				if (!Producer::buffer)
 				{
-					Producer::buffer = new uint8_t[RTC::MtuSize + 100];
+					Producer::buffer = new uint8_t[RTC::Consts::MtuSize + 100];
 				}
 
 				// Copy the received packet into this buffer so it can be expanded later.

--- a/worker/src/RTC/RTCP/CompoundPacket.cpp
+++ b/worker/src/RTC/RTCP/CompoundPacket.cpp
@@ -3,6 +3,7 @@
 
 #include "RTC/RTCP/CompoundPacket.hpp"
 #include "Logger.hpp"
+#include "RTC/Consts.hpp"
 
 namespace RTC
 {
@@ -101,7 +102,7 @@ namespace RTC
 			}
 
 			// New items can hold in the packet, report it.
-			if (GetSize() <= RTC::MaxPacketSize)
+			if (GetSize() <= RTC::Consts::RtcpPacketMaxSize)
 			{
 				return true;
 			}
@@ -160,7 +161,7 @@ namespace RTC
 			}
 
 			// New items can hold in the packet, report it.
-			if (GetSize() <= RTC::MaxPacketSize)
+			if (GetSize() <= RTC::Consts::RtcpPacketMaxSize)
 			{
 				return true;
 			}
@@ -206,7 +207,7 @@ namespace RTC
 			}
 
 			// New items can hold in the packet, report it.
-			if (GetSize() <= RTC::MaxPacketSize)
+			if (GetSize() <= RTC::Consts::RtcpPacketMaxSize)
 			{
 				return true;
 			}

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -4,6 +4,7 @@
 #include "RTC/RtpPacket.hpp"
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
+#include "RTC/Consts.hpp"
 #include <cstring>  // std::memcpy(), std::memmove(), std::memset()
 #include <iterator> // std::ostream_iterator
 #include <sstream>  // std::ostringstream
@@ -580,13 +581,13 @@ namespace RTC
 
 		const size_t midLen = mid.length();
 
-		// Here we assume that there is MidMaxLength available bytes, even if now
-		// they are padding bytes.
-		if (midLen > RTC::MidMaxLength)
+		// Here we assume that there is MidRtpExtensionMaxLength available bytes,
+		// even if now they are padding bytes.
+		if (midLen > RTC::Consts::MidRtpExtensionMaxLength)
 		{
 			MS_ERROR(
 			  "no enough space for MID value [MidMaxLength:%" PRIu8 ", mid:'%s']",
-			  RTC::MidMaxLength,
+			  RTC::Consts::MidRtpExtensionMaxLength,
 			  mid.c_str());
 
 			return;
@@ -692,7 +693,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		auto* buffer = new uint8_t[MtuSize + 100];
+		auto* buffer = new uint8_t[RTC::Consts::MtuSize + 100];
 		auto* ptr    = const_cast<uint8_t*>(buffer);
 
 		size_t numBytes{ 0 };

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -7,6 +7,7 @@
 #endif
 #include "Logger.hpp"
 #include "Utils.hpp"
+#include "RTC/Consts.hpp"
 #include "RTC/RtpDictionaries.hpp"
 
 namespace RTC
@@ -374,7 +375,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		if (packet->GetSize() > RTC::MtuSize)
+		if (packet->GetSize() > RTC::Consts::MtuSize)
 		{
 			MS_WARN_TAG(
 			  rtp,

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -760,7 +760,7 @@ namespace RTC
 					if (createTccServer)
 					{
 						this->tccServer = std::make_shared<RTC::TransportCongestionControlServer>(
-						  this, bweType, RTC::Consts::MidRtpExtensionMaxLength);
+						  this, bweType, RTC::Consts::RtcpPacketMaxSize);
 
 						if (this->maxIncomingBitrate != 0u)
 						{

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -11,6 +11,7 @@
 #include "Utils.hpp"
 #include "FBS/transport.h"
 #include "RTC/BweType.hpp"
+#include "RTC/Consts.hpp"
 #include "RTC/PipeConsumer.hpp"
 #include "RTC/RTCP/FeedbackPs.hpp"
 #include "RTC/RTCP/FeedbackPsAfb.hpp"
@@ -759,7 +760,7 @@ namespace RTC
 					if (createTccServer)
 					{
 						this->tccServer = std::make_shared<RTC::TransportCongestionControlServer>(
-						  this, bweType, RTC::MaxPacketSize);
+						  this, bweType, RTC::Consts::MidRtpExtensionMaxLength);
 
 						if (this->maxIncomingBitrate != 0u)
 						{

--- a/worker/test/src/RTC/TestTransportCongestionControlServer.cpp
+++ b/worker/test/src/RTC/TestTransportCongestionControlServer.cpp
@@ -1,5 +1,6 @@
 #include "common.hpp"
 #include "DepLibUV.hpp"
+#include "RTC/Consts.hpp"
 #include "RTC/TransportCongestionControlServer.hpp"
 #include <catch2/catch_test_macros.hpp>
 
@@ -88,7 +89,7 @@ void validate(std::vector<TestTransportCongestionControlServerInput>& inputs, Te
 {
 	TestTransportCongestionControlServerListener listener;
 	auto tccServer =
-	  TransportCongestionControlServer(&listener, RTC::BweType::TRANSPORT_CC, RTC::MtuSize);
+	  TransportCongestionControlServer(&listener, RTC::BweType::TRANSPORT_CC, RTC::Consts::MtuSize);
 
 	tccServer.SetMaxIncomingBitrate(150000);
 	tccServer.TransportConnected();


### PR DESCRIPTION
## Details

- It doesn't make sense that `MtuSize` is exposed within namespace `RTC` if it's defined in `RtpPacket.hpp`. Same for others.
- So let's create `worker/include/RTC/Consts.hpp` file containing those things.
- Also add pending CHANGELOG line.