### PR TITLE
Fix wrong SCTP stream parameters in SCTP `DataConsumer` that consumes from a direct `DataProducer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - CI: Remove redundant hosts `macos-14` and `windows-2022` from `mediasoup-worker-prebuild` job ([PR #1506](https://github.com/versatica/mediasoup/pull/1506)).
 - Node: Modernize code ([PR #1513](https://github.com/versatica/mediasoup/pull/1513)).
-- Fix wrong SCTP stream parameters in SCTP `DataConsumer` that consume from direct `DataProducers` ([PR #1516](https://github.com/versatica/mediasoup/pull/1516)).
+- Fix wrong SCTP stream parameters in SCTP `DataConsumer` that consumes from a direct `DataProducer` ([PR #1516](https://github.com/versatica/mediasoup/pull/1516)).
 
 ### 3.15.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - CI: Remove redundant hosts `macos-14` and `windows-2022` from `mediasoup-worker-prebuild` job ([PR #1506](https://github.com/versatica/mediasoup/pull/1506)).
 - Node: Modernize code ([PR #1513](https://github.com/versatica/mediasoup/pull/1513)).
+- Fix wrong SCTP stream parameters in SCTP `DataConsumer` that consume from direct `DataProducers` ([PR #1516](https://github.com/versatica/mediasoup/pull/1516)).
 
 ### 3.15.6
 

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -864,26 +864,25 @@ export abstract class TransportImpl<
 			this.#sctpStreamIds![sctpStreamId] = 1;
 			sctpStreamParameters.streamId = sctpStreamId;
 
-			// Override if given.
 			if (ordered !== undefined) {
 				sctpStreamParameters.ordered = ordered;
 
 				if (ordered) {
-					maxPacketLifeTime = undefined;
-					maxRetransmits = undefined;
 					sctpStreamParameters.maxPacketLifeTime = undefined;
 					sctpStreamParameters.maxRetransmits = undefined;
 				}
 			}
 
-			if (maxPacketLifeTime !== undefined) {
-				sctpStreamParameters.ordered = undefined;
-				sctpStreamParameters.maxPacketLifeTime = maxPacketLifeTime;
-			}
+			if (!ordered) {
+				if (maxPacketLifeTime !== undefined) {
+					sctpStreamParameters.ordered = false;
+					sctpStreamParameters.maxPacketLifeTime = maxPacketLifeTime;
+				}
 
-			if (maxRetransmits !== undefined) {
-				sctpStreamParameters.ordered = undefined;
-				sctpStreamParameters.maxRetransmits = maxRetransmits;
+				if (maxRetransmits !== undefined) {
+					sctpStreamParameters.ordered = false;
+					sctpStreamParameters.maxRetransmits = maxRetransmits;
+				}
 			}
 		}
 

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -830,15 +830,39 @@ export abstract class TransportImpl<
 		let sctpStreamParameters: SctpStreamParameters | undefined;
 		let sctpStreamId: number;
 
+		// If this is a DirectTransport, sctpStreamParameters must not be used.
+		if (this.type === 'direct') {
+			type = 'direct';
+
+			if (
+				ordered !== undefined ||
+				maxPacketLifeTime !== undefined ||
+				maxRetransmits !== undefined
+			) {
+				logger.warn(
+					'consumeData() | ordered, maxPacketLifeTime and maxRetransmits are ignored when consuming data on a DirectTransport'
+				);
+			}
+		}
 		// If this is not a DirectTransport, use sctpStreamParameters from the
 		// DataProducer (if type 'sctp') unless they are given in method parameters.
-		if (this.type !== 'direct') {
+		// If the DataProducer is type 'sctp' and no sctpStreamParameters are given,
+		// generate proper ones.
+		else {
 			type = 'sctp';
 
-			sctpStreamParameters =
-				utils.clone<SctpStreamParameters | undefined>(
-					dataProducer.sctpStreamParameters
-				) ?? ({} as SctpStreamParameters);
+			// This may throw.
+			sctpStreamId = this.getNextSctpStreamId();
+
+			sctpStreamParameters = dataProducer.sctpStreamParameters
+				? utils.clone<SctpStreamParameters>(dataProducer.sctpStreamParameters)
+				: {
+						streamId: sctpStreamId,
+						ordered: true,
+					};
+
+			this.#sctpStreamIds![sctpStreamId] = 1;
+			sctpStreamParameters.streamId = sctpStreamId;
 
 			// Override if given.
 			if (ordered !== undefined) {
@@ -851,26 +875,6 @@ export abstract class TransportImpl<
 
 			if (maxRetransmits !== undefined) {
 				sctpStreamParameters.maxRetransmits = maxRetransmits;
-			}
-
-			// This may throw.
-			sctpStreamId = this.getNextSctpStreamId();
-
-			this.#sctpStreamIds![sctpStreamId] = 1;
-			sctpStreamParameters.streamId = sctpStreamId;
-		}
-		// If this is a DirectTransport, sctpStreamParameters must not be used.
-		else {
-			type = 'direct';
-
-			if (
-				ordered !== undefined ||
-				maxPacketLifeTime !== undefined ||
-				maxRetransmits !== undefined
-			) {
-				logger.warn(
-					'consumeData() | ordered, maxPacketLifeTime and maxRetransmits are ignored when consuming data on a DirectTransport'
-				);
 			}
 		}
 

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -867,13 +867,22 @@ export abstract class TransportImpl<
 			// Override if given.
 			if (ordered !== undefined) {
 				sctpStreamParameters.ordered = ordered;
+
+				if (ordered) {
+					maxPacketLifeTime = undefined;
+					maxRetransmits = undefined;
+					sctpStreamParameters.maxPacketLifeTime = undefined;
+					sctpStreamParameters.maxRetransmits = undefined;
+				}
 			}
 
 			if (maxPacketLifeTime !== undefined) {
+				sctpStreamParameters.ordered = undefined;
 				sctpStreamParameters.maxPacketLifeTime = maxPacketLifeTime;
 			}
 
 			if (maxRetransmits !== undefined) {
+				sctpStreamParameters.ordered = undefined;
 				sctpStreamParameters.maxRetransmits = maxRetransmits;
 			}
 		}

--- a/node/src/test/test-DataConsumer.ts
+++ b/node/src/test/test-DataConsumer.ts
@@ -4,25 +4,27 @@ import type { WorkerEvents, DataConsumerEvents } from '../types';
 import * as utils from '../utils';
 
 type TestContext = {
-	dataProducerOptions: mediasoup.types.DataProducerOptions;
+	sctpDataProducerOptions: mediasoup.types.DataProducerOptions;
 	worker?: mediasoup.types.Worker;
 	router?: mediasoup.types.Router;
 	webRtcTransport1?: mediasoup.types.WebRtcTransport;
 	webRtcTransport2?: mediasoup.types.WebRtcTransport;
 	directTransport?: mediasoup.types.DirectTransport;
-	dataProducer?: mediasoup.types.DataProducer;
+	sctpDataProducer?: mediasoup.types.DataProducer;
+	directDataProducer?: mediasoup.types.DataProducer;
 };
 
 const ctx: TestContext = {
-	dataProducerOptions: utils.deepFreeze<mediasoup.types.DataProducerOptions>({
-		sctpStreamParameters: {
-			streamId: 12345,
-			ordered: false,
-			maxPacketLifeTime: 5000,
-		},
-		label: 'foo',
-		protocol: 'bar',
-	}),
+	sctpDataProducerOptions:
+		utils.deepFreeze<mediasoup.types.DataProducerOptions>({
+			sctpStreamParameters: {
+				streamId: 12345,
+				ordered: false,
+				maxPacketLifeTime: 5000,
+			},
+			label: 'foo',
+			protocol: 'bar',
+		}),
 };
 
 beforeEach(async () => {
@@ -37,9 +39,10 @@ beforeEach(async () => {
 		enableSctp: true,
 	});
 	ctx.directTransport = await ctx.router.createDirectTransport();
-	ctx.dataProducer = await ctx.webRtcTransport1.produceData(
-		ctx.dataProducerOptions
+	ctx.sctpDataProducer = await ctx.webRtcTransport1.produceData(
+		ctx.sctpDataProducerOptions
 	);
+	ctx.directDataProducer = await ctx.directTransport.produceData();
 });
 
 afterEach(async () => {
@@ -58,8 +61,8 @@ test('transport.consumeData() succeeds', async () => {
 		onObserverNewDataConsumer
 	);
 
-	const dataConsumer1 = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
+		dataProducerId: ctx.sctpDataProducer!.id,
 		maxPacketLifeTime: 4000,
 		// Valid values are 0...65535 so others and duplicated ones will be
 		// discarded.
@@ -68,49 +71,49 @@ test('transport.consumeData() succeeds', async () => {
 	});
 
 	expect(onObserverNewDataConsumer).toHaveBeenCalledTimes(1);
-	expect(onObserverNewDataConsumer).toHaveBeenCalledWith(dataConsumer1);
-	expect(typeof dataConsumer1.id).toBe('string');
-	expect(dataConsumer1.dataProducerId).toBe(ctx.dataProducer!.id);
-	expect(dataConsumer1.closed).toBe(false);
-	expect(dataConsumer1.type).toBe('sctp');
-	expect(typeof dataConsumer1.sctpStreamParameters).toBe('object');
-	expect(typeof dataConsumer1.sctpStreamParameters?.streamId).toBe('number');
-	expect(dataConsumer1.sctpStreamParameters?.ordered).toBe(false);
-	expect(dataConsumer1.sctpStreamParameters?.maxPacketLifeTime).toBe(4000);
-	expect(dataConsumer1.sctpStreamParameters?.maxRetransmits).toBeUndefined();
-	expect(dataConsumer1.label).toBe('foo');
-	expect(dataConsumer1.protocol).toBe('bar');
-	expect(dataConsumer1.paused).toBe(false);
-	expect(dataConsumer1.subchannels).toEqual(
+	expect(onObserverNewDataConsumer).toHaveBeenCalledWith(dataConsumer);
+	expect(typeof dataConsumer.id).toBe('string');
+	expect(dataConsumer.dataProducerId).toBe(ctx.sctpDataProducer!.id);
+	expect(dataConsumer.closed).toBe(false);
+	expect(dataConsumer.type).toBe('sctp');
+	expect(typeof dataConsumer.sctpStreamParameters).toBe('object');
+	expect(typeof dataConsumer.sctpStreamParameters!.streamId).toBe('number');
+	expect(dataConsumer.sctpStreamParameters!.ordered).toBe(false);
+	expect(dataConsumer.sctpStreamParameters!.maxPacketLifeTime).toBe(4000);
+	expect(dataConsumer.sctpStreamParameters!.maxRetransmits).toBeUndefined();
+	expect(dataConsumer.label).toBe('foo');
+	expect(dataConsumer.protocol).toBe('bar');
+	expect(dataConsumer.paused).toBe(false);
+	expect(dataConsumer.subchannels).toEqual(
 		expect.arrayContaining([0, 1, 2, 100, 65535])
 	);
-	expect(dataConsumer1.appData).toEqual({ baz: 'LOL' });
+	expect(dataConsumer.appData).toEqual({ baz: 'LOL' });
 
 	const dump = await ctx.router!.dump();
 
 	expect(dump.mapDataProducerIdDataConsumerIds).toEqual(
 		expect.arrayContaining([
-			{ key: ctx.dataProducer!.id, values: [dataConsumer1.id] },
+			{ key: ctx.sctpDataProducer!.id, values: [dataConsumer.id] },
 		])
 	);
 
 	expect(dump.mapDataConsumerIdDataProducerId).toEqual(
 		expect.arrayContaining([
-			{ key: dataConsumer1.id, value: ctx.dataProducer!.id },
+			{ key: dataConsumer.id, value: ctx.sctpDataProducer!.id },
 		])
 	);
 
 	await expect(ctx.webRtcTransport2!.dump()).resolves.toMatchObject({
 		id: ctx.webRtcTransport2!.id,
 		dataProducerIds: [],
-		dataConsumerIds: [dataConsumer1.id],
+		dataConsumerIds: [dataConsumer.id],
 	});
 }, 2000);
 
 test('dataConsumer.dump() succeeds', async () => {
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
-		maxPacketLifeTime: 4000,
+		dataProducerId: ctx.sctpDataProducer!.id,
+		ordered: true,
 		// Valid values are 0...65535 so others and duplicated ones will be
 		// discarded.
 		subchannels: [0, 1, 1, 1, 2, 65535, 65536, 65537, 100],
@@ -124,10 +127,10 @@ test('dataConsumer.dump() succeeds', async () => {
 	expect(dump.type).toBe('sctp');
 	expect(typeof dump.sctpStreamParameters).toBe('object');
 	expect(dump.sctpStreamParameters!.streamId).toBe(
-		dataConsumer.sctpStreamParameters?.streamId
+		dataConsumer.sctpStreamParameters!.streamId
 	);
-	expect(dump.sctpStreamParameters!.ordered).toBe(false);
-	expect(dump.sctpStreamParameters!.maxPacketLifeTime).toBe(4000);
+	expect(dump.sctpStreamParameters!.ordered).toBe(true);
+	expect(dump.sctpStreamParameters!.maxPacketLifeTime).toBeUndefined();
 	expect(dump.sctpStreamParameters!.maxRetransmits).toBeUndefined();
 	expect(dump.label).toBe('foo');
 	expect(dump.protocol).toBe('bar');
@@ -140,7 +143,7 @@ test('dataConsumer.dump() succeeds', async () => {
 
 test('dataConsumer.getStats() succeeds', async () => {
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: ctx.sctpDataProducer!.id,
 	});
 
 	await expect(dataConsumer.getStats()).resolves.toMatchObject([
@@ -156,7 +159,7 @@ test('dataConsumer.getStats() succeeds', async () => {
 
 test('dataConsumer.setSubchannels() succeeds', async () => {
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: ctx.sctpDataProducer!.id,
 	});
 
 	await dataConsumer.setSubchannels([999, 999, 998, 65536]);
@@ -168,7 +171,7 @@ test('dataConsumer.setSubchannels() succeeds', async () => {
 
 test('dataConsumer.addSubchannel() and .removeSubchannel() succeed', async () => {
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: ctx.sctpDataProducer!.id,
 	});
 
 	await dataConsumer.setSubchannels([]);
@@ -193,6 +196,83 @@ test('dataConsumer.addSubchannel() and .removeSubchannel() succeed', async () =>
 	expect(dataConsumer.subchannels).toEqual([]);
 }, 2000);
 
+test('transport.consumeData() from a direct DataProducer succeeds', async () => {
+	const onObserverNewDataConsumer = jest.fn();
+
+	ctx.webRtcTransport2!.observer.once(
+		'newdataconsumer',
+		onObserverNewDataConsumer
+	);
+
+	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
+		dataProducerId: ctx.directDataProducer!.id,
+	});
+
+	expect(onObserverNewDataConsumer).toHaveBeenCalledTimes(1);
+	expect(onObserverNewDataConsumer).toHaveBeenCalledWith(dataConsumer);
+	expect(typeof dataConsumer.id).toBe('string');
+	expect(dataConsumer.dataProducerId).toBe(ctx.directDataProducer!.id);
+	expect(dataConsumer.closed).toBe(false);
+	expect(dataConsumer.type).toBe('sctp');
+	expect(typeof dataConsumer.sctpStreamParameters).toBe('object');
+	expect(typeof dataConsumer.sctpStreamParameters!.streamId).toBe('number');
+	expect(dataConsumer.sctpStreamParameters!.ordered).toBe(true);
+	expect(dataConsumer.sctpStreamParameters!.maxPacketLifeTime).toBeUndefined();
+	expect(dataConsumer.sctpStreamParameters!.maxRetransmits).toBeUndefined();
+	expect(dataConsumer.label).toBe('');
+	expect(dataConsumer.protocol).toBe('');
+	expect(dataConsumer.paused).toBe(false);
+	expect(dataConsumer.subchannels).toEqual([]);
+	expect(dataConsumer.appData).toEqual({});
+
+	const dump = await ctx.router!.dump();
+
+	expect(dump.mapDataProducerIdDataConsumerIds).toEqual(
+		expect.arrayContaining([
+			{ key: ctx.directDataProducer!.id, values: [dataConsumer.id] },
+		])
+	);
+
+	expect(dump.mapDataConsumerIdDataProducerId).toEqual(
+		expect.arrayContaining([
+			{ key: dataConsumer.id, value: ctx.directDataProducer!.id },
+		])
+	);
+
+	await expect(ctx.webRtcTransport2!.dump()).resolves.toMatchObject({
+		id: ctx.webRtcTransport2!.id,
+		dataProducerIds: [],
+		dataConsumerIds: [dataConsumer.id],
+	});
+}, 2000);
+
+test('dataConsumer.dump() consuming from a direct DataProducer succeeds', async () => {
+	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
+		dataProducerId: ctx.directDataProducer!.id,
+		ordered: false,
+		maxRetransmits: 2,
+		subchannels: [0, 1],
+	});
+
+	const dump = await dataConsumer.dump();
+
+	expect(dump.id).toBe(dataConsumer.id);
+	expect(dump.dataProducerId).toBe(dataConsumer.dataProducerId);
+	expect(dump.type).toBe('sctp');
+	expect(typeof dump.sctpStreamParameters).toBe('object');
+	expect(dump.sctpStreamParameters!.streamId).toBe(
+		dataConsumer.sctpStreamParameters!.streamId
+	);
+	expect(dump.sctpStreamParameters!.ordered).toBe(false);
+	expect(dump.sctpStreamParameters!.maxPacketLifeTime).toBeUndefined();
+	expect(dump.sctpStreamParameters!.maxRetransmits).toBe(2);
+	expect(dump.label).toBe('');
+	expect(dump.protocol).toBe('');
+	expect(dump.paused).toBe(false);
+	expect(dump.dataProducerPaused).toBe(false);
+	expect(dump.subchannels).toEqual(expect.arrayContaining([0, 1]));
+}, 2000);
+
 test('transport.consumeData() on a DirectTransport succeeds', async () => {
 	const onObserverNewDataConsumer = jest.fn();
 
@@ -202,7 +282,7 @@ test('transport.consumeData() on a DirectTransport succeeds', async () => {
 	);
 
 	const dataConsumer = await ctx.directTransport!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: ctx.sctpDataProducer!.id,
 		paused: true,
 		appData: { hehe: 'HEHE' },
 	});
@@ -210,7 +290,7 @@ test('transport.consumeData() on a DirectTransport succeeds', async () => {
 	expect(onObserverNewDataConsumer).toHaveBeenCalledTimes(1);
 	expect(onObserverNewDataConsumer).toHaveBeenCalledWith(dataConsumer);
 	expect(typeof dataConsumer.id).toBe('string');
-	expect(dataConsumer.dataProducerId).toBe(ctx.dataProducer!.id);
+	expect(dataConsumer.dataProducerId).toBe(ctx.sctpDataProducer!.id);
 	expect(dataConsumer.closed).toBe(false);
 	expect(dataConsumer.type).toBe('direct');
 	expect(dataConsumer.sctpStreamParameters).toBeUndefined();
@@ -221,14 +301,14 @@ test('transport.consumeData() on a DirectTransport succeeds', async () => {
 
 	await expect(ctx.directTransport!.dump()).resolves.toMatchObject({
 		id: ctx.directTransport!.id,
-		dataProducerIds: [],
+		dataProducerIds: [ctx.directDataProducer!.id],
 		dataConsumerIds: [dataConsumer.id],
 	});
 }, 2000);
 
 test('dataConsumer.dump() on a DirectTransport succeeds', async () => {
 	const dataConsumer = await ctx.directTransport!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: ctx.sctpDataProducer!.id,
 		paused: true,
 	});
 
@@ -246,7 +326,7 @@ test('dataConsumer.dump() on a DirectTransport succeeds', async () => {
 
 test('dataConsumer.getStats() on a DirectTransport succeeds', async () => {
 	const dataConsumer = await ctx.directTransport!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: ctx.sctpDataProducer!.id,
 	});
 
 	await expect(dataConsumer.getStats()).resolves.toMatchObject([
@@ -265,7 +345,7 @@ test('dataConsumer.pause() and resume() succeed', async () => {
 	const onObserverResume = jest.fn();
 
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: ctx.sctpDataProducer!.id,
 	});
 
 	dataConsumer.observer.on('pause', onObserverPause);
@@ -302,7 +382,7 @@ test('dataConsumer.pause() and resume() succeed', async () => {
 
 test('dataProducer.pause() and resume() emit events', async () => {
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: ctx.sctpDataProducer!.id,
 	});
 	const promises = [];
 	const events: string[] = [];
@@ -315,8 +395,8 @@ test('dataProducer.pause() and resume() emit events', async () => {
 		events.push('pause');
 	});
 
-	promises.push(ctx.dataProducer!.pause());
-	promises.push(ctx.dataProducer!.resume());
+	promises.push(ctx.sctpDataProducer!.pause());
+	promises.push(ctx.sctpDataProducer!.resume());
 
 	await Promise.all(promises);
 
@@ -330,7 +410,7 @@ test('dataProducer.pause() and resume() emit events', async () => {
 test('dataConsumer.close() succeeds', async () => {
 	const onObserverClose = jest.fn();
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: ctx.sctpDataProducer!.id,
 	});
 
 	dataConsumer.observer.once('close', onObserverClose);
@@ -342,7 +422,7 @@ test('dataConsumer.close() succeeds', async () => {
 	const dump = await ctx.router!.dump();
 
 	expect(dump.mapDataProducerIdDataConsumerIds).toEqual(
-		expect.arrayContaining([{ key: ctx.dataProducer!.id, values: [] }])
+		expect.arrayContaining([{ key: ctx.sctpDataProducer!.id, values: [] }])
 	);
 
 	expect(dump.mapDataConsumerIdDataProducerId).toEqual([]);
@@ -356,7 +436,7 @@ test('dataConsumer.close() succeeds', async () => {
 
 test('Consumer methods reject if closed', async () => {
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: ctx.sctpDataProducer!.id,
 	});
 
 	dataConsumer.close();
@@ -368,7 +448,7 @@ test('Consumer methods reject if closed', async () => {
 
 test('DataConsumer emits "dataproducerclose" if DataProducer is closed', async () => {
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: ctx.sctpDataProducer!.id,
 	});
 	const onObserverClose = jest.fn();
 
@@ -379,7 +459,7 @@ test('DataConsumer emits "dataproducerclose" if DataProducer is closed', async (
 		'dataproducerclose'
 	);
 
-	ctx.dataProducer!.close();
+	ctx.sctpDataProducer!.close();
 	await promise;
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
@@ -388,7 +468,7 @@ test('DataConsumer emits "dataproducerclose" if DataProducer is closed', async (
 
 test('DataConsumer emits "transportclose" if Transport is closed', async () => {
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: ctx.sctpDataProducer!.id,
 	});
 	const onObserverClose = jest.fn();
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # NEXT
 
+- Fix wrong SCTP stream parameters in SCTP `DataConsumer` that consumes from a direct `DataProducer` (PR #1516).
+
 # 0.17.2
 
 - Fix `PipeConsumer::get_stats()` (PR #1511).

--- a/rust/src/router/data_consumer.rs
+++ b/rust/src/router/data_consumer.rs
@@ -100,7 +100,7 @@ impl DataConsumerOptions {
     pub fn new_sctp_ordered(data_producer_id: DataProducerId) -> Self {
         Self {
             data_producer_id,
-            ordered: None,
+            ordered: Some(true),
             max_packet_life_time: None,
             max_retransmits: None,
             paused: false,
@@ -118,7 +118,7 @@ impl DataConsumerOptions {
     ) -> Self {
         Self {
             data_producer_id,
-            ordered: None,
+            ordered: Some(false),
             max_packet_life_time: Some(max_packet_life_time),
             max_retransmits: None,
             paused: false,
@@ -135,7 +135,7 @@ impl DataConsumerOptions {
     ) -> Self {
         Self {
             data_producer_id,
-            ordered: None,
+            ordered: Some(false),
             max_packet_life_time: None,
             max_retransmits: Some(max_retransmits),
             paused: false,

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -789,8 +789,8 @@ pub(super) trait TransportImpl: TransportGeneric {
                     SctpStreamParameters {
                         stream_id,
                         ordered: true,
-                        max_packet_life_time,
-                        max_retransmits,
+                        max_packet_life_time: None,
+                        max_retransmits: None,
                     },
                     |mut sctp_parameters| {
                         sctp_parameters.stream_id = stream_id;
@@ -800,12 +800,21 @@ pub(super) trait TransportImpl: TransportGeneric {
                 );
                 if let Some(ordered) = ordered {
                     sctp_stream_parameters.ordered = ordered;
+
+                    if ordered {
+                        sctp_stream_parameters.max_packet_life_time = None;
+                        sctp_stream_parameters.max_retransmits = None;
+                    }
                 }
-                if let Some(max_packet_life_time) = max_packet_life_time {
-                    sctp_stream_parameters.max_packet_life_time = Some(max_packet_life_time);
-                }
-                if let Some(max_retransmits) = max_retransmits {
-                    sctp_stream_parameters.max_retransmits = Some(max_retransmits);
+                if ordered != Some(true) {
+                    if let Some(max_packet_life_time) = max_packet_life_time {
+                        sctp_stream_parameters.ordered = false;
+                        sctp_stream_parameters.max_packet_life_time = Some(max_packet_life_time);
+                    }
+                    if let Some(max_retransmits) = max_retransmits {
+                        sctp_stream_parameters.ordered = false;
+                        sctp_stream_parameters.max_retransmits = Some(max_retransmits);
+                    }
                 }
 
                 Some(sctp_stream_parameters)

--- a/rust/tests/integration/data_consumer.rs
+++ b/rust/tests/integration/data_consumer.rs
@@ -447,11 +447,10 @@ fn consume_data_from_a_direct_data_producer_succeeds() {
             .expect("Failed to create data producer");
 
         let data_consumer = webrtc_transport
-            .consume_data({
-                let options = DataConsumerOptions::new_direct(direct_data_producer.id(), None);
-
-                options
-            })
+            .consume_data(DataConsumerOptions::new_direct(
+                direct_data_producer.id(),
+                None,
+            ))
             .await
             .expect("Failed to consume data");
 
@@ -497,14 +496,10 @@ fn dump_consuming_from_a_direct_data_producer_succeeds() {
             .expect("Failed to create data producer");
 
         let data_consumer = webrtc_transport
-            .consume_data({
-                let options = DataConsumerOptions::new_sctp_unordered_with_retransmits(
-                    direct_data_producer.id(),
-                    2,
-                );
-
-                options
-            })
+            .consume_data(DataConsumerOptions::new_sctp_unordered_with_retransmits(
+                direct_data_producer.id(),
+                2,
+            ))
             .await
             .expect("Failed to consume data");
 

--- a/rust/tests/integration/data_consumer.rs
+++ b/rust/tests/integration/data_consumer.rs
@@ -28,7 +28,7 @@ struct CustomAppData2 {
     hehe: &'static str,
 }
 
-fn data_producer_options() -> DataProducerOptions {
+fn sctp_data_producer_options() -> DataProducerOptions {
     let mut options = DataProducerOptions::new_sctp(
         SctpStreamParameters::new_unordered_with_life_time(12345, 5000),
     );
@@ -60,7 +60,7 @@ async fn init() -> (Worker, Router, WebRtcTransport, DataProducer) {
         .await
         .expect("Failed to create router");
 
-    let transport = router
+    let webrtc_transport = router
         .create_webrtc_transport({
             let mut transport_options =
                 WebRtcTransportOptions::new(WebRtcTransportListenInfos::new(ListenInfo {
@@ -81,20 +81,20 @@ async fn init() -> (Worker, Router, WebRtcTransport, DataProducer) {
         .await
         .expect("Failed to create transport1");
 
-    let data_producer = transport
-        .produce_data(data_producer_options())
+    let sctp_data_producer = webrtc_transport
+        .produce_data(sctp_data_producer_options())
         .await
         .expect("Failed to create data producer");
 
-    (worker, router, transport, data_producer)
+    (worker, router, webrtc_transport, sctp_data_producer)
 }
 
 #[test]
 fn consume_data_succeeds() {
     future::block_on(async move {
-        let (_worker, router, _transport1, data_producer) = init().await;
+        let (_worker, router, _webrtc_transport, sctp_data_producer) = init().await;
 
-        let transport2 = router
+        let plain_transport = router
             .create_plain_transport({
                 let mut transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
@@ -116,7 +116,7 @@ fn consume_data_succeeds() {
 
         let new_data_consumer_count = Arc::new(AtomicUsize::new(0));
 
-        transport2
+        plain_transport
             .on_new_data_consumer({
                 let new_data_consumer_count = Arc::clone(&new_data_consumer_count);
 
@@ -126,12 +126,9 @@ fn consume_data_succeeds() {
             })
             .detach();
 
-        let data_consumer = transport2
+        let data_consumer = plain_transport
             .consume_data({
-                let mut options = DataConsumerOptions::new_sctp_unordered_with_life_time(
-                    data_producer.id(),
-                    4000,
-                );
+                let mut options = DataConsumerOptions::new_sctp(sctp_data_producer.id());
 
                 options.subchannels = Some(vec![0, 1, 1, 1, 2, 65535, 100]);
                 options.app_data = AppData::new(CustomAppData { baz: "LOL" });
@@ -141,8 +138,7 @@ fn consume_data_succeeds() {
             .await
             .expect("Failed to consume data");
 
-        assert_eq!(new_data_consumer_count.load(Ordering::SeqCst), 1);
-        assert_eq!(data_consumer.data_producer_id(), data_producer.id());
+        assert_eq!(data_consumer.data_producer_id(), sctp_data_producer.id());
         assert!(!data_consumer.closed());
         assert_eq!(data_consumer.r#type(), DataConsumerType::Sctp);
         {
@@ -151,7 +147,7 @@ fn consume_data_succeeds() {
             assert!(!sctp_stream_parameters.unwrap().ordered());
             assert_eq!(
                 sctp_stream_parameters.unwrap().max_packet_life_time(),
-                Some(4000),
+                Some(5000)
             );
             assert_eq!(sctp_stream_parameters.unwrap().max_retransmits(), None);
         }
@@ -176,7 +172,7 @@ fn consume_data_succeeds() {
 
             assert_eq!(dump.map_data_producer_id_data_consumer_ids, {
                 let mut map = HashedMap::default();
-                map.insert(data_producer.id(), {
+                map.insert(sctp_data_producer.id(), {
                     let mut set = HashedSet::default();
                     set.insert(data_consumer.id());
                     set
@@ -185,15 +181,18 @@ fn consume_data_succeeds() {
             });
             assert_eq!(dump.map_data_consumer_id_data_producer_id, {
                 let mut map = HashedMap::default();
-                map.insert(data_consumer.id(), data_producer.id());
+                map.insert(data_consumer.id(), sctp_data_producer.id());
                 map
             });
         }
 
         {
-            let dump = transport2.dump().await.expect("Failed to dump transport");
+            let dump = plain_transport
+                .dump()
+                .await
+                .expect("Failed to dump transport");
 
-            assert_eq!(dump.id, transport2.id());
+            assert_eq!(dump.id, plain_transport.id());
             assert_eq!(dump.data_producer_ids, vec![]);
             assert_eq!(dump.data_consumer_ids, vec![data_consumer.id()]);
         }
@@ -203,9 +202,9 @@ fn consume_data_succeeds() {
 #[test]
 fn weak() {
     future::block_on(async move {
-        let (_worker, router, _transport1, data_producer) = init().await;
+        let (_worker, router, _webrtc_transport, sctp_data_producer) = init().await;
 
-        let transport2 = router
+        let plain_transport = router
             .create_plain_transport({
                 let mut transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
@@ -225,10 +224,10 @@ fn weak() {
             .await
             .expect("Failed to create transport1");
 
-        let data_consumer = transport2
+        let data_consumer = plain_transport
             .consume_data({
                 let mut options = DataConsumerOptions::new_sctp_unordered_with_life_time(
-                    data_producer.id(),
+                    sctp_data_producer.id(),
                     4000,
                 );
 
@@ -252,14 +251,11 @@ fn weak() {
 #[test]
 fn dump_succeeds() {
     future::block_on(async move {
-        let (_worker, _router, transport, data_producer) = init().await;
+        let (_worker, _router, webrtc_transport, sctp_data_producer) = init().await;
 
-        let data_consumer = transport
+        let data_consumer = webrtc_transport
             .consume_data({
-                let mut options = DataConsumerOptions::new_sctp_unordered_with_life_time(
-                    data_producer.id(),
-                    4000,
-                );
+                let mut options = DataConsumerOptions::new_sctp_ordered(sctp_data_producer.id());
 
                 options.app_data = AppData::new(CustomAppData { baz: "LOL" });
 
@@ -283,11 +279,8 @@ fn dump_succeeds() {
                 sctp_stream_parameters.unwrap().stream_id(),
                 data_consumer.sctp_stream_parameters().unwrap().stream_id(),
             );
-            assert!(!sctp_stream_parameters.unwrap().ordered());
-            assert_eq!(
-                sctp_stream_parameters.unwrap().max_packet_life_time(),
-                Some(4000),
-            );
+            assert!(sctp_stream_parameters.unwrap().ordered());
+            assert_eq!(sctp_stream_parameters.unwrap().max_packet_life_time(), None);
             assert_eq!(sctp_stream_parameters.unwrap().max_retransmits(), None);
         }
         assert_eq!(dump.label.as_str(), "foo");
@@ -298,12 +291,12 @@ fn dump_succeeds() {
 #[test]
 fn get_stats_succeeds() {
     future::block_on(async move {
-        let (_worker, _router, transport, data_producer) = init().await;
+        let (_worker, _router, webrtc_transport, sctp_data_producer) = init().await;
 
-        let data_consumer = transport
+        let data_consumer = webrtc_transport
             .consume_data({
                 let mut options = DataConsumerOptions::new_sctp_unordered_with_life_time(
-                    data_producer.id(),
+                    sctp_data_producer.id(),
                     4000,
                 );
 
@@ -330,11 +323,11 @@ fn get_stats_succeeds() {
 #[test]
 fn set_subchannels() {
     future::block_on(async move {
-        let (_worker, _router, transport1, data_producer) = init().await;
+        let (_worker, _router, transport1, sctp_data_producer) = init().await;
 
         let data_consumer = transport1
             .consume_data(DataConsumerOptions::new_sctp_unordered_with_life_time(
-                data_producer.id(),
+                sctp_data_producer.id(),
                 4000,
             ))
             .await
@@ -355,11 +348,11 @@ fn set_subchannels() {
 #[test]
 fn add_and_remove_subchannel() {
     future::block_on(async move {
-        let (_worker, _router, transport1, data_producer) = init().await;
+        let (_worker, _router, transport1, sctp_data_producer) = init().await;
 
         let data_consumer = transport1
             .consume_data(DataConsumerOptions::new_sctp_unordered_with_life_time(
-                data_producer.id(),
+                sctp_data_producer.id(),
                 4000,
             ))
             .await
@@ -439,18 +432,115 @@ fn add_and_remove_subchannel() {
 }
 
 #[test]
+fn consume_data_from_a_direct_data_producer_succeeds() {
+    future::block_on(async move {
+        let (_worker, router, webrtc_transport, sctp_data_producer) = init().await;
+
+        let direct_transport = router
+            .create_direct_transport(DirectTransportOptions::default())
+            .await
+            .expect("Failed to create Direct transport");
+
+        let direct_data_producer = direct_transport
+            .produce_data(DataProducerOptions::new_direct())
+            .await
+            .expect("Failed to create data producer");
+
+        let data_consumer = webrtc_transport
+            .consume_data({
+                let options = DataConsumerOptions::new_direct(direct_data_producer.id(), None);
+
+                options
+            })
+            .await
+            .expect("Failed to consume data");
+
+        assert_eq!(data_consumer.data_producer_id(), direct_data_producer.id());
+        assert!(!data_consumer.closed());
+        assert_eq!(data_consumer.r#type(), DataConsumerType::Sctp);
+        {
+            let sctp_stream_parameters = data_consumer.sctp_stream_parameters();
+            assert!(sctp_stream_parameters.is_some());
+            assert!(sctp_stream_parameters.unwrap().ordered());
+            assert_eq!(sctp_stream_parameters.unwrap().max_packet_life_time(), None);
+            assert_eq!(sctp_stream_parameters.unwrap().max_retransmits(), None);
+        }
+        assert_eq!(data_consumer.label().as_str(), "");
+        assert_eq!(data_consumer.protocol().as_str(), "");
+
+        {
+            let dump = webrtc_transport
+                .dump()
+                .await
+                .expect("Failed to dump transport");
+
+            assert_eq!(dump.id, webrtc_transport.id());
+            assert_eq!(dump.data_producer_ids, vec![sctp_data_producer.id()]);
+            assert_eq!(dump.data_consumer_ids, vec![data_consumer.id()]);
+        }
+    });
+}
+
+#[test]
+fn dump_consuming_from_a_direct_data_producer_succeeds() {
+    future::block_on(async move {
+        let (_worker, router, webrtc_transport, _sctp_data_producer) = init().await;
+
+        let direct_transport = router
+            .create_direct_transport(DirectTransportOptions::default())
+            .await
+            .expect("Failed to create Direct transport");
+
+        let direct_data_producer = direct_transport
+            .produce_data(DataProducerOptions::new_direct())
+            .await
+            .expect("Failed to create data producer");
+
+        let data_consumer = webrtc_transport
+            .consume_data({
+                let options = DataConsumerOptions::new_sctp_unordered_with_retransmits(
+                    direct_data_producer.id(),
+                    2,
+                );
+
+                options
+            })
+            .await
+            .expect("Failed to consume data");
+
+        let dump = data_consumer
+            .dump()
+            .await
+            .expect("Data consumer dump failed");
+
+        assert_eq!(dump.id, data_consumer.id());
+        assert_eq!(dump.data_producer_id, data_consumer.data_producer_id());
+        assert_eq!(dump.r#type, DataConsumerType::Sctp);
+        {
+            let sctp_stream_parameters = data_consumer.sctp_stream_parameters();
+            assert!(sctp_stream_parameters.is_some());
+            assert!(!sctp_stream_parameters.unwrap().ordered());
+            assert_eq!(sctp_stream_parameters.unwrap().max_packet_life_time(), None);
+            assert_eq!(sctp_stream_parameters.unwrap().max_retransmits(), Some(2));
+        }
+        assert_eq!(dump.label.as_str(), "");
+        assert_eq!(dump.protocol.as_str(), "");
+    });
+}
+
+#[test]
 fn consume_data_on_direct_transport_succeeds() {
     future::block_on(async move {
-        let (_worker, router, _transport1, data_producer) = init().await;
+        let (_worker, router, _webrtc_transport, sctp_data_producer) = init().await;
 
-        let transport3 = router
+        let direct_transport = router
             .create_direct_transport(DirectTransportOptions::default())
             .await
             .expect("Failed to create Direct transport");
 
         let new_data_consumer_count = Arc::new(AtomicUsize::new(0));
 
-        transport3
+        direct_transport
             .on_new_data_consumer({
                 let new_data_consumer_count = Arc::clone(&new_data_consumer_count);
 
@@ -460,9 +550,9 @@ fn consume_data_on_direct_transport_succeeds() {
             })
             .detach();
 
-        let data_consumer = transport3
+        let data_consumer = direct_transport
             .consume_data({
-                let mut options = DataConsumerOptions::new_direct(data_producer.id(), None);
+                let mut options = DataConsumerOptions::new_direct(sctp_data_producer.id(), None);
 
                 options.app_data = AppData::new(CustomAppData2 { hehe: "HEHE" });
 
@@ -472,7 +562,7 @@ fn consume_data_on_direct_transport_succeeds() {
             .expect("Failed to consume data");
 
         assert_eq!(new_data_consumer_count.load(Ordering::SeqCst), 1);
-        assert_eq!(data_consumer.data_producer_id(), data_producer.id());
+        assert_eq!(data_consumer.data_producer_id(), sctp_data_producer.id());
         assert!(!data_consumer.closed());
         assert_eq!(data_consumer.r#type(), DataConsumerType::Direct);
         assert_eq!(data_consumer.sctp_stream_parameters(), None);
@@ -488,9 +578,12 @@ fn consume_data_on_direct_transport_succeeds() {
         );
 
         {
-            let dump = transport3.dump().await.expect("Failed to dump transport");
+            let dump = direct_transport
+                .dump()
+                .await
+                .expect("Failed to dump transport");
 
-            assert_eq!(dump.id, transport3.id());
+            assert_eq!(dump.id, direct_transport.id());
             assert_eq!(dump.data_producer_ids, vec![]);
             assert_eq!(dump.data_consumer_ids, vec![data_consumer.id()]);
         }
@@ -500,16 +593,16 @@ fn consume_data_on_direct_transport_succeeds() {
 #[test]
 fn dump_on_direct_transport_succeeds() {
     future::block_on(async move {
-        let (_worker, router, _transport1, data_producer) = init().await;
+        let (_worker, router, _webrtc_transport, sctp_data_producer) = init().await;
 
-        let transport3 = router
+        let direct_transport = router
             .create_direct_transport(DirectTransportOptions::default())
             .await
             .expect("Failed to create Direct transport");
 
-        let data_consumer = transport3
+        let data_consumer = direct_transport
             .consume_data({
-                let mut options = DataConsumerOptions::new_direct(data_producer.id(), None);
+                let mut options = DataConsumerOptions::new_direct(sctp_data_producer.id(), None);
 
                 options.app_data = AppData::new(CustomAppData2 { hehe: "HEHE" });
 
@@ -535,16 +628,16 @@ fn dump_on_direct_transport_succeeds() {
 #[test]
 fn get_stats_on_direct_transport_succeeds() {
     future::block_on(async move {
-        let (_worker, router, _transport1, data_producer) = init().await;
+        let (_worker, router, _webrtc_transport, sctp_data_producer) = init().await;
 
-        let transport3 = router
+        let direct_transport = router
             .create_direct_transport(DirectTransportOptions::default())
             .await
             .expect("Failed to create Direct transport");
 
-        let data_consumer = transport3
+        let data_consumer = direct_transport
             .consume_data({
-                let mut options = DataConsumerOptions::new_direct(data_producer.id(), None);
+                let mut options = DataConsumerOptions::new_direct(sctp_data_producer.id(), None);
 
                 options.app_data = AppData::new(CustomAppData2 { hehe: "HEHE" });
 
@@ -569,9 +662,9 @@ fn get_stats_on_direct_transport_succeeds() {
 #[test]
 fn close_event() {
     future::block_on(async move {
-        let (_worker, router, _transport1, data_producer) = init().await;
+        let (_worker, router, _webrtc_transport, sctp_data_producer) = init().await;
 
-        let transport2 = router
+        let plain_transport = router
             .create_plain_transport({
                 let mut transport_options = PlainTransportOptions::new(ListenInfo {
                     protocol: Protocol::Udp,
@@ -591,10 +684,10 @@ fn close_event() {
             .await
             .expect("Failed to create transport1");
 
-        let data_consumer = transport2
+        let data_consumer = plain_transport
             .consume_data({
                 let mut options = DataConsumerOptions::new_sctp_unordered_with_life_time(
-                    data_producer.id(),
+                    sctp_data_producer.id(),
                     4000,
                 );
 
@@ -623,7 +716,7 @@ fn close_event() {
 
             assert_eq!(dump.map_data_producer_id_data_consumer_ids, {
                 let mut map = HashedMap::default();
-                map.insert(data_producer.id(), HashedSet::default());
+                map.insert(sctp_data_producer.id(), HashedSet::default());
                 map
             });
             assert_eq!(
@@ -633,7 +726,10 @@ fn close_event() {
         }
 
         {
-            let dump = transport2.dump().await.expect("Failed to dump transport");
+            let dump = plain_transport
+                .dump()
+                .await
+                .expect("Failed to dump transport");
 
             assert_eq!(dump.data_producer_ids, vec![]);
             assert_eq!(dump.data_consumer_ids, vec![]);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
 		"declarationMap": true,
 		"emitDeclarationOnly": false,
 		"declarationDir": "node/lib",
-		"isolatedModules": false,
+		"isolatedModules": true,
 		"verbatimModuleSyntax": false,
 		"useDefineForClassFields": true,
 		"esModuleInterop": false,


### PR DESCRIPTION
Fixes #1515

## Details

As exposed in the ticket #1515, let's assume this scenario:

- Alice and Bob create a WebRTC `dataProducer` with `ordered: true` (so a reliable DataChannel).
- In mediasoup side, there is a `directTransport` and a `directDataConsumer` which consumes those WebRTC `dataProducer` of Alice and Bob.
- The server runs some logic with messages received from Alice and Bob and then delivers those messages to Alice or Bob by using a `directDataProducer` created in that `directTransport`. 
- For that to work, Alice and Bob create a WebRTC `dataConsumer` that consumes messages from that `directDataProducer`.

**So what was the problem?**

- `dataProducers` created on a `directTransport` are always reliable. Why? Because they send messages through the mediasoup UnixSocket which is a reliable transport.
- So it makes sense that when we create a WebRTC `dataConsumer` in a `webRtcTransport` that consumes that `directDataProducer`, such a `dataConsumer` should be reliable (it should have `directDataConsumer.sctpParameters.ordered === true`.
- **However this was not true!** Or in other words, this was only true if `webRtcTransport.consumeData()` was called with `ordered: true` **explicitly**. But the point is that by default it should be reliable (so `ordered: true`) because we are consuming from a `directDataProducer` that is reliable/ordered by design.
- So at the end, assuming we don't include `ordered: true` in `webRtcTransport.consumeData()`, the resulting `dataConsumer` (which is the one that will deliver messages to the browser) is **unreliable** (it has `dataConsumer.sctpParameters.ordered === false`) so messages sent to the browser could reach the browser out or order **and be dispatched by the browser WebRTC `PeerConnection` out of order**, and some messages could be lost!
- So imagine that Alice sends messages "A", "B" and "C" to mediasoup, those messages travel through the `directTransport` blablabla and finally they are sent to Bob via WebRTC `dataConsumer`. It could happen that Bob receives "C" and "B" (in that order). Ok, that can always happen due to network conditions, but the problem is that, since the `dataConsumer` is configured as unreliable (it has `ordered: false`) the `dataConsumer` in Bob's browser will dispatch "message" events in that wrong order, this is: "C" and "B".
- Note that if the `dataConsumer` was reliable, then the WebRTC engine of the browser would buffer "C" and "B" and wouldn't dispatch them to the app until "A" is received, and it would dispatch them in order: "A", "B", "C".
- And even worse: mediasoup would try to retransmit "A" N times (depending on `sctpParameters.maxRetransmits`) and if none of the retransmissions of "A" reaches Bob's browser, the `webRtcTransport` of Bob in mediasoup side **won't emit "sctpstatechange" with `state: 'closed'`**!

**Good news**

This is fixed in this PR.

