### PR TITLE
Worker: Fix, encode retransmitted packets with the corresponding data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### NEXT
 
+- Worker: Fix, encode retransmitted packets with the corresponding data
+  ([PR #1527](https://github.com/versatica/mediasoup/pull/1527)).
+
 ### 3.15.7
 
 - CI: Remove redundant hosts `macos-14` and `windows-2022` from `mediasoup-worker-prebuild` job ([PR #1506](https://github.com/versatica/mediasoup/pull/1506)).

--- a/worker/include/RTC/Codecs/H264.hpp
+++ b/worker/include/RTC/Codecs/H264.hpp
@@ -15,7 +15,7 @@ namespace RTC
 			struct PayloadDescriptor : public RTC::Codecs::PayloadDescriptor
 			{
 				/* Pure virtual methods inherited from RTC::Codecs::PayloadDescriptor. */
-				~PayloadDescriptor() = default;
+				~PayloadDescriptor() override = default;
 
 				void Dump() const override;
 
@@ -66,7 +66,7 @@ namespace RTC
 			{
 			public:
 				explicit PayloadDescriptorHandler(PayloadDescriptor* payloadDescriptor);
-				~PayloadDescriptorHandler() = default;
+				~PayloadDescriptorHandler() override = default;
 
 			public:
 				void Dump() const override
@@ -74,7 +74,16 @@ namespace RTC
 					this->payloadDescriptor->Dump();
 				}
 				bool Process(RTC::Codecs::EncodingContext* encodingContext, uint8_t* data, bool& marker) override;
-				void Restore(uint8_t* data) override;
+				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
+				{
+					return nullptr;
+				}
+				void Encode(uint8_t* data, Codecs::PayloadDescriptor::Encoder* encoder) override
+				{
+				}
+				void Restore(uint8_t* data) override
+				{
+				}
 				uint8_t GetSpatialLayer() const override
 				{
 					return 0u;

--- a/worker/include/RTC/Codecs/H264_SVC.hpp
+++ b/worker/include/RTC/Codecs/H264_SVC.hpp
@@ -15,7 +15,7 @@ namespace RTC
 		public:
 			struct PayloadDescriptor : public RTC::Codecs::PayloadDescriptor
 			{
-				~PayloadDescriptor() = default;
+				~PayloadDescriptor() override = default;
 
 				void Dump() const override;
 
@@ -80,7 +80,7 @@ namespace RTC
 			{
 			public:
 				explicit PayloadDescriptorHandler(PayloadDescriptor* payloadDescriptor);
-				~PayloadDescriptorHandler() = default;
+				~PayloadDescriptorHandler() override = default;
 
 			public:
 				void Dump() const override
@@ -88,7 +88,16 @@ namespace RTC
 					this->payloadDescriptor->Dump();
 				}
 				bool Process(RTC::Codecs::EncodingContext* encodingContext, uint8_t* data, bool& marker) override;
-				void Restore(uint8_t* data) override;
+				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
+				{
+					return nullptr;
+				}
+				void Encode(uint8_t* data, Codecs::PayloadDescriptor::Encoder* encoder) override
+				{
+				}
+				void Restore(uint8_t* data) override
+				{
+				}
 				uint8_t GetSpatialLayer() const override
 				{
 					// return 0u;

--- a/worker/include/RTC/Codecs/Opus.hpp
+++ b/worker/include/RTC/Codecs/Opus.hpp
@@ -16,7 +16,7 @@ namespace RTC
 			struct PayloadDescriptor : public RTC::Codecs::PayloadDescriptor
 			{
 				/* Pure virtual methods inherited from RTC::Codecs::PayloadDescriptor. */
-				~PayloadDescriptor() = default;
+				~PayloadDescriptor() override = default;
 
 				void Dump() const override;
 
@@ -57,7 +57,7 @@ namespace RTC
 			{
 			public:
 				explicit PayloadDescriptorHandler(PayloadDescriptor* payloadDescriptor);
-				~PayloadDescriptorHandler() = default;
+				~PayloadDescriptorHandler() override = default;
 
 			public:
 				void Dump() const override
@@ -65,10 +65,16 @@ namespace RTC
 					this->payloadDescriptor->Dump();
 				}
 				bool Process(RTC::Codecs::EncodingContext* encodingContext, uint8_t* data, bool& marker) override;
+				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
+				{
+					return nullptr;
+				}
+				void Encode(uint8_t* data, Codecs::PayloadDescriptor::Encoder* encoder) override
+				{
+				}
 				void Restore(uint8_t* data) override
 				{
-					return;
-				};
+				}
 				uint8_t GetSpatialLayer() const override
 				{
 					return 0u;

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -12,6 +12,11 @@ namespace RTC
 		// Codec payload descriptor.
 		struct PayloadDescriptor
 		{
+			struct Encoder
+			{
+				virtual ~Encoder() = default;
+			};
+
 			virtual ~PayloadDescriptor() = default;
 			virtual void Dump() const    = 0;
 		};
@@ -214,6 +219,8 @@ namespace RTC
 		public:
 			virtual void Dump() const                                                                = 0;
 			virtual bool Process(RTC::Codecs::EncodingContext* context, uint8_t* data, bool& marker) = 0;
+			virtual std::unique_ptr<PayloadDescriptor::Encoder> GetEncoder() const                   = 0;
+			virtual void Encode(uint8_t* data, PayloadDescriptor::Encoder* encoder)                  = 0;
 			virtual void Restore(uint8_t* data)                                                      = 0;
 			virtual uint8_t GetSpatialLayer() const                                                  = 0;
 			virtual uint8_t GetTemporalLayer() const                                                 = 0;

--- a/worker/include/RTC/Codecs/VP8.hpp
+++ b/worker/include/RTC/Codecs/VP8.hpp
@@ -37,13 +37,47 @@ namespace RTC
 		public:
 			struct PayloadDescriptor : public RTC::Codecs::PayloadDescriptor
 			{
+				struct EncodingData
+				{
+					uint16_t pictureId;
+					uint8_t tl0PictureIndex;
+				};
+
+				struct Encoder : public RTC::Codecs::PayloadDescriptor::Encoder
+				{
+					~Encoder() override = default;
+					explicit Encoder(EncodingData encodingData) : encodingData(encodingData)
+					{
+					}
+					void Encode(uint8_t* data, const VP8::PayloadDescriptor* payloadDescriptor) const;
+
+					EncodingData encodingData;
+				};
+
 				/* Pure virtual methods inherited from RTC::Codecs::PayloadDescriptor. */
-				~PayloadDescriptor() = default;
+				~PayloadDescriptor() override = default;
 
 				void Dump() const override;
 				// Rewrite the buffer with the given pictureId and tl0PictureIndex values.
 				void Encode(uint8_t* data, uint16_t pictureId, uint8_t tl0PictureIndex) const;
+				void Encode(uint8_t* data) const;
 				void Restore(uint8_t* data) const;
+				std::unique_ptr<Codecs::PayloadDescriptor::Encoder> GetEncoder() const
+				{
+					if (this->encoder.has_value())
+					{
+						return std::make_unique<Encoder>(this->encoder.value());
+					}
+					else
+					{
+						return nullptr;
+					}
+				}
+
+				void CreateEncoder(EncodingData encodingData)
+				{
+					this->encoder = Encoder(encodingData);
+				}
 
 				// Mandatory fields.
 				uint8_t extended : 1;
@@ -68,6 +102,8 @@ namespace RTC
 				bool hasTwoBytesPictureId{ false };
 				bool hasTl0PictureIndex{ false };
 				bool hasTlIndex{ false };
+
+				std::optional<Encoder> encoder{ std::nullopt };
 			};
 
 		public:
@@ -106,7 +142,7 @@ namespace RTC
 			{
 			public:
 				explicit PayloadDescriptorHandler(PayloadDescriptor* payloadDescriptor);
-				~PayloadDescriptorHandler() = default;
+				~PayloadDescriptorHandler() override = default;
 
 			public:
 				void Dump() const override
@@ -114,6 +150,11 @@ namespace RTC
 					this->payloadDescriptor->Dump();
 				}
 				bool Process(RTC::Codecs::EncodingContext* encodingContext, uint8_t* data, bool& marker) override;
+				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
+				{
+					return this->payloadDescriptor->GetEncoder();
+				}
+				void Encode(uint8_t* data, Codecs::PayloadDescriptor::Encoder* encoder) override;
 				void Restore(uint8_t* data) override;
 				uint8_t GetSpatialLayer() const override
 				{
@@ -129,7 +170,7 @@ namespace RTC
 				}
 
 			private:
-				std::unique_ptr<PayloadDescriptor> payloadDescriptor;
+				std::unique_ptr<VP8::PayloadDescriptor> payloadDescriptor;
 			};
 		};
 	} // namespace Codecs

--- a/worker/include/RTC/Codecs/VP9.hpp
+++ b/worker/include/RTC/Codecs/VP9.hpp
@@ -58,7 +58,7 @@ namespace RTC
 			struct PayloadDescriptor : public RTC::Codecs::PayloadDescriptor
 			{
 				/* Pure virtual methods inherited from RTC::Codecs::PayloadDescriptor. */
-				~PayloadDescriptor() = default;
+				~PayloadDescriptor() override = default;
 
 				void Dump() const override;
 
@@ -129,7 +129,16 @@ namespace RTC
 					this->payloadDescriptor->Dump();
 				}
 				bool Process(RTC::Codecs::EncodingContext* encodingContext, uint8_t* data, bool& marker) override;
-				void Restore(uint8_t* data) override;
+				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
+				{
+					return nullptr;
+				}
+				void Encode(uint8_t* data, Codecs::PayloadDescriptor::Encoder* encoder) override
+				{
+				}
+				void Restore(uint8_t* data) override
+				{
+				}
 				uint8_t GetSpatialLayer() const override
 				{
 					return this->payloadDescriptor->hasSlIndex ? this->payloadDescriptor->slIndex : 0u;

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -657,6 +657,10 @@ namespace RTC
 
 		bool ProcessPayload(RTC::Codecs::EncodingContext* context, bool& marker);
 
+		std::unique_ptr<Codecs::PayloadDescriptor::Encoder> GetPayloadEncoder();
+
+		void EncodePayload(Codecs::PayloadDescriptor::Encoder* encoder);
+
 		void RestorePayload();
 
 		void ShiftPayload(size_t payloadOffset, size_t shift, bool expand = true);

--- a/worker/include/RTC/RtpRetransmissionBuffer.hpp
+++ b/worker/include/RTC/RtpRetransmissionBuffer.hpp
@@ -2,6 +2,7 @@
 #define MS_RTC_RTP_RETRANSMISSION_BUFFER_HPP
 
 #include "common.hpp"
+#include "RTC/Codecs/PayloadDescriptorHandler.hpp"
 #include "RTC/RtpPacket.hpp"
 #include <deque>
 
@@ -20,6 +21,8 @@ namespace RTC
 
 			// Original packet.
 			std::shared_ptr<RTC::RtpPacket> packet{ nullptr };
+			// Payload descriptor encoder.
+			std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> encoder{ nullptr };
 			// Correct SSRC since original packet may not have the same.
 			uint32_t ssrc{ 0u };
 			// Correct sequence number since original packet may not have the same.

--- a/worker/src/RTC/Codecs/H264.cpp
+++ b/worker/src/RTC/Codecs/H264.cpp
@@ -255,10 +255,5 @@ namespace RTC
 
 			return true;
 		}
-
-		void H264::PayloadDescriptorHandler::Restore(uint8_t* /*data*/)
-		{
-			MS_TRACE();
-		}
 	} // namespace Codecs
 } // namespace RTC

--- a/worker/src/RTC/Codecs/H264_SVC.cpp
+++ b/worker/src/RTC/Codecs/H264_SVC.cpp
@@ -469,10 +469,5 @@ namespace RTC
 
 			return true;
 		}
-
-		void H264_SVC::PayloadDescriptorHandler::Restore(uint8_t* /*data*/)
-		{
-			MS_TRACE();
-		}
 	} // namespace Codecs
 } // namespace RTC

--- a/worker/src/RTC/Codecs/VP8.cpp
+++ b/worker/src/RTC/Codecs/VP8.cpp
@@ -242,11 +242,38 @@ namespace RTC
 			}
 		}
 
