### PR TITLE
rust: Implement feature flag to disable worker build

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ mediasoup and its client side libraries provide a super low level API. They are 
 - Data message exchange (via WebRTC DataChannels, SCTP over plain UDP, and direct termination in Node.js/Rust).
 - Extremely powerful (media worker thread/subprocess coded in C++ on top of [libuv](https://libuv.org)).
 
+## Including as a Dependency
+
+If you are including mediasoup a a dependency for it's prelude types and do not need access to the libmediasoup-worker bindings, you can include the project without the `worker` feature enabled to speed up compile times and reduce build dependencies.
+
+```toml
+[dependencies]
+mediasoup = { version = "0", default-features = false }
+```
+
 ## Demo Online
 
 [![][mediasoup-demo-screenshot]][mediasoup-demo]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -20,6 +20,10 @@ include = [
 default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
+[features]
+default = ["worker"]
+worker = ["mediasoup-sys/worker"]
+
 [dependencies]
 async-channel = "1.7.1"
 async-executor = "1.4.1"
@@ -47,6 +51,8 @@ version = "0.8.1"
 [dependencies.mediasoup-sys]
 path = "../worker"
 version = "0.9.1"
+default-features = false
+features = []
 
 [dependencies.parking_lot]
 version = "0.12.1"

--- a/rust/src/worker/utils.rs
+++ b/rust/src/worker/utils.rs
@@ -20,6 +20,9 @@ pub enum ExitError {
     /// Settings error.
     #[error("Worker exited with settings error")]
     Settings,
+    /// Feature not enabled.
+    #[error("Worker exited with feature not enabled error")]
+    FeatureNotEnabled,
     /// Unknown error.
     #[error("Worker exited with unknown error and status code {status_code}")]
     Unknown {
@@ -91,6 +94,7 @@ where
                 0 => Ok(()),
                 1 => Err(ExitError::Generic),
                 42 => Err(ExitError::Settings),
+                43 => Err(ExitError::FeatureNotEnabled),
                 status_code => Err(ExitError::Unknown { status_code }),
             });
         })

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -30,6 +30,10 @@ include = [
 default-target = "x86_64-unknown-linux-gnu"
 targets = []
 
+[features]
+default = ["worker"]
+worker = []
+
 [build-dependencies]
 planus-codegen = "0.4.0"
 planus-translation = "0.4.0"

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -1,17 +1,17 @@
+#[cfg(feature = "worker")]
 use std::process::Command;
 use std::{env, fs};
 
 fn main() {
-    // On Windows Rust always links against release version of MSVC runtime, thus requires
-    // Release build here
-    let build_type = if cfg!(all(debug_assertions, not(windows))) {
-        "Debug"
-    } else {
-        "Release"
-    };
-
     let out_dir = env::var("OUT_DIR").unwrap();
 
+    compile_flatbuffers(&out_dir);
+
+    #[cfg(feature = "worker")]
+    compile_worker(&out_dir);
+}
+
+fn compile_flatbuffers(out_dir: &str) {
     // Compile Rust flatbuffers
     let flatbuffers_declarations = planus_translation::translate_files(
         &fs::read_dir("fbs")
@@ -39,10 +39,22 @@ fn main() {
             .expect("Failed to generate Rust code from flatbuffers"),
     )
     .expect("Failed to write generated Rust flatbuffers into fbs.rs");
+}
+
+#[cfg(feature = "worker")]
+fn compile_worker(out_dir: &str) {
     if env::var("DOCS_RS").is_ok() {
-        // Skip everything when building docs on docs.rs
+        // Skip building libmediasoup-worker when building docs on docs.rs
         return;
     }
+
+    // On Windows Rust always links against release version of MSVC runtime, thus requires
+    // Release build here
+    let build_type = if cfg!(all(debug_assertions, not(windows))) {
+        "Debug"
+    } else {
+        "Release"
+    };
 
     // Force forward slashes on Windows too so that is plays well with our tasks.py
     let mediasoup_out_dir = format!("{}/out", out_dir.replace('\\', "/"));

--- a/worker/src/lib.rs
+++ b/worker/src/lib.rs
@@ -45,6 +45,7 @@ pub type ChannelWriteFn = unsafe extern "C" fn(
 
 unsafe impl Send for ChannelWriteCtx {}
 
+#[cfg(feature = "worker")]
 #[link(name = "mediasoup-worker", kind = "static")]
 extern "C" {
     /// Returns `0` on success, or an error code `< 0` on failure
@@ -61,4 +62,35 @@ extern "C" {
         channel_write_fn: ChannelWriteFn,
         channel_write_ctx: ChannelWriteCtx,
     ) -> c_int;
+}
+
+/// A stub implementation of uv_async_send when the worker feature is disabled
+///
+/// # Safety
+///
+/// This is a stub implementation that is safe to call with any value when the worker feature is disabled.
+#[cfg(not(feature = "worker"))]
+pub unsafe fn uv_async_send(_handle: UvAsyncT) -> c_int {
+    43
+}
+
+/// A stub implementation of mediasoup_worker_run when the worker feature is disabled
+///
+/// # Safety
+///
+/// This is a stub implementation that is safe to call with any values when the worker feature is disabled.
+#[cfg(not(feature = "worker"))]
+#[allow(clippy::too_many_arguments)]
+pub unsafe fn mediasoup_worker_run(
+    _argc: c_int,
+    _argv: *const *const c_char,
+    _version: *const c_char,
+    _consumer_channel_fd: c_int,
+    _producer_channel_fd: c_int,
+    _channel_read_fn: ChannelReadFn,
+    _channel_read_ctx: ChannelReadCtx,
+    _channel_write_fn: ChannelWriteFn,
+    _channel_write_ctx: ChannelWriteCtx,
+) -> c_int {
+    43
 }


### PR DESCRIPTION
The `mediasoup` crate may need to be included to allow for using prelude or other defined types without the need to include the `mediasoup-sys` bindings to `libmediasoup-worker`.

Place the compilation of `mediasoup-sys` behind a feature flag that is enabled by defaault. When the feature is disabled, build speeds are dramatically increased and the build dependencies of the library are not needed in the environment.

Example use-case: In our project, we have the mediasoup-based SFU separate from our websocket signaling server. However, since we are passing messages that contain mediasoup types in our message structs, we need to include the mediasoup crate. The websocket server has no need for the libmediasoup C++ bindings, but without this change we still have to build it when the crate is included. Compiling with the `worker` feature disabled drastically reduces compile times, and also lets us build on CI platforms without the dependencies that are typically needed for the C++ compilation.

Care has been taken to ensure that the default build still works as expected, including the existing `DOCS_RS` environment variable setting that provides similar functionality during the docs build.