### PR TITLE
Revert "Make Router::rtp_capabilities() return Arc<RwLock<RtpCapabilitiesFinalized>> to avoid having to clone rtp_capabilities"

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -6,7 +6,6 @@
 - Remove H265 codec and deprecated frame-marking RTP extension (PR #1564).
 - Remove H264-SVC codec (PR #1568).
 - Add `Router::update_media_codecs()` to dynamically change Router's RTP capabilities (#1571).
-- Make `Router::rtp_capabilities()` return `Arc<RwLock<RtpCapabilitiesFinalized>>` (#1571).
 
 # 0.18.2
 

--- a/rust/examples/echo.rs
+++ b/rust/examples/echo.rs
@@ -237,7 +237,7 @@ impl Actor for EchoConnection {
                 ice_candidates: self.transports.producer.ice_candidates().clone(),
                 ice_parameters: self.transports.producer.ice_parameters().clone(),
             },
-            router_rtp_capabilities: (*self.router.rtp_capabilities().read()).clone(),
+            router_rtp_capabilities: self.router.rtp_capabilities().clone(),
         };
 
         ctx.address().do_send(server_init_message);

--- a/rust/examples/multiopus.rs
+++ b/rust/examples/multiopus.rs
@@ -272,7 +272,7 @@ impl Actor for EchoConnection {
                 ice_candidates: self.consumer_transport.ice_candidates().clone(),
                 ice_parameters: self.consumer_transport.ice_parameters().clone(),
             },
-            router_rtp_capabilities: (*self.router.rtp_capabilities().read()).clone(),
+            router_rtp_capabilities: self.router.rtp_capabilities().clone(),
             rtp_producer_id: self.rtp_producer.id(),
         };
 

--- a/rust/examples/svc-simulcast.rs
+++ b/rust/examples/svc-simulcast.rs
@@ -257,7 +257,7 @@ impl Actor for SvcSimulcastConnection {
                 ice_candidates: self.transports.producer.ice_candidates().clone(),
                 ice_parameters: self.transports.producer.ice_parameters().clone(),
             },
-            router_rtp_capabilities: (*self.router.rtp_capabilities().read()).clone(),
+            router_rtp_capabilities: self.router.rtp_capabilities().clone(),
         };
 
         ctx.address().do_send(server_init_message);

--- a/rust/examples/videoroom.rs
+++ b/rust/examples/videoroom.rs
@@ -556,7 +556,7 @@ mod participant {
                     ice_candidates: self.transports.producer.ice_candidates().clone(),
                     ice_parameters: self.transports.producer.ice_parameters().clone(),
                 },
-                router_rtp_capabilities: (*self.room.router().rtp_capabilities().read()).clone(),
+                router_rtp_capabilities: self.room.router().rtp_capabilities().clone(),
             };
 
             let address = ctx.address();

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -67,6 +67,7 @@ use std::fmt;
 use std::net::{IpAddr, Ipv4Addr};
 use std::ops::Deref;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Mutex as SyncMutex;
 use std::sync::{Arc, Weak};
 use thiserror::Error;
 