+		void VP8::PayloadDescriptor::Encode(uint8_t* data) const
+		{
+			MS_TRACE();
+
+			if (this->encoder == std::nullopt)
+			{
+				return;
+			}
+
+			this->encoder->Encode(data, this);
+		}
+
 		void VP8::PayloadDescriptor::Restore(uint8_t* data) const
 		{
 			MS_TRACE();
 
-			Encode(data, this->pictureId, this->tl0PictureIndex);
+			// clang-format off
+			if (
+				this->hasPictureId &&
+				this->hasTl0PictureIndex
+			)
+			// clang-format on
+			{
+				Encode(data, this->pictureId, this->tl0PictureIndex);
+			}
+		}
+
+		void VP8::PayloadDescriptor::Encoder::Encode(
+		  uint8_t* data, const PayloadDescriptor* payloadDescriptor) const
+		{
+			payloadDescriptor->Encode(
+			  data, this->encodingData.pictureId, this->encodingData.tl0PictureIndex);
 		}
 
 		VP8::PayloadDescriptorHandler::PayloadDescriptorHandler(VP8::PayloadDescriptor* payloadDescriptor)
@@ -388,11 +415,22 @@ namespace RTC
 			)
 			// clang-format on
 			{
-				this->payloadDescriptor->Encode(data, pictureId, tl0PictureIndex);
+				// Store the encoding data for retransmissions.
+				this->payloadDescriptor->CreateEncoder({ pictureId, tl0PictureIndex });
+				this->payloadDescriptor->Encode(data);
 			}
 
 			return true;
 		};
