### PR TITLE
Add missing libsrtp error codes

### DIFF
--- a/worker/include/DepLibSRTP.hpp
+++ b/worker/include/DepLibSRTP.hpp
@@ -2,25 +2,25 @@
 #define MS_DEP_LIBSRTP_HPP
 
 #include <srtp.h>
-#include <vector>
+#include <string>
+#include <unordered_map>
 
 class DepLibSRTP
 {
 public:
 	static void ClassInit();
+
 	static void ClassDestroy();
+
 	static bool IsError(srtp_err_status_t code)
 	{
 		return (code != srtp_err_status_ok);
 	}
-	static const char* GetErrorString(srtp_err_status_t code)
-	{
-		// This throws out_of_range if the given index is not in the vector.
-		return DepLibSRTP::errors.at(code);
-	}
+
+	static const std::string& GetErrorString(srtp_err_status_t code);
 
 private:
-	static std::vector<const char*> errors;
+	static std::unordered_map<srtp_err_status_t, std::string> mapErrorCodeString;
 };
 
 #endif

--- a/worker/src/DepLibSRTP.cpp
+++ b/worker/src/DepLibSRTP.cpp
@@ -11,35 +11,43 @@
 static std::mutex GlobalSyncMutex;
 static size_t GlobalInstances = 0;
 
+// NOTE: This map must always be in sync with the srtp_err_status_t in srtp.h
+// in libsrtp library:
+//   https://github.com/cisco/libsrtp/blob/main/include/srtp.h
+//
 // clang-format off
-std::vector<const char*> DepLibSRTP::errors =
+std::unordered_map<srtp_err_status_t, std::string> DepLibSRTP::mapErrorCodeString =
 {
-	// From 0 (srtp_err_status_ok) to 24 (srtp_err_status_pfkey_err).
-	"success (srtp_err_status_ok)",
-	"unspecified failure (srtp_err_status_fail)",
-	"unsupported parameter (srtp_err_status_bad_param)",
-	"couldn't allocate memory (srtp_err_status_alloc_fail)",
-	"couldn't deallocate memory (srtp_err_status_dealloc_fail)",
-	"couldn't initialize (srtp_err_status_init_fail)",
-	"can’t process as much data as requested (srtp_err_status_terminus)",
-	"authentication failure (srtp_err_status_auth_fail)",
-	"cipher failure (srtp_err_status_cipher_fail)",
-	"replay check failed (bad index) (srtp_err_status_replay_fail)",
-	"replay check failed (index too old) (srtp_err_status_replay_old)",
-	"algorithm failed test routine (srtp_err_status_algo_fail)",
-	"unsupported operation (srtp_err_status_no_such_op)",
-	"no appropriate context found (srtp_err_status_no_ctx)",
-	"unable to perform desired validation (srtp_err_status_cant_check)",
-	"can’t use key any more (srtp_err_status_key_expired)",
-	"error in use of socket (srtp_err_status_socket_err)",
-	"error in use POSIX signals (srtp_err_status_signal_err)",
-	"nonce check failed (srtp_err_status_nonce_bad)",
-	"couldn’t read data (srtp_err_status_read_fail)",
-	"couldn’t write data (srtp_err_status_write_fail)",
-	"error parsing data (srtp_err_status_parse_err)",
-	"error encoding data (srtp_err_status_encode_err)",
-	"error while using semaphores (srtp_err_status_semaphore_err)",
-	"error while using pfkey (srtp_err_status_pfkey_err)"
+	{ srtp_err_status_ok,            "nothing to report" },
+	{ srtp_err_status_fail,          "unspecified failure" },
+	{ srtp_err_status_bad_param,     "unsupported parameter" },
+	{ srtp_err_status_alloc_fail,    "couldn't allocate memory" },
+	{ srtp_err_status_dealloc_fail,  "couldn't deallocate properly" },
+	{ srtp_err_status_init_fail,     "couldn't initialize" },
+	{ srtp_err_status_terminus,      "can't process as much data as requested" },
+	{ srtp_err_status_auth_fail,     "authentication failure" },
+	{ srtp_err_status_cipher_fail,   "cipher failure" },
+	{ srtp_err_status_replay_fail,   "replay check failed (bad index)" },
+	{ srtp_err_status_replay_old,    "replay check failed (index too old)" },
+	{ srtp_err_status_algo_fail,     "algorithm failed test routine" },
+	{ srtp_err_status_no_such_op,    "unsupported operation" },
+	{ srtp_err_status_no_ctx,        "no appropriate context found" },
+	{ srtp_err_status_cant_check,    "unable to perform desired validation" },
+	{ srtp_err_status_key_expired,   "can't use key any more" },
+	{ srtp_err_status_socket_err,    "error in use of socket" },
+	{ srtp_err_status_signal_err,    "error in use POSIX signals" },
+	{ srtp_err_status_nonce_bad,     "nonce check failed" },
+	{ srtp_err_status_read_fail,     "couldn't read data" },
+	{ srtp_err_status_write_fail,    "couldn't write data" },
+	{ srtp_err_status_parse_err,     "error parsing data" },
+	{ srtp_err_status_encode_err,    "error encoding data" },
+	{ srtp_err_status_semaphore_err, "error while using semaphores" },
+	{ srtp_err_status_pfkey_err,     "error while using pfkey" },
+	{ srtp_err_status_bad_mki,       "error MKI present in packet is invalid" },
+	{ srtp_err_status_pkt_idx_old,   "packet index is too old to consider" },
+	{ srtp_err_status_pkt_idx_adv,   "packet index advanced, reset needed" },
+	{ srtp_err_status_buffer_small,  "out buffer is too small" },
+	{ srtp_err_status_cryptex_err,   "unsupported cryptex operation" }
 };
 // clang-format on
 
