### PR TITLE
worker: H264, enable Dependency Descriptor

### DIFF
--- a/worker/fuzzer/src/RTC/Codecs/FuzzerH264.cpp
+++ b/worker/fuzzer/src/RTC/Codecs/FuzzerH264.cpp
@@ -3,7 +3,10 @@
 
 void Fuzzer::RTC::Codecs::H264::Fuzz(const uint8_t* data, size_t len)
 {
-	::RTC::Codecs::H264::PayloadDescriptor* descriptor = ::RTC::Codecs::H264::Parse(data, len);
+	::RTC::Codecs::DependencyDescriptor* dependencyDescriptor{ nullptr };
+
+	::RTC::Codecs::H264::PayloadDescriptor* descriptor =
+	  ::RTC::Codecs::H264::Parse(data, len, dependencyDescriptor);
 
 	if (!descriptor)
 	{

--- a/worker/include/RTC/Codecs/AV1.hpp
+++ b/worker/include/RTC/Codecs/AV1.hpp
@@ -19,10 +19,13 @@ namespace RTC
 
 				void Dump() const override;
 
+				// Fields in Dependency Descriptor extension.
 				bool startOfFrame{ false };
 				bool endOfFrame{ false };
 				uint8_t spatialLayer{ 0 };
 				uint8_t temporalLayer{ 0 };
+
+				// Parsed values.
 				bool isKeyFrame{ false };
 			};
 

--- a/worker/include/RTC/Codecs/H264.hpp
+++ b/worker/include/RTC/Codecs/H264.hpp
@@ -15,34 +15,28 @@ namespace RTC
 			struct PayloadDescriptor : public RTC::Codecs::PayloadDescriptor
 			{
 				/* Pure virtual methods inherited from RTC::Codecs::PayloadDescriptor. */
-				~PayloadDescriptor() = default;
+				~PayloadDescriptor() override = default;
 
 				void Dump() const override;
 
-				// Fields in frame-marking extension.
-				uint8_t s : 1;          // Start of Frame.
-				uint8_t e : 1;          // End of Frame.
-				uint8_t i : 1;          // Independent Frame.
-				uint8_t d : 1;          // Discardable Frame.
-				uint8_t b : 1;          // Base Layer Sync.
-				uint8_t tid{ 0 };       // Temporal layer id.
-				uint8_t lid{ 0 };       // Spatial layer id.
-				uint8_t tl0picidx{ 0 }; // TL0PICIDX
+				// Fields in Dependency Descriptor extension.
+				bool startOfFrame{ false };
+				bool endOfFrame{ false };
+				uint8_t spatialLayer{ 0 };
+				uint8_t temporalLayer{ 0 };
 
 				// Parsed values.
-				bool hasLid{ false };
-				bool hasTid{ false };
-				bool hasTl0picidx{ false };
 				bool isKeyFrame{ false };
 			};
 
 		public:
 			static H264::PayloadDescriptor* Parse(
-			  const uint8_t* data,
-			  size_t len,
-			  RTC::RtpPacket::FrameMarking* frameMarking = nullptr,
-			  uint8_t frameMarkingLen                    = 0);
-			static void ProcessRtpPacket(RTC::RtpPacket* packet);
+			  const uint8_t* data, size_t len, RTC::Codecs::DependencyDescriptor* dependencyDescriptor);
+			static bool IsKeyFrame(const uint8_t* data, size_t len);
+			static void ProcessRtpPacket(
+			  RTC::RtpPacket* packet,
+			  std::unique_ptr<RTC::Codecs::DependencyDescriptor::TemplateDependencyStructure>&
+			    templateDependencyStructure);
 
 		public:
 			class EncodingContext : public RTC::Codecs::EncodingContext
