### PR TITLE
Silence GCC false warnings

### DIFF
--- a/worker/include/RTC/Codecs/Tools.hpp
+++ b/worker/include/RTC/Codecs/Tools.hpp
@@ -31,9 +31,14 @@ namespace RTC
 							case RTC::RtpCodecMimeType::Subtype::VP9:
 							case RTC::RtpCodecMimeType::Subtype::H264:
 							case RTC::RtpCodecMimeType::Subtype::H264_SVC:
+							{
 								return true;
+							}
+
 							default:
+							{
 								return false;
+							}
 						}
 					}
 
@@ -134,9 +139,14 @@ namespace RTC
 								{
 									case RTC::RtpCodecMimeType::Subtype::VP8:
 									case RTC::RtpCodecMimeType::Subtype::H264:
+									{
 										return true;
+									}
+
 									default:
+									{
 										return false;
+									}
 								}
 							}
 
@@ -158,9 +168,14 @@ namespace RTC
 									case RTC::RtpCodecMimeType::Subtype::VP9:
 									case RTC::RtpCodecMimeType::Subtype::H264_SVC:
 									case RTC::RtpCodecMimeType::Subtype::AV1:
+									{
 										return true;
+									}
+
 									default:
+									{
 										return false;
+									}
 								}
 							}
 
@@ -175,6 +190,8 @@ namespace RTC
 					{
 						return true;
 					}
+
+						NO_DEFAULT_GCC();
 				}
 			}
 
@@ -188,17 +205,34 @@ namespace RTC
 						switch (mimeType.subtype)
 						{
 							case RTC::RtpCodecMimeType::Subtype::VP8:
+							{
 								return new RTC::Codecs::VP8::EncodingContext(params);
+							}
+
 							case RTC::RtpCodecMimeType::Subtype::VP9:
+							{
 								return new RTC::Codecs::VP9::EncodingContext(params);
+							}
+
 							case RTC::RtpCodecMimeType::Subtype::AV1:
+							{
 								return new RTC::Codecs::AV1::EncodingContext(params);
+							}
+
 							case RTC::RtpCodecMimeType::Subtype::H264:
+							{
 								return new RTC::Codecs::H264::EncodingContext(params);
+							}
+
 							case RTC::RtpCodecMimeType::Subtype::H264_SVC:
+							{
 								return new RTC::Codecs::H264_SVC::EncodingContext(params);
+							}
+
 							default:
+							{
 								return nullptr;
+							}
 						}
 					}
 
@@ -208,9 +242,14 @@ namespace RTC
 						{
 							case RTC::RtpCodecMimeType::Subtype::OPUS:
 							case RTC::RtpCodecMimeType::Subtype::MULTIOPUS:
+							{
 								return new RTC::Codecs::Opus::EncodingContext(params);
+							}
+
 							default:
+							{
 								return nullptr;
+							}
 						}
 					}
 

--- a/worker/include/common.hpp
+++ b/worker/include/common.hpp
@@ -24,6 +24,16 @@ typedef SSIZE_T ssize_t;
 #include <sys/socket.h> // struct sockaddr, struct sockaddr_storage, AF_INET, AF_INET6
 #endif
 
+// This is a macro to silence false warnings in GCC in switch() blocks with FBS
+// types.
+#if defined(__GNUC__) && !defined(__clang__)
+#define NO_DEFAULT_GCC()                                                                           \
+	default:                                                                                         \
+		__builtin_unreachable()
+#else
+#define NO_DEFAULT_GCC()
+#endif
+
 using ChannelReadCtx    = void*;
 using ChannelReadFreeFn = void (*)(uint8_t*, uint32_t, size_t);
 // Returns `ChannelReadFree` on successful read that must be used to free

--- a/worker/src/DepLibUring.cpp
+++ b/worker/src/DepLibUring.cpp
@@ -6,6 +6,7 @@
 #include "MediaSoupErrors.hpp"
 #include "Settings.hpp"
 #include "Utils.hpp"
+#include <stdexcept>
 #include <sys/eventfd.h>
 #include <sys/resource.h>
 #include <sys/utsname.h>
@@ -382,7 +383,15 @@ DepLibUring::LibUring::~LibUring()
 		// Get positive errno.
 		int error = -err;
 
-		MS_ABORT("close() failed: %s", std::strerror(error));
+		try
+		{
+			MS_ABORT("close() failed: %s", std::strerror(error));
+		}
+		catch (const std::exception& error)
+		{
+			// NOTE: This is to avoid a warning:
+			// warning: ‘throw’ will always call ‘terminate’ [-Wterminate]
+		}
 	}
 
 	// Close the ring.

--- a/worker/src/RTC/ActiveSpeakerObserver.cpp
+++ b/worker/src/RTC/ActiveSpeakerObserver.cpp
@@ -220,8 +220,8 @@ namespace RTC
 			return;
 		}
 
-		uint8_t level;
-		bool voice;
+		uint8_t level{ 0 };
+		bool voice{ false };
 
 		if (!packet->ReadSsrcAudioLevel(level, voice))
 		{

--- a/worker/src/RTC/AudioLevelObserver.cpp
+++ b/worker/src/RTC/AudioLevelObserver.cpp
@@ -89,8 +89,8 @@ namespace RTC
 			return;
 		}
 
-		uint8_t volume;
-		bool voice;
+		uint8_t volume{ 0 };
+		bool voice{ false };
 
 		if (!packet->ReadSsrcAudioLevel(volume, voice))
 		{

--- a/worker/src/RTC/Codecs/DependencyDescriptor.cpp
+++ b/worker/src/RTC/Codecs/DependencyDescriptor.cpp
@@ -220,7 +220,7 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			auto templateIndex = (this->frameDependencyTemplateId + 64 - this->templateIdOffset) % 64;
+			uint8_t templateIndex = (this->frameDependencyTemplateId + 64 - this->templateIdOffset) % 64;
 
 			if (this->templateDependencyStructure->templateLayers.size() <= templateIndex)
 			{

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -219,6 +219,8 @@ namespace RTC
 			{
 				return DtlsTransport::Role::SERVER;
 			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -240,6 +242,8 @@ namespace RTC
 			{
 				return FBS::WebRtcTransport::DtlsRole::SERVER;
 			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -271,6 +275,8 @@ namespace RTC
 			{
 				return FBS::WebRtcTransport::DtlsState::CLOSED;
 			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -303,6 +309,8 @@ namespace RTC
 			{
 				return DtlsTransport::FingerprintAlgorithm::SHA512;
 			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -335,6 +343,8 @@ namespace RTC
 			{
 				return FBS::WebRtcTransport::FingerprintAlgorithm::SHA512;
 			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -570,12 +580,10 @@ namespace RTC
 		}
 
 		// Enable ECDH ciphers.
-		// DOC: http://en.wikibooks.org/wiki/OpenSSL/Diffie-Hellman_parameters
-		// NOTE: https://code.google.com/p/chromium/issues/detail?id=406458
-		// NOTE: https://bugs.ruby-lang.org/issues/12324
-
-		// For OpenSSL >= 1.0.2.
-		SSL_CTX_set_ecdh_auto(DtlsTransport::sslCtx, 1);
+		//
+		// NOTE: As per official docs:
+		// "In OpenSSL 1.1.0, ECDH handling was made automatic. Applications should
+		// not call SSL_CTX_set_ecdh_auto() or similar APIs anymore."
 
 		// Set the "use_srtp" DTLS extension.
 		for (auto it = DtlsTransport::srtpCryptoSuites.begin();
@@ -1378,6 +1386,8 @@ namespace RTC
 				hashFunction = EVP_sha512();
 				break;
 			}
+
+				NO_DEFAULT_GCC();
 		}
 
 		// Compare the remote fingerprint with the value given via signaling.

--- a/worker/src/RTC/IceCandidate.cpp
+++ b/worker/src/RTC/IceCandidate.cpp
@@ -14,7 +14,11 @@ namespace RTC
 		switch (type)
 		{
 			case FBS::WebRtcTransport::IceCandidateType::HOST:
+			{
 				return IceCandidate::CandidateType::HOST;
+			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -23,7 +27,11 @@ namespace RTC
 		switch (type)
 		{
 			case IceCandidate::CandidateType::HOST:
+			{
 				return FBS::WebRtcTransport::IceCandidateType::HOST;
+			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -33,7 +41,11 @@ namespace RTC
 		switch (type)
 		{
 			case FBS::WebRtcTransport::IceCandidateTcpType::PASSIVE:
+			{
 				return IceCandidate::TcpCandidateType::PASSIVE;
+			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -43,7 +55,11 @@ namespace RTC
 		switch (type)
 		{
 			case IceCandidate::TcpCandidateType::PASSIVE:
+			{
 				return FBS::WebRtcTransport::IceCandidateTcpType::PASSIVE;
+			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 

--- a/worker/src/RTC/IceServer.cpp
+++ b/worker/src/RTC/IceServer.cpp
@@ -39,6 +39,8 @@ namespace RTC
 			{
 				return IceServer::IceState::DISCONNECTED;
 			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -65,6 +67,8 @@ namespace RTC
 			{
 				return FBS::WebRtcTransport::IceState::DISCONNECTED;
 			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1456,9 +1456,9 @@ namespace RTC
 
 		if (this->kind == RTC::Media::Kind::VIDEO)
 		{
-			bool camera;
-			bool flip;
-			uint16_t rotation;
+			bool camera{ false };
+			bool flip{ false };
+			uint16_t rotation{ 0 };
 
 			if (packet->ReadVideoOrientation(camera, flip, rotation))
 			{

--- a/worker/src/RTC/RtpDictionaries/RtpHeaderExtensionUri.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpHeaderExtensionUri.cpp
@@ -77,6 +77,8 @@ namespace RTC
 			{
 				return RtpHeaderExtensionUri::Type::DEPENDENCY_DESCRIPTOR;
 			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -149,6 +151,8 @@ namespace RTC
 			{
 				return FBS::RtpParameters::RtpHeaderExtensionUri::DependencyDescriptor;
 			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 

--- a/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
@@ -90,6 +90,8 @@ namespace RTC
 			{
 				return FBS::RtpParameters::Type::PIPE;
 			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -254,7 +254,7 @@ namespace RTC
 		}
 		if (this->transportWideCc01ExtensionId != 0u)
 		{
-			uint16_t wideSeqNumber;
+			uint16_t wideSeqNumber{ 0 };
 
 			if (ReadTransportWideCc01(wideSeqNumber))
 			{
@@ -275,8 +275,8 @@ namespace RTC
 		}
 		if (this->ssrcAudioLevelExtensionId != 0u)
 		{
-			uint8_t volume;
-			bool voice;
+			uint8_t volume{ 0 };
+			bool voice{ false };
 
 			if (ReadSsrcAudioLevel(volume, voice))
 			{
@@ -289,9 +289,9 @@ namespace RTC
 		}
 		if (this->videoOrientationExtensionId != 0u)
 		{
-			bool camera;
-			bool flip;
-			uint16_t rotation;
+			bool camera{ false };
+			bool flip{ false };
+			uint16_t rotation{ 0 };
 
 			if (ReadVideoOrientation(camera, flip, rotation))
 			{
@@ -305,8 +305,8 @@ namespace RTC
 		}
 		if (this->playoutDelayExtensionId != 0u)
 		{
-			uint16_t minDelay;
-			uint16_t maxDelay;
+			uint16_t minDelay{ 0 };
+			uint16_t maxDelay{ 0 };
 
 			if (ReadPlayoutDelay(minDelay, maxDelay))
 			{
@@ -362,7 +362,7 @@ namespace RTC
 		}
 
 		// Add wideSequenceNumber.
-		uint16_t wideSequenceNumber;
+		uint16_t wideSequenceNumber{ 0 };
 		bool wideSequenceNumberSet = false;
 
 		if (this->transportWideCc01ExtensionId != 0u)

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -37,7 +37,7 @@ namespace RTC
 
 		if (this->params.useNack)
 		{
-			uint32_t maxRetransmissionDelayMs;
+			uint32_t maxRetransmissionDelayMs{ 0 };
 
 			switch (params.mimeType.type)
 			{

--- a/worker/src/RTC/SrtpSession.cpp
+++ b/worker/src/RTC/SrtpSession.cpp
@@ -37,16 +37,26 @@ namespace RTC
 		switch (cryptoSuite)
 		{
 			case SrtpSession::CryptoSuite::AEAD_AES_256_GCM:
+			{
 				return FBS::SrtpParameters::SrtpCryptoSuite::AEAD_AES_256_GCM;
+			}
 
 			case SrtpSession::CryptoSuite::AEAD_AES_128_GCM:
+			{
 				return FBS::SrtpParameters::SrtpCryptoSuite::AEAD_AES_128_GCM;
+			}
 
 			case SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_80:
+			{
 				return FBS::SrtpParameters::SrtpCryptoSuite::AES_CM_128_HMAC_SHA1_80;
+			}
 
 			case SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_32:
+			{
 				return FBS::SrtpParameters::SrtpCryptoSuite::AES_CM_128_HMAC_SHA1_32;
+			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -55,16 +65,26 @@ namespace RTC
 		switch (cryptoSuite)
 		{
 			case FBS::SrtpParameters::SrtpCryptoSuite::AEAD_AES_256_GCM:
+			{
 				return SrtpSession::CryptoSuite::AEAD_AES_256_GCM;
+			}
 
 			case FBS::SrtpParameters::SrtpCryptoSuite::AEAD_AES_128_GCM:
+			{
 				return SrtpSession::CryptoSuite::AEAD_AES_128_GCM;
+			}
 
 			case FBS::SrtpParameters::SrtpCryptoSuite::AES_CM_128_HMAC_SHA1_80:
+			{
 				return SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_80;
+			}
 
 			case FBS::SrtpParameters::SrtpCryptoSuite::AES_CM_128_HMAC_SHA1_32:
+			{
 				return SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_32;
+			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -75,20 +95,32 @@ namespace RTC
 		switch (data->event)
 		{
 			case event_ssrc_collision:
+			{
 				MS_WARN_TAG(srtp, "SSRC collision occurred");
+
 				break;
+			}
 
 			case event_key_soft_limit:
+			{
 				MS_WARN_TAG(srtp, "stream reached the soft key usage limit and will expire soon");
+
 				break;
+			}
 
 			case event_key_hard_limit:
+			{
 				MS_WARN_TAG(srtp, "stream reached the hard key usage limit and has expired");
+
 				break;
+			}
 
 			case event_packet_index_limit:
+			{
 				MS_WARN_TAG(srtp, "stream reached the hard packet limit (2^48 packets)");
+
 				break;
+			}
 		}
 	}
 
@@ -145,18 +177,23 @@ namespace RTC
 		}
 
 		MS_ASSERT(
-		  (int)keyLen == policy.rtp.cipher_key_len,
-		  "given keyLen does not match policy.rtp.cipher_keyLen");
+		  keyLen == policy.rtp.cipher_key_len, "given keyLen does not match policy.rtp.cipher_keyLen");
 
 		switch (type)
 		{
 			case Type::INBOUND:
+			{
 				policy.ssrc.type = ssrc_any_inbound;
+
 				break;
+			}
 
 			case Type::OUTBOUND:
+			{
 				policy.ssrc.type = ssrc_any_outbound;
+
 				break;
+			}
 		}
 
 		policy.ssrc.value = 0;

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -329,7 +329,7 @@ namespace RTC
 		// Add sctpParameters.
 		flatbuffers::Offset<FBS::SctpParameters::SctpParameters> sctpParameters;
 		// Add sctpState.
-		FBS::SctpAssociation::SctpState sctpState;
+		FBS::SctpAssociation::SctpState sctpState{ FBS::SctpAssociation::SctpState::NEW };
 		// Add sctpListener.
 		flatbuffers::Offset<FBS::Transport::SctpListener> sctpListener;
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -414,7 +414,7 @@ namespace RTC
 		auto nowMs = DepLibUV::GetTimeMs();
 
 		// Add sctpState.
-		FBS::SctpAssociation::SctpState sctpState;
+		FBS::SctpAssociation::SctpState sctpState{ FBS::SctpAssociation::SctpState::NEW };
 
 		if (this->sctpAssociation)
 		{

--- a/worker/src/RTC/TransportCongestionControlServer.cpp
+++ b/worker/src/RTC/TransportCongestionControlServer.cpp
@@ -115,7 +115,7 @@ namespace RTC
 		{
 			case RTC::BweType::TRANSPORT_CC:
 			{
-				uint16_t wideSeqNumber;
+				uint16_t wideSeqNumber{ 0 };
 
 				if (!packet->ReadTransportWideCc01(wideSeqNumber))
 				{
@@ -155,7 +155,7 @@ namespace RTC
 
 			case RTC::BweType::REMB:
 			{
-				uint32_t absSendTime;
+				uint32_t absSendTime{ 0 };
 
 				if (!packet->ReadAbsSendTime(absSendTime))
 				{

--- a/worker/src/RTC/TransportTuple.cpp
+++ b/worker/src/RTC/TransportTuple.cpp
@@ -16,10 +16,16 @@ namespace RTC
 		switch (protocol)
 		{
 			case FBS::Transport::Protocol::UDP:
+			{
 				return TransportTuple::Protocol::UDP;
+			}
 
 			case FBS::Transport::Protocol::TCP:
+			{
 				return TransportTuple::Protocol::TCP;
+			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -30,10 +36,16 @@ namespace RTC
 		switch (protocol)
 		{
 			case TransportTuple::Protocol::UDP:
+			{
 				return FBS::Transport::Protocol::UDP;
+			}
 
 			case TransportTuple::Protocol::TCP:
+			{
 				return FBS::Transport::Protocol::TCP;
+			}
+
+				NO_DEFAULT_GCC();
 		}
 	}
 
@@ -101,12 +113,18 @@ namespace RTC
 		switch (GetProtocol())
 		{
 			case Protocol::UDP:
+			{
 				MS_DUMP("  protocol: udp");
+
 				break;
+			}
 
 			case Protocol::TCP:
+			{
 				MS_DUMP("  protocol: tcp");
+
 				break;
+			}
 		}
 
 		MS_DUMP("</TransportTuple>");

--- a/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
@@ -105,7 +105,7 @@ SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
 
 		ReceiverReportPacket packet;
 
-		for (auto i = 1; i <= count; i++)
+		for (size_t i = 1; i <= count; i++)
 		{
 			// Create report and add to packet.
 			ReceiverReport* report = new ReceiverReport();
@@ -136,13 +136,13 @@ SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
 
 		auto reportIt = packet2->Begin();
 
-		for (auto i = 1; i <= 31; i++, reportIt++)
+		for (size_t i = 1; i <= 31; ++i, ++reportIt)
 		{
 			auto* report = *reportIt;
 
 			REQUIRE(report->GetSsrc() == i);
 			REQUIRE(report->GetFractionLost() == i);
-			REQUIRE(report->GetTotalLost() == i);
+			REQUIRE(report->GetTotalLost() == static_cast<int32_t>(i));
 			REQUIRE(report->GetLastSeq() == i);
 			REQUIRE(report->GetJitter() == i);
 			REQUIRE(report->GetLastSenderReport() == i);
@@ -156,13 +156,13 @@ SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
 
 		reportIt = packet3->Begin();
 
-		for (auto i = 1; i <= 2; i++, reportIt++)
+		for (size_t i = 1; i <= 2; ++i, ++reportIt)
 		{
 			auto* report = *reportIt;
 
 			REQUIRE(report->GetSsrc() == 31 + i);
 			REQUIRE(report->GetFractionLost() == 31 + i);
-			REQUIRE(report->GetTotalLost() == 31 + i);
+			REQUIRE(report->GetTotalLost() == static_cast<int32_t>(31 + i));
 			REQUIRE(report->GetLastSeq() == 31 + i);
 			REQUIRE(report->GetJitter() == 31 + i);
 			REQUIRE(report->GetLastSenderReport() == 31 + i);

--- a/worker/test/src/RTC/RTCP/TestSdes.cpp
+++ b/worker/test/src/RTC/RTCP/TestSdes.cpp
@@ -392,7 +392,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 		auto chunkSize = chunk->GetSize();
 
-		for (auto i{ 1 }; i <= count; ++i)
+		for (size_t i{ 1 }; i <= count; ++i)
 		{
 			// Create chunk and add to packet.
 			SdesChunk* chunk = new SdesChunk(i /*ssrc*/);
@@ -422,7 +422,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 		auto reportIt = packet2->Begin();
 
-		for (auto i{ 1 }; i <= 31; ++i, reportIt++)
+		for (size_t i{ 1 }; i <= 31; ++i, ++reportIt)
 		{
 			auto* chunk = *reportIt;
 
@@ -455,7 +455,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 		auto chunkSize = chunk->GetSize();
 
-		for (auto i{ 1 }; i <= count; ++i)
+		for (size_t i{ 1 }; i <= count; ++i)
 		{
 			// Create chunk and add to packet.
 			SdesChunk* chunk = new SdesChunk(i /*ssrc*/);
@@ -484,7 +484,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 		auto reportIt = packet2->Begin();
 
-		for (auto i{ 1 }; i <= 31; ++i, reportIt++)
+		for (size_t i{ 1 }; i <= 31; ++i, ++reportIt)
 		{
 			auto* chunk = *reportIt;
 
@@ -505,7 +505,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 		reportIt = packet3->Begin();
 
-		for (auto i{ 1 }; i <= 2; ++i, reportIt++)
+		for (size_t i{ 1 }; i <= 2; ++i, ++reportIt)
 		{
 			auto* chunk = *reportIt;
 

--- a/worker/test/src/RTC/RTCP/TestSenderReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestSenderReport.cpp
@@ -96,7 +96,7 @@ SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 
 		SenderReportPacket packet;
 
-		for (auto i = 1; i <= count; i++)
+		for (size_t i = 1; i <= count; ++i)
 		{
 			// Create report and add to packet.
 			SenderReport* report = new SenderReport();
@@ -137,7 +137,7 @@ SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 
 		reports[2] = *(packet4->Begin());
 
-		for (auto i = 1; i <= count; i++)
+		for (size_t i = 1; i <= count; ++i)
 		{
 			auto* report = reports[i - 1];
 

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -85,9 +85,9 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		size_t len;
 		uint8_t extenLen;
 		uint8_t* extenValue;
-		bool voice;
-		uint8_t volume;
-		uint32_t absSendTime;
+		bool voice{ false };
+		uint8_t volume{ 0 };
+		uint32_t absSendTime{ 0 };
 
 		if (!helpers::readBinaryFile("data/packet3.raw", buffer, &len))
 		{
@@ -846,8 +846,8 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		packet->SetFrameMarkingExtensionId(3);
 
-		RtpPacket::FrameMarking* frameMarking;
-		uint8_t frameMarkingLen;
+		RtpPacket::FrameMarking* frameMarking{ nullptr };
+		uint8_t frameMarkingLen{ 0 };
 
 		REQUIRE(packet->ReadFrameMarking(&frameMarking, frameMarkingLen) == true);
 		REQUIRE(frameMarkingLen == 3);

--- a/worker/test/src/RTC/TestTransportCongestionControlServer.cpp
+++ b/worker/test/src/RTC/TestTransportCongestionControlServer.cpp
@@ -3,6 +3,7 @@
 #include "RTC/Consts.hpp"
 #include "RTC/TransportCongestionControlServer.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <cstdint>
 
 using namespace RTC;
 
@@ -54,7 +55,7 @@ public:
 
 			if (packetResultIt->received)
 			{
-				REQUIRE(packetResultIt->receivedAtMs == testResultIt->timestamp);
+				REQUIRE(packetResultIt->receivedAtMs == static_cast<int64_t>(testResultIt->timestamp));
 			}
 		}
 	}

--- a/worker/test/src/helpers.cpp
+++ b/worker/test/src/helpers.cpp
@@ -34,14 +34,14 @@ namespace helpers
 
 	bool addToBuffer(uint8_t* buf, int* size, uint8_t* data, size_t len)
 	{
-		static int BUFFER_SIZE = 65536;
+		static size_t BUFFER_SIZE{ 65536 };
 
 		if (*size + len > BUFFER_SIZE)
 		{
 			return false;
 		}
 
-		int i = 0;
+		size_t i{ 0 };
 
 		if (len == 1)
 		{
@@ -49,7 +49,7 @@ namespace helpers
 		}
 		else
 		{
-			for (i = 0; i < len; i++)
+			for (i = 0; i < len; ++i)
 			{
 				buf[*size + i] = data[i];
 			}


### PR DESCRIPTION
## Details

- Fixes #1556
- Add a `NO_DEFAULT_GCC()` macro that only works with GCC and silences false warnings.
- clang remains detecting missing enums in `switch()` blocks.
- Also initialize some variables to make GCC happy.

### How to review this PR?

Check all `mediasoup-worker` CI workflows. There should be no gcc/clang warnings related to code in `worker/src`, `worker/include` and `worker/test`.