### PR TITLE
CI: Remove deprecated ubuntu-20.04 host and add windows-2025, ubuntu-22.04-arm and ubuntu-24.04-arm

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -56,11 +56,13 @@ jobs:
             node: 22
             cc: gcc
             cxx: g++
-          - os: ubuntu-24.04-arm
-            node: 22
-            cc: gcc
-            cxx: g++
-            meson_args: '-Db_sanitize=address'
+          # TOOD: Uncomment when this issue is fixed:
+          # https://github.com/versatica/mediasoup/issues/1502
+          # - os: ubuntu-24.04-arm
+          #   node: 22
+          #   cc: gcc
+          #   cxx: g++
+          #   meson_args: '-Db_sanitize=address'
           - os: ubuntu-24.04-arm
             node: 22
             cc: clang

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -21,7 +21,15 @@ jobs:
             node: 18
             cc: gcc
             cxx: g++
+          - os: ubuntu-22.04-arm
+            node: 18
+            cc: gcc
+            cxx: g++
           - os: ubuntu-24.04
+            node: 20
+            cc: gcc
+            cxx: g++
+          - os: ubuntu-24.04-arm
             node: 20
             cc: gcc
             cxx: g++
@@ -40,6 +48,25 @@ jobs:
             cxx: clang++
             meson_args: '-Db_sanitize=undefined'
           - os: ubuntu-24.04
+            node: 22
+            cc: gcc
+            cxx: g++
+            meson_args: '-Db_sanitize=thread'
+          - os: ubuntu-24.04-arm
+            node: 22
+            cc: gcc
+            cxx: g++
+          - os: ubuntu-24.04-arm
+            node: 22
+            cc: gcc
+            cxx: g++
+            meson_args: '-Db_sanitize=address'
+          - os: ubuntu-24.04-arm
+            node: 22
+            cc: clang
+            cxx: clang++
+            meson_args: '-Db_sanitize=undefined'
+          - os: ubuntu-24.04-arm
             node: 22
             cc: gcc
             cxx: g++

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -2,7 +2,7 @@ name: mediasoup-node
 
 on:
   push:
-    branches: [ v3 ]
+    branches: [v3]
   pull_request:
   workflow_dispatch:
 
@@ -17,15 +17,15 @@ jobs:
     strategy:
       matrix:
         build:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             node: 18
             cc: gcc
             cxx: g++
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             node: 20
             cc: gcc
             cxx: g++
-          - os: ubuntu-22.04
+          - os: ubuntu-24.04
             node: 22
             cc: gcc
             cxx: g++
@@ -61,6 +61,10 @@ jobs:
             cc: cl
             cxx: cl
           - os: windows-2022
+            node: 22
+            cc: cl
+            cxx: cl
+          - os: windows-2025
             node: 22
             cc: cl
             cxx: cl

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -21,7 +21,9 @@ jobs:
       matrix:
         build:
           - os: ubuntu-22.04
+          - os: ubuntu-22.04-arm
           - os: ubuntu-24.04
+          - os: ubuntu-24.04-arm
           - os: macos-13
           - os: macos-14
           - os: macos-15

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -2,7 +2,7 @@ name: mediasoup-rust
 
 on:
   push:
-    branches: [ v3 ]
+    branches: [v3]
   pull_request:
   workflow_dispatch:
 
@@ -20,13 +20,13 @@ jobs:
     strategy:
       matrix:
         build:
-          - os: ubuntu-20.04
           - os: ubuntu-22.04
           - os: ubuntu-24.04
           - os: macos-13
           - os: macos-14
           - os: macos-15
           - os: windows-2022
+          - os: windows-2025
 
     runs-on: ${{ matrix.build.os }}
 

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -2,7 +2,7 @@ name: mediasoup-worker-fuzzer
 
 on:
   push:
-    branches: [ v3 ]
+    branches: [v3]
   pull_request:
   workflow_dispatch:
 
@@ -18,6 +18,10 @@ jobs:
       matrix:
         build:
           - os: ubuntu-24.04
+            cc: clang
+            cxx: clang++
+            pip-break-system-packages: true
+          - os: ubuntu-24.04-arm
             cc: clang
             cxx: clang++
             pip-break-system-packages: true

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -3,24 +3,18 @@ name: mediasoup-worker-prebuild
 # Only trigger on GitHub releases.
 on:
   release:
-    types: [ published ]
+    types: [published]
 
 jobs:
   ci:
     strategy:
       matrix:
         build:
-          # Worker prebuild for Linux with kernel version 5 Ubuntu (20.04).
-          # Let's use an old version of Ubuntu (20.04) that builds the
-          # mediasoup-worker binary using an old version of GLib, so it will work
+          # Worker prebuild for Linux with kernel version 6 Ubuntu (22.04).
+          # Let's use Ubuntu 22.04 instead of 24.04 so that it builds the
+          # mediasoup-worker binary using an old version of GLib that will work
           # on Linux hosts running more modern GLib versions.
           # See https://github.com/versatica/mediasoup/issues/1089.
-          - os: ubuntu-20.04
-            cc: gcc
-            cxx: g++
-          # Worker prebuild for Linux with kernel version 6 Ubuntu (22.04).
-          # Let's not use Ubuntu 24.04 to avoid same potential problem as described
-          # above.
           - os: ubuntu-22.04
             cc: gcc
             cxx: g++
@@ -34,6 +28,9 @@ jobs:
             cc: clang
             cxx: clang++
           - os: windows-2022
+            cc: cl
+            cxx: cl
+          - os: windows-2025
             cc: cl
             cxx: cl
         node:

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -18,6 +18,9 @@ jobs:
           - os: ubuntu-22.04
             cc: gcc
             cxx: g++
+          - os: ubuntu-22.04-arm
+            cc: gcc
+            cxx: g++
           - os: macos-13
             cc: clang
             cxx: clang++

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -74,6 +74,13 @@ jobs:
             run-test-asan-address: false
             run-test-asan-undefined: false
             run-test-asan-thread: false
+          - os: windows-2025
+            cc: cl
+            cxx: cl
+            # Address Sanitizer does not work on Windows.
+            run-test-asan-address: false
+            run-test-asan-undefined: false
+            run-test-asan-thread: false
         # A single Node.js version should be fine for C++.
         node:
           - 22

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -22,24 +22,34 @@ jobs:
           - os: ubuntu-22.04
             cc: gcc
             cxx: g++
+            run-lint: true
+            run-test: true
             run-test-asan-address: true
             run-test-asan-undefined: false
             run-test-asan-thread: true
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
+            run-lint: true
+            run-test: true
             run-test-asan-address: true
             run-test-asan-undefined: true
             run-test-asan-thread: true
           - os: ubuntu-22.04-arm
             cc: gcc
             cxx: g++
+            # No clang-format for ARM.
+            run-lint: false
+            run-test: true
             run-test-asan-address: true
             run-test-asan-undefined: false
             run-test-asan-thread: true
           - os: ubuntu-22.04-arm
             cc: clang
             cxx: clang++
+            # No clang-format for ARM.
+            run-lint: false
+            run-test: true
             run-test-asan-address: true
             run-test-asan-undefined: true
             run-test-asan-thread: true
@@ -47,6 +57,8 @@ jobs:
             cc: gcc
             cxx: g++
             pip-break-system-packages: true
+            run-lint: true
+            run-test: true
             run-test-asan-address: true
             run-test-asan-undefined: false
             run-test-asan-thread: true
@@ -54,6 +66,8 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
+            run-lint: true
+            run-test: true
             run-test-asan-address: true
             run-test-asan-undefined: true
             run-test-asan-thread: true
@@ -61,6 +75,9 @@ jobs:
             cc: gcc
             cxx: g++
             pip-break-system-packages: true
+            # No clang-format for ARM.
+            run-lint: false
+            run-test: true
             run-test-asan-address: true
             run-test-asan-undefined: false
             run-test-asan-thread: true
@@ -68,6 +85,9 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
+            # No clang-format for ARM.
+            run-lint: false
+            run-test: true
             run-test-asan-address: true
             run-test-asan-undefined: true
             run-test-asan-thread: true
@@ -75,6 +95,8 @@ jobs:
             cc: gcc
             cxx: g++
             pip-break-system-packages: true
+            run-lint: true
+            run-test: true
             # Address Sanitizer does not work on MacOS.
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -83,6 +105,8 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
+            run-lint: true
+            run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
             run-test-asan-thread: false
@@ -90,12 +114,18 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
+            run-lint: true
+            run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
             run-test-asan-thread: false
           - os: windows-2022
             cc: cl
             cxx: cl
+            # No clang-format for Windows.
+            run-lint: false
+            # Maybe some day we fix this.
+            run-test: true
             # Address Sanitizer does not work on Windows.
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -103,6 +133,10 @@ jobs:
           - os: windows-2025
             cc: cl
             cxx: cl
+            # No clang-format for Windows.
+            run-lint: false
+            # Maybe some day we fix this.
+            run-test: true
             # Address Sanitizer does not work on Windows.
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -152,20 +186,19 @@ jobs:
         run: pip3 install --break-system-packages invoke
 
       # We need to install npm deps of worker/scripts/package.json.
-      - if: runner.os != 'Windows'
+      - if: ${{ matrix.build.run-lint }}
         name: npm ci --prefix worker/scripts
         run: npm ci --prefix worker/scripts --foreground-scripts
 