@@ -81,7 +75,7 @@ namespace RTC
 				}
 				uint8_t GetTemporalLayer() const override
 				{
-					return this->payloadDescriptor->tid;
+					return this->payloadDescriptor->temporalLayer;
 				}
 				bool IsKeyFrame() const override
 				{

--- a/worker/include/RTC/Codecs/Tools.hpp
+++ b/worker/include/RTC/Codecs/Tools.hpp
@@ -72,7 +72,7 @@ namespace RTC
 
 							case RTC::RtpCodecMimeType::Subtype::H264:
 							{
-								RTC::Codecs::H264::ProcessRtpPacket(packet);
+								RTC::Codecs::H264::ProcessRtpPacket(packet, templateDependencyStructure);
 
 								break;
 							}

--- a/worker/src/RTC/Codecs/DependencyDescriptor.cpp
+++ b/worker/src/RTC/Codecs/DependencyDescriptor.cpp
@@ -20,7 +20,7 @@ namespace RTC
 
 			if (len < 3)
 			{
-				MS_ERROR("ignoring payload with length < 3");
+				MS_WARN_DEV("ignoring payload with length < 3");
 
 				return nullptr;
 			}

--- a/worker/src/RTC/Codecs/H264.cpp
+++ b/worker/src/RTC/Codecs/H264.cpp
@@ -12,7 +12,31 @@ namespace RTC
 		/* Class methods. */
 
 		H264::PayloadDescriptor* H264::Parse(
-		  const uint8_t* data, size_t len, RTC::RtpPacket::FrameMarking* frameMarking, uint8_t frameMarkingLen)
+		  const uint8_t* data, size_t len, Codecs::DependencyDescriptor* dependencyDescriptor)
+		{
+			MS_TRACE();
+
+			std::unique_ptr<PayloadDescriptor> payloadDescriptor(new PayloadDescriptor());
+
+			if (dependencyDescriptor)
+			{
+				// Read fields.
+				payloadDescriptor->startOfFrame  = dependencyDescriptor->startOfFrame;
+				payloadDescriptor->endOfFrame    = dependencyDescriptor->endOfFrame;
+				payloadDescriptor->spatialLayer  = dependencyDescriptor->spatialLayer;
+				payloadDescriptor->temporalLayer = dependencyDescriptor->temporalLayer;
+
+				payloadDescriptor->isKeyFrame = dependencyDescriptor->isKeyFrame;
+			}
+			else
+			{
+				payloadDescriptor->isKeyFrame = IsKeyFrame(data, len);
+			}
+
+			return payloadDescriptor.release();
+		}
+
+		bool H264::IsKeyFrame(const uint8_t* data, size_t len)
 		{
 			MS_TRACE();
 
@@ -20,132 +44,87 @@ namespace RTC
 			{
 				MS_WARN_DEV("ignoring payload with length < 2");
 
-				return nullptr;
+				return false;
 			}
 
-			std::unique_ptr<PayloadDescriptor> payloadDescriptor(new PayloadDescriptor());
+			const uint8_t nal = *data & 0x1F;
 
-			// Use frame-marking.
-			if (frameMarking)
+			switch (nal)
 			{
-				// Read fields.
-				payloadDescriptor->s   = frameMarking->start;
-				payloadDescriptor->e   = frameMarking->end;
-				payloadDescriptor->i   = frameMarking->independent;
-				payloadDescriptor->d   = frameMarking->discardable;
-				payloadDescriptor->b   = frameMarking->base;
-				payloadDescriptor->tid = frameMarking->tid;
-
-				payloadDescriptor->hasTid = true;
-
-				if (frameMarkingLen >= 2)
+				// Single NAL unit packet.
+				// IDR (instantaneous decoding picture).
+				case 7:
 				{
-					payloadDescriptor->hasLid = true;
-					payloadDescriptor->lid    = frameMarking->lid;
+					return true;
 				}
 
-				if (frameMarkingLen == 3)
+				// Aggreation packet.
+				// STAP-A.
+				case 24:
 				{
-					payloadDescriptor->hasTl0picidx = true;
-					payloadDescriptor->tl0picidx    = frameMarking->tl0picidx;
-				}
+					size_t offset{ 1 };
 
-				// Detect key frame.
-				if (frameMarking->start && frameMarking->independent)
-				{
-					payloadDescriptor->isKeyFrame = true;
-				}
-			}
+					len -= 1;
 
-			// NOTE: Unfortunately libwebrtc produces wrong Frame-Marking (without i=1 in
-			// keyframes) when it uses H264 hardware encoder (at least in Mac):
-			//   https://bugs.chromium.org/p/webrtc/issues/detail?id=10746
-			//
-			// As a temporal workaround, always do payload parsing to detect keyframes if
-			// there is no frame-marking or if there is but keyframe was not detected above.
-			if (!frameMarking || !payloadDescriptor->isKeyFrame)
-			{
-				const uint8_t nal = *data & 0x1F;
-
-				switch (nal)
-				{
-					// Single NAL unit packet.
-					// IDR (instantaneous decoding picture).
-					case 7:
+					// Iterate NAL units.
+					while (len >= 3)
 					{
-						payloadDescriptor->isKeyFrame = true;
+						auto naluSize        = Utils::Byte::Get2Bytes(data, offset);
+						const uint8_t subnal = *(data + offset + sizeof(naluSize)) & 0x1F;
 
-						break;
-					}
-
-					// Aggreation packet.
-					// STAP-A.
-					case 24:
-					{
-						size_t offset{ 1 };
-
-						len -= 1;
-
-						// Iterate NAL units.
-						while (len >= 3)
+						if (subnal == 7)
 						{
-							auto naluSize        = Utils::Byte::Get2Bytes(data, offset);
-							const uint8_t subnal = *(data + offset + sizeof(naluSize)) & 0x1F;
-
-							if (subnal == 7)
-							{
-								payloadDescriptor->isKeyFrame = true;
-
-								break;
-							}
-
-							// Check if there is room for the indicated NAL unit size.
-							if (len < (naluSize + sizeof(naluSize)))
-							{
-								break;
-							}
-
-							offset += naluSize + sizeof(naluSize);
-							len -= naluSize + sizeof(naluSize);
+							return true;
 						}
 
-						break;
-					}
-
-					// Aggreation packet.
-					// FU-A, FU-B.
-					case 28:
-					case 29:
-					{
-						const uint8_t subnal   = *(data + 1) & 0x1F;
-						const uint8_t startBit = *(data + 1) & 0x80;
-
-						if (subnal == 7 && startBit == 128)
+						// Check if there is room for the indicated NAL unit size.
+						if (len < (naluSize + sizeof(naluSize)))
 						{
-							payloadDescriptor->isKeyFrame = true;
+							break;
 						}
 
-						break;
+						offset += naluSize + sizeof(naluSize);
+						len -= naluSize + sizeof(naluSize);
 					}
+
+					break;
+				}
+
+				// Aggreation packet.
+				// FU-A, FU-B.
+				case 28:
+				case 29:
+				{
+					const uint8_t subnal   = *(data + 1) & 0x1F;
+					const uint8_t startBit = *(data + 1) & 0x80;
+
+					if (subnal == 7 && startBit == 128)
+					{
+						return true;
+					}
+
+					break;
 				}
 			}
 
-			return payloadDescriptor.release();
+			return false;
 		}
 
