### PR TITLE
CI: Remove redundant hosts `macos-14` and `windows-2022` from `mediasoup-worker-prebuild` job

### DIFF
--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -24,15 +24,9 @@ jobs:
           - os: macos-13
             cc: clang
             cxx: clang++
-          - os: macos-14
-            cc: clang
-            cxx: clang++
           - os: macos-15
             cc: clang
             cxx: clang++
-          - os: windows-2022
-            cc: cl
-            cxx: cl
           - os: windows-2025
             cc: cl
             cxx: cl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- CI: Remove redundant hosts `macos-14` and `windows-2022` from `mediasoup-worker-prebuild` job ([PR #1506](https://github.com/versatica/mediasoup/pull/1506)).
+
 ### 3.15.6
 
 - CI: Remove deprecated `ubuntu-20.04` host and add `windows-2025`, `ubuntu-22.04-arm` and `ubuntu-24.04-arm` hosts ([PR #1500](https://github.com/versatica/mediasoup/pull/1500)).


### PR DESCRIPTION
## Details

- Remove `windows-2022` host because we also have `windows-2025` and both produce the same binary name so they override one to each other: `mediasoup-worker-3.15.6-win32-x64.tgz`
- Remove `macos-14` host because we also have `macos-15` (same reason).