@@ -60,7 +68,7 @@ void DepLibSRTP::ClassInit()
 
 			if (DepLibSRTP::IsError(err))
 			{
-				MS_THROW_ERROR("srtp_init() failed: %s", DepLibSRTP::GetErrorString(err));
+				MS_THROW_ERROR("srtp_init() failed: %s", DepLibSRTP::GetErrorString(err).c_str());
 			}
 		}
 
@@ -81,4 +89,20 @@ void DepLibSRTP::ClassDestroy()
 			srtp_shutdown();
 		}
 	}
+}
+
+const std::string& DepLibSRTP::GetErrorString(srtp_err_status_t code)
+{
+	MS_TRACE();
+
+	static const std::string UnknownError("unknown libsrtp error");
+
+	auto it = DepLibSRTP::mapErrorCodeString.find(code);
+
+	if (it == DepLibSRTP::mapErrorCodeString.end())
+	{
+		return UnknownError;
+	}
+
+	return it->second;
 }

--- a/worker/src/RTC/SrtpSession.cpp
+++ b/worker/src/RTC/SrtpSession.cpp
@@ -28,7 +28,8 @@ namespace RTC
 
 		if (DepLibSRTP::IsError(err))
 		{
-			MS_THROW_ERROR("srtp_install_event_handler() failed: %s", DepLibSRTP::GetErrorString(err));
+			MS_THROW_ERROR(
+			  "srtp_install_event_handler() failed: %s", DepLibSRTP::GetErrorString(err).c_str());
 		}
 	}
 
@@ -208,7 +209,7 @@ namespace RTC
 
 		if (DepLibSRTP::IsError(err))
 		{
-			MS_THROW_ERROR("srtp_create() failed: %s", DepLibSRTP::GetErrorString(err));
+			MS_THROW_ERROR("srtp_create() failed: %s", DepLibSRTP::GetErrorString(err).c_str());
 		}
 	}
 
@@ -224,7 +225,7 @@ namespace RTC
 			{
 				try
 				{
-					MS_ABORT("srtp_dealloc() failed: %s", DepLibSRTP::GetErrorString(err));
+					MS_ABORT("srtp_dealloc() failed: %s", DepLibSRTP::GetErrorString(err).c_str());
 				}
 				catch (const std::exception& error)
 				{
@@ -282,7 +283,7 @@ namespace RTC
 
 		if (DepLibSRTP::IsError(err))
 		{
-			MS_WARN_TAG(srtp, "srtp_protect() failed: %s", DepLibSRTP::GetErrorString(err));
+			MS_WARN_TAG(srtp, "srtp_protect() failed: %s", DepLibSRTP::GetErrorString(err).c_str());
 
 			return false;
 		}
@@ -309,7 +310,7 @@ namespace RTC
 
 		if (DepLibSRTP::IsError(err))
 		{
-			MS_DEBUG_TAG(srtp, "srtp_unprotect() failed: %s", DepLibSRTP::GetErrorString(err));
+			MS_DEBUG_TAG(srtp, "srtp_unprotect() failed: %s", DepLibSRTP::GetErrorString(err).c_str());
 
 			return false;
 		}
@@ -345,7 +346,7 @@ namespace RTC
 
 		if (DepLibSRTP::IsError(err))
 		{
-			MS_WARN_TAG(srtp, "srtp_protect_rtcp() failed: %s", DepLibSRTP::GetErrorString(err));
+			MS_WARN_TAG(srtp, "srtp_protect_rtcp() failed: %s", DepLibSRTP::GetErrorString(err).c_str());
 
 			return false;
 		}
@@ -372,7 +373,7 @@ namespace RTC
 
 		if (DepLibSRTP::IsError(err))
 		{
-			MS_DEBUG_TAG(srtp, "srtp_unprotect_rtcp() failed: %s", DepLibSRTP::GetErrorString(err));
+			MS_DEBUG_TAG(srtp, "srtp_unprotect_rtcp() failed: %s", DepLibSRTP::GetErrorString(err).c_str());
 
 			return false;
 		}


### PR DESCRIPTION
## Details

- Add missing `srtp_err_status_t` enum values in our `DepLibSRTP`.
- Replace the super dangerous `vector` based list of libsrtp errors with a proper map and make `GetErrorString()` ready for unknown error codes (instead of throwing).
- To be clear: If `srtp_err_status_buffer_small` happened now in v3 (for whatever reason) mediasoup would crash due to `std::out_of_range` unhandled exception. This is because `srtp_err_status_buffer_small` was not present in the previous vector based list.