+
+		void VP8::PayloadDescriptorHandler::Encode(uint8_t* data, Codecs::PayloadDescriptor::Encoder* encoder)
+		{
+			MS_TRACE();
+
+			auto* vp8Encoder = static_cast<VP8::PayloadDescriptor::Encoder*>(encoder);
+
+			vp8Encoder->Encode(data, this->payloadDescriptor.get());
+		}
 
 		void VP8::PayloadDescriptorHandler::Restore(uint8_t* data)
 		{

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -413,10 +413,5 @@ namespace RTC
 
 			return true;
 		}
-
-		void VP9::PayloadDescriptorHandler::Restore(uint8_t* /*data*/)
-		{
-			MS_TRACE();
-		}
 	} // namespace Codecs
 } // namespace RTC

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -870,6 +870,30 @@ namespace RTC
 		return this->payloadDescriptorHandler->Process(context, this->payload, marker);
 	}
 
+	std::unique_ptr<Codecs::PayloadDescriptor::Encoder> RtpPacket::GetPayloadEncoder()
+	{
+		MS_TRACE();
+
+		if (!this->payloadDescriptorHandler)
+		{
+			return nullptr;
+		}
+
+		return this->payloadDescriptorHandler->GetEncoder();
+	}
+
+	void RtpPacket::EncodePayload(Codecs::PayloadDescriptor::Encoder* encoder)
+	{
+		MS_TRACE();
+
+		if (!this->payloadDescriptorHandler)
+		{
+			return;
+		}
+
+		this->payloadDescriptorHandler->Encode(this->payload, encoder);
+	}
+
 	void RtpPacket::RestorePayload()
 	{
 		MS_TRACE();

--- a/worker/src/RTC/RtpRetransmissionBuffer.cpp
+++ b/worker/src/RTC/RtpRetransmissionBuffer.cpp
@@ -31,6 +31,7 @@ namespace RTC
 
 		// Store original packet and some extra info into the item.
 		item->packet         = sharedPacket;
+		item->encoder        = packet->GetPayloadEncoder();
 		item->ssrc           = packet->GetSsrc();
 		item->sequenceNumber = packet->GetSequenceNumber();
 		item->timestamp      = packet->GetTimestamp();

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -449,6 +449,11 @@ namespace RTC
 					packet->SetSequenceNumber(item->sequenceNumber);
 					packet->SetTimestamp(item->timestamp);
 
+					if (item->encoder != nullptr)
+					{
+						packet->EncodePayload(item->encoder.get());
+					}
+
 					// Update MID RTP extension value.
 					if (!this->mid.empty())
 					{

--- a/worker/test/src/RTC/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP8.cpp
@@ -154,6 +154,67 @@ SCENARIO("parse VP8 payload descriptor", "[codecs][vp8]")
 		}
 	};
 
