### PR TITLE
Node: Require Node >= 20 (drop support for Node 18)

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -18,14 +18,10 @@ jobs:
       matrix:
         build:
           - os: ubuntu-22.04
-            node: 18
+            node: 20
             cc: gcc
             cxx: g++
           - os: ubuntu-22.04-arm
-            node: 18
-            cc: gcc
-            cxx: g++
-          - os: ubuntu-24.04
             node: 20
             cc: gcc
             cxx: g++
@@ -48,10 +44,6 @@ jobs:
             cc: gcc
             cxx: g++
             meson_args: '-Db_sanitize=thread'
-          - os: ubuntu-24.04-arm
-            node: 20
-            cc: gcc
-            cxx: g++
           - os: ubuntu-24.04-arm
             node: 22
             cc: gcc
@@ -76,7 +68,7 @@ jobs:
             cxx: g++
             meson_args: '-Db_sanitize=thread'
           - os: macos-13
-            node: 18
+            node: 20
             cc: clang
             cxx: clang++
           - os: macos-14

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -20,8 +20,6 @@ jobs:
     strategy:
       matrix:
         build:
-          - os: ubuntu-22.04
-          - os: ubuntu-22.04-arm
           - os: ubuntu-24.04
           - os: ubuntu-24.04-arm
           - os: macos-13

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -44,15 +44,6 @@ jobs:
             run-test-asan-address: true
             run-test-asan-undefined: false
             run-test-asan-thread: true
-          - os: ubuntu-22.04-arm
-            cc: clang
-            cxx: clang++
-            # No clang-format for ARM.
-            run-lint: false
-            run-test: true
-            run-test-asan-address: true
-            run-test-asan-undefined: true
-            run-test-asan-thread: true
           - os: ubuntu-24.04
             cc: gcc
             cxx: g++

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ### NEXT
 
 - Node: Make `worker.close()` close the worker process by sending a `WORKER_CLOSE` request through the channel instead of by sending a SIGINT signal ([PR #1534](https://github.com/versatica/mediasoup/pull/1534)).
-- Worker: Add initial AV1 codec support ([PR #1508](https://github.com/versatica/mediasoup/pull/1535)).
+- Worker: Add initial AV1 codec support ([PR #1508](https://github.com/versatica/mediasoup/pull/1508)).
 - `SvcConsumer`: Fix K-SVC bitrate in `IncreaseLayer()` method ([PR #1535](https://github.com/versatica/mediasoup/pull/1535) by @vpalmisano).
+- Node: Require Node >= 20 (drop support for Node 18) ([PR #1536](https://github.com/versatica/mediasoup/pull/1536)).
 
 ### 3.15.8
 

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"worker/tasks.py"
 	],
 	"engines": {
-		"node": ">=18"
+		"node": ">=20"
 	},
 	"keywords": [
 		"webrtc",


### PR DESCRIPTION
## Details

- Node 18 is too old, it's not maintaned anymore and we are already having problems with some NPM deps that require Node >= 20.
- Also remove some hosts from CI jobs (not many for now but that's another story).