### PR TITLE
Node: close worker process by sending `WORKER_CLOSE` through the channel instead of by sending a SIGINT signal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Node: Make `worker.close()` close the worker process by sending a `WORKER_CLOSE` request through the channel instead of by sending a SIGINT signal ([PR #1528](https://github.com/versatica/mediasoup/pull/1528)).
+- Node: Make `worker.close()` close the worker process by sending a `WORKER_CLOSE` request through the channel instead of by sending a SIGINT signal ([PR #1534](https://github.com/versatica/mediasoup/pull/1534)).
 
 ### 3.15.8
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Node: Make `worker.close()` close the worker process by sending a `WORKER_CLOSE` request through the channel instead of by sending a SIGINT signal ([PR #1528](https://github.com/versatica/mediasoup/pull/1528)).
+
 ### 3.15.8
 
 - `Worker`: Fix encode retransmitted packets with the corresponding data ([PR #1527](https://github.com/versatica/mediasoup/pull/1527)).

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -78,7 +78,7 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 	// Died dlag.
 	#died = false;
 
-	// Worker subprocess closed flag.
+	// Worker process closed flag.
 	#subprocessClosed = false;
 
 	// Custom app data.
@@ -211,8 +211,8 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 		});
 
 		this.#child.on('exit', (code, signal) => {
-			// If killed by ourselves, do nothing.
-			if (this.#child.killed) {
+			// If closed by ourselves, do nothing.
+			if (this.#closed) {
 				return;
 			}
 
@@ -249,8 +249,8 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 		});
 
 		this.#child.on('error', error => {
-			// If killed by ourselves, do nothing.
-			if (this.#child.killed) {
+			// If closed by ourselves, do nothing.
+			if (this.#closed) {
 				return;
 			}
 
@@ -274,12 +274,16 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 
 		this.#child.on('close', (code, signal) => {
 			logger.debug(
-				`worker subprocess closed [pid:${this.#pid}, code:${code}, signal:${signal}]`
+				`worker process closed [pid:${this.#pid}, code:${code}, signal:${signal}]`
 			);
 
-			this.#subprocessClosed = true;
+			if (!this.#subprocessClosed) {
+				this.#subprocessClosed = true;
 
-			this.safeEmit('subprocessclose');
+				logger.debug(`emitting 'subprocessclose' event`);
+
+				this.safeEmit('subprocessclose');
+			}
 		});
 
 		// Be ready for 3rd party worker libraries logging to stdout.
@@ -354,12 +358,6 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 
 		this.#closed = true;
 
-		// Kill the worker process.
-		this.#child.kill('SIGTERM');
-
-		// Close the Channel instance.
-		this.#channel.close();
-
 		// Close every Router.
 		for (const router of this.#routers) {
 			router.workerClosed();
@@ -371,6 +369,23 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 			webRtcServer.workerClosed();
 		}
 		this.#webRtcServers.clear();
+
+		/* Send Request. */
+		this.#channel
+			.request(FbsRequest.Method.WORKER_CLOSE)
+			.then(() => {
+				// Close the Channel instance now.
+				this.#channel.close();
+			})
+			.catch(error => {
+				logger.error(
+					'close() | worker process failed to process the close request:',
+					error
+				);
+
+				// Close the Channel instance anyway.
+				this.#channel.close();
+			});
 
 		// Emit observer event.
 		this.#observer.safeEmit('close');
@@ -561,9 +576,10 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 			return;
 		}
 
-		logger.debug(`died() [error:${error.toString()}]`);
+		logger.debug(`workerDied() [error:${error.toString()}]`);
 
 		this.#closed = true;
+		this.#subprocessClosed = true;
 		this.#died = true;
 
 		// Close the Channel instance.
@@ -581,7 +597,10 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 		}
 		this.#webRtcServers.clear();
 
+		logger.debug(`workerDied() | emitting 'died' and 'subprocessclose' events`);
+
 		this.safeEmit('died', error);
+		this.safeEmit('subprocessclose');
 
 		// Emit observer event.
 		this.#observer.safeEmit('close');

--- a/node/src/test/test-Worker.ts
+++ b/node/src/test/test-Worker.ts
@@ -46,6 +46,7 @@ test('mediasoup.createWorker() succeeds', async () => {
 	expect(worker1.constructor.name).toBe('WorkerImpl');
 	expect(typeof worker1.pid).toBe('number');
 	expect(worker1.closed).toBe(false);
+	expect(worker1.subprocessClosed).toBe(false);
 	expect(worker1.died).toBe(false);
 
 	worker1.close();
@@ -53,6 +54,7 @@ test('mediasoup.createWorker() succeeds', async () => {
 	await enhancedOnce<WorkerEvents>(worker1, 'subprocessclose');
 
 	expect(worker1.closed).toBe(true);
+	expect(worker1.subprocessClosed).toBe(true);
 	expect(worker1.died).toBe(false);
 
 	const worker2 = await mediasoup.createWorker<{ foo: number; bar?: string }>({
@@ -70,6 +72,7 @@ test('mediasoup.createWorker() succeeds', async () => {
 	expect(worker2.constructor.name).toBe('WorkerImpl');
 	expect(typeof worker2.pid).toBe('number');
 	expect(worker2.closed).toBe(false);
+	expect(worker2.subprocessClosed).toBe(false);
 	expect(worker2.died).toBe(false);
 	expect(worker2.appData).toEqual({ foo: 456 });
 
@@ -78,6 +81,7 @@ test('mediasoup.createWorker() succeeds', async () => {
 	await enhancedOnce<WorkerEvents>(worker2, 'subprocessclose');
 
 	expect(worker2.closed).toBe(true);
+	expect(worker2.subprocessClosed).toBe(true);
 	expect(worker2.died).toBe(false);
 }, 2000);
 
@@ -194,6 +198,7 @@ test('worker.close() succeeds', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(worker.closed).toBe(true);
+	expect(worker.subprocessClosed).toBe(true);
 	expect(worker.died).toBe(false);
 }, 2000);
 
@@ -226,13 +231,10 @@ test('Worker emits "died" if mediasoup-worker process died unexpectedly', async 
 		process.kill(worker1.pid, 'SIGINT');
 	});
 
-	if (!worker1.subprocessClosed) {
-		await enhancedOnce<WorkerEvents>(worker1, 'subprocessclose');
-	}
-
 	expect(onDied).toHaveBeenCalledTimes(1);
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(worker1.closed).toBe(true);
+	expect(worker1.subprocessClosed).toBe(true);
 	expect(worker1.died).toBe(true);
 
 	const worker2 = await mediasoup.createWorker({ logLevel: 'warn' });
@@ -260,13 +262,10 @@ test('Worker emits "died" if mediasoup-worker process died unexpectedly', async 
 		process.kill(worker2.pid, 'SIGTERM');
 	});
 
-	if (!worker2.subprocessClosed) {
-		await enhancedOnce<WorkerEvents>(worker2, 'subprocessclose');
-	}
-
 	expect(onDied).toHaveBeenCalledTimes(1);
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(worker2.closed).toBe(true);
+	expect(worker2.subprocessClosed).toBe(true);
 	expect(worker2.died).toBe(true);
 
 	const worker3 = await mediasoup.createWorker({ logLevel: 'warn' });
@@ -294,13 +293,10 @@ test('Worker emits "died" if mediasoup-worker process died unexpectedly', async 
 		process.kill(worker3.pid, 'SIGKILL');
 	});
 
-	if (!worker3.subprocessClosed) {
-		await enhancedOnce<WorkerEvents>(worker3, 'subprocessclose');
-	}
-
 	expect(onDied).toHaveBeenCalledTimes(1);
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(worker3.closed).toBe(true);
+	expect(worker3.subprocessClosed).toBe(true);
 	expect(worker3.died).toBe(true);
 }, 5000);
 
@@ -321,6 +317,8 @@ if (os.platform() !== 'win32') {
 
 			setTimeout(() => {
 				expect(worker.closed).toBe(false);
+				expect(worker.subprocessClosed).toBe(false);
+				expect(worker.died).toBe(false);
 
 				worker.on('subprocessclose', resolve);
 				worker.close();

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -290,7 +290,9 @@ void Worker::HandleRequest(Channel::ChannelRequest* request)
 				return;
 			}
 
-			MS_DEBUG_DEV("Worker close request, stopping");
+			MS_DEBUG_DEV("closing Worker");
+
+			request->Accept();
 
 			Close();
 


### PR DESCRIPTION
# Details

- I have no idea why (before this PR) `worker.close()` sends a `SIGINT` signal to the worker process instead of sending a `WORKER_CLOSE` request via the channel. In fact `WORKER_CLOSE` request was **not** used (at least in mediasoup Node).
- The problem with that design is that a signal can reach the worker at arbitrary time. For instance, it can reach the worker process sooner than a channel request that was sent before. Or the signal could reach the worker process later than a channel request that was sent later. Meaning that the signal could interrupt legitimate channel requests sent before.
- If instead, we send a close request through the channel, then the close request will reach the worker immediately after previously sent requests (guaranteed since the channel is a `UnixSocket` in stream mode, so order is guaranteed).
- So I've changed it.
- I've also made `Worker.cpp` reply (with success) to the `WORKER_CLOSE` request so mediasoup Node knows it and can close its `this.#channel` when appropiate (and give a proper chance to incoming logs to reach Node land).
- Also improve `Worker.ts` state (`this.subprocessClosed` was not properly set in all cases, or not when it should be set).