### PR TITLE
`Router`: Add `updateMediaCodecs()` method to dynamically change Router's RTP capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- `Router`: Add `updateMediaCodecs()` method to dynamically change Router's RTP capabilities ([PR #1571](https://github.com/versatica/mediasoup/pull/1571)).
+
 ### 3.16.6
 
 - Remove H265 codec and deprecated frame-marking RTP extension ([PR #1564](https://github.com/versatica/mediasoup/pull/1564)).

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -63,7 +63,7 @@ import type {
 	AudioLevelObserverOptions,
 } from './AudioLevelObserverTypes';
 import { AudioLevelObserverImpl } from './AudioLevelObserver';
-import type { RtpCapabilities } from './rtpParametersTypes';
+import type { RtpCapabilities, RtpCodecCapability } from './rtpParametersTypes';
 import { cryptoSuiteToFbs } from './srtpParametersFbsUtils';
 import type { AppData } from './types';
 import * as utils from './utils';
@@ -1365,6 +1365,21 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 
 			return false;
 		}
+	}
+
+	updateMediaCodecs(mediaCodecs: RtpCodecCapability[]): void {
+		logger.debug('updateMediaCodecs()');
+
+		// Clone given media codecs to not modify input data.
+		const clonedMediaCodecs = utils.clone<RtpCodecCapability[] | undefined>(
+			mediaCodecs
+		);
+
+		// This may throw.
+		const rtpCapabilities =
+			ortc.generateRouterRtpCapabilities(clonedMediaCodecs);
+
+		this.#data.rtpCapabilities = rtpCapabilities;
 	}
 
 	private handleListenerError(): void {

--- a/node/src/RouterTypes.ts
+++ b/node/src/RouterTypes.ts
@@ -287,4 +287,10 @@ export interface Router<RouterAppData extends AppData = AppData>
 		producerId: string;
 		rtpCapabilities: RtpCapabilities;
 	}): boolean;
+
+	/**
+	 * Update the Router media codecs. Once called, the return value of the
+	 * router.rtpCapabilities getter changes.
+	 */
+	updateMediaCodecs(mediaCodecs: RtpCodecCapability[]): void;
 }

--- a/node/src/test/test-Router.ts
+++ b/node/src/test/test-Router.ts
@@ -150,6 +150,25 @@ test('worker.createRouter() rejects with InvalidStateError if Worker is closed',
 	).rejects.toThrow(InvalidStateError);
 }, 2000);
 
