### PR TITLE
libsrtp: Update to v3.0.0-beta version in our fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- libsrtp: Update to v3.0.0-beta version in our fork ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 3.16.0
 
 - Node: Make `worker.close()` close the worker process by sending a `WORKER_CLOSE` request through the channel instead of by sending a SIGINT signal ([PR #1534](https://github.com/versatica/mediasoup/pull/1534)).

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -259,8 +259,8 @@ libuv_proj = subproject(
   ],
 )
 
-libsrtp2_proj = subproject(
-  'libsrtp2',
+libsrtp3_proj = subproject(
+  'libsrtp3',
   default_options: [
     'warning_level=0',
     'crypto-library=openssl',
@@ -310,7 +310,7 @@ dependencies = [
   abseil_cpp_proj.get_variable('absl_container_dep'),
   openssl_proj.get_variable('openssl_dep'),
   libuv_proj.get_variable('libuv_dep'),
-  libsrtp2_proj.get_variable('libsrtp2_dep'),
+  libsrtp3_proj.get_variable('libsrtp3_dep'),
   usrsctp_proj.get_variable('usrsctp_dep'),
   flatbuffers_proj.get_variable('flatbuffers_dep'),
   flatbuffers_generator_dep,
@@ -322,7 +322,7 @@ link_whole = [
   openssl_proj.get_variable('libcrypto_lib'),
   openssl_proj.get_variable('libssl_lib'),
   libuv_proj.get_variable('libuv'),
-  libsrtp2_proj.get_variable('libsrtp2'),
+  libsrtp3_proj.get_variable('libsrtp3'),
   usrsctp_proj.get_variable('usrsctp'),
   flatbuffers_proj.get_variable('flatbuffers_lib'),
   libwebrtc,

--- a/worker/src/RTC/SrtpSession.cpp
+++ b/worker/src/RTC/SrtpSession.cpp
@@ -8,7 +8,7 @@
 #endif
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
-#include <cstring> // std::memset(), std::memcpy()
+#include <cstring> // std::memset()
 
 namespace RTC
 {
@@ -202,6 +202,7 @@ namespace RTC
 		}
 
 		uint8_t* encryptBuffer = EncryptBuffer;
+		size_t encryptLen      = EncryptBufferSize;
 
 #ifdef MS_LIBURING_SUPPORTED
 		if (DepLibUring::IsEnabled())
@@ -217,15 +218,20 @@ namespace RTC
 			if (sendBuffer)
 			{
 				encryptBuffer = sendBuffer;
+				encryptLen    = DepLibUring::SendBufferSize;
 			}
 		}
 
 	protect:
 #endif
 
-		std::memcpy(encryptBuffer, *data, *len);
-
-		const srtp_err_status_t err = srtp_protect(this->session, encryptBuffer, len);
+		const srtp_err_status_t err = srtp_protect(
+		  /*srtp_t ctx*/ this->session,
+		  /*const uint8_t* rtp*/ *data,
+		  /*size_t rtp_len*/ *len,
+		  /*uint8_t* srtp*/ encryptBuffer,
+		  /*size_t* srtp_len*/ std::addressof(encryptLen),
+		  /*size_t mki_index*/ 0);
 
 		if (DepLibSRTP::IsError(err))
 		{
@@ -234,8 +240,9 @@ namespace RTC
 			return false;
 		}
 
-		// Update the given data pointer.
+		// Update the given data pointer and len.
 		*data = const_cast<const uint8_t*>(encryptBuffer);
+		*len  = encryptLen;
 
 		return true;
 	}
@@ -244,7 +251,14 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		const srtp_err_status_t err = srtp_unprotect(this->session, data, len);
+		size_t decryptLen = *len;
+
+		const srtp_err_status_t err = srtp_unprotect(
+		  /*srtp_t ctx*/ this->session,
+		  /*const uint8_t* srtp*/ data,
+		  /*size_t srtp_len*/ *len,
+		  /*uint8_t* rtp*/ data,
+		  /*size_t* rtp_len*/ std::addressof(decryptLen));
 
 		if (DepLibSRTP::IsError(err))
 		{
@@ -252,6 +266,9 @@ namespace RTC
 
 			return false;
 		}
+
+		// Update the given len.
+		*len = decryptLen;
 
 		return true;
 	}
@@ -268,9 +285,16 @@ namespace RTC
 			return false;
 		}
 
-		std::memcpy(EncryptBuffer, *data, *len);
+		uint8_t* encryptBuffer = EncryptBuffer;
+		size_t encryptLen      = EncryptBufferSize;
 
-		const srtp_err_status_t err = srtp_protect_rtcp(this->session, EncryptBuffer, len);
+		const srtp_err_status_t err = srtp_protect_rtcp(
+		  /*srtp_t ctx*/ this->session,
+		  /*const uint8_t* rtcp*/ *data,
+		  /*size_t rtcp_len*/ *len,
+		  /*uint8_t* srtcp*/ encryptBuffer,
+		  /*size_t* srtcp_len*/ std::addressof(encryptLen),
+		  /*size_t mki_index*/ 0);
 
 		if (DepLibSRTP::IsError(err))
 		{
@@ -279,8 +303,9 @@ namespace RTC
 			return false;
 		}
 
-		// Update the given data pointer.
+		// Update the given data pointer and len.
 		*data = (const uint8_t*)EncryptBuffer;
+		*len  = encryptLen;
 
 		return true;
 	}
@@ -289,7 +314,14 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		const srtp_err_status_t err = srtp_unprotect_rtcp(this->session, data, len);
+		size_t decryptLen = *len;
+
+		const srtp_err_status_t err = srtp_unprotect_rtcp(
+		  /*srtp_t ctx*/ this->session,
+		  /*const uint8_t* srtcp*/ data,
+		  /*size_t srtcp_len*/ *len,
+		  /*uint8_t* rtcp*/ data,
+		  /*size_t* rtcp_len*/ std::addressof(decryptLen));
 
 		if (DepLibSRTP::IsError(err))
 		{
@@ -297,6 +329,9 @@ namespace RTC
 
 			return false;
 		}
+
+		// Update the given len.
+		*len = decryptLen;
 
 		return true;
 	}