@@ -381,7 +382,7 @@ struct Handlers {
 struct Inner {
     id: RouterId,
     executor: Arc<Executor<'static>>,
-    rtp_capabilities: Arc<RwLock<RtpCapabilitiesFinalized>>,
+    rtp_capabilities: SyncMutex<RtpCapabilitiesFinalized>,
     channel: Channel,
     handlers: Arc<Handlers>,
     app_data: AppData,
@@ -492,7 +493,7 @@ impl Router {
         let inner = Arc::new(Inner {
             id,
             executor,
-            rtp_capabilities: Arc::new(RwLock::new(rtp_capabilities)),
+            rtp_capabilities: SyncMutex::new(rtp_capabilities),
             channel,
             handlers,
             producers,
@@ -541,8 +542,8 @@ impl Router {
     /// * See also how to [filter these RTP capabilities](https://mediasoup.org/documentation/v3/tricks/#rtp-capabilities-filtering)
     ///   before using them into a client.
     #[must_use]
-    pub fn rtp_capabilities(&self) -> Arc<RwLock<RtpCapabilitiesFinalized>> {
-        Arc::clone(&self.inner.rtp_capabilities)
+    pub fn rtp_capabilities(&self) -> RtpCapabilitiesFinalized {
+        self.inner.rtp_capabilities.lock().unwrap().clone()
     }
 
     /// Dump Router.
@@ -1413,8 +1414,8 @@ impl Router {
         let rtp_capabilities = ortc::generate_router_rtp_capabilities(media_codecs)
             .map_err(UpdateMediaCodecsError::FailedRtpCapabilitiesGeneration)?;
 
-        let mut locked_rtp_capabilities = self.inner.rtp_capabilities.write();
-        *locked_rtp_capabilities = rtp_capabilities;
+        let mut locked = self.inner.rtp_capabilities.lock().unwrap();
+        *locked = rtp_capabilities;
 
         Ok(())
     }

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -535,26 +535,16 @@ pub(super) trait TransportImpl: TransportGeneric {
 
         let router_rtp_capabilities = self.router().rtp_capabilities();
 
-        let _guard_block = {
-            let router_rtp_capabilities_guard = router_rtp_capabilities.read();
+        let rtp_mapping =
+            ortc::get_producer_rtp_parameters_mapping(&rtp_parameters, &router_rtp_capabilities)
+                .map_err(ProduceError::FailedRtpParametersMapping)?;
 
-            let rtp_mapping = ortc::get_producer_rtp_parameters_mapping(
-                &rtp_parameters,
-                &router_rtp_capabilities_guard,
-            )
-            .map_err(ProduceError::FailedRtpParametersMapping)?;
-
-            let consumable_rtp_parameters = ortc::get_consumable_rtp_parameters(
-                kind,
-                &rtp_parameters,
-                &router_rtp_capabilities_guard,
-                &rtp_mapping,
-            );
-
-            (rtp_mapping, consumable_rtp_parameters)
-        };
-
-        let (rtp_mapping, consumable_rtp_parameters) = _guard_block;
+        let consumable_rtp_parameters = ortc::get_consumable_rtp_parameters(
+            kind,
+            &rtp_parameters,
+            &router_rtp_capabilities,
+            &rtp_mapping,
+        );
 
         let producer_id = id.unwrap_or_else(ProducerId::new);
 

--- a/rust/tests/integration/router.rs
+++ b/rust/tests/integration/router.rs
@@ -99,7 +99,7 @@ fn create_router_succeeds() {
         assert_eq!(new_router_count.load(Ordering::SeqCst), 1);
         assert!(!router.closed());
         // 3 codecs + 2 RTX codecs.
-        assert_eq!(router.rtp_capabilities().read().codecs.len(), 5);
+        assert_eq!(router.rtp_capabilities().codecs.len(), 5);
         assert_eq!(
             router.app_data().downcast_ref::<CustomAppData>(),
             Some(&CustomAppData { foo: 123 }),
@@ -148,11 +148,11 @@ fn update_media_codecs_succeeds() {
 
         assert!(!router.closed());
         // 3 codecs + 2 RTX codecs.
-        assert_eq!(router.rtp_capabilities().read().codecs.len(), 5);
+        assert_eq!(router.rtp_capabilities().codecs.len(), 5);
 
-        let _ = router.update_media_codecs([].to_vec());
+        router.update_media_codecs([].to_vec());
 
-        assert_eq!(router.rtp_capabilities().read().codecs.len(), 0);
+        assert_eq!(router.rtp_capabilities().codecs.len(), 0);
     });
 }
 

--- a/rust/tests/integration/router.rs
+++ b/rust/tests/integration/router.rs
@@ -150,7 +150,7 @@ fn update_media_codecs_succeeds() {
         // 3 codecs + 2 RTX codecs.
         assert_eq!(router.rtp_capabilities().codecs.len(), 5);
 
-        router.update_media_codecs([].to_vec());
+        let _ = router.update_media_codecs([].to_vec());
 
         assert_eq!(router.rtp_capabilities().codecs.len(), 0);
     });


### PR DESCRIPTION
This reverts commit https://github.com/versatica/mediasoup/commit/eea7922cde20c060df8db194ad9439e1314630f1.