### PR TITLE
Consumer: Fix sequence number gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- `Consumer`: Fix sequence number gap ([PR #1494](https://github.com/versatica/mediasoup/pull/1494)).
+
 ### 3.15.4
 
 - `Worker`: Drop VP8 packets with a higher temporal layer than the current one ([PR #1009](https://github.com/versatica/mediasoup/pull/1009)).

--- a/worker/include/Channel/ChannelSocket.hpp
+++ b/worker/include/Channel/ChannelSocket.hpp
@@ -82,6 +82,8 @@ namespace Channel
 		};
 
 	public:
+		// For testing purposes only.
+		explicit ChannelSocket();
 		explicit ChannelSocket(int consumerFd, int producerFd);
 		explicit ChannelSocket(
 		  ChannelReadFn channelReadFn,

--- a/worker/include/Channel/ChannelSocket.hpp
+++ b/worker/include/Channel/ChannelSocket.hpp
@@ -82,8 +82,9 @@ namespace Channel
 		};
 
 	public:
-		// For testing purposes only.
+#ifdef MS_TEST
 		explicit ChannelSocket();
+#endif
 		explicit ChannelSocket(int consumerFd, int producerFd);
 		explicit ChannelSocket(
 		  ChannelReadFn channelReadFn,

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -333,6 +333,7 @@ test_sources = [
   'test/src/RTC/TestRtpStreamSend.cpp',
   'test/src/RTC/TestRtpStreamRecv.cpp',
   'test/src/RTC/TestSeqManager.cpp',
+  'test/src/RTC/TestSimpleConsumer.cpp',
   'test/src/RTC/TestTrendCalculator.cpp',
   'test/src/RTC/TestRtpEncodingParameters.cpp',
   'test/src/RTC/TestTransportCongestionControlServer.cpp',

--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -30,10 +30,12 @@ namespace Channel
 
 	/* Instance methods. */
 
+#ifdef MS_TEST
 	ChannelSocket::ChannelSocket()
 	{
 		MS_TRACE_STD();
 	}
+#endif
 
 	ChannelSocket::ChannelSocket(int consumerFd, int producerFd)
 	  : consumerSocket(new ConsumerSocket(consumerFd, MessageMaxLen, this)),
@@ -264,10 +266,6 @@ namespace Channel
 		else if (this->producerSocket)
 		{
 			this->producerSocket->Write(payload, payloadLen);
-		}
-		else
-		{
-			MS_DEBUG_DEV("sending Channel message: %s", payload);
 		}
 	}
 

--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -30,6 +30,11 @@ namespace Channel
 
 	/* Instance methods. */
 
+	ChannelSocket::ChannelSocket()
+	{
+		MS_TRACE_STD();
+	}
+
 	ChannelSocket::ChannelSocket(int consumerFd, int producerFd)
 	  : consumerSocket(new ConsumerSocket(consumerFd, MessageMaxLen, this)),
 	    producerSocket(new ProducerSocket(producerFd, MessageMaxLen))
@@ -256,9 +261,13 @@ namespace Channel
 		{
 			this->channelWriteFn(payload, payloadLen, this->channelWriteCtx);
 		}
-		else
+		else if (this->producerSocket)
 		{
 			this->producerSocket->Write(payload, payloadLen);
+		}
+		else
+		{
+			MS_DEBUG_DEV("sending Channel message: %s", payload);
 		}
 	}
 

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -320,6 +320,8 @@ namespace RTC
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);
 #endif
 
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
 			return;
 		}
 
@@ -334,6 +336,8 @@ namespace RTC
 #ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE);
 #endif
+
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -355,6 +359,8 @@ namespace RTC
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::DROPPED_BY_CODEC);
 #endif
 
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
 			return;
 		}
 
@@ -366,17 +372,19 @@ namespace RTC
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
 #endif
 
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
 			return;
 		}
 
 		// Packets with only padding are not forwarded.
 		if (packet->GetPayloadLength() == 0)
 		{
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
-
 #ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::EMPTY_PAYLOAD);
 #endif
+
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
 
 			return;
 		}

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -736,6 +736,8 @@ namespace RTC
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);
 #endif
 
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
 			return;
 		}
 
@@ -744,6 +746,8 @@ namespace RTC
 #ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::INVALID_TARGET_LAYER);
 #endif
+
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -777,6 +781,7 @@ namespace RTC
 				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
 #endif
 
+				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
 				return;
 			}
 
@@ -804,6 +809,7 @@ namespace RTC
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
 #endif
 
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
 			return;
 		}
 
@@ -811,11 +817,11 @@ namespace RTC
 		// not have payload other than padding, then drop it.
 		if (spatialLayer == this->currentSpatialLayer && packet->GetPayloadLength() == 0)
 		{
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
-
 #ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::EMPTY_PAYLOAD);
 #endif
+
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -935,6 +941,7 @@ namespace RTC
 					packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::TOO_HIGH_TIMESTAMP_EXTRA_NEEDED);
 #endif
 
+					this->rtpSeqManager->Drop(packet->GetSequenceNumber());
 					return;
 				}
 
@@ -979,6 +986,8 @@ namespace RTC
 				packet->logger.Dropped(
 				  RtcLogger::RtpPacket::DropReason::PACKET_PREVIOUS_TO_SPATIAL_LAYER_SWITCH);
 #endif
+
+				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
 
 				return;
 			}
@@ -1027,6 +1036,8 @@ namespace RTC
 #ifdef MS_RTC_LOGGER_RTP
 				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::DROPPED_BY_CODEC);
 #endif
