### PR TITLE
Return status code 134 instead of abort when built as a library

### DIFF
--- a/worker/include/Logger.hpp
+++ b/worker/include/Logger.hpp
@@ -430,6 +430,7 @@ public:
 	} \
 	while (false)
 
+#ifdef MS_EXECUTABLE
 #define MS_ABORT(desc, ...) \
 	do \
 	{ \
@@ -438,6 +439,18 @@ public:
 		std::abort(); \
 	} \
 	while (false)
+#else
+#define MS_ABORT(desc, ...) \
+	do \
+	{ \
+		std::fprintf(stderr, "(ABORT) " _MS_LOG_STR_DESC desc _MS_LOG_SEPARATOR_CHAR_STD, _MS_LOG_ARG, ##__VA_ARGS__); \
+		std::fflush(stderr); \
+		char abortMessage[Logger::BufferSize]; \
+		std::snprintf(abortMessage, Logger::BufferSize, "(ABORT) " _MS_LOG_STR_DESC desc _MS_LOG_SEPARATOR_CHAR_STD, _MS_LOG_ARG, ##__VA_ARGS__); \
+		throw std::runtime_error(abortMessage); \
+	} \
+	while (false)
+#endif
 
 #define MS_ASSERT(condition, desc, ...) \
 	if (!(condition)) \

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -167,10 +167,12 @@ extern "C" int mediasoup_worker_run(
 		// 40 is a custom exit code to notify "unknown error" to the Node library.
 		return 40;
 	}
+#ifndef MS_EXECUTABLE
 	catch (const std::runtime_error& error)
 	{
 		return 134; // 134 is the exit code for SIGABRT.
 	}
+#endif
 }
 
 void IgnoreSignals()

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -167,6 +167,10 @@ extern "C" int mediasoup_worker_run(
 		// 40 is a custom exit code to notify "unknown error" to the Node library.
 		return 40;
 	}
+	catch (const std::runtime_error& error)
+	{
+		return 134; // 134 is the exit code for SIGABRT.
+	}
 }
 
 void IgnoreSignals()


### PR DESCRIPTION
When built as a library, the program no longer aborts but returns status code 134 instead. This is because environments using the library may not be able to handle signals properly.

We encountered the following error in our environment, which caused server to shut down:
```
(ABORT) RTC::SimulcastConsumer::SendRtpPacket() | failed assertion `producerTsReferenceRtpStream->GetSenderReportNtpMs()': no Sender Report for TS reference RTP stream
```

This change modifies the behavior so that when built as a library, only the worker thread stops instead of shutting down the entire process.


This behavioral change also affects https://github.com/versatica/mediasoup/pull/1394, and I believe this new behavior is more desirable.