### PR TITLE
Consumer: add target layer retransmission buffer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - libuv: Update to v1.51.0 ([PR #1543](https://github.com/versatica/mediasoup/pull/1543)).
 - libsrtp: Update to v3.0.0-beta version in our fork ([PR #1544](https://github.com/versatica/mediasoup/pull/1544)).
+- `Consumer`: Add target layer retransmission buffer ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
 
 ### 3.16.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - libuv: Update to v1.51.0 ([PR #1543](https://github.com/versatica/mediasoup/pull/1543)).
 - libsrtp: Update to v3.0.0-beta version in our fork ([PR #1544](https://github.com/versatica/mediasoup/pull/1544)).
-- `Consumer`: Add target layer retransmission buffer ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- `XxxxConsumer`: Add target layer retransmission buffer ([PR #1548](https://github.com/versatica/mediasoup/pull/1548)).
 
 ### 3.16.0
 

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -5,6 +5,7 @@
 #include "RTC/Consumer.hpp"
 #include "RTC/SeqManager.hpp"
 #include "RTC/Shared.hpp"
+#include <map>
 
 namespace RTC
 {
@@ -72,6 +73,8 @@ namespace RTC
 		void UserOnResumed() override;
 		void CreateRtpStream();
 		void RequestKeyFrame();
+		void StorePacketInTargetLayerRetransmissionBuffer(
+		  RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket);
 		void EmitScore() const;
 
 		/* Pure virtual methods inherited from RtpStreamSend::Listener. */
@@ -90,6 +93,10 @@ namespace RTC
 		std::unique_ptr<RTC::SeqManager<uint16_t>> rtpSeqManager;
 		bool managingBitrate{ false };
 		std::unique_ptr<RTC::Codecs::EncodingContext> encodingContext;
+		// Buffer to store packets that arrive earlier than the first packet of the
+		// video key frame.
+		std::map<uint16_t, std::shared_ptr<RTC::RtpPacket>, RTC::SeqManager<uint16_t>::SeqLowerThan>
+		  targetLayerRetransmissionBuffer;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -6,6 +6,7 @@
 #include "RTC/Consumer.hpp"
 #include "RTC/SeqManager.hpp"
 #include "RTC/Shared.hpp"
+#include <map>
 
 namespace RTC
 {

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -94,6 +94,8 @@ namespace RTC
 		bool RecalculateTargetLayers(int16_t& newTargetSpatialLayer, int16_t& newTargetTemporalLayer) const;
 		void UpdateTargetLayers(int16_t newTargetSpatialLayer, int16_t newTargetTemporalLayer);
 		bool CanSwitchToSpatialLayer(int16_t spatialLayer) const;
+		void StorePacketInTargetLayerRetransmissionBuffer(
+		  RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket);
 		void EmitScore() const;
 		void EmitLayersChange() const;
 		RTC::RtpStreamRecv* GetProducerCurrentRtpStream() const;
@@ -130,6 +132,10 @@ namespace RTC
 		uint32_t tsOffset{ 0u }; // RTP Timestamp offset.
 		bool keyFrameForTsOffsetRequested{ false };
 		uint64_t lastBweDowngradeAtMs{ 0u }; // Last time we moved to lower spatial layer due to BWE.
+		// Buffer to store packets that arrive earlier than the first packet of the
+		// video key frame.
+		std::map<uint16_t, std::shared_ptr<RTC::RtpPacket>, RTC::SeqManager<uint16_t>::SeqLowerThan>
+		  targetLayerRetransmissionBuffer;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -85,6 +85,8 @@ namespace RTC
 		void MayChangeLayers(bool force = false);
 		bool RecalculateTargetLayers(int16_t& newTargetSpatialLayer, int16_t& newTargetTemporalLayer) const;
 		void UpdateTargetLayers(int16_t newTargetSpatialLayer, int16_t newTargetTemporalLayer);
+		void StorePacketInTargetLayerRetransmissionBuffer(
+		  RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket);
 		void EmitScore() const;
 		void EmitLayersChange() const;
 
@@ -107,6 +109,10 @@ namespace RTC
 		int16_t provisionalTargetTemporalLayer{ -1 };
 		std::unique_ptr<RTC::Codecs::EncodingContext> encodingContext;
 		uint64_t lastBweDowngradeAtMs{ 0u }; // Last time we moved to lower spatial layer due to BWE.
+		// Buffer to store packets that arrive earlier than the first packet of the
+		// video key frame.
+		std::map<uint16_t, std::shared_ptr<RTC::RtpPacket>, RTC::SeqManager<uint16_t>::SeqLowerThan>
+		  targetLayerRetransmissionBuffer;
 	};
 } // namespace RTC
 

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -11,6 +11,10 @@
 
 namespace RTC
 {
+	/* Static. */
+
+	static constexpr size_t TargetLayerRetransmissionBufferSize{ 20u };
+
 	/* Instance methods. */
 
 	SimpleConsumer::SimpleConsumer(
@@ -74,6 +78,7 @@ namespace RTC
 		this->shared->channelMessageRegistrator->UnregisterHandler(this->id);
 
 		delete this->rtpStream;
+		this->targetLayerRetransmissionBuffer.clear();
 	}
 
 	flatbuffers::Offset<FBS::Consumer::DumpResponse> SimpleConsumer::FillBuffer(
@@ -362,19 +367,6 @@ namespace RTC
 			return;
 		}
 
-		// If we need to sync, support key frames and this is not a key frame, ignore
-		// the packet.
-		if (this->syncRequired && this->keyFrameSupported && !packet->IsKeyFrame())
-		{
-#ifdef MS_RTC_LOGGER_RTP
-			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
-#endif
-
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
-
-			return;
-		}
-
 		// Packets with only padding are not forwarded.
 		if (packet->GetPayloadLength() == 0)
 		{
@@ -387,6 +379,20 @@ namespace RTC
 			return;
 		}
 
+		// If we need to sync, support key frames and this is not a key frame, do not
+		// send the packet and store it for the scenario in which this packet is part
+		// of the key frame and arrived before the first packet of the key frame.
+		if (this->syncRequired && this->keyFrameSupported && !packet->IsKeyFrame())
+		{
+			StorePacketInTargetLayerRetransmissionBuffer(packet, sharedPacket);
+
+			return;
+		}
+
+		// Whether packets stored in the target layer retransmission buffer must be
+		// sent once this packet is sent.
+		bool sendPacketsInTargetLayerRetransmissionBuffer{ false };
+
 		// Whether this is the first packet after re-sync.
 		const bool isSyncPacket = this->syncRequired;
 
@@ -395,7 +401,13 @@ namespace RTC
 		{
 			if (packet->IsKeyFrame())
 			{
-				MS_DEBUG_TAG(rtp, "sync key frame received");
+				MS_DEBUG_TAG(
+				  rtp,
+				  "sync key frame received [seq:%" PRIu16 ", ts:%" PRIu32 "]",
+				  packet->GetSequenceNumber(),
+				  packet->GetTimestamp());
+
+				sendPacketsInTargetLayerRetransmissionBuffer = true;
 			}
 
 			this->rtpSeqManager->Sync(packet->GetSequenceNumber() - 1);
@@ -457,6 +469,28 @@ namespace RTC
 		// Restore packet fields.
 		packet->SetSsrc(origSsrc);
 		packet->SetSequenceNumber(origSeq);
+
+		// If sent packet was the first packet of a key frame, we may need to send
+		// buffered packets belonging to the same key frame that arrived earlier due
+		// to packet misorder.
+		if (sendPacketsInTargetLayerRetransmissionBuffer)
+		{
+			for (auto& pair : this->targetLayerRetransmissionBuffer)
+			{
+				auto& bufferedSharedPacket = pair.second;
+				auto* bufferedPacket       = bufferedSharedPacket.get();
+
+				MS_DEBUG_DEV(
+				  "sending packet buffered in the target layer retransmission buffer [seq:%" PRIu16
+				  ", ts:%" PRIu32 "]",
+				  bufferedPacket->GetSequenceNumber(),
+				  bufferedPacket->GetTimestamp());
+
+				SendRtpPacket(bufferedPacket, bufferedSharedPacket);
+			}
+
+			this->targetLayerRetransmissionBuffer.clear();
+		}
 	}
 
 	bool SimpleConsumer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs)
@@ -607,6 +641,7 @@ namespace RTC
 		MS_TRACE();
 
 		this->rtpStream->Pause();
+		this->targetLayerRetransmissionBuffer.clear();
 	}
 
 	void SimpleConsumer::UserOnPaused()
@@ -614,6 +649,7 @@ namespace RTC
 		MS_TRACE();
 
 		this->rtpStream->Pause();
+		this->targetLayerRetransmissionBuffer.clear();
 
 		if (this->externallyManagedBitrate && this->kind == RTC::Media::Kind::VIDEO)
 		{
@@ -727,6 +763,31 @@ namespace RTC
 		auto mappedSsrc = this->consumableRtpEncodings[0].ssrc;
 
 		this->listener->OnConsumerKeyFrameRequested(this, mappedSsrc);
+	}
+
+	void SimpleConsumer::StorePacketInTargetLayerRetransmissionBuffer(
+	  RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket)
+	{
+		MS_TRACE();
+
+		MS_DEBUG_DEV(
+		  "storing packet in target layer retransmission buffer [seq:%" PRIu16 ", ts:%" PRIu32 "]",
+		  packet->GetSequenceNumber(),
+		  packet->GetTimestamp());
+
+		// Store original packet into the buffer. Only clone once and only if
+		// necessary.
+		if (!sharedPacket)
+		{
+			sharedPacket.reset(packet->Clone());
+		}
+
+		this->targetLayerRetransmissionBuffer[packet->GetSequenceNumber()] = sharedPacket;
+
+		if (this->targetLayerRetransmissionBuffer.size() > TargetLayerRetransmissionBufferSize)
+		{
+			this->targetLayerRetransmissionBuffer.erase(this->targetLayerRetransmissionBuffer.begin());
+		}
 	}
 
 	inline void SimpleConsumer::EmitScore() const

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -13,7 +13,7 @@ namespace RTC
 {
 	/* Static. */
 
-	static constexpr size_t TargetLayerRetransmissionBufferSize{ 20u };
+	static constexpr size_t TargetLayerRetransmissionBufferSize{ 15u };
 
 	/* Instance methods. */
 
@@ -384,6 +384,12 @@ namespace RTC
 		// of the key frame and arrived before the first packet of the key frame.
 		if (this->syncRequired && this->keyFrameSupported && !packet->IsKeyFrame())
 		{
+#ifdef MS_RTC_LOGGER_RTP
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+#endif
+
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
 			StorePacketInTargetLayerRetransmissionBuffer(packet, sharedPacket);
 
 			return;

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -384,11 +384,9 @@ namespace RTC
 		// of the key frame and arrived before the first packet of the key frame.
 		if (this->syncRequired && this->keyFrameSupported && !packet->IsKeyFrame())
 		{
-#ifdef MS_RTC_LOGGER_RTP
-			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
-#endif
-
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+			// No need to drop in the sequence manager the packet since we are blocking
+			// all packets that are not a key frame and anyway we are syncing below when
+			// the key frame arrives.
 
 			StorePacketInTargetLayerRetransmissionBuffer(packet, sharedPacket);
 

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -480,13 +480,16 @@ namespace RTC
 				auto& bufferedSharedPacket = pair.second;
 				auto* bufferedPacket       = bufferedSharedPacket.get();
 
-				MS_DEBUG_DEV(
-				  "sending packet buffered in the target layer retransmission buffer [seq:%" PRIu16
-				  ", ts:%" PRIu32 "]",
-				  bufferedPacket->GetSequenceNumber(),
-				  bufferedPacket->GetTimestamp());
+				if (bufferedPacket->GetSequenceNumber() > origSeq)
+				{
+					MS_DEBUG_DEV(
+					  "sending packet buffered in the target layer retransmission buffer [seq:%" PRIu16
+					  ", ts:%" PRIu32 "]",
+					  bufferedPacket->GetSequenceNumber(),
+					  bufferedPacket->GetTimestamp());
 
-				SendRtpPacket(bufferedPacket, bufferedSharedPacket);
+					SendRtpPacket(bufferedPacket, bufferedSharedPacket);
+				}
 			}
 
 			this->targetLayerRetransmissionBuffer.clear();

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -16,6 +16,7 @@ namespace RTC
 	static constexpr uint64_t BweDowngradeConservativeMs{ 10000u }; // In ms.
 	static constexpr uint64_t BweDowngradeMinActiveMs{ 8000u };     // In ms.
 	static constexpr uint16_t MaxSequenceNumberGap{ 100u };
+	static constexpr size_t TargetLayerRetransmissionBufferSize{ 20u };
 
 	/* Instance methods. */
 
@@ -133,6 +134,7 @@ namespace RTC
 		this->shared->channelMessageRegistrator->UnregisterHandler(this->id);
 
 		delete this->rtpStream;
+		this->targetLayerRetransmissionBuffer.clear();
 	}
 
 	flatbuffers::Offset<FBS::Consumer::DumpResponse> SimulcastConsumer::FillBuffer(
@@ -776,14 +778,12 @@ namespace RTC
 		// the current spatial layer.
 		if (this->currentSpatialLayer != this->targetSpatialLayer && spatialLayer == this->targetSpatialLayer)
 		{
-			// Ignore if not a key frame.
+			// If not a key frame store the packet for the scenario in which this
+			// packet is part of the key frame and arrived before the first packet
+			// of the key frame.
 			if (!packet->IsKeyFrame())
 			{
-#ifdef MS_RTC_LOGGER_RTP
-				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
-#endif
-
-				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+				StorePacketInTargetLayerRetransmissionBuffer(packet, sharedPacket);
 
 				return;
 			}
@@ -805,18 +805,6 @@ namespace RTC
 			return;
 		}
 
-		// If we need to sync and this is not a key frame, ignore the packet.
-		if (this->syncRequired && !packet->IsKeyFrame())
-		{
-#ifdef MS_RTC_LOGGER_RTP
-			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
-#endif
-
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
-
-			return;
-		}
-
 		// If the packet belongs to current spatial layer being sent and packet does
 		// not have payload other than padding, then drop it.
 		if (spatialLayer == this->currentSpatialLayer && packet->GetPayloadLength() == 0)
@@ -830,6 +818,20 @@ namespace RTC
 			return;
 		}
 
+		// If we need to sync and this is not a key frame, do not send the packet
+		// and store it for the scenario in which this packet is part of the key
+		// frame and arrived before the first packet of the key frame.
+		if (this->syncRequired && !packet->IsKeyFrame())
+		{
+			StorePacketInTargetLayerRetransmissionBuffer(packet, sharedPacket);
+
+			return;
+		}
+
+		// Whether packets stored in the target layer retransmission buffer must be
+		// sent once this packet is sent.
+		bool sendPacketsInTargetLayerRetransmissionBuffer{ false };
+
 		// Whether this is the first packet after re-sync.
 		const bool isSyncPacket = this->syncRequired;
 
@@ -838,7 +840,13 @@ namespace RTC
 		{
 			if (packet->IsKeyFrame())
 			{
-				MS_DEBUG_TAG(rtp, "sync key frame received");
+				MS_DEBUG_TAG(
+				  rtp,
+				  "sync key frame received [seq:%" PRIu16 ", ts:%" PRIu32 "]",
+				  packet->GetSequenceNumber(),
+				  packet->GetTimestamp());
+
+				sendPacketsInTargetLayerRetransmissionBuffer = true;
 			}
 
 			uint32_t tsOffset{ 0u };
@@ -1125,6 +1133,31 @@ namespace RTC
 
 		// Restore the original payload if needed.
 		packet->RestorePayload();
+
+		// If sent packet was the first packet of a key frame, we may need to send
+		// buffered packets belonging to the same key frame that arrived earlier due
+		// to packet misorder.
+		if (sendPacketsInTargetLayerRetransmissionBuffer)
+		{
+			for (auto& pair : this->targetLayerRetransmissionBuffer)
+			{
+				auto& bufferedSharedPacket = pair.second;
+				auto* bufferedPacket       = bufferedSharedPacket.get();
+
+				if (bufferedPacket->GetSequenceNumber() > origSeq)
+				{
+					MS_DEBUG_DEV(
+					  "sending packet buffered in the target layer retransmission buffer [seq:%" PRIu16
+					  ", ts:%" PRIu32 "]",
+					  bufferedPacket->GetSequenceNumber(),
+					  bufferedPacket->GetTimestamp());
+
+					SendRtpPacket(bufferedPacket, bufferedSharedPacket);
+				}
+			}
+
+			this->targetLayerRetransmissionBuffer.clear();
+		}
 	}
 
 	bool SimulcastConsumer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs)
@@ -1279,6 +1312,7 @@ namespace RTC
 		this->lastBweDowngradeAtMs = 0u;
 
 		this->rtpStream->Pause();
+		this->targetLayerRetransmissionBuffer.clear();
 
 		UpdateTargetLayers(-1, -1);
 	}
@@ -1290,6 +1324,7 @@ namespace RTC
 		this->lastBweDowngradeAtMs = 0u;
 
 		this->rtpStream->Pause();
+		this->targetLayerRetransmissionBuffer.clear();
 
 		UpdateTargetLayers(-1, -1);
 
@@ -1665,6 +1700,31 @@ namespace RTC
 			this->producerRtpStreams.at(spatialLayer)->GetSenderReportNtpMs()
 		);
 		// clang-format on
+	}
+
+	void SimulcastConsumer::StorePacketInTargetLayerRetransmissionBuffer(
+	  RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket)
+	{
+		MS_TRACE();
+
+		MS_DEBUG_DEV(
+		  "storing packet in target layer retransmission buffer [seq:%" PRIu16 ", ts:%" PRIu32 "]",
+		  packet->GetSequenceNumber(),
+		  packet->GetTimestamp());
+
+		// Store original packet into the buffer. Only clone once and only if
+		// necessary.
+		if (!sharedPacket)
+		{
+			sharedPacket.reset(packet->Clone());
+		}
+
+		this->targetLayerRetransmissionBuffer[packet->GetSequenceNumber()] = sharedPacket;
+
+		if (this->targetLayerRetransmissionBuffer.size() > TargetLayerRetransmissionBufferSize)
+		{
+			this->targetLayerRetransmissionBuffer.erase(this->targetLayerRetransmissionBuffer.begin());
+		}
 	}
 
 	inline void SimulcastConsumer::EmitScore() const

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -16,7 +16,7 @@ namespace RTC
 	static constexpr uint64_t BweDowngradeConservativeMs{ 10000u }; // In ms.
 	static constexpr uint64_t BweDowngradeMinActiveMs{ 8000u };     // In ms.
 	static constexpr uint16_t MaxSequenceNumberGap{ 100u };
-	static constexpr size_t TargetLayerRetransmissionBufferSize{ 20u };
+	static constexpr size_t TargetLayerRetransmissionBufferSize{ 30u };
 
 	/* Instance methods. */
 
@@ -783,6 +783,12 @@ namespace RTC
 			// of the key frame.
 			if (!packet->IsKeyFrame())
 			{
+#ifdef MS_RTC_LOGGER_RTP
+				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+#endif
+
+				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
 				StorePacketInTargetLayerRetransmissionBuffer(packet, sharedPacket);
 
 				return;
@@ -823,6 +829,12 @@ namespace RTC
 		// frame and arrived before the first packet of the key frame.
 		if (this->syncRequired && !packet->IsKeyFrame())
 		{
+#ifdef MS_RTC_LOGGER_RTP
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+#endif
+
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
 			StorePacketInTargetLayerRetransmissionBuffer(packet, sharedPacket);
 
 			return;

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -783,11 +783,8 @@ namespace RTC
 			// of the key frame.
 			if (!packet->IsKeyFrame())
 			{
-#ifdef MS_RTC_LOGGER_RTP
-				packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
-#endif
-
-				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+				// We don't drop in the sequence manager because this packet doesn't
+				// to the current stream.
 
 				StorePacketInTargetLayerRetransmissionBuffer(packet, sharedPacket);
 
@@ -829,11 +826,9 @@ namespace RTC
 		// frame and arrived before the first packet of the key frame.
 		if (this->syncRequired && !packet->IsKeyFrame())
 		{
-#ifdef MS_RTC_LOGGER_RTP
-			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
-#endif
-
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+			// No need to drop in the sequence manager the packet since we are blocking
+			// all packets that are not a key frame and anyway we are syncing below when
+			// the key frame arrives.
 
 			StorePacketInTargetLayerRetransmissionBuffer(packet, sharedPacket);
 
@@ -868,7 +863,8 @@ namespace RTC
 			{
 				tsOffset = 0u;
 			}
-			// If this is not the RTP stream we use as TS reference, do NTP based RTP TS synchronization.
+			// If this is not the RTP stream we use as TS reference, do NTP based RTP TS
+			// synchronization.
 			else
 			{
 				auto* producerTsReferenceRtpStream = GetProducerTsReferenceRtpStream();

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -703,11 +703,9 @@ namespace RTC
 		// frame and arrived before the first packet of the key frame.
 		if (this->syncRequired && !packet->IsKeyFrame())
 		{
-#ifdef MS_RTC_LOGGER_RTP
-			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
-#endif
-
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+			// No need to drop in the sequence manager the packet since we are blocking
+			// all packets that are not a key frame and anyway we are syncing below when
+			// the key frame arrives.
 
 			StorePacketInTargetLayerRetransmissionBuffer(packet, sharedPacket);
 

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -14,6 +14,7 @@ namespace RTC
 
 	static constexpr uint64_t BweDowngradeConservativeMs{ 10000u }; // In ms.
 	static constexpr uint64_t BweDowngradeMinActiveMs{ 8000u };     // In ms.
+	static constexpr size_t TargetLayerRetransmissionBufferSize{ 20u };
 
 	/* Instance methods. */
 
@@ -115,6 +116,7 @@ namespace RTC
 		this->shared->channelMessageRegistrator->UnregisterHandler(this->id);
 
 		delete this->rtpStream;
+		this->targetLayerRetransmissionBuffer.clear();
 	}
 
 	flatbuffers::Offset<FBS::Consumer::DumpResponse> SvcConsumer::FillBuffer(
@@ -684,18 +686,6 @@ namespace RTC
 			return;
 		}
 
-		// If we need to sync and this is not a key frame, ignore the packet.
-		if (this->syncRequired && !packet->IsKeyFrame())
-		{
-#ifdef MS_RTC_LOGGER_RTP
-			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
-#endif
-
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
-
-			return;
-		}
-
 		// Packets with only padding are not forwarded.
 		if (packet->GetPayloadLength() == 0)
 		{
@@ -708,6 +698,26 @@ namespace RTC
 			return;
 		}
 
+		// If we need to sync and this is not a key frame, do not send the packet
+		// and store it for the scenario in which this packet is part of the key
+		// frame and arrived before the first packet of the key frame.
+		if (this->syncRequired && !packet->IsKeyFrame())
+		{
+#ifdef MS_RTC_LOGGER_RTP
+			packet->logger.Dropped(RtcLogger::RtpPacket::DropReason::NOT_A_KEYFRAME);
+#endif
+
+			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+
+			StorePacketInTargetLayerRetransmissionBuffer(packet, sharedPacket);
+
+			return;
+		}
+
+		// Whether packets stored in the target layer retransmission buffer must be
+		// sent once this packet is sent.
+		bool sendPacketsInTargetLayerRetransmissionBuffer{ false };
+
 		// Whether this is the first packet after re-sync.
 		const bool isSyncPacket = this->syncRequired;
 
@@ -716,7 +726,13 @@ namespace RTC
 		{
 			if (packet->IsKeyFrame())
 			{
-				MS_DEBUG_TAG(rtp, "sync key frame received");
+				MS_DEBUG_TAG(
+				  rtp,
+				  "sync key frame received [seq:%" PRIu16 ", ts:%" PRIu32 "]",
+				  packet->GetSequenceNumber(),
+				  packet->GetTimestamp());
+
+				sendPacketsInTargetLayerRetransmissionBuffer = true;
 			}
 
 			this->rtpSeqManager->Sync(packet->GetSequenceNumber() - 1);
@@ -817,6 +833,31 @@ namespace RTC
 
 		// Restore the original payload if needed.
 		packet->RestorePayload();
+
+		// If sent packet was the first packet of a key frame, we may need to send
+		// buffered packets belonging to the same key frame that arrived earlier due
+		// to packet misorder.
+		if (sendPacketsInTargetLayerRetransmissionBuffer)
+		{
+			for (auto& pair : this->targetLayerRetransmissionBuffer)
+			{
+				auto& bufferedSharedPacket = pair.second;
+				auto* bufferedPacket       = bufferedSharedPacket.get();
+
+				if (bufferedPacket->GetSequenceNumber() > origSeq)
+				{
+					MS_DEBUG_DEV(
+					  "sending packet buffered in the target layer retransmission buffer [seq:%" PRIu16
+					  ", ts:%" PRIu32 "]",
+					  bufferedPacket->GetSequenceNumber(),
+					  bufferedPacket->GetTimestamp());
+
+					SendRtpPacket(bufferedPacket, bufferedSharedPacket);
+				}
+			}
+
+			this->targetLayerRetransmissionBuffer.clear();
+		}
 	}
 
 	bool SvcConsumer::GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs)
@@ -967,6 +1008,7 @@ namespace RTC
 		this->lastBweDowngradeAtMs = 0u;
 
 		this->rtpStream->Pause();
+		this->targetLayerRetransmissionBuffer.clear();
 
 		UpdateTargetLayers(-1, -1);
 	}
@@ -978,6 +1020,7 @@ namespace RTC
 		this->lastBweDowngradeAtMs = 0u;
 
 		this->rtpStream->Pause();
+		this->targetLayerRetransmissionBuffer.clear();
 
 		UpdateTargetLayers(-1, -1);
 
@@ -1249,6 +1292,31 @@ namespace RTC
 
 				RequestKeyFrame();
 			}
+		}
+	}
+
+	void SvcConsumer::StorePacketInTargetLayerRetransmissionBuffer(
+	  RTC::RtpPacket* packet, std::shared_ptr<RTC::RtpPacket>& sharedPacket)
+	{
+		MS_TRACE();
+
+		MS_DEBUG_DEV(
+		  "storing packet in target layer retransmission buffer [seq:%" PRIu16 ", ts:%" PRIu32 "]",
+		  packet->GetSequenceNumber(),
+		  packet->GetTimestamp());
+
+		// Store original packet into the buffer. Only clone once and only if
+		// necessary.
+		if (!sharedPacket)
+		{
+			sharedPacket.reset(packet->Clone());
+		}
+
+		this->targetLayerRetransmissionBuffer[packet->GetSequenceNumber()] = sharedPacket;
+
+		if (this->targetLayerRetransmissionBuffer.size() > TargetLayerRetransmissionBufferSize)
+		{
+			this->targetLayerRetransmissionBuffer.erase(this->targetLayerRetransmissionBuffer.begin());
 		}
 	}
 

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -54,7 +54,7 @@ void validate(SeqManager<T, N>& seqManager, std::vector<TestSeqManagerInput<T>>&
 	}
 }
 
-SCENARIO("SeqManager", "[rtc][SeqMananger]")
+SCENARIO("SeqManager", "[rtc][SeqManager]")
 {
 	SECTION("0 is greater than 65000")
 	{


### PR DESCRIPTION
## Details

- Fixes #1547.

## TODO

1. In `SimulcastConsumer` we should only add packets to the new buffer if it's belong to the target spatial layer.
2. Implement it in `PipeConsumer`.