+	SECTION("parse payload descriptor, encode")
+	{
+		/** VP8 Payload Descriptor
+		 *
+		 * 1 = X bit: Extended control bits present (I L T K)
+		 * 1 = R bit: Reserved for future use (Error should be zero)
+		 * 0 = N bit: Reference frame
+		 * 1 = S bit: Start of VP8 partition
+		 * Part Id: 0
+		 * 1 = I bit: Picture ID byte present
+		 * 1 = L bit: TL0PICIDX byte present
+		 * 0 = T bit: TID (temporal layer index) byte not present
+		 * 0 = K bit: TID/KEYIDX byte not present
+		 * 0000 = Reserved A: 0
+		 * 0001 0001 = Picture Id: 17
+		 * 0000 0011 = TL0PICIDX: 3
+		 */
+
+		// clang-format off
+		uint8_t originalBuffer[] =
+		{
+			0xd0, 0xc0, 0x11, 0x03
+		};
+		// clang-format on
+
+		// Keep a copy of the original buffer for comparing.
+		uint8_t buffer[4] = { 0 };
+
+		std::memcpy(buffer, originalBuffer, sizeof(buffer));
+
+		std::unique_ptr<Codecs::VP8::PayloadDescriptor> payloadDescriptor{ Codecs::VP8::Parse(
+			buffer, sizeof(buffer)) };
+
+		REQUIRE(payloadDescriptor);
+
+		REQUIRE(payloadDescriptor->pictureId == 17);
+		REQUIRE(payloadDescriptor->tl0PictureIndex == 3);
+
+		SECTION("encode payload descriptor")
+		{
+			payloadDescriptor->Encode(buffer, 20, 1);
+
+			std::unique_ptr<Codecs::VP8::PayloadDescriptor> payloadDescriptor{ Codecs::VP8::Parse(
+				buffer, sizeof(buffer)) };
+
+			REQUIRE(payloadDescriptor->pictureId == 20);
+			REQUIRE(payloadDescriptor->tl0PictureIndex == 1);
+		}
+
+		SECTION("restore payload descriptor")
+		{
+			payloadDescriptor->Restore(buffer);
+
+			std::unique_ptr<Codecs::VP8::PayloadDescriptor> payloadDescriptor{ Codecs::VP8::Parse(
+				buffer, sizeof(buffer)) };
+
+			REQUIRE(payloadDescriptor->pictureId == 17);
+			REQUIRE(payloadDescriptor->tl0PictureIndex == 3);
+		}
+	}
+
 	SECTION("parse payload descriptor. I flag set but no space for pictureId")
 	{
 		/** VP8 Payload Descriptor
@@ -205,7 +266,7 @@ SCENARIO("parse VP8 payload descriptor", "[codecs][vp8]")
 		};
 		// clang-format on
 
-		auto payloadDescriptor = Codecs::VP8::Parse(buffer, sizeof(buffer));
+		auto* payloadDescriptor = Codecs::VP8::Parse(buffer, sizeof(buffer));
 
 		REQUIRE_FALSE(payloadDescriptor);
 	}
@@ -385,5 +446,89 @@ SCENARIO("process VP8 payload descriptor", "[codecs][vp8]")
 		forwarded = ProcessPacket(context, 3, 0, 1);
 		REQUIRE_FALSE(forwarded);
 		REQUIRE(context.GetCurrentTemporalLayer() == 0);
+	}
+}
+
+SCENARIO("encode VP8 payload descriptor", "[codecs][vp8]")
+{
+	/** VP8 Payload Descriptor
+	 *
+	 * 1 = X bit: Extended control bits present (I L T K)
+	 * 0 = R bit: Reserved for future use
+	 * 0 = N bit: Reference frame
+	 * 0 = S bit: Continuation of VP8 partition
+	 * 000 = Part Id: 0
+	 * 1 = I bit: Picture byte ID
+	 * 1 = L bit: TL0PICIDX byte present
+	 * 1 = T bit: TID (temporal layer index) byte present
+	 * 0 = K bit: TID/KEYIDX byte present
+	 * 0000 = Reserved A: 14
+	 * 0000000000000001 = PictureId
+	 */
+
+	// clang-format off
+	uint8_t buffer[] =
+	{
+		0x80, 0xe0, 0x01, 0x01,
+		0xe8, 0x40, 0x7a, 0xd8
+	};
+
+	// clang-format on
+	// clang-format on
+	bool marker;
+
+	SECTION("encode based on specific encoder")
+	{
+		std::unique_ptr<Codecs::VP8::PayloadDescriptor> payloadDescriptor{ Codecs::VP8::Parse(
+			buffer, sizeof(buffer)) };
+
+		REQUIRE(payloadDescriptor);
+		REQUIRE(payloadDescriptor.get());
+
+		RTC::Codecs::EncodingContext::Params params;
+		params.spatialLayers  = 0;
+		params.temporalLayers = 3;
+		Codecs::VP8::EncodingContext context(params);
+
+		context.SetCurrentTemporalLayer(3);
+		context.SetTargetTemporalLayer(3);
+
+		REQUIRE(payloadDescriptor->pictureId == 1);
+
+		auto* payloadDescriptorHandler =
+		  new Codecs::VP8::PayloadDescriptorHandler(payloadDescriptor.get());
+
+		auto forwarded = payloadDescriptorHandler->Process(&context, buffer, marker);
+		REQUIRE(forwarded);
+
+		auto encoder1 = payloadDescriptorHandler->GetEncoder();
+		REQUIRE(encoder1);
+
+		// Update pictureId.
+		payloadDescriptor->pictureId = 2;
+
+		forwarded = payloadDescriptorHandler->Process(&context, buffer, marker);
+		REQUIRE(forwarded);
+		REQUIRE(payloadDescriptor->pictureId == 2);
+
+		// encoder2 contains the pictureId value 2.
+		auto encoder2 = payloadDescriptorHandler->GetEncoder();
+		REQUIRE(encoder2);
+
+		// Encode with encoder1.
+		payloadDescriptorHandler->Encode(buffer, encoder1.get());
+
+		// Parse the buffer.
+		auto* payloadDescriptor2 = Codecs::VP8::Parse(buffer, sizeof(buffer));
+		REQUIRE(payloadDescriptor2);
+		REQUIRE(payloadDescriptor2->pictureId == 1);
+
+		// Encode with encoder2.
+		payloadDescriptorHandler->Encode(buffer, encoder2.get());
+
+		// Parse the buffer.
+		auto* payloadDescriptor3 = Codecs::VP8::Parse(buffer, sizeof(buffer));
+		REQUIRE(payloadDescriptor3);
+		REQUIRE(payloadDescriptor3->pictureId == 2);
 	}
 }

