### PR TITLE
don't skip counting padding-only packets

### DIFF
--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -303,18 +303,17 @@ namespace RTC
 		// Calculate Jitter.
 		CalculateJitter(packet->GetTimestamp());
 
-		// Padding only packet, do not consider it for counter increase nor
-		// stream activation.
-		if (packet->GetPayloadLength() == 0)
-		{
-			return true;
-		}
-
 		// Increase transmission counter.
 		this->transmissionCounter.Update(packet);
 
 		// Increase media transmission counter.
 		this->mediaTransmissionCounter.Update(packet);
+
+		// Padding only packet, do not consider it for stream activation.
+		if (packet->GetPayloadLength() == 0)
+		{
+			return true;
+		}
 
 		// Not inactive anymore.
 		if (this->inactive)


### PR DESCRIPTION
This is to address [Issue 1577](https://github.com/versatica/mediasoup/issues/1577)
Fixes #1577

Padding-only RTP packets should be included in the received packet count to ensure accurate producer score calculation.