-      # NOTE: Maybe make it work on Windows someday.
-      - if: runner.os != 'Windows'
+      - if: ${{ matrix.build.run-lint }}
         name: invoke -r worker lint
         run: invoke -r worker lint
 
       - name: invoke -r worker mediasoup-worker
         run: invoke -r worker mediasoup-worker
 
-      # NOTE: Maybe make it work on Windows someday.
       - if: runner.os != 'Windows'
+      - if: ${{ matrix.build.run-test }}
         name: invoke -r worker test
         run: invoke -r worker test
 

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -31,6 +31,18 @@ jobs:
             run-test-asan-address: true
             run-test-asan-undefined: true
             run-test-asan-thread: true
+          - os: ubuntu-22.04-arm
+            cc: gcc
+            cxx: g++
+            run-test-asan-address: true
+            run-test-asan-undefined: false
+            run-test-asan-thread: true
+          - os: ubuntu-22.04-arm
+            cc: clang
+            cxx: clang++
+            run-test-asan-address: true
+            run-test-asan-undefined: true
+            run-test-asan-thread: true
           - os: ubuntu-24.04
             cc: gcc
             cxx: g++
@@ -39,6 +51,20 @@ jobs:
             run-test-asan-undefined: false
             run-test-asan-thread: true
           - os: ubuntu-24.04
+            cc: clang
+            cxx: clang++
+            pip-break-system-packages: true
+            run-test-asan-address: true
+            run-test-asan-undefined: true
+            run-test-asan-thread: true
+          - os: ubuntu-24.04-arm
+            cc: gcc
+            cxx: g++
+            pip-break-system-packages: true
+            run-test-asan-address: true
+            run-test-asan-undefined: false
+            run-test-asan-thread: true
+          - os: ubuntu-24.04-arm
             cc: clang
             cxx: clang++
             pip-break-system-packages: true

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -125,7 +125,7 @@ jobs:
             # No clang-format for Windows.
             run-lint: false
             # Maybe some day we fix this.
-            run-test: true
+            run-test: false
             # Address Sanitizer does not work on Windows.
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -136,7 +136,7 @@ jobs:
             # No clang-format for Windows.
             run-lint: false
             # Maybe some day we fix this.
-            run-test: true
+            run-test: false
             # Address Sanitizer does not work on Windows.
             run-test-asan-address: false
             run-test-asan-undefined: false

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -2,7 +2,7 @@ name: mediasoup-worker
 
 on:
   push:
-    branches: [ v3 ]
+    branches: [v3]
   pull_request:
   workflow_dispatch:
 
@@ -19,25 +19,6 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          - os: ubuntu-20.04
-            cc: gcc
-            cxx: g++
-            # Workaround for this issue in Ubunt 20.04:
-            # https://github.com/versatica/mediasoup/actions/runs/9992113733/job/27616379442?pr=1427
-            workaround-ubuntu-20-04: true
-            run-test-asan-address: true
-            # Skip test-asan-undefined in Linux with GCC due to a bug in GCC
-            # that affects abseil-cpp:
-            # https://github.com/abseil/abseil-cpp/issues/1634
-            run-test-asan-undefined: false
-            run-test-asan-thread: true
-          - os: ubuntu-20.04
-            cc: clang
-            cxx: clang++
-            workaround-ubuntu-20-04: true
-            run-test-asan-address: true
-            run-test-asan-undefined: true
-            run-test-asan-thread: true
           - os: ubuntu-22.04
             cc: gcc
             cxx: g++
@@ -141,12 +122,6 @@ jobs:
       - if: runner.os != 'Windows'
         name: npm ci --prefix worker/scripts
         run: npm ci --prefix worker/scripts --foreground-scripts
-
-      # Workaround for this issue in Ubuntu 20.04:
-      # https://github.com/versatica/mediasoup/actions/runs/9992113733/job/27616379442?pr=1427
-      - if: ${{ matrix.build.workaround-ubuntu-20-04 }}
-        name: workaround for Ubuntu 20.04
-        run: sudo apt install -y libgcc-10-dev && sudo ln -s /usr/lib/gcc/x86_64-linux-gnu/10/libtsan_preinit.o /usr/lib/libtsan_preinit.o
 
       # NOTE: Maybe make it work on Windows someday.
       - if: runner.os != 'Windows'

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -197,7 +197,6 @@ jobs:
       - name: invoke -r worker mediasoup-worker
         run: invoke -r worker mediasoup-worker
 
-      - if: runner.os != 'Windows'
       - if: ${{ matrix.build.run-test }}
         name: invoke -r worker test
         run: invoke -r worker test


### PR DESCRIPTION
### Details

- https://github.com/actions/runner-images/issues/11101
- https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners