### PR TITLE
Rust: Don't log error if `xxx.close()` fails due to channel closed

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # NEXT
 
-- Don't log error if `close()` on an object fails because channel is closed already (PR #1559).
+- Don't log error if `close()` on an object fails because channel is closed already (PR #1560).
 
 # 0.18.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # NEXT
 
-- Don't log error if `close()` is called on an already object (PR #1559).
+- Don't log error if `close()` on an object fails because channel is closed already (PR #1559).
 
 # 0.18.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # NEXT
 
+- Don't log error if `close()` is called on an already object (PR #1559).
+
 # 0.18.0
 
 - Fix wrong SCTP stream parameters in SCTP `DataConsumer` that consumes from a direct `DataProducer` (PR #1516).

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -404,10 +404,17 @@ impl Inner {
             {
                 let channel = self.channel.clone();
                 let request = RouterCloseRequest { router_id: self.id };
+
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request("", request).await {
-                            error!("router closing failed on drop: {}", error);
+                        match channel.request("", request).await {
+                            Err(RequestError::ChannelClosed) => {
+                                println!("router closing failed on drop: Channel already closed");
+                            }
+                            Err(error) => {
+                                error!("router closing failed on drop: {}", error);
+                            }
+                            Ok(_) => {}
                         }
                     })
                     .detach();

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -409,7 +409,7 @@ impl Inner {
                     .spawn(async move {
                         match channel.request("", request).await {
                             Err(RequestError::ChannelClosed) => {
-                                println!("router closing failed on drop: Channel already closed");
+                                debug!("router closing failed on drop: Channel already closed");
                             }
                             Err(error) => {
                                 error!("router closing failed on drop: {}", error);

--- a/rust/src/router/active_speaker_observer.rs
+++ b/rust/src/router/active_speaker_observer.rs
@@ -140,7 +140,7 @@ impl Inner {
                     .spawn(async move {
                         match channel.request(router_id, request).await {
                             Err(RequestError::ChannelClosed) => {
-                                println!("active speaker observer closing failed on drop: Channel already closed");
+                                debug!("active speaker observer closing failed on drop: Channel already closed");
                             }
                             Err(error) => {
                                 error!("active speaker observer closing failed on drop: {}", error);

--- a/rust/src/router/active_speaker_observer.rs
+++ b/rust/src/router/active_speaker_observer.rs
@@ -138,8 +138,14 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(router_id, request).await {
-                            error!("active speaker observer closing failed on drop: {}", error);
+                        match channel.request(router_id, request).await {
+                            Err(RequestError::ChannelClosed) => {
+                                println!("active speaker observer closing failed on drop: Channel already closed");
+                            }
+                            Err(error) => {
+                                error!("active speaker observer closing failed on drop: {}", error);
+                            }
+                            Ok(_) => {}
                         }
                     })
                     .detach();

--- a/rust/src/router/audio_level_observer.rs
+++ b/rust/src/router/audio_level_observer.rs
@@ -162,7 +162,7 @@ impl Inner {
                     .spawn(async move {
                         match channel.request(router_id, request).await {
                             Err(RequestError::ChannelClosed) => {
-                                println!("audio level observer closing failed on drop: Channel already closed");
+                                debug!("audio level observer closing failed on drop: Channel already closed");
                             }
                             Err(error) => {
                                 error!("audio level observer closing failed on drop: {}", error);

--- a/rust/src/router/audio_level_observer.rs
+++ b/rust/src/router/audio_level_observer.rs
@@ -160,8 +160,14 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(router_id, request).await {
-                            error!("audio level observer closing failed on drop: {}", error);
+                        match channel.request(router_id, request).await {
+                            Err(RequestError::ChannelClosed) => {
+                                println!("audio level observer closing failed on drop: Channel already closed");
+                            }
+                            Err(error) => {
+                                error!("audio level observer closing failed on drop: {}", error);
+                            }
+                            Ok(_) => {}
                         }
                     })
                     .detach();

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -734,8 +734,16 @@ impl Inner {
                 self.executor
                     .spawn(async move {
                         if weak_producer.upgrade().is_some() {
-                            if let Err(error) = channel.request(transport_id, request).await {
-                                error!("consumer closing failed on drop: {}", error);
+                            match channel.request(transport_id, request).await {
+                                Err(RequestError::ChannelClosed) => {
+                                    println!(
+                                        "consumer closing failed on drop: Channel already closed"
+                                    );
+                                }
+                                Err(error) => {
+                                    error!("consumer closing failed on drop: {}", error);
+                                }
+                                Ok(_) => {}
                             }
                         }
                     })

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -736,7 +736,7 @@ impl Inner {
                         if weak_producer.upgrade().is_some() {
                             match channel.request(transport_id, request).await {
                                 Err(RequestError::ChannelClosed) => {
-                                    println!(
+                                    debug!(
                                         "consumer closing failed on drop: Channel already closed"
                                     );
                                 }

--- a/rust/src/router/data_consumer.rs
+++ b/rust/src/router/data_consumer.rs
@@ -355,7 +355,7 @@ impl Inner {
                         if weak_data_producer.upgrade().is_some() {
                             match channel.request(transport_id, request).await {
                                 Err(RequestError::ChannelClosed) => {
-                                    println!("data consumer closing failed on drop: Channel already closed");
+                                    debug!("data consumer closing failed on drop: Channel already closed");
                                 }
                                 Err(error) => {
                                     error!("data consumer closing failed on drop: {}", error);

--- a/rust/src/router/data_consumer.rs
+++ b/rust/src/router/data_consumer.rs
@@ -353,8 +353,14 @@ impl Inner {
                 self.executor
                     .spawn(async move {
                         if weak_data_producer.upgrade().is_some() {
-                            if let Err(error) = channel.request(transport_id, request).await {
-                                error!("consumer closing failed on drop: {}", error);
+                            match channel.request(transport_id, request).await {
+                                Err(RequestError::ChannelClosed) => {
+                                    println!("data consumer closing failed on drop: Channel already closed");
+                                }
+                                Err(error) => {
+                                    error!("data consumer closing failed on drop: {}", error);
+                                }
+                                Ok(_) => {}
                             }
                         }
                     })

--- a/rust/src/router/data_producer.rs
+++ b/rust/src/router/data_producer.rs
@@ -211,8 +211,16 @@ impl Inner {
                 };
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(transport_id, request).await {
-                            error!("data producer closing failed on drop: {}", error);
+                        match channel.request(transport_id, request).await {
+                            Err(RequestError::ChannelClosed) => {
+                                println!(
+                                    "data producer closing failed on drop: Channel already closed"
+                                );
+                            }
+                            Err(error) => {
+                                error!("data producer closing failed on drop: {}", error);
+                            }
+                            Ok(_) => {}
                         }
                     })
                     .detach();

--- a/rust/src/router/data_producer.rs
+++ b/rust/src/router/data_producer.rs
@@ -213,7 +213,7 @@ impl Inner {
                     .spawn(async move {
                         match channel.request(transport_id, request).await {
                             Err(RequestError::ChannelClosed) => {
-                                println!(
+                                debug!(
                                     "data producer closing failed on drop: Channel already closed"
                                 );
                             }

--- a/rust/src/router/direct_transport.rs
+++ b/rust/src/router/direct_transport.rs
@@ -311,9 +311,7 @@ impl Inner {
                     .spawn(async move {
                         match channel.request(router_id, request).await {
                             Err(RequestError::ChannelClosed) => {
-                                println!(
-                                    "transport closing failed on drop: Channel already closed"
-                                );
+                                debug!("transport closing failed on drop: Channel already closed");
                             }
                             Err(error) => {
                                 error!("transport closing failed on drop: {}", error);

--- a/rust/src/router/direct_transport.rs
+++ b/rust/src/router/direct_transport.rs
@@ -309,8 +309,16 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(router_id, request).await {
-                            error!("transport closing failed on drop: {}", error);
+                        match channel.request(router_id, request).await {
+                            Err(RequestError::ChannelClosed) => {
+                                println!(
+                                    "transport closing failed on drop: Channel already closed"
+                                );
+                            }
+                            Err(error) => {
+                                error!("transport closing failed on drop: {}", error);
+                            }
+                            Ok(_) => {}
                         }
                     })
                     .detach();

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -368,8 +368,16 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(router_id, request).await {
-                            error!("transport closing failed on drop: {}", error);
+                        match channel.request(router_id, request).await {
+                            Err(RequestError::ChannelClosed) => {
+                                println!(
+                                    "transport closing failed on drop: Channel already closed"
+                                );
+                            }
+                            Err(error) => {
+                                error!("transport closing failed on drop: {}", error);
+                            }
+                            Ok(_) => {}
                         }
                     })
                     .detach();

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -370,9 +370,7 @@ impl Inner {
                     .spawn(async move {
                         match channel.request(router_id, request).await {
                             Err(RequestError::ChannelClosed) => {
-                                println!(
-                                    "transport closing failed on drop: Channel already closed"
-                                );
+                                debug!("transport closing failed on drop: Channel already closed");
                             }
                             Err(error) => {
                                 error!("transport closing failed on drop: {}", error);

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -441,8 +441,16 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(router_id, request).await {
-                            error!("transport closing failed on drop: {}", error);
+                        match channel.request(router_id, request).await {
+                            Err(RequestError::ChannelClosed) => {
+                                println!(
+                                    "transport closing failed on drop: Channel already closed"
+                                );
+                            }
+                            Err(error) => {
+                                error!("transport closing failed on drop: {}", error);
+                            }
+                            Ok(_) => {}
                         }
                     })
                     .detach();

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -443,9 +443,7 @@ impl Inner {
                     .spawn(async move {
                         match channel.request(router_id, request).await {
                             Err(RequestError::ChannelClosed) => {
-                                println!(
-                                    "transport closing failed on drop: Channel already closed"
-                                );
+                                debug!("transport closing failed on drop: Channel already closed");
                             }
                             Err(error) => {
                                 error!("transport closing failed on drop: {}", error);

--- a/rust/src/router/producer.rs
+++ b/rust/src/router/producer.rs
@@ -634,8 +634,14 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(transport_id, request).await {
-                            error!("producer closing failed on drop: {}", error);
+                        match channel.request(transport_id, request).await {
+                            Err(RequestError::ChannelClosed) => {
+                                println!("producer closing failed on drop: Channel already closed");
+                            }
+                            Err(error) => {
+                                error!("producer closing failed on drop: {}", error);
+                            }
+                            Ok(_) => {}
                         }
                     })
                     .detach();

--- a/rust/src/router/producer.rs
+++ b/rust/src/router/producer.rs
@@ -636,7 +636,7 @@ impl Inner {
                     .spawn(async move {
                         match channel.request(transport_id, request).await {
                             Err(RequestError::ChannelClosed) => {
-                                println!("producer closing failed on drop: Channel already closed");
+                                debug!("producer closing failed on drop: Channel already closed");
                             }
                             Err(error) => {
                                 error!("producer closing failed on drop: {}", error);

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -554,9 +554,7 @@ impl Inner {
                     .spawn(async move {
                         match channel.request(router_id, request).await {
                             Err(RequestError::ChannelClosed) => {
-                                println!(
-                                    "transport closing failed on drop: Channel already closed"
-                                );
+                                debug!("transport closing failed on drop: Channel already closed");
                             }
                             Err(error) => {
                                 error!("transport closing failed on drop: {}", error);

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -552,8 +552,16 @@ impl Inner {
 
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request(router_id, request).await {
-                            error!("transport closing failed on drop: {}", error);
+                        match channel.request(router_id, request).await {
+                            Err(RequestError::ChannelClosed) => {
+                                println!(
+                                    "transport closing failed on drop: Channel already closed"
+                                );
+                            }
+                            Err(error) => {
+                                error!("transport closing failed on drop: {}", error);
+                            }
+                            Ok(_) => {}
                         }
                     })
                     .detach();

--- a/rust/src/webrtc_server.rs
+++ b/rust/src/webrtc_server.rs
@@ -187,7 +187,7 @@ impl Inner {
                     .spawn(async move {
                         match channel.request("", request).await {
                             Err(RequestError::ChannelClosed) => {
-                                println!(
+                                debug!(
                                     "WebRTC server closing failed on drop: Channel already closed"
                                 );
                             }

--- a/rust/src/webrtc_server.rs
+++ b/rust/src/webrtc_server.rs
@@ -182,10 +182,19 @@ impl Inner {
                 let request = WebRtcServerCloseRequest {
                     webrtc_server_id: self.id,
                 };
+
                 self.executor
                     .spawn(async move {
-                        if let Err(error) = channel.request("", request).await {
-                            error!("WebRTC server closing failed on drop: {}", error);
+                        match channel.request("", request).await {
+                            Err(RequestError::ChannelClosed) => {
+                                println!(
+                                    "WebRTC server closing failed on drop: Channel already closed"
+                                );
+                            }
+                            Err(error) => {
+                                error!("WebRTC server closing failed on drop: {}", error);
+                            }
+                            Ok(_) => {}
                         }
                     })
                     .detach();


### PR DESCRIPTION
Fixes #1396