+
+				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
 
 				return;
 			}

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -782,6 +782,7 @@ namespace RTC
 #endif
 
 				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
 				return;
 			}
 
@@ -942,6 +943,7 @@ namespace RTC
 #endif
 
 					this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
 					return;
 				}
 
@@ -1031,8 +1033,6 @@ namespace RTC
 			// Rewrite payload if needed. Drop packet if necessary.
 			if (!packet->ProcessPayload(this->encodingContext.get(), marker))
 			{
-				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
-
 #ifdef MS_RTC_LOGGER_RTP
 				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::DROPPED_BY_CODEC);
 #endif

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -645,6 +645,8 @@ namespace RTC
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::CONSUMER_INACTIVE);
 #endif
 
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
 			return;
 		}
 
@@ -658,6 +660,8 @@ namespace RTC
 #ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::INVALID_TARGET_LAYER);
 #endif
+
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -674,6 +678,8 @@ namespace RTC
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::UNSUPPORTED_PAYLOAD_TYPE);
 #endif
 
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
 			return;
 		}
 
@@ -684,17 +690,19 @@ namespace RTC
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
 #endif
 
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
 			return;
 		}
 
 		// Packets with only padding are not forwarded.
 		if (packet->GetPayloadLength() == 0)
 		{
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
-
 #ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::EMPTY_PAYLOAD);
 #endif
+
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
 
 			return;
 		}

--- a/worker/test/src/RTC/TestSimpleConsumer.cpp
+++ b/worker/test/src/RTC/TestSimpleConsumer.cpp
@@ -153,131 +153,131 @@ RtpStreamRecv* CreateRtpStreamRecv()
 
 SCENARIO("SimpleConsumer", "[rtp][consumer]")
 {
-	// clang-format off
+    // clang-format off
     uint8_t buffer[] =
     {
         0x80, 0x01, 0x00, 0x08,
         0x00, 0x00, 0x00, 0x04,
         0x00, 0x00, 0x00, 0x05
     };
-	// clang-format on
+    // clang-format on
 
-	SECTION("RTP packets are not forwarded when the consumer is not active")
-	{
-		auto* listener = new ConsumerListener();
-		auto* consumer = CreateConsumer(listener);
+    SECTION("RTP packets are not forwarded when the consumer is not active")
+    {
+        auto* listener = new ConsumerListener();
+        auto* consumer = CreateConsumer(listener);
 
-		auto* rtpStream = CreateRtpStreamRecv();
+        auto* rtpStream = CreateRtpStreamRecv();
 
-		// Set producer scores and producer stream.
-		std::vector<uint8_t> scores{ 10 };
+        // Set producer scores and producer stream.
+        std::vector<uint8_t> scores{ 10 };
 
-		consumer->ProducerRtpStreamScores(&scores);
-		consumer->ProducerNewRtpStream(rtpStream, 1234);
+        consumer->ProducerRtpStreamScores(&scores);
+        consumer->ProducerNewRtpStream(rtpStream, 1234);
 
-		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
-		std::shared_ptr<RtpPacket> sharedPacket;
+        std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+        std::shared_ptr<RtpPacket> sharedPacket;
 
-		packet->SetPayloadType(PayloadType);
-		packet->SetPayloadLength(64);
+        packet->SetPayloadType(PayloadType);
+        packet->SetPayloadLength(64);
 
-		consumer->SendRtpPacket(packet.get(), sharedPacket);
+        consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-		listener->Verify(0);
-	}
+        listener->Verify(0);
+    }
 
-	SECTION("RTP packets are not forwarded for unsupported payload types")
-	{
-		auto* listener = new ConsumerListener();
-		auto* consumer = CreateConsumer(listener);
+    SECTION("RTP packets are not forwarded for unsupported payload types")
+    {
+        auto* listener = new ConsumerListener();
+        auto* consumer = CreateConsumer(listener);
 
-		// Indicate that the transport is connected in order to activate the consumer.
-		dynamic_cast<Consumer*>(consumer)->TransportConnected();
+        // Indicate that the transport is connected in order to activate the consumer.
+        dynamic_cast<Consumer*>(consumer)->TransportConnected();
 
-		auto* rtpStream = CreateRtpStreamRecv();
+        auto* rtpStream = CreateRtpStreamRecv();
 
-		// Set producer scores and producer stream.
-		std::vector<uint8_t> scores{ 10 };
+        // Set producer scores and producer stream.
+        std::vector<uint8_t> scores{ 10 };
 
-		consumer->ProducerRtpStreamScores(&scores);
-		consumer->ProducerNewRtpStream(rtpStream, 1234);
+        consumer->ProducerRtpStreamScores(&scores);
+        consumer->ProducerNewRtpStream(rtpStream, 1234);
 
-		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
-		std::shared_ptr<RtpPacket> sharedPacket;
+        std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+        std::shared_ptr<RtpPacket> sharedPacket;
 
-		packet->SetPayloadType(PayloadType + 1);
-		packet->SetPayloadLength(64);
+        packet->SetPayloadType(PayloadType + 1);
+        packet->SetPayloadLength(64);
 
-		consumer->SendRtpPacket(packet.get(), sharedPacket);
+        consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-		listener->Verify(0);
-	}
+        listener->Verify(0);
+    }
 
-	SECTION("RTP packets with empty payload are not forwarded")
-	{
-		auto* listener = new ConsumerListener();
-		auto* consumer = CreateConsumer(listener);
+    SECTION("RTP packets with empty payload are not forwarded")
+    {
+        auto* listener = new ConsumerListener();
+        auto* consumer = CreateConsumer(listener);
 
-		// Indicate that the transport is connected in order to activate the consumer.
-		dynamic_cast<Consumer*>(consumer)->TransportConnected();
+        // Indicate that the transport is connected in order to activate the consumer.
+        dynamic_cast<Consumer*>(consumer)->TransportConnected();
 
-		auto* rtpStream = CreateRtpStreamRecv();
+        auto* rtpStream = CreateRtpStreamRecv();
 
-		// Set producer scores and producer stream.
-		std::vector<uint8_t> scores{ 10 };
+        // Set producer scores and producer stream.
+        std::vector<uint8_t> scores{ 10 };
 
-		consumer->ProducerRtpStreamScores(&scores);
-		consumer->ProducerNewRtpStream(rtpStream, 1234);
+        consumer->ProducerRtpStreamScores(&scores);
+        consumer->ProducerNewRtpStream(rtpStream, 1234);
 
-		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
-		std::shared_ptr<RtpPacket> sharedPacket;
+        std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+        std::shared_ptr<RtpPacket> sharedPacket;
 
-		packet->SetPayloadType(PayloadType + 1);
-		packet->SetPayloadLength(0);
+        packet->SetPayloadType(PayloadType + 1);
+        packet->SetPayloadLength(0);
 
-		consumer->SendRtpPacket(packet.get(), sharedPacket);
+        consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-		listener->Verify(0);
-	}
+        listener->Verify(0);
+    }
 
-	SECTION("outgoing RTP packets are forwarded with increased sequence number")
-	{
-		auto* listener = new ConsumerListener();
-		auto* consumer = CreateConsumer(listener);
+    SECTION("outgoing RTP packets are forwarded with increased sequence number")
+    {
+        auto* listener = new ConsumerListener();
+        auto* consumer = CreateConsumer(listener);
 
-		// Indicate that the transport is connected in order to activate the consumer.
-		dynamic_cast<Consumer*>(consumer)->TransportConnected();
+        // Indicate that the transport is connected in order to activate the consumer.
+        dynamic_cast<Consumer*>(consumer)->TransportConnected();
 
-		auto* rtpStream = CreateRtpStreamRecv();
+        auto* rtpStream = CreateRtpStreamRecv();
 
-		// Set producer scores and producer stream.
-		std::vector<uint8_t> scores{ 10 };
+        // Set producer scores and producer stream.
+        std::vector<uint8_t> scores{ 10 };
 
-		consumer->ProducerRtpStreamScores(&scores);
-		consumer->ProducerNewRtpStream(rtpStream, 1234);
+        consumer->ProducerRtpStreamScores(&scores);
+        consumer->ProducerNewRtpStream(rtpStream, 1234);
 
-		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
-		std::shared_ptr<RtpPacket> sharedPacket;
+        std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+        std::shared_ptr<RtpPacket> sharedPacket;
 
-		uint16_t seq = 1;
+        uint16_t seq = 1;
 
-		packet->SetSequenceNumber(seq++);
-		packet->SetPayloadType(PayloadType);
-		packet->SetPayloadLength(64);
+        packet->SetSequenceNumber(seq++);
+        packet->SetPayloadType(PayloadType);
+        packet->SetPayloadLength(64);
 
-		consumer->SendRtpPacket(packet.get(), sharedPacket);
+        consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-		packet->SetSequenceNumber(seq++);
-		consumer->SendRtpPacket(packet.get(), sharedPacket);
+        packet->SetSequenceNumber(seq++);
+        consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-		packet->SetSequenceNumber(seq++);
-		packet->SetPayloadLength(0);
-		consumer->SendRtpPacket(packet.get(), sharedPacket);
+        packet->SetSequenceNumber(seq++);
+        packet->SetPayloadLength(0);
+        consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-		packet->SetSequenceNumber(seq++);
-		packet->SetPayloadLength(20);
-		consumer->SendRtpPacket(packet.get(), sharedPacket);
+        packet->SetSequenceNumber(seq++);
+        packet->SetPayloadLength(20);
+        consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-		listener->Verify(3);
-	}
+        listener->Verify(3);
+    }
 }

--- a/worker/test/src/RTC/TestSimpleConsumer.cpp
+++ b/worker/test/src/RTC/TestSimpleConsumer.cpp
@@ -10,7 +10,11 @@
 
 using namespace RTC;
 
-const uint8_t PayloadType = 111;
+const uint8_t PayloadType       = 111;
+auto* channelMessageRegistrator = new ChannelMessageRegistrator();
+auto* channelSocket             = new Channel::ChannelSocket();
+auto* channelNotifier           = new Channel::ChannelNotifier(channelSocket);
+auto shared                     = Shared(channelMessageRegistrator, channelNotifier);
 
 class RtpStreamRecvListener : public RtpStreamRecv::Listener
 {
@@ -73,11 +77,11 @@ flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<FBS::RtpParamete
 {
 	std::vector<flatbuffers::Offset<FBS::RtpParameters::RtpEncodingParameters>> encodings;
 
-	auto* encoding = new RTC::RtpEncodingParameters();
+	auto encoding = RTC::RtpEncodingParameters();
 
-	encoding->ssrc = 1234567890;
+	encoding.ssrc = 1234567890;
 
-	encodings.emplace_back(encoding->FillBuffer(builder));
+	encodings.emplace_back(encoding.FillBuffer(builder));
 
 	return builder.CreateVector(encodings);
 };
@@ -102,13 +106,8 @@ flatbuffers::Offset<FBS::RtpParameters::RtpParameters> CreateRtpParameters(
 	return rtpParameters.FillBuffer(builder);
 };
 
-RTC::SimpleConsumer* CreateConsumer(ConsumerListener* listener)
+std::unique_ptr<RTC::SimpleConsumer> CreateConsumer(ConsumerListener* listener)
 {
-	auto* channelMessageRegistrator = new ChannelMessageRegistrator();
-	auto* channelSocket             = new Channel::ChannelSocket();
-	auto* channelNotifier           = new Channel::ChannelNotifier(channelSocket);
-	auto* shared                    = new Shared(channelMessageRegistrator, channelNotifier);
-
 	flatbuffers::FlatBufferBuilder bufferBuilder;
 
 	auto consumerId          = bufferBuilder.CreateString("consumerId");
@@ -116,39 +115,39 @@ RTC::SimpleConsumer* CreateConsumer(ConsumerListener* listener)
 	auto rtpParameters       = CreateRtpParameters(bufferBuilder);
 	auto consumableEncodings = CreateRtpEncodingParameters(bufferBuilder);
 
-	auto* consumeRequestBuilder = new FBS::Transport::ConsumeRequestBuilder(bufferBuilder);
+	auto consumeRequestBuilder = FBS::Transport::ConsumeRequestBuilder(bufferBuilder);
 
-	consumeRequestBuilder->add_consumerId(consumerId);
-	consumeRequestBuilder->add_producerId(producerId);
-	consumeRequestBuilder->add_kind(FBS::RtpParameters::MediaKind::AUDIO);
-	consumeRequestBuilder->add_rtpParameters(rtpParameters);
-	consumeRequestBuilder->add_type(FBS::RtpParameters::Type::SIMPLE);
-	consumeRequestBuilder->add_consumableRtpEncodings(consumableEncodings);
-	consumeRequestBuilder->add_paused(false);
-	consumeRequestBuilder->add_preferredLayers(0);
-	consumeRequestBuilder->add_ignoreDtx(false);
+	consumeRequestBuilder.add_consumerId(consumerId);
+	consumeRequestBuilder.add_producerId(producerId);
+	consumeRequestBuilder.add_kind(FBS::RtpParameters::MediaKind::AUDIO);
+	consumeRequestBuilder.add_rtpParameters(rtpParameters);
+	consumeRequestBuilder.add_type(FBS::RtpParameters::Type::SIMPLE);
+	consumeRequestBuilder.add_consumableRtpEncodings(consumableEncodings);
+	consumeRequestBuilder.add_paused(false);
+	consumeRequestBuilder.add_preferredLayers(0);
+	consumeRequestBuilder.add_ignoreDtx(false);
 
-	auto offset = consumeRequestBuilder->Finish();
+	auto offset = consumeRequestBuilder.Finish();
 	bufferBuilder.Finish(offset);
 
 	auto* buf = bufferBuilder.GetBufferPointer();
 
 	const auto* consumeRequest = flatbuffers::GetRoot<FBS::Transport::ConsumeRequest>(buf);
 
-	return new SimpleConsumer(
-	  shared,
+	return std::make_unique<SimpleConsumer>(
+	  &shared,
 	  consumeRequest->consumerId()->str(),
 	  consumeRequest->producerId()->str(),
 	  listener,
 	  consumeRequest);
 }
 
-RtpStreamRecv* CreateRtpStreamRecv()
+std::unique_ptr<RtpStreamRecv> CreateRtpStreamRecv()
 {
 	RtpStreamRecvListener streamRecvListener;
 	RtpStream::Params params;
 
-	return new RtpStreamRecv(&streamRecvListener, params, 0u, false);
+	return std::make_unique<RtpStreamRecv>(&streamRecvListener, params, 0u, false);
 }
 
 SCENARIO("SimpleConsumer", "[rtp][consumer]")
@@ -164,16 +163,15 @@ SCENARIO("SimpleConsumer", "[rtp][consumer]")
 
 	SECTION("RTP packets are not forwarded when the consumer is not active")
 	{
-		auto* listener = new ConsumerListener();
-		auto* consumer = CreateConsumer(listener);
-
-		auto* rtpStream = CreateRtpStreamRecv();
+		auto listener  = std::make_unique<ConsumerListener>();
+		auto consumer  = CreateConsumer(listener.get());
+		auto rtpStream = CreateRtpStreamRecv();
 
 		// Set producer scores and producer stream.
 		std::vector<uint8_t> scores{ 10 };
 
 		consumer->ProducerRtpStreamScores(&scores);
-		consumer->ProducerNewRtpStream(rtpStream, 1234);
+		consumer->ProducerNewRtpStream(rtpStream.get(), 1234);
 
 		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
 		std::shared_ptr<RtpPacket> sharedPacket;
@@ -188,19 +186,19 @@ SCENARIO("SimpleConsumer", "[rtp][consumer]")
 
 	SECTION("RTP packets are not forwarded for unsupported payload types")
 	{
-		auto* listener = new ConsumerListener();
-		auto* consumer = CreateConsumer(listener);
+		auto listener = std::make_unique<ConsumerListener>();
+		auto consumer = CreateConsumer(listener.get());
 
 		// Indicate that the transport is connected in order to activate the consumer.
-		dynamic_cast<Consumer*>(consumer)->TransportConnected();
+		dynamic_cast<Consumer*>(consumer.get())->TransportConnected();
 
-		auto* rtpStream = CreateRtpStreamRecv();
+		auto rtpStream = CreateRtpStreamRecv();
 
 		// Set producer scores and producer stream.
 		std::vector<uint8_t> scores{ 10 };
 
 		consumer->ProducerRtpStreamScores(&scores);
-		consumer->ProducerNewRtpStream(rtpStream, 1234);
+		consumer->ProducerNewRtpStream(rtpStream.get(), 1234);
 
 		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
 		std::shared_ptr<RtpPacket> sharedPacket;
@@ -215,19 +213,19 @@ SCENARIO("SimpleConsumer", "[rtp][consumer]")
 
 	SECTION("RTP packets with empty payload are not forwarded")
 	{
-		auto* listener = new ConsumerListener();
-		auto* consumer = CreateConsumer(listener);
+		auto listener = std::make_unique<ConsumerListener>();
+		auto consumer = CreateConsumer(listener.get());
 
 		// Indicate that the transport is connected in order to activate the consumer.
-		dynamic_cast<Consumer*>(consumer)->TransportConnected();
+		dynamic_cast<Consumer*>(consumer.get())->TransportConnected();
 
-		auto* rtpStream = CreateRtpStreamRecv();
+		auto rtpStream = CreateRtpStreamRecv();
 
 		// Set producer scores and producer stream.
 		std::vector<uint8_t> scores{ 10 };
 
 		consumer->ProducerRtpStreamScores(&scores);
-		consumer->ProducerNewRtpStream(rtpStream, 1234);
+		consumer->ProducerNewRtpStream(rtpStream.get(), 1234);
 
 		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
 		std::shared_ptr<RtpPacket> sharedPacket;
@@ -243,18 +241,18 @@ SCENARIO("SimpleConsumer", "[rtp][consumer]")
 	SECTION("outgoing RTP packets are forwarded with increased sequence number")
 	{
 		auto* listener = new ConsumerListener();
-		auto* consumer = CreateConsumer(listener);
+		auto consumer  = CreateConsumer(listener);
 
 		// Indicate that the transport is connected in order to activate the consumer.
-		dynamic_cast<Consumer*>(consumer)->TransportConnected();
+		dynamic_cast<Consumer*>(consumer.get())->TransportConnected();
 
-		auto* rtpStream = CreateRtpStreamRecv();
+		auto rtpStream = CreateRtpStreamRecv();
 
 		// Set producer scores and producer stream.
 		std::vector<uint8_t> scores{ 10 };
 
 		consumer->ProducerRtpStreamScores(&scores);
-		consumer->ProducerNewRtpStream(rtpStream, 1234);
+		consumer->ProducerNewRtpStream(rtpStream.get(), 1234);
 
 		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
 		std::shared_ptr<RtpPacket> sharedPacket;

--- a/worker/test/src/RTC/TestSimpleConsumer.cpp
+++ b/worker/test/src/RTC/TestSimpleConsumer.cpp
@@ -153,131 +153,131 @@ RtpStreamRecv* CreateRtpStreamRecv()
 
 SCENARIO("SimpleConsumer", "[rtp][consumer]")
 {
-    // clang-format off
+	// clang-format off
     uint8_t buffer[] =
     {
         0x80, 0x01, 0x00, 0x08,
         0x00, 0x00, 0x00, 0x04,
         0x00, 0x00, 0x00, 0x05
     };
-    // clang-format on
+	// clang-format on
 
-    SECTION("RTP packets are not forwarded when the consumer is not active")
-    {
-        auto* listener = new ConsumerListener();
-        auto* consumer = CreateConsumer(listener);
+	SECTION("RTP packets are not forwarded when the consumer is not active")
+	{
+		auto* listener = new ConsumerListener();
+		auto* consumer = CreateConsumer(listener);
 
-        auto* rtpStream = CreateRtpStreamRecv();
+		auto* rtpStream = CreateRtpStreamRecv();
 
-        // Set producer scores and producer stream.
-        std::vector<uint8_t> scores{ 10 };
+		// Set producer scores and producer stream.
+		std::vector<uint8_t> scores{ 10 };
 
-        consumer->ProducerRtpStreamScores(&scores);
-        consumer->ProducerNewRtpStream(rtpStream, 1234);
+		consumer->ProducerRtpStreamScores(&scores);
+		consumer->ProducerNewRtpStream(rtpStream, 1234);
 
-        std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
-        std::shared_ptr<RtpPacket> sharedPacket;
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+		std::shared_ptr<RtpPacket> sharedPacket;
 
-        packet->SetPayloadType(PayloadType);
-        packet->SetPayloadLength(64);
+		packet->SetPayloadType(PayloadType);
+		packet->SetPayloadLength(64);
 
-        consumer->SendRtpPacket(packet.get(), sharedPacket);
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-        listener->Verify(0);
-    }
+		listener->Verify(0);
+	}
 
-    SECTION("RTP packets are not forwarded for unsupported payload types")
-    {
-        auto* listener = new ConsumerListener();
-        auto* consumer = CreateConsumer(listener);
+	SECTION("RTP packets are not forwarded for unsupported payload types")
+	{
+		auto* listener = new ConsumerListener();
+		auto* consumer = CreateConsumer(listener);
 
-        // Indicate that the transport is connected in order to activate the consumer.
-        dynamic_cast<Consumer*>(consumer)->TransportConnected();
+		// Indicate that the transport is connected in order to activate the consumer.
+		dynamic_cast<Consumer*>(consumer)->TransportConnected();
 
-        auto* rtpStream = CreateRtpStreamRecv();
+		auto* rtpStream = CreateRtpStreamRecv();
 
-        // Set producer scores and producer stream.
-        std::vector<uint8_t> scores{ 10 };
+		// Set producer scores and producer stream.
+		std::vector<uint8_t> scores{ 10 };
 
-        consumer->ProducerRtpStreamScores(&scores);
-        consumer->ProducerNewRtpStream(rtpStream, 1234);
+		consumer->ProducerRtpStreamScores(&scores);
+		consumer->ProducerNewRtpStream(rtpStream, 1234);
 
-        std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
-        std::shared_ptr<RtpPacket> sharedPacket;
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+		std::shared_ptr<RtpPacket> sharedPacket;
 
-        packet->SetPayloadType(PayloadType + 1);
-        packet->SetPayloadLength(64);
+		packet->SetPayloadType(PayloadType + 1);
+		packet->SetPayloadLength(64);
 
-        consumer->SendRtpPacket(packet.get(), sharedPacket);
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-        listener->Verify(0);
-    }
+		listener->Verify(0);
+	}
 
-    SECTION("RTP packets with empty payload are not forwarded")
-    {
-        auto* listener = new ConsumerListener();
-        auto* consumer = CreateConsumer(listener);
+	SECTION("RTP packets with empty payload are not forwarded")
+	{
+		auto* listener = new ConsumerListener();
+		auto* consumer = CreateConsumer(listener);
 
-        // Indicate that the transport is connected in order to activate the consumer.
-        dynamic_cast<Consumer*>(consumer)->TransportConnected();
+		// Indicate that the transport is connected in order to activate the consumer.
+		dynamic_cast<Consumer*>(consumer)->TransportConnected();
 
-        auto* rtpStream = CreateRtpStreamRecv();
+		auto* rtpStream = CreateRtpStreamRecv();
 
-        // Set producer scores and producer stream.
-        std::vector<uint8_t> scores{ 10 };
+		// Set producer scores and producer stream.
+		std::vector<uint8_t> scores{ 10 };
 
-        consumer->ProducerRtpStreamScores(&scores);
-        consumer->ProducerNewRtpStream(rtpStream, 1234);
+		consumer->ProducerRtpStreamScores(&scores);
+		consumer->ProducerNewRtpStream(rtpStream, 1234);
 
-        std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
-        std::shared_ptr<RtpPacket> sharedPacket;
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+		std::shared_ptr<RtpPacket> sharedPacket;
 
-        packet->SetPayloadType(PayloadType + 1);
-        packet->SetPayloadLength(0);
+		packet->SetPayloadType(PayloadType + 1);
+		packet->SetPayloadLength(0);
 
-        consumer->SendRtpPacket(packet.get(), sharedPacket);
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-        listener->Verify(0);
-    }
+		listener->Verify(0);
+	}
 
-    SECTION("outgoing RTP packets are forwarded with increased sequence number")
-    {
-        auto* listener = new ConsumerListener();
-        auto* consumer = CreateConsumer(listener);
+	SECTION("outgoing RTP packets are forwarded with increased sequence number")
+	{
+		auto* listener = new ConsumerListener();
+		auto* consumer = CreateConsumer(listener);
 
-        // Indicate that the transport is connected in order to activate the consumer.
-        dynamic_cast<Consumer*>(consumer)->TransportConnected();
+		// Indicate that the transport is connected in order to activate the consumer.
+		dynamic_cast<Consumer*>(consumer)->TransportConnected();
 
-        auto* rtpStream = CreateRtpStreamRecv();
+		auto* rtpStream = CreateRtpStreamRecv();
 
-        // Set producer scores and producer stream.
-        std::vector<uint8_t> scores{ 10 };
+		// Set producer scores and producer stream.
+		std::vector<uint8_t> scores{ 10 };
 
-        consumer->ProducerRtpStreamScores(&scores);
-        consumer->ProducerNewRtpStream(rtpStream, 1234);
+		consumer->ProducerRtpStreamScores(&scores);
+		consumer->ProducerNewRtpStream(rtpStream, 1234);
 
-        std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
-        std::shared_ptr<RtpPacket> sharedPacket;
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+		std::shared_ptr<RtpPacket> sharedPacket;
 
-        uint16_t seq = 1;
+		uint16_t seq = 1;
 
-        packet->SetSequenceNumber(seq++);
-        packet->SetPayloadType(PayloadType);
-        packet->SetPayloadLength(64);
+		packet->SetSequenceNumber(seq++);
+		packet->SetPayloadType(PayloadType);
+		packet->SetPayloadLength(64);
 
-        consumer->SendRtpPacket(packet.get(), sharedPacket);
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-        packet->SetSequenceNumber(seq++);
-        consumer->SendRtpPacket(packet.get(), sharedPacket);
+		packet->SetSequenceNumber(seq++);
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-        packet->SetSequenceNumber(seq++);
-        packet->SetPayloadLength(0);
-        consumer->SendRtpPacket(packet.get(), sharedPacket);
+		packet->SetSequenceNumber(seq++);
+		packet->SetPayloadLength(0);
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-        packet->SetSequenceNumber(seq++);
-        packet->SetPayloadLength(20);
-        consumer->SendRtpPacket(packet.get(), sharedPacket);
+		packet->SetSequenceNumber(seq++);
+		packet->SetPayloadLength(20);
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
 
-        listener->Verify(3);
-    }
+		listener->Verify(3);
+	}
 }

--- a/worker/test/src/RTC/TestSimpleConsumer.cpp
+++ b/worker/test/src/RTC/TestSimpleConsumer.cpp
@@ -240,8 +240,8 @@ SCENARIO("SimpleConsumer", "[rtp][consumer]")
 
 	SECTION("outgoing RTP packets are forwarded with increased sequence number")
 	{
-		auto* listener = new ConsumerListener();
-		auto consumer  = CreateConsumer(listener);
+		auto listener = std::make_unique<ConsumerListener>();
+		auto consumer = CreateConsumer(listener.get());
 
 		// Indicate that the transport is connected in order to activate the consumer.
 		dynamic_cast<Consumer*>(consumer.get())->TransportConnected();

--- a/worker/test/src/RTC/TestSimpleConsumer.cpp
+++ b/worker/test/src/RTC/TestSimpleConsumer.cpp
@@ -1,0 +1,283 @@
+#include "flatbuffers/buffer.h"
+#include "Channel/ChannelNotifier.hpp"
+#include "Channel/ChannelSocket.hpp"
+#include "FBS/rtpParameters.h"
+#include "FBS/transport.h"
+#include "RTC/RtpDictionaries.hpp"
+#include "RTC/Shared.hpp"
+#include "RTC/SimpleConsumer.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+using namespace RTC;
+
+const uint8_t PayloadType = 111;
+
+class RtpStreamRecvListener : public RtpStreamRecv::Listener
+{
+public:
+	void OnRtpStreamScore(RtpStream* /*rtpStream*/, uint8_t /*score*/, uint8_t /*previousScore*/) override
+	{
+	}
+
+	void OnRtpStreamSendRtcpPacket(RtpStreamRecv* rtpStream, RTCP::Packet* packet) override
+	{
+	}
+
+	void OnRtpStreamNeedWorstRemoteFractionLost(
+	  RTC::RtpStreamRecv* /*rtpStream*/, uint8_t& /*worstRemoteFractionLost*/) override
+	{
+	}
+};
+
+class ConsumerListener : public Consumer::Listener
+{
+	void OnConsumerSendRtpPacket(RTC::Consumer* /*consumer*/, RTC::RtpPacket* packet) final
+	{
+		this->sent.push_back(packet->GetSequenceNumber());
+	};
+	void OnConsumerRetransmitRtpPacket(RTC::Consumer* consumer, RTC::RtpPacket* packet) final
+	{
+	}
+	void OnConsumerKeyFrameRequested(RTC::Consumer* consumer, uint32_t mappedSsrc) final{};
+	void OnConsumerNeedBitrateChange(RTC::Consumer* consumer) final{};
+	void OnConsumerNeedZeroBitrate(RTC::Consumer* consumer) final{};
+	void OnConsumerProducerClosed(RTC::Consumer* consumer) final{};
+
+public:
+	// Verifies that the given number of packets have been sent,
+	// and that the sequence numbers are consecutive.
+	void Verify(size_t size)
+	{
+		REQUIRE(this->sent.size() == size);
+
+		if (this->sent.size() <= 1)
+		{
+			return;
+		}
+
+		auto currentSeq = this->sent[0];
+
+		for (auto it = std::next(this->sent.begin()); it != this->sent.end(); ++it)
+		{
+			REQUIRE(*it == currentSeq + 1);
+			currentSeq = *it;
+		}
+	}
+
+private:
+	std::vector<uint16_t> sent;
+};
+
+flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<FBS::RtpParameters::RtpEncodingParameters>>> CreateRtpEncodingParameters(
+  flatbuffers::FlatBufferBuilder& builder)
+{
+	std::vector<flatbuffers::Offset<FBS::RtpParameters::RtpEncodingParameters>> encodings;
+
+	auto* encoding = new RTC::RtpEncodingParameters();
+
+	encoding->ssrc = 1234567890;
+
+	encodings.emplace_back(encoding->FillBuffer(builder));
+
+	return builder.CreateVector(encodings);
+};
+
+flatbuffers::Offset<FBS::RtpParameters::RtpParameters> CreateRtpParameters(
+  flatbuffers::FlatBufferBuilder& builder)
+{
+	auto rtpParameters = RTC::RtpParameters();
+	auto codec         = RTC::RtpCodecParameters();
+	auto encoding      = RTC::RtpEncodingParameters();
+
+	codec.mimeType.SetMimeType("audio/opus");
+	codec.payloadType = PayloadType;
+
+	encoding.ssrc = 1234567890;
+
+	rtpParameters.mid = "mid";
+	rtpParameters.codecs.emplace_back(codec);
+	rtpParameters.encodings.emplace_back(encoding);
+	rtpParameters.headerExtensions = std::vector<RtpHeaderExtensionParameters>();
+
+	return rtpParameters.FillBuffer(builder);
+};
+
+RTC::SimpleConsumer* CreateConsumer(ConsumerListener* listener)
+{
+	auto* channelMessageRegistrator = new ChannelMessageRegistrator();
+	auto* channelSocket             = new Channel::ChannelSocket();
+	auto* channelNotifier           = new Channel::ChannelNotifier(channelSocket);
+	auto* shared                    = new Shared(channelMessageRegistrator, channelNotifier);
+
+	flatbuffers::FlatBufferBuilder bufferBuilder;
+
+	auto consumerId          = bufferBuilder.CreateString("consumerId");
+	auto producerId          = bufferBuilder.CreateString("producerId");
+	auto rtpParameters       = CreateRtpParameters(bufferBuilder);
+	auto consumableEncodings = CreateRtpEncodingParameters(bufferBuilder);
+
+	auto* consumeRequestBuilder = new FBS::Transport::ConsumeRequestBuilder(bufferBuilder);
+
+	consumeRequestBuilder->add_consumerId(consumerId);
+	consumeRequestBuilder->add_producerId(producerId);
+	consumeRequestBuilder->add_kind(FBS::RtpParameters::MediaKind::AUDIO);
+	consumeRequestBuilder->add_rtpParameters(rtpParameters);
+	consumeRequestBuilder->add_type(FBS::RtpParameters::Type::SIMPLE);
+	consumeRequestBuilder->add_consumableRtpEncodings(consumableEncodings);
+	consumeRequestBuilder->add_paused(false);
+	consumeRequestBuilder->add_preferredLayers(0);
+	consumeRequestBuilder->add_ignoreDtx(false);
+
+	auto offset = consumeRequestBuilder->Finish();
+	bufferBuilder.Finish(offset);
+
+	auto* buf = bufferBuilder.GetBufferPointer();
+
+	const auto* consumeRequest = flatbuffers::GetRoot<FBS::Transport::ConsumeRequest>(buf);
+
+	return new SimpleConsumer(
+	  shared,
+	  consumeRequest->consumerId()->str(),
+	  consumeRequest->producerId()->str(),
+	  listener,
+	  consumeRequest);
+}
+
+RtpStreamRecv* CreateRtpStreamRecv()
+{
+	RtpStreamRecvListener streamRecvListener;
+	RtpStream::Params params;
+
+	return new RtpStreamRecv(&streamRecvListener, params, 0u, false);
+}
+
+SCENARIO("SimpleConsumer", "[rtp][consumer]")
+{
+	// clang-format off
+    uint8_t buffer[] =
+    {
+        0x80, 0x01, 0x00, 0x08,
+        0x00, 0x00, 0x00, 0x04,
+        0x00, 0x00, 0x00, 0x05
+    };
+	// clang-format on
+
+	SECTION("RTP packets are not forwarded when the consumer is not active")
+	{
+		auto* listener = new ConsumerListener();
+		auto* consumer = CreateConsumer(listener);
+
+		auto* rtpStream = CreateRtpStreamRecv();
+
+		// Set producer scores and producer stream.
+		std::vector<uint8_t> scores{ 10 };
+
+		consumer->ProducerRtpStreamScores(&scores);
+		consumer->ProducerNewRtpStream(rtpStream, 1234);
+
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+		std::shared_ptr<RtpPacket> sharedPacket;
+
+		packet->SetPayloadType(PayloadType);
+		packet->SetPayloadLength(64);
+
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
+
+		listener->Verify(0);
+	}
+
+	SECTION("RTP packets are not forwarded for unsupported payload types")
+	{
+		auto* listener = new ConsumerListener();
+		auto* consumer = CreateConsumer(listener);
+
+		// Indicate that the transport is connected in order to activate the consumer.
+		dynamic_cast<Consumer*>(consumer)->TransportConnected();
+
+		auto* rtpStream = CreateRtpStreamRecv();
+
+		// Set producer scores and producer stream.
+		std::vector<uint8_t> scores{ 10 };
+
+		consumer->ProducerRtpStreamScores(&scores);
+		consumer->ProducerNewRtpStream(rtpStream, 1234);
+
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+		std::shared_ptr<RtpPacket> sharedPacket;
+
+		packet->SetPayloadType(PayloadType + 1);
+		packet->SetPayloadLength(64);
+
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
+
+		listener->Verify(0);
+	}
+
+	SECTION("RTP packets with empty payload are not forwarded")
+	{
+		auto* listener = new ConsumerListener();
+		auto* consumer = CreateConsumer(listener);
+
+		// Indicate that the transport is connected in order to activate the consumer.
+		dynamic_cast<Consumer*>(consumer)->TransportConnected();
+
+		auto* rtpStream = CreateRtpStreamRecv();
+
+		// Set producer scores and producer stream.
+		std::vector<uint8_t> scores{ 10 };
+
+		consumer->ProducerRtpStreamScores(&scores);
+		consumer->ProducerNewRtpStream(rtpStream, 1234);
+
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+		std::shared_ptr<RtpPacket> sharedPacket;
+
+		packet->SetPayloadType(PayloadType + 1);
+		packet->SetPayloadLength(0);
+
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
+
+		listener->Verify(0);
+	}
+
+	SECTION("outgoing RTP packets are forwarded with increased sequence number")
+	{
+		auto* listener = new ConsumerListener();
+		auto* consumer = CreateConsumer(listener);
+
+		// Indicate that the transport is connected in order to activate the consumer.
+		dynamic_cast<Consumer*>(consumer)->TransportConnected();
+
+		auto* rtpStream = CreateRtpStreamRecv();
+
+		// Set producer scores and producer stream.
+		std::vector<uint8_t> scores{ 10 };
+
+		consumer->ProducerRtpStreamScores(&scores);
+		consumer->ProducerNewRtpStream(rtpStream, 1234);
+
+		std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+		std::shared_ptr<RtpPacket> sharedPacket;
+
+		uint16_t seq = 1;
+
+		packet->SetSequenceNumber(seq++);
+		packet->SetPayloadType(PayloadType);
+		packet->SetPayloadLength(64);
+
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
+
+		packet->SetSequenceNumber(seq++);
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
+
+		packet->SetSequenceNumber(seq++);
+		packet->SetPayloadLength(0);
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
+
+		packet->SetSequenceNumber(seq++);
+		packet->SetPayloadLength(20);
+		consumer->SendRtpPacket(packet.get(), sharedPacket);
+
+		listener->Verify(3);
+	}
+}


### PR DESCRIPTION
Drop the given sequence number if the RTP packet cannot be forwarded.

Fixes  #1069 

By not doing so, we are incorrectly generating non legitimate sequence number jumps which involves:

- The other end requesting NACKs for packets that do not exist, and us processing them.
- The other end waiting for those packets that will never arrive.
- Possible implications an jitter buffer and decoding level.

This problem is very apparent when using BWE and the available BW is low enough to discard a lot of packets, or when the outgoing bitrate is manually set low enough too.