--- a/worker/test/src/RTC/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP8.cpp
@@ -472,9 +472,8 @@ SCENARIO("encode VP8 payload descriptor", "[codecs][vp8]")
 		0x80, 0xe0, 0x01, 0x01,
 		0xe8, 0x40, 0x7a, 0xd8
 	};
+	// clang-format on
 
-	// clang-format on
-	// clang-format on
 	bool marker;
 
 	SECTION("encode based on specific encoder")

--- a/worker/test/src/RTC/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP8.cpp
@@ -479,11 +479,9 @@ SCENARIO("encode VP8 payload descriptor", "[codecs][vp8]")
 
 	SECTION("encode based on specific encoder")
 	{
-		std::unique_ptr<Codecs::VP8::PayloadDescriptor> payloadDescriptor{ Codecs::VP8::Parse(
-			buffer, sizeof(buffer)) };
+		auto* payloadDescriptor = Codecs::VP8::Parse(buffer, sizeof(buffer));
 
 		REQUIRE(payloadDescriptor);
-		REQUIRE(payloadDescriptor.get());
 
 		RTC::Codecs::EncodingContext::Params params;
 		params.spatialLayers  = 0;
@@ -495,8 +493,7 @@ SCENARIO("encode VP8 payload descriptor", "[codecs][vp8]")
 
 		REQUIRE(payloadDescriptor->pictureId == 1);
 
-		auto* payloadDescriptorHandler =
-		  new Codecs::VP8::PayloadDescriptorHandler(payloadDescriptor.get());
+		auto* payloadDescriptorHandler = new Codecs::VP8::PayloadDescriptorHandler(payloadDescriptor);
 
 		auto forwarded = payloadDescriptorHandler->Process(&context, buffer, marker);
 		REQUIRE(forwarded);
@@ -530,5 +527,9 @@ SCENARIO("encode VP8 payload descriptor", "[codecs][vp8]")
 		auto* payloadDescriptor3 = Codecs::VP8::Parse(buffer, sizeof(buffer));
 		REQUIRE(payloadDescriptor3);
 		REQUIRE(payloadDescriptor3->pictureId == 2);
+
+		delete payloadDescriptor3;
+		delete payloadDescriptor2;
+		delete payloadDescriptorHandler;
 	}
 }

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -40,28 +40,35 @@ public:
 	~TestPayloadDescriptorHandler() override = default;
 	void Dump() const override
 	{
-		return;
-	};
+	}
 	bool Process(Codecs::EncodingContext* /*context*/, uint8_t* /*data*/, bool& /*marker*/) override
 	{
 		return true;
-	};
+	}
+
+	std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
+	{
+		return nullptr;
+	}
+
+	void Encode(uint8_t* /*data*/, RTC::Codecs::PayloadDescriptor::Encoder* /*encoder*/) override
+	{
+	}
 	void Restore(uint8_t* /*data*/) override
 	{
-		return;
-	};
+	}
 	uint8_t GetSpatialLayer() const override
 	{
 		return 0;
-	};
+	}
 	uint8_t GetTemporalLayer() const override
 	{
 		return 0;
-	};
+	}
 	bool IsKeyFrame() const override
 	{
 		return this->isKeyFrame;
-	};
+	}
 
 private:
 	bool isKeyFrame{ false };

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -469,6 +469,9 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 		auto* payloadDescriptor5 = Codecs::VP8::Parse(packet->GetPayload(), packet->GetPayloadLength());
 		REQUIRE(payloadDescriptor5);
 		REQUIRE(payloadDescriptor5->pictureId == 2);
+
+		delete payloadDescriptor4;
+		delete payloadDescriptor5;
 	}
 
 	SECTION("packets get retransmitted as long as they don't exceed MaxRetransmissionDelayForVideoMs")

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -1,4 +1,5 @@
 #include "common.hpp"
+#include "RTC/Codecs/VP8.hpp"
 #include "RTC/RTCP/FeedbackRtpNack.hpp"
 #include "RTC/RtpPacket.hpp"
 #include "RTC/RtpStream.hpp"
@@ -309,6 +310,165 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack]")
 
 		CheckRtxPacket(rtxPacket1, packet1->GetSequenceNumber(), packet1->GetTimestamp());
 		CheckRtxPacket(rtxPacket2, packet2->GetSequenceNumber(), packet2->GetTimestamp());
+	}
+
+	SECTION("retransmitted packets are correctly encoded")
+	{
+		// clang-format off
+		uint8_t rtpBuffer1[] =
+		{
+			0x80, 0x7b, 0x52, 0x0e,
+			0x5b, 0x6b, 0xca, 0xb5,
+			0x00, 0x00, 0x00, 0x02,
+			0x80, 0xe0, 0x80, 0x01,
+			0xe8, 0x40, 0x7a, 0xd8
+		};
+		uint8_t rtpBuffer2[] =
+		{
+			0x80, 0x7b, 0x52, 0x0e,
+			0x5b, 0x6b, 0xca, 0xb5,
+			0x00, 0x00, 0x00, 0x02,
+			0x80, 0xe0, 0x80, 0x02,
+			0xe9, 0x40, 0x7a, 0xd8
+		};
+		uint8_t rtpBuffer3[] =
+		{
+			0x80, 0x7b, 0x52, 0x0e,
+			0x5b, 0x6b, 0xca, 0xb5,
+			0x00, 0x00, 0x00, 0x02,
+			0x80, 0xe0, 0x80, 0x03,
+			0xea, 0x40, 0x7a, 0xd8
+		};
+		// clang-format on
+
+		// packet1 [pt:123, seq:1, timestamp:1]
+		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 1, 1));
+		// packet2 [pt:123, seq:2, timestamp:1]
+		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 2, 1));
+		// packet3 [pt:123, seq:3, timestamp:1]
+		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 3, 1));
+
+		// Create two RtpStreamSend instances.
+		TestRtpStreamListener testRtpStreamListener1;
+		TestRtpStreamListener testRtpStreamListener2;
+
+		RtpStream::Params params1;
+
+		params1.ssrc          = 1111;
+		params1.clockRate     = 90000;
+		params1.useNack       = true;
+		params1.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
+
+		std::string mid;
+		std::unique_ptr<RtpStreamSend> stream1(new RtpStreamSend(&testRtpStreamListener1, params1, mid));
+
+		RtpStream::Params params2;
+
+		params2.ssrc          = 2222;
+		params2.clockRate     = 90000;
+		params2.useNack       = true;
+		params2.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
+
+		std::unique_ptr<RtpStreamSend> stream2(new RtpStreamSend(&testRtpStreamListener2, params2, mid));
+
+		// Create two VP8 encoding contexts.
+		RTC::Codecs::EncodingContext::Params params;
+		params.spatialLayers  = 0;
+		params.temporalLayers = 3;
+		Codecs::VP8::EncodingContext context1(params);
+
+		context1.SetCurrentTemporalLayer(3);
+		context1.SetTargetTemporalLayer(3);
+
+		Codecs::VP8::EncodingContext context2(params);
+
+		context2.SetCurrentTemporalLayer(0);
+		context2.SetTargetTemporalLayer(0);
+
+		// Parse the first packet.
+		auto* payloadDescriptor1 = Codecs::VP8::Parse(packet1->GetPayload(), packet1->GetPayloadLength());
+		REQUIRE(payloadDescriptor1->pictureId == 1);
+
+		auto* payloadDescriptorHandler1 = new Codecs::VP8::PayloadDescriptorHandler(payloadDescriptor1);
+		packet1->SetPayloadDescriptorHandler(payloadDescriptorHandler1);
+
+		bool marker = false;
+
+		// Process the first packet with context1.
+		auto forwarded = payloadDescriptorHandler1->Process(&context1, packet1->GetPayload(), marker);
+		REQUIRE(forwarded);
+
+		// Parse the second packet.
+		auto* payloadDescriptor2 = Codecs::VP8::Parse(packet2->GetPayload(), packet2->GetPayloadLength());
+		REQUIRE(payloadDescriptor2->pictureId == 2);
+
+		auto* payloadDescriptorHandler2 = new Codecs::VP8::PayloadDescriptorHandler(payloadDescriptor2);
+		packet2->SetPayloadDescriptorHandler(payloadDescriptorHandler2);
+
+		// Process the second packet with context1.
+		forwarded = payloadDescriptorHandler2->Process(&context1, packet2->GetPayload(), marker);
+		REQUIRE(forwarded);
+
+		// Process the second packet for context2.
+		forwarded = payloadDescriptorHandler2->Process(&context2, packet2->GetPayload(), marker);
+		// It must not forwared because the target temporal layer is 0.
+		REQUIRE(!forwarded);
+
+		// Parse the third packet
+		auto* payloadDescriptor3 = Codecs::VP8::Parse(packet3->GetPayload(), packet3->GetPayloadLength());
+		REQUIRE(payloadDescriptor3->pictureId == 3);
+
+		auto* payloadDescriptorHandler3 = new Codecs::VP8::PayloadDescriptorHandler(payloadDescriptor3);
+		packet2->SetPayloadDescriptorHandler(payloadDescriptorHandler3);
+
+		// Process the third packet for context1.
+		forwarded = payloadDescriptorHandler3->Process(&context1, packet3->GetPayload(), marker);
+		REQUIRE(forwarded);
+
+		// Receive the third packet in the first stream.
+		SendRtpPacket({ { stream1.get(), params1.ssrc } }, packet3.get());
+
+		// Update current/target temporal layers for context2.
+		context2.SetCurrentTemporalLayer(3);
+		context2.SetTargetTemporalLayer(3);
+
+		forwarded = payloadDescriptorHandler3->Process(&context2, packet3->GetPayload(), marker);
+		REQUIRE(forwarded);
+
+		// Receive the third packet in the second stream.
+		SendRtpPacket({ { stream2.get(), params2.ssrc } }, packet3.get());
+
+		// Create a NACK item that requests the third packet.
+		RTCP::FeedbackRtpNackPacket nackPacket(0, params1.ssrc);
+		auto* nackItem = new RTCP::FeedbackRtpNackItem(3, 0b0000000000000000);
+
+		nackPacket.AddItem(nackItem);
+
+		REQUIRE(nackItem->GetPacketId() == 3);
+		REQUIRE(nackItem->GetLostPacketBitmask() == 0b0000000000000000);
+
+		// Process the NACK packet on stream1.
+		stream1->ReceiveNack(&nackPacket);
+
+		REQUIRE(testRtpStreamListener1.retransmittedPackets.size() == 1);
+
+		auto* packet = testRtpStreamListener1.retransmittedPackets[0];
+
+		// Parse payload and check pictureId.
+		auto* payloadDescriptor4 = Codecs::VP8::Parse(packet->GetPayload(), packet->GetPayloadLength());
+		REQUIRE(payloadDescriptor4->pictureId == 3);
+
+		// Process the NACK packet on stream2.
+		stream2->ReceiveNack(&nackPacket);
+
+		REQUIRE(testRtpStreamListener2.retransmittedPackets.size() == 1);
+
+		packet = testRtpStreamListener2.retransmittedPackets[0];
+
+		// Parse payload and check pictureId.
+		auto* payloadDescriptor5 = Codecs::VP8::Parse(packet->GetPayload(), packet->GetPayloadLength());
+		REQUIRE(payloadDescriptor5);
+		REQUIRE(payloadDescriptor5->pictureId == 2);
 	}
 
 	SECTION("packets get retransmitted as long as they don't exceed MaxRetransmissionDelayForVideoMs")


### PR DESCRIPTION
NOTE: Only affects VP8.

Each VP8 RTP packet leaves the worker with its own encoded payload, as we are rewriting the `pictureId` and `tl0PictureIndex` per Consumer. When multiple Consumers are conusming the same Producer, we were not honouring that data on retransmissions.

This change should make mediasoup more resilient on lossy networks.