--- a/worker/subprojects/libsrtp2.wrap
+++ b/worker/subprojects/libsrtp2.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
-directory = libsrtp-3.0-alpha
-source_url = https://github.com/versatica/libsrtp/archive/v3.0-alpha.zip
-source_filename = libsrtp-3.0-alpha.zip
-source_hash = 946a472b888ca8d51df172def7681f3f9b14768109ffd22af08fddb1be77d2c6
+directory = libsrtp-3.0.0-beta
+source_url = https://github.com/versatica/libsrtp/archive/v3.0.0-beta.zip
+source_filename = libsrtp-3.0.0-beta.zip
+source_hash = b0cb21aaf27120b1a242f3d9b07c145b4a6c7a02a25da0824539fd95611f690c
 
 [provide]
 libsrtp2 = libsrtp2_dep

--- a/worker/subprojects/libsrtp3.wrap
+++ b/worker/subprojects/libsrtp3.wrap
@@ -5,4 +5,4 @@ source_filename = libsrtp-3.0.0-beta.zip
 source_hash = b0cb21aaf27120b1a242f3d9b07c145b4a6c7a02a25da0824539fd95611f690c
 
 [provide]
-libsrtp2 = libsrtp2_dep
+libsrtp3 = libsrtp3_dep


### PR DESCRIPTION
## Details

- https://github.com/versatica/libsrtp/releases
- Rename `subprojects/libsrtp2.wrap` to `subprojects/libsrtp3.wrap` (since in recent commits in mainstream libsrtp, `libsrtp2_dep` has been renamed to `libsrtp3_dep`.