-		void H264::ProcessRtpPacket(RTC::RtpPacket* packet)
+		void H264::ProcessRtpPacket(
+		  RTC::RtpPacket* packet,
+		  std::unique_ptr<RTC::Codecs::DependencyDescriptor::TemplateDependencyStructure>&
+		    templateDependencyStructure)
 		{
 			MS_TRACE();
 
 			auto* data = packet->GetPayload();
 			auto len   = packet->GetPayloadLength();
-			RtpPacket::FrameMarking* frameMarking{ nullptr };
-			uint8_t frameMarkingLen{ 0 };
+			std::unique_ptr<Codecs::DependencyDescriptor> dependencyDescriptor;
 
-			// Read frame-marking.
-			packet->ReadFrameMarking(&frameMarking, frameMarkingLen);
+			// Read dependency descriptor.
+			packet->ReadDependencyDescriptor(dependencyDescriptor, templateDependencyStructure);
 
-			PayloadDescriptor* payloadDescriptor = H264::Parse(data, len, frameMarking, frameMarkingLen);
+			PayloadDescriptor* payloadDescriptor = H264::Parse(data, len, dependencyDescriptor.get());
 
 			if (!payloadDescriptor)
 			{
@@ -164,25 +143,9 @@ namespace RTC
 			MS_TRACE();
 
 			MS_DUMP("<H264::PayloadDescriptor>");
-			MS_DUMP(
-			  "  s:%" PRIu8 "|e:%" PRIu8 "|i:%" PRIu8 "|d:%" PRIu8 "|b:%" PRIu8,
-			  this->s,
-			  this->e,
-			  this->i,
-			  this->d,
-			  this->b);
-			if (this->hasTid)
-			{
-				MS_DUMP("  tid: %" PRIu8, this->tid);
-			}
-			if (this->hasLid)
-			{
-				MS_DUMP("  lid: %" PRIu8, this->lid);
-			}
-			if (this->hasTl0picidx)
-			{
-				MS_DUMP("  tl0picidx: %" PRIu8, this->tl0picidx);
-			}
+			MS_DUMP("  startOfFrame:%" PRIu8 "|endOfFrame:%" PRIu8, this->startOfFrame, this->endOfFrame);
+			MS_DUMP("  spatialLayer:%" PRIu8, this->spatialLayer);
+			MS_DUMP("  temporalLayer:%" PRIu8, this->temporalLayer);
 			MS_DUMP("  isKeyFrame: %s", this->isKeyFrame ? "true" : "false");
 			MS_DUMP("</H264::PayloadDescriptor>");
 		}
@@ -203,49 +166,15 @@ namespace RTC
 
 			MS_ASSERT(context->GetTargetTemporalLayer() >= 0, "target temporal layer cannot be -1");
 
-			// Check if the payload should contain temporal layer info.
-			if (context->GetTemporalLayers() > 1 && !this->payloadDescriptor->hasTid)
-			{
-				MS_WARN_DEV("stream is supposed to have >1 temporal layers but does not have tid field");
-			}
-
-			// clang-format off
-			if (
-				this->payloadDescriptor->hasTid &&
-				this->payloadDescriptor->tid > context->GetTargetTemporalLayer()
-			)
-			// clang-format on
-			{
-				return false;
-			}
-			// Upgrade required. Drop current packet if base flag is not set.
-			// NOTE: This is possible once this bug in libwebrtc has been fixed:
-			//   https://github.com/versatica/mediasoup/issues/306
-			//
-			// clang-format off
-			else if (
-				this->payloadDescriptor->hasTid &&
-				this->payloadDescriptor->tid > context->GetCurrentTemporalLayer() &&
-				!this->payloadDescriptor->b
-			)
-			// clang-format on
+			if (this->payloadDescriptor->temporalLayer > context->GetTargetTemporalLayer())
 			{
 				return false;
 			}
 
 			// Update/fix current temporal layer.
-			// clang-format off
-			if (
-				this->payloadDescriptor->hasTid &&
-				this->payloadDescriptor->tid > context->GetCurrentTemporalLayer()
-			)
-			// clang-format on
+			if (this->payloadDescriptor->temporalLayer > context->GetCurrentTemporalLayer())
 			{
-				context->SetCurrentTemporalLayer(this->payloadDescriptor->tid);
-			}
-			else if (!this->payloadDescriptor->hasTid)
-			{
-				context->SetCurrentTemporalLayer(0);
+				context->SetCurrentTemporalLayer(this->payloadDescriptor->temporalLayer);
 			}
 
 			if (context->GetCurrentTemporalLayer() > context->GetTargetTemporalLayer())

--- a/worker/test/src/RTC/Codecs/TestH264.cpp
+++ b/worker/test/src/RTC/Codecs/TestH264.cpp
@@ -21,8 +21,10 @@ SCENARIO("parse H264 payload descriptor", "[codecs][h264]")
 
 		std::memcpy(buffer, originalBuffer, sizeof(buffer));
 
+		Codecs::DependencyDescriptor* dependencyDescriptor{ nullptr };
+
 		std::unique_ptr<Codecs::H264::PayloadDescriptor> payloadDescriptor{ Codecs::H264::Parse(
-			buffer, sizeof(buffer)) };
+			buffer, sizeof(buffer), dependencyDescriptor) };
 
 		REQUIRE(payloadDescriptor);
 	}


### PR DESCRIPTION
This PR base branch is `dependency_descriptor`

Uses Dependency Descriptor header extension rather than the obsolete FrameMarking in order to retrieve the temporal layers.