+test('router.updateMediaCodecs() succeeds', async () => {
+	const router = await ctx.worker!.createRouter({
+		mediaCodecs: ctx.mediaCodecs,
+	});
+
+	expect(typeof router.rtpCapabilities).toBe('object');
+	expect(Array.isArray(router.rtpCapabilities.codecs)).toBe(true);
+	// 3 codecs + 2 RTX codecs.
+	expect(router.rtpCapabilities.codecs?.length).toBe(5);
+	expect(Array.isArray(router.rtpCapabilities.headerExtensions)).toBe(true);
+
+	router.updateMediaCodecs([]);
+
+	expect(typeof router.rtpCapabilities).toBe('object');
+	expect(Array.isArray(router.rtpCapabilities.codecs)).toBe(true);
+	expect(router.rtpCapabilities.codecs?.length).toBe(0);
+	expect(Array.isArray(router.rtpCapabilities.headerExtensions)).toBe(true);
+}, 2000);
+
 test('router.close() succeeds', async () => {
 	const router = await ctx.worker!.createRouter({
 		mediaCodecs: ctx.mediaCodecs,

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,8 +3,9 @@
 # NEXT
 
 - Enable AV1 codec (PR #1563).
-- Remove H265 codec and deprecated frame-marking RTP extension (PR #1564)
-- Remove H264-SVC codec (PR #1568)
+- Remove H265 codec and deprecated frame-marking RTP extension (PR #1564).
+- Remove H264-SVC codec (PR #1568).
+- Add `Router::update_media_codecs()` to dynamically change Router's RTP capabilities (#1571).
 
 # 0.18.2
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Remove H265 codec and deprecated frame-marking RTP extension (PR #1564).
 - Remove H264-SVC codec (PR #1568).
 - Add `Router::update_media_codecs()` to dynamically change Router's RTP capabilities (#1571).
+- Make `Router::rtp_capabilities()` return `Arc<RwLock<RtpCapabilitiesFinalized>>` (#1571).
 
 # 0.18.2
 

--- a/rust/examples/echo.rs
+++ b/rust/examples/echo.rs
@@ -237,7 +237,7 @@ impl Actor for EchoConnection {
                 ice_candidates: self.transports.producer.ice_candidates().clone(),
                 ice_parameters: self.transports.producer.ice_parameters().clone(),
             },
-            router_rtp_capabilities: self.router.rtp_capabilities().clone(),
+            router_rtp_capabilities: (*self.router.rtp_capabilities().read()).clone(),
         };
 
         ctx.address().do_send(server_init_message);

--- a/rust/examples/multiopus.rs
+++ b/rust/examples/multiopus.rs
@@ -272,7 +272,7 @@ impl Actor for EchoConnection {
                 ice_candidates: self.consumer_transport.ice_candidates().clone(),
                 ice_parameters: self.consumer_transport.ice_parameters().clone(),
             },
-            router_rtp_capabilities: self.router.rtp_capabilities().clone(),
+            router_rtp_capabilities: (*self.router.rtp_capabilities().read()).clone(),
             rtp_producer_id: self.rtp_producer.id(),
         };
 

--- a/rust/examples/svc-simulcast.rs
+++ b/rust/examples/svc-simulcast.rs
@@ -257,7 +257,7 @@ impl Actor for SvcSimulcastConnection {
                 ice_candidates: self.transports.producer.ice_candidates().clone(),
                 ice_parameters: self.transports.producer.ice_parameters().clone(),
             },
-            router_rtp_capabilities: self.router.rtp_capabilities().clone(),
+            router_rtp_capabilities: (*self.router.rtp_capabilities().read()).clone(),
         };
 
         ctx.address().do_send(server_init_message);

--- a/rust/examples/videoroom.rs
+++ b/rust/examples/videoroom.rs
@@ -556,7 +556,7 @@ mod participant {
                     ice_candidates: self.transports.producer.ice_candidates().clone(),
                     ice_parameters: self.transports.producer.ice_parameters().clone(),
                 },
-                router_rtp_capabilities: self.room.router().rtp_capabilities().clone(),
+                router_rtp_capabilities: (*self.room.router().rtp_capabilities().read()).clone(),
             };
 
             let address = ctx.address();

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -67,7 +67,6 @@ use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
 use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Mutex as SyncMutex;
 use std::sync::{Arc, Weak};
 use thiserror::Error;
 
@@ -382,7 +381,7 @@ struct Handlers {
 struct Inner {
     id: RouterId,
     executor: Arc<Executor<'static>>,
-    rtp_capabilities: SyncMutex<RtpCapabilitiesFinalized>,
+    rtp_capabilities: Arc<RwLock<RtpCapabilitiesFinalized>>,
     channel: Channel,
     handlers: Arc<Handlers>,
     app_data: AppData,
@@ -493,7 +492,7 @@ impl Router {
         let inner = Arc::new(Inner {
             id,
             executor,
-            rtp_capabilities: SyncMutex::new(rtp_capabilities),
+            rtp_capabilities: Arc::new(RwLock::new(rtp_capabilities)),
             channel,
             handlers,
             producers,
@@ -542,8 +541,8 @@ impl Router {
     /// * See also how to [filter these RTP capabilities](https://mediasoup.org/documentation/v3/tricks/#rtp-capabilities-filtering)
     ///   before using them into a client.
     #[must_use]
-    pub fn rtp_capabilities(&self) -> RtpCapabilitiesFinalized {
-        self.inner.rtp_capabilities.lock().unwrap().clone()
+    pub fn rtp_capabilities(&self) -> Arc<RwLock<RtpCapabilitiesFinalized>> {
+        Arc::clone(&self.inner.rtp_capabilities)
     }
 
     /// Dump Router.
@@ -1414,8 +1413,8 @@ impl Router {
         let rtp_capabilities = ortc::generate_router_rtp_capabilities(media_codecs)
             .map_err(UpdateMediaCodecsError::FailedRtpCapabilitiesGeneration)?;
 
-        let mut locked = self.inner.rtp_capabilities.lock().unwrap();
-        *locked = rtp_capabilities;
+        let mut locked_rtp_capabilities = self.inner.rtp_capabilities.write();
+        *locked_rtp_capabilities = rtp_capabilities;
 
         Ok(())
     }

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -67,6 +67,7 @@ use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
 use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex as SyncMutex;
 use std::sync::{Arc, Weak};
 use thiserror::Error;
 
@@ -271,6 +272,14 @@ impl From<ProduceDataError> for PipeDataProducerToRouterError {
     }
 }
 
+/// Error that caused [`Router::update_media_codecs`] to fail.
+#[derive(Debug, Error)]
+pub enum UpdateMediaCodecsError {
+    /// RTP capabilities generation error
+    #[error("RTP capabilities generation error: {0}")]
+    FailedRtpCapabilitiesGeneration(ortc::RtpCapabilitiesError),
+}
+
 #[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 #[doc(hidden)]
@@ -373,7 +382,7 @@ struct Handlers {
 struct Inner {
     id: RouterId,
     executor: Arc<Executor<'static>>,
-    rtp_capabilities: RtpCapabilitiesFinalized,
+    rtp_capabilities: SyncMutex<RtpCapabilitiesFinalized>,
     channel: Channel,
     handlers: Arc<Handlers>,
     app_data: AppData,
@@ -484,7 +493,7 @@ impl Router {
         let inner = Arc::new(Inner {
             id,
             executor,
-            rtp_capabilities,
+            rtp_capabilities: SyncMutex::new(rtp_capabilities),
             channel,
             handlers,
             producers,
@@ -533,8 +542,8 @@ impl Router {
     /// * See also how to [filter these RTP capabilities](https://mediasoup.org/documentation/v3/tricks/#rtp-capabilities-filtering)
     ///   before using them into a client.
     #[must_use]
-    pub fn rtp_capabilities(&self) -> &RtpCapabilitiesFinalized {
-        &self.inner.rtp_capabilities
+    pub fn rtp_capabilities(&self) -> RtpCapabilitiesFinalized {
+        self.inner.rtp_capabilities.lock().unwrap().clone()
     }
 
     /// Dump Router.
@@ -1392,6 +1401,23 @@ impl Router {
             );
             false
         }
+    }
+
+    /// Update the Router media codecs. Once called, the return value of
+    /// router.rtp_capabilities() changes.
+    pub fn update_media_codecs(
+        &mut self,
+        media_codecs: Vec<RtpCodecCapability>,
+    ) -> Result<(), UpdateMediaCodecsError> {
+        debug!("update_media_codecs()");
+
+        let rtp_capabilities = ortc::generate_router_rtp_capabilities(media_codecs)
+            .map_err(UpdateMediaCodecsError::FailedRtpCapabilitiesGeneration)?;
+
+        let mut locked = self.inner.rtp_capabilities.lock().unwrap();
+        *locked = rtp_capabilities;
+
+        Ok(())
     }
 
     /// Callback is called when a new transport is created.

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -535,16 +535,26 @@ pub(super) trait TransportImpl: TransportGeneric {
 
         let router_rtp_capabilities = self.router().rtp_capabilities();
 
-        let rtp_mapping =
-            ortc::get_producer_rtp_parameters_mapping(&rtp_parameters, &router_rtp_capabilities)
-                .map_err(ProduceError::FailedRtpParametersMapping)?;
+        let _guard_block = {
+            let router_rtp_capabilities_guard = router_rtp_capabilities.read();
 
-        let consumable_rtp_parameters = ortc::get_consumable_rtp_parameters(
-            kind,
-            &rtp_parameters,
-            &router_rtp_capabilities,
-            &rtp_mapping,
-        );
+            let rtp_mapping = ortc::get_producer_rtp_parameters_mapping(
+                &rtp_parameters,
+                &router_rtp_capabilities_guard,
+            )
+            .map_err(ProduceError::FailedRtpParametersMapping)?;
+
+            let consumable_rtp_parameters = ortc::get_consumable_rtp_parameters(
+                kind,
+                &rtp_parameters,
+                &router_rtp_capabilities_guard,
+                &rtp_mapping,
+            );
+
+            (rtp_mapping, consumable_rtp_parameters)
+        };
+
+        let (rtp_mapping, consumable_rtp_parameters) = _guard_block;
 
         let producer_id = id.unwrap_or_else(ProducerId::new);
 

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -536,13 +536,13 @@ pub(super) trait TransportImpl: TransportGeneric {
         let router_rtp_capabilities = self.router().rtp_capabilities();
 
         let rtp_mapping =
-            ortc::get_producer_rtp_parameters_mapping(&rtp_parameters, router_rtp_capabilities)
+            ortc::get_producer_rtp_parameters_mapping(&rtp_parameters, &router_rtp_capabilities)
                 .map_err(ProduceError::FailedRtpParametersMapping)?;
 
         let consumable_rtp_parameters = ortc::get_consumable_rtp_parameters(
             kind,
             &rtp_parameters,
-            router_rtp_capabilities,
+            &router_rtp_capabilities,
             &rtp_mapping,
         );
 

--- a/rust/tests/integration/router.rs
+++ b/rust/tests/integration/router.rs
@@ -137,6 +137,30 @@ fn create_router_succeeds() {
 }
 
 #[test]
+fn update_media_codecs_succeeds() {
+    future::block_on(async move {
+        let worker = init().await;
+
+        let mut router = worker
+            .create_router({
+                let router_options = RouterOptions::new(media_codecs());
+
+                router_options
+            })
+            .await
+            .expect("Failed to create router");
+
+        assert!(!router.closed());
+        // 3 codecs + 2 RTX codecs.
+        assert_eq!(router.rtp_capabilities().codecs.len(), 5);
+
+        router.update_media_codecs([].to_vec());
+
+        assert_eq!(router.rtp_capabilities().codecs.len(), 0);
+    });
+}
+
+#[test]
 fn close_event() {
     future::block_on(async move {
         let worker = init().await;

--- a/rust/tests/integration/router.rs
+++ b/rust/tests/integration/router.rs
@@ -99,7 +99,7 @@ fn create_router_succeeds() {
         assert_eq!(new_router_count.load(Ordering::SeqCst), 1);
         assert!(!router.closed());
         // 3 codecs + 2 RTX codecs.
-        assert_eq!(router.rtp_capabilities().codecs.len(), 5);
+        assert_eq!(router.rtp_capabilities().read().codecs.len(), 5);
         assert_eq!(
             router.app_data().downcast_ref::<CustomAppData>(),
             Some(&CustomAppData { foo: 123 }),
@@ -152,11 +152,11 @@ fn update_media_codecs_succeeds() {
 
         assert!(!router.closed());
         // 3 codecs + 2 RTX codecs.
-        assert_eq!(router.rtp_capabilities().codecs.len(), 5);
+        assert_eq!(router.rtp_capabilities().read().codecs.len(), 5);
 
-        router.update_media_codecs([].to_vec());
+        let _ = router.update_media_codecs([].to_vec());
 
-        assert_eq!(router.rtp_capabilities().codecs.len(), 0);
+        assert_eq!(router.rtp_capabilities().read().codecs.len(), 0);
     });
 }
 

--- a/rust/tests/integration/router.rs
+++ b/rust/tests/integration/router.rs
@@ -142,11 +142,7 @@ fn update_media_codecs_succeeds() {
         let worker = init().await;
 
         let mut router = worker
-            .create_router({
-                let router_options = RouterOptions::new(media_codecs());
-
-                router_options
-            })
+            .create_router(RouterOptions::new(media_codecs()))
             .await
             .expect("Failed to create router");
 


### PR DESCRIPTION
## Details

- Added `router.updateMediaCodecs(mediaCodecs)` method that recomputes Router's RTP capabilities.
- Fixes #1564