### PR TITLE
RtcLogger: Use MS_DUMP() instead of std::cout()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Worker: RtcLogger: Use `MS_DUMP()` instead of `std::cout()` ([PR #1553](https://github.com/versatica/mediasoup/pull/1553)).
+- RtcLogger: Use `MS_DUMP()` instead of `std::cout()` ([PR #1553](https://github.com/versatica/mediasoup/pull/1553)).
 
 ### 3.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,5 @@
 # Changelog
 
-### NEXT
-
-- `RtcLogger`: Use `MS_DUMP()` instead of `std::cout()` ([PR #1553](https://github.com/versatica/mediasoup/pull/1553)).
-
 ### 3.16.1
 
 - libuv: Update to v1.51.0 ([PR #1543](https://github.com/versatica/mediasoup/pull/1543)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Worker: RtcLogger: Use MS_DUMP() instead of std::cout() ([PR #1553](https://github.com/versatica/mediasoup/pull/1553)).
+- Worker: RtcLogger: Use `MS_DUMP()` instead of `std::cout()` ([PR #1553](https://github.com/versatica/mediasoup/pull/1553)).
 
 ### 3.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- RtcLogger: Use `MS_DUMP()` instead of `std::cout()` ([PR #1553](https://github.com/versatica/mediasoup/pull/1553)).
+- `RtcLogger`: Use `MS_DUMP()` instead of `std::cout()` ([PR #1553](https://github.com/versatica/mediasoup/pull/1553)).
 
 ### 3.16.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### NEXT
+
+- Worker: RtcLogger: Use MS_DUMP() instead of std::cout() ([PR #1553](https://github.com/versatica/mediasoup/pull/1553)).
+
 ### 3.16.1
 
 - libuv: Update to v1.51.0 ([PR #1543](https://github.com/versatica/mediasoup/pull/1543)).

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -3,6 +3,7 @@
 
 #include "RTC/RtcLogger.hpp"
 #include "Logger.hpp"
+#include <sstream>
 
 namespace RTC
 {

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -52,42 +52,41 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			// TODO: Here we are using std::cout() which means that it's directly
-			// written to stdout. When in Node, it means that Worker.ts captures it
-			// and prints it ONLY if DEBUG env contains "Worker", and it prefixes the
-			// log with "(stdout)". We should move to MS_DUMP() or MS_DUMP_CLEAN().
+			std::stringstream ss;
 
-			std::cout << "{";
-			std::cout << "\"timestamp\": " << this->timestamp;
+			ss << "{";
+			ss << "\"timestamp\": " << this->timestamp;
 
 			if (!this->recvTransportId.empty())
 			{
-				std::cout << R"(, "recvTransportId": ")" << this->recvTransportId << "\"";
+				ss << R"(, "recvTransportId": ")" << this->recvTransportId << "\"";
 			}
 			if (!this->sendTransportId.empty())
 			{
-				std::cout << R"(, "sendTransportId": ")" << this->sendTransportId << "\"";
+				ss << R"(, "sendTransportId": ")" << this->sendTransportId << "\"";
 			}
 			if (!this->routerId.empty())
 			{
-				std::cout << R"(, "routerId": ")" << this->routerId << "\"";
+				ss << R"(, "routerId": ")" << this->routerId << "\"";
 			}
 			if (!this->producerId.empty())
 			{
-				std::cout << R"(, "producerId": ")" << this->producerId << "\"";
+				ss << R"(, "producerId": ")" << this->producerId << "\"";
 			}
 			if (!this->consumerId.empty())
 			{
-				std::cout << R"(, "consumerId": ")" << this->consumerId << "\"";
+				ss << R"(, "consumerId": ")" << this->consumerId << "\"";
 			}
 
-			std::cout << ", \"recvRtpTimestamp\": " << this->recvRtpTimestamp;
-			std::cout << ", \"sendRtpTimestamp\": " << this->sendRtpTimestamp;
-			std::cout << ", \"recvSeqNumber\": " << this->recvSeqNumber;
-			std::cout << ", \"sendSeqNumber\": " << this->sendSeqNumber;
-			std::cout << ", \"discarded\": " << (this->discarded ? "true" : "false");
-			std::cout << ", \"discardReason\": '" << discardReason2String[this->discardReason] << "'";
-			std::cout << "}" << std::endl;
+			ss << ", \"recvRtpTimestamp\": " << this->recvRtpTimestamp;
+			ss << ", \"sendRtpTimestamp\": " << this->sendRtpTimestamp;
+			ss << ", \"recvSeqNumber\": " << this->recvSeqNumber;
+			ss << ", \"sendSeqNumber\": " << this->sendSeqNumber;
+			ss << ", \"discarded\": " << (this->discarded ? "true" : "false");
+			ss << ", \"discardReason\": '" << discardReason2String[this->discardReason] << "'";
+			ss << "}";
+
+			MS_DUMP("%s", ss.str().c_str());
 		}
 
 		void RtpPacket::Clear()


### PR DESCRIPTION
Closes #1551

Output looks like:

```log
RTC::RtcLogger::Log() | {"timestamp": 4518452978, "recvTransportId": "fe2bf4c2-f939-4d51-b8fd-73ba30b3a196", "producerId": "3d47591c-1ffc-40ce-87c9-b2636ee39df9", "recvRtpTimestamp": 1962299018, "sendRtpTimestamp": 0, "recvSeqNumber": 12595, "sendSeqNumber": 0, "discarded": true, "discardReason": 'RecvRtpStreamNotFound'}
```