### PR TITLE
Make `RtpCodecCapability.preferredPayloadType` mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Node: Make `RtpCodecCapability.preferredPayloadType` mandatory and add `RouterRtpCodecCapability` in which `preferredPayloadType` is optional ([PR #15XX](https://github.com/versatica/mediasoup/pull/15XX)).
+
 ### 3.17.1
 
 - `WebRtcServer`: Remove the limit of 8 `listenInfos`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Node: Make `RtpCodecCapability.preferredPayloadType` mandatory and add `RouterRtpCodecCapability` in which `preferredPayloadType` is optional ([PR #15XX](https://github.com/versatica/mediasoup/pull/15XX)).
+- Node: Make `RtpCodecCapability.preferredPayloadType` mandatory and add `RouterRtpCodecCapability` type (in which `preferredPayloadType` is optional) and `RouterRtpCapabilities` type ([PR #15XX](https://github.com/versatica/mediasoup/pull/15XX)).
 
 ### 3.17.1
 

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -63,7 +63,10 @@ import type {
 	AudioLevelObserverOptions,
 } from './AudioLevelObserverTypes';
 import { AudioLevelObserverImpl } from './AudioLevelObserver';
-import type { RtpCapabilities, RtpCodecCapability } from './rtpParametersTypes';
+import type {
+	RtpCapabilities,
+	RouterRtpCodecCapability,
+} from './rtpParametersTypes';
 import { cryptoSuiteToFbs } from './srtpParametersFbsUtils';
 import type { AppData } from './types';
 import * as utils from './utils';
@@ -1371,13 +1374,13 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 		}
 	}
 
-	updateMediaCodecs(mediaCodecs: RtpCodecCapability[]): void {
+	updateMediaCodecs(mediaCodecs: RouterRtpCodecCapability[]): void {
 		logger.debug('updateMediaCodecs()');
 
 		// Clone given media codecs to not modify input data.
-		const clonedMediaCodecs = utils.clone<RtpCodecCapability[] | undefined>(
-			mediaCodecs
-		);
+		const clonedMediaCodecs = utils.clone<
+			RouterRtpCodecCapability[] | undefined
+		>(mediaCodecs);
 
 		// This may throw.
 		const rtpCapabilities =

--- a/node/src/RouterTypes.ts
+++ b/node/src/RouterTypes.ts
@@ -30,7 +30,10 @@ import type {
 	AudioLevelObserver,
 	AudioLevelObserverOptions,
 } from './AudioLevelObserverTypes';
-import type { RtpCapabilities, RtpCodecCapability } from './rtpParametersTypes';
+import type {
+	RtpCapabilities,
+	RouterRtpCodecCapability,
+} from './rtpParametersTypes';
 import type { NumSctpStreams } from './sctpParametersTypes';
 import type { Either, AppData } from './types';
 
@@ -38,7 +41,7 @@ export type RouterOptions<RouterAppData extends AppData = AppData> = {
 	/**
 	 * Router media codecs.
 	 */
-	mediaCodecs?: RtpCodecCapability[];
+	mediaCodecs?: RouterRtpCodecCapability[];
 
 	/**
 	 * Custom application data.
@@ -292,5 +295,5 @@ export interface Router<RouterAppData extends AppData = AppData>
 	 * Update the Router media codecs. Once called, the return value of the
 	 * router.rtpCapabilities getter changes.
 	 */
-	updateMediaCodecs(mediaCodecs: RtpCodecCapability[]): void;
+	updateMediaCodecs(mediaCodecs: RouterRtpCodecCapability[]): void;
 }

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -22,7 +22,7 @@ import { WebRtcServerImpl } from './WebRtcServer';
 import type { Router, RouterOptions } from './RouterTypes';
 import { RouterImpl } from './Router';
 import { portRangeToFbs, socketFlagsToFbs } from './Transport';
-import type { RtpCodecCapability } from './rtpParametersTypes';
+import type { RouterRtpCodecCapability } from './rtpParametersTypes';
 import * as utils from './utils';
 import * as fbsUtils from './fbsUtils';
 import type { AppData } from './types';
@@ -533,9 +533,9 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 		}
 
 		// Clone given media codecs to not modify input data.
-		const clonedMediaCodecs = utils.clone<RtpCodecCapability[] | undefined>(
-			mediaCodecs
-		);
+		const clonedMediaCodecs = utils.clone<
+			RouterRtpCodecCapability[] | undefined
+		>(mediaCodecs);
 
 		// This may throw.
 		const rtpCapabilities =

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -9,7 +9,7 @@ import type {
 import type { Worker, WorkerSettings } from './WorkerTypes';
 import { WorkerImpl, workerBin } from './Worker';
 import { supportedRtpCapabilities } from './supportedRtpCapabilities';
-import type { RtpCapabilities } from './rtpParametersTypes';
+import type { RouterRtpCapabilities } from './rtpParametersTypes';
 import { parseScalabilityMode } from './scalabilityModesUtils';
 import type { AppData } from './types';
 import * as utils from './utils';
@@ -135,8 +135,8 @@ export async function createWorker<WorkerAppData extends AppData = AppData>({
 /**
  * Get a cloned copy of the mediasoup supported RTP capabilities.
  */
-export function getSupportedRtpCapabilities(): RtpCapabilities {
-	return utils.clone<RtpCapabilities>(supportedRtpCapabilities);
+export function getSupportedRtpCapabilities(): RouterRtpCapabilities {
+	return utils.clone<RouterRtpCapabilities>(supportedRtpCapabilities);
 }
 
 /**

--- a/node/src/indexTypes.ts
+++ b/node/src/indexTypes.ts
@@ -1,6 +1,6 @@
 import type { EnhancedEventEmitter } from './enhancedEvents';
 import type { Worker, WorkerSettings } from './WorkerTypes';
-import type { RtpCapabilities } from './rtpParametersTypes';
+import type { RouterRtpCapabilities } from './rtpParametersTypes';
 import type { parseScalabilityMode } from './scalabilityModesUtils';
 import type { AppData } from './types';
 
@@ -27,6 +27,6 @@ export interface Index {
 	createWorker: <WorkerAppData extends AppData = AppData>(
 		options?: WorkerSettings<WorkerAppData>
 	) => Promise<Worker<WorkerAppData>>;
-	getSupportedRtpCapabilities: () => RtpCapabilities;
+	getSupportedRtpCapabilities: () => RouterRtpCapabilities;
 	parseScalabilityMode: typeof parseScalabilityMode;
 }

--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -6,6 +6,7 @@ import type {
 	RtpCapabilities,
 	MediaKind,
 	RtpCodecCapability,
+	RouterRtpCodecCapability,
 	RtpHeaderExtension,
 	RtpParameters,
 	RtpCodecParameters,
@@ -193,7 +194,7 @@ export function validateSctpStreamParameters(
  * mediasoup supported RTP capabilities.
  */
 export function generateRouterRtpCapabilities(
-	mediaCodecs: RtpCodecCapability[] = []
+	mediaCodecs: RouterRtpCodecCapability[] = []
 ): RtpCapabilities {
 	// Normalize supported RTP capabilities.
 	validateRtpCapabilities(supportedRtpCapabilities);
@@ -227,7 +228,9 @@ export function generateRouterRtpCapabilities(
 		}
 
 		// Clone the supported codec.
-		const codec = utils.clone<RtpCodecCapability>(matchedSupportedCodec);
+		const codec = utils.clone<RtpCodecCapability | RouterRtpCodecCapability>(
+			matchedSupportedCodec
+		);
 
 		// If the given media codec has preferredPayloadType, keep it.
 		if (typeof mediaCodec.preferredPayloadType === 'number') {
@@ -315,8 +318,10 @@ export function getProducerRtpParametersMapping(
 	};
 
 	// Match parameters media codecs to capabilities media codecs.
-	const codecToCapCodec: Map<RtpCodecParameters, RtpCodecCapability> =
-		new Map();
+	const codecToCapCodec: Map<
+		RtpCodecParameters,
+		RtpCodecCapability | RouterRtpCodecCapability
+	> = new Map();
 
 	for (const codec of params.codecs) {
 		if (isRtxCodec(codec)) {
@@ -807,13 +812,15 @@ export function getPipeConsumerRtpParameters({
 	return consumerParams;
 }
 
-function isRtxCodec(codec: RtpCodecCapability | RtpCodecParameters): boolean {
+function isRtxCodec(
+	codec: RtpCodecCapability | RouterRtpCodecCapability | RtpCodecParameters
+): boolean {
 	return /.+\/rtx$/i.test(codec.mimeType);
 }
 
 function matchCodecs(
-	aCodec: RtpCodecCapability | RtpCodecParameters,
-	bCodec: RtpCodecCapability | RtpCodecParameters,
+	aCodec: RtpCodecCapability | RouterRtpCodecCapability | RtpCodecParameters,
+	bCodec: RtpCodecCapability | RouterRtpCodecCapability | RtpCodecParameters,
 	{ strict = false, modify = false } = {}
 ): boolean {
 	const aMimeType = aCodec.mimeType.toLowerCase();
@@ -957,7 +964,9 @@ export function serializeRtpMapping(
  * fields with default values.
  * It throws if invalid.
  */
-function validateRtpCodecCapability(codec: RtpCodecCapability): void {
+function validateRtpCodecCapability(
+	codec: RtpCodecCapability | RouterRtpCodecCapability
+): void {
 	const MimeTypeRegex = new RegExp('^(audio|video)/(.+)', 'i');
 
 	if (typeof codec !== 'object') {
@@ -978,7 +987,7 @@ function validateRtpCodecCapability(codec: RtpCodecCapability): void {
 	// Just override kind with media component of mimeType.
 	codec.kind = mimeTypeMatch[1]!.toLowerCase() as MediaKind;
 
-	// preferredPayloadType is optional.
+	// preferredPayloadType is optional in RouterRtpCodecCapability.
 	if (
 		codec.preferredPayloadType &&
 		typeof codec.preferredPayloadType !== 'number'

--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -4,6 +4,7 @@ import { supportedRtpCapabilities } from './supportedRtpCapabilities';
 import { parseScalabilityMode } from './scalabilityModesUtils';
 import type {
 	RtpCapabilities,
+	RouterRtpCapabilities,
 	MediaKind,
 	RtpCodecCapability,
 	RouterRtpCodecCapability,
@@ -44,7 +45,9 @@ const DynamicPayloadTypes = [
  * fields with default values.
  * It throws if invalid.
  */
-export function validateRtpCapabilities(caps: RtpCapabilities): void {
+export function validateRtpCapabilities(
+	caps: RtpCapabilities | RouterRtpCapabilities
+): void {
 	if (typeof caps !== 'object') {
 		throw new TypeError('caps is not an object');
 	}
@@ -203,7 +206,7 @@ export function generateRouterRtpCapabilities(
 		throw new TypeError('mediaCodecs must be an Array');
 	}
 
-	const clonedSupportedRtpCapabilities = utils.clone<RtpCapabilities>(
+	const clonedSupportedRtpCapabilities = utils.clone<RouterRtpCapabilities>(
 		supportedRtpCapabilities
 	);
 	const dynamicPayloadTypes = utils.clone<number[]>(DynamicPayloadTypes);
@@ -228,9 +231,7 @@ export function generateRouterRtpCapabilities(
 		}
 
 		// Clone the supported codec.
-		const codec = utils.clone<RtpCodecCapability | RouterRtpCodecCapability>(
-			matchedSupportedCodec
-		);
+		const codec = utils.clone<RouterRtpCodecCapability>(matchedSupportedCodec);
 
 		// If the given media codec has preferredPayloadType, keep it.
 		if (typeof mediaCodec.preferredPayloadType === 'number') {
@@ -272,7 +273,7 @@ export function generateRouterRtpCapabilities(
 		codec.parameters = { ...codec.parameters, ...mediaCodec.parameters };
 
 		// Append to the codec list.
-		caps.codecs!.push(codec);
+		caps.codecs!.push(codec as RtpCodecCapability);
 
 		// Add a RTX video codec if video.
 		if (codec.kind === 'video') {
@@ -318,10 +319,8 @@ export function getProducerRtpParametersMapping(
 	};
 
 	// Match parameters media codecs to capabilities media codecs.
-	const codecToCapCodec: Map<
-		RtpCodecParameters,
-		RtpCodecCapability | RouterRtpCodecCapability
-	> = new Map();
+	const codecToCapCodec: Map<RtpCodecParameters, RtpCodecCapability> =
+		new Map();
 
 	for (const codec of params.codecs) {
 		if (isRtxCodec(codec)) {
@@ -383,7 +382,7 @@ export function getProducerRtpParametersMapping(
 	for (const [codec, capCodec] of codecToCapCodec) {
 		rtpMapping.codecs.push({
 			payloadType: codec.payloadType,
-			mappedPayloadType: capCodec.preferredPayloadType!,
+			mappedPayloadType: capCodec.preferredPayloadType,
 		});
 	}
 
@@ -436,7 +435,7 @@ export function getConsumableRtpParameters(
 
 		const consumableCodec: RtpCodecParameters = {
 			mimeType: matchedCapCodec.mimeType,
-			payloadType: matchedCapCodec.preferredPayloadType!,
+			payloadType: matchedCapCodec.preferredPayloadType,
 			clockRate: matchedCapCodec.clockRate,
 			channels: matchedCapCodec.channels,
 			parameters: codec.parameters, // Keep the Producer codec parameters.
@@ -454,7 +453,7 @@ export function getConsumableRtpParameters(
 		if (consumableCapRtxCodec) {
 			const consumableRtxCodec: RtpCodecParameters = {
 				mimeType: consumableCapRtxCodec.mimeType,
-				payloadType: consumableCapRtxCodec.preferredPayloadType!,
+				payloadType: consumableCapRtxCodec.preferredPayloadType,
 				clockRate: consumableCapRtxCodec.clockRate,
 				parameters: consumableCapRtxCodec.parameters,
 				rtcpFeedback: consumableCapRtxCodec.rtcpFeedback,
@@ -812,9 +811,7 @@ export function getPipeConsumerRtpParameters({
 	return consumerParams;
 }
 
-function isRtxCodec(
-	codec: RtpCodecCapability | RouterRtpCodecCapability | RtpCodecParameters
-): boolean {
+function isRtxCodec(codec: RtpCodecCapability | RtpCodecParameters): boolean {
 	return /.+\/rtx$/i.test(codec.mimeType);
 }
 

--- a/node/src/rtpParametersTypes.ts
+++ b/node/src/rtpParametersTypes.ts
@@ -1,4 +1,9 @@
 /**
+ * Media kind ('audio' or 'video').
+ */
+export type MediaKind = 'audio' | 'video';
+
+/**
  * The RTP capabilities define what mediasoup or an endpoint can receive at
  * media level.
  */
@@ -6,7 +11,7 @@ export type RtpCapabilities = {
 	/**
 	 * Supported media and RTX codecs.
 	 */
-	codecs?: (RtpCodecCapability | RouterRtpCodecCapability)[];
+	codecs?: RtpCodecCapability[];
 
 	/**
 	 * Supported RTP header extensions.
@@ -15,9 +20,12 @@ export type RtpCapabilities = {
 };
 
 /**
- * Media kind ('audio' or 'video').
+ * Special RtpCapabilities for `supportedRtpCapabilities` in which `codecs`
+ * is an array of RouterRtpCodecCapability.
  */
-export type MediaKind = 'audio' | 'video';
+export type RouterRtpCapabilities = Omit<RtpCapabilities, 'codecs'> & {
+	codecs?: RouterRtpCodecCapability[];
+};
 
 /**
  * Provides information on the capabilities of a codec within the RTP
@@ -80,7 +88,7 @@ export type RtpCodecCapability = {
 };
 
 /**
- * Special RtpCodecCapability for RouterOptions in which preferredPayloadType
+ * Special RtpCodecCapability for RouterOptions in which `preferredPayloadType`
  * is optional.
  */
 export type RouterRtpCodecCapability = Omit<

--- a/node/src/rtpParametersTypes.ts
+++ b/node/src/rtpParametersTypes.ts
@@ -6,7 +6,7 @@ export type RtpCapabilities = {
 	/**
 	 * Supported media and RTX codecs.
 	 */
-	codecs?: RtpCodecCapability[];
+	codecs?: (RtpCodecCapability | RouterRtpCodecCapability)[];
 
 	/**
 	 * Supported RTP header extensions.
@@ -49,8 +49,11 @@ export type RtpCodecCapability = {
 
 	/**
 	 * The preferred RTP payload type.
+	 *
+	 * NOTE: Despite it's a mandatory field, it's optional in `mediaCodecs` of
+	 * RouterOptions.
 	 */
-	preferredPayloadType?: number;
+	preferredPayloadType: number;
 
 	/**
 	 * Codec clock rate expressed in Hertz.
@@ -74,6 +77,17 @@ export type RtpCodecCapability = {
 	 * Transport layer and codec-specific feedback messages for this codec.
 	 */
 	rtcpFeedback?: RtcpFeedback[];
+};
+
+/**
+ * Special RtpCodecCapability for RouterOptions in which preferredPayloadType
+ * is optional.
+ */
+export type RouterRtpCodecCapability = Omit<
+	RtpCodecCapability,
+	'preferredPayloadType'
+> & {
+	preferredPayloadType?: number;
 };
 
 /**

--- a/node/src/supportedRtpCapabilities.ts
+++ b/node/src/supportedRtpCapabilities.ts
@@ -1,6 +1,6 @@
-import type { RtpCapabilities } from './rtpParametersTypes';
+import type { RouterRtpCapabilities } from './rtpParametersTypes';
 
-const supportedRtpCapabilities: RtpCapabilities = {
+const supportedRtpCapabilities: RouterRtpCapabilities = {
 	codecs: [
 		{
 			kind: 'audio',

--- a/node/src/test/test-ActiveSpeakerObserver.ts
+++ b/node/src/test/test-ActiveSpeakerObserver.ts
@@ -4,13 +4,13 @@ import type { WorkerEvents, ActiveSpeakerObserverEvents } from '../types';
 import * as utils from '../utils';
 
 type TestContext = {
-	mediaCodecs: mediasoup.types.RtpCodecCapability[];
+	mediaCodecs: mediasoup.types.RouterRtpCodecCapability[];
 	worker?: mediasoup.types.Worker;
 	router?: mediasoup.types.Router;
 };
 
 const ctx: TestContext = {
-	mediaCodecs: utils.deepFreeze<mediasoup.types.RtpCodecCapability[]>([
+	mediaCodecs: utils.deepFreeze<mediasoup.types.RouterRtpCodecCapability[]>([
 		{
 			kind: 'audio',
 			mimeType: 'audio/opus',

--- a/node/src/test/test-AudioLevelObserver.ts
+++ b/node/src/test/test-AudioLevelObserver.ts
@@ -4,13 +4,13 @@ import type { WorkerEvents, AudioLevelObserverEvents } from '../types';
 import * as utils from '../utils';
 
 type TestContext = {
-	mediaCodecs: mediasoup.types.RtpCodecCapability[];
+	mediaCodecs: mediasoup.types.RouterRtpCodecCapability[];
 	worker?: mediasoup.types.Worker;
 	router?: mediasoup.types.Router;
 };
 
 const ctx: TestContext = {
-	mediaCodecs: utils.deepFreeze<mediasoup.types.RtpCodecCapability[]>([
+	mediaCodecs: utils.deepFreeze<mediasoup.types.RouterRtpCodecCapability[]>([
 		{
 			kind: 'audio',
 			mimeType: 'audio/opus',

--- a/node/src/test/test-Consumer.ts
+++ b/node/src/test/test-Consumer.ts
@@ -13,7 +13,7 @@ import {
 import * as FbsConsumer from '../fbs/consumer';
 
 type TestContext = {
-	mediaCodecs: mediasoup.types.RtpCodecCapability[];
+	mediaCodecs: mediasoup.types.RouterRtpCodecCapability[];
 	audioProducerOptions: mediasoup.types.ProducerOptions;
 	videoProducerOptions: mediasoup.types.ProducerOptions;
 	consumerDeviceCapabilities: mediasoup.types.RtpCapabilities;
@@ -26,7 +26,7 @@ type TestContext = {
 };
 
 const ctx: TestContext = {
-	mediaCodecs: utils.deepFreeze<mediasoup.types.RtpCodecCapability[]>([
+	mediaCodecs: utils.deepFreeze<mediasoup.types.RouterRtpCodecCapability[]>([
 		{
 			kind: 'audio',
 			mimeType: 'audio/opus',

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -10,7 +10,7 @@ import type {
 import * as utils from '../utils';
 
 type TestContext = {
-	mediaCodecs: mediasoup.types.RtpCodecCapability[];
+	mediaCodecs: mediasoup.types.RouterRtpCodecCapability[];
 	audioProducerOptions: mediasoup.types.ProducerOptions;
 	videoProducerOptions: mediasoup.types.ProducerOptions;
 	dataProducerOptions: mediasoup.types.DataProducerOptions;
@@ -29,7 +29,7 @@ type TestContext = {
 };
 
 const ctx: TestContext = {
-	mediaCodecs: utils.deepFreeze<mediasoup.types.RtpCodecCapability[]>([
+	mediaCodecs: utils.deepFreeze<mediasoup.types.RouterRtpCodecCapability[]>([
 		{
 			kind: 'audio',
 			mimeType: 'audio/opus',

--- a/node/src/test/test-PlainTransport.ts
+++ b/node/src/test/test-PlainTransport.ts
@@ -8,13 +8,13 @@ import * as utils from '../utils';
 const IS_WINDOWS = os.platform() === 'win32';
 
 type TestContext = {
-	mediaCodecs: mediasoup.types.RtpCodecCapability[];
+	mediaCodecs: mediasoup.types.RouterRtpCodecCapability[];
 	worker?: mediasoup.types.Worker;
 	router?: mediasoup.types.Router;
 };
 
 const ctx: TestContext = {
-	mediaCodecs: utils.deepFreeze<mediasoup.types.RtpCodecCapability[]>([
+	mediaCodecs: utils.deepFreeze<mediasoup.types.RouterRtpCodecCapability[]>([
 		{
 			kind: 'audio',
 			mimeType: 'audio/opus',

--- a/node/src/test/test-Producer.ts
+++ b/node/src/test/test-Producer.ts
@@ -13,7 +13,7 @@ import {
 import * as FbsProducer from '../fbs/producer';
 
 type TestContext = {
-	mediaCodecs: mediasoup.types.RtpCodecCapability[];
+	mediaCodecs: mediasoup.types.RouterRtpCodecCapability[];
 	audioProducerOptions: mediasoup.types.ProducerOptions;
 	videoProducerOptions: mediasoup.types.ProducerOptions;
 	worker?: mediasoup.types.Worker;
@@ -23,7 +23,7 @@ type TestContext = {
 };
 
 const ctx: TestContext = {
-	mediaCodecs: utils.deepFreeze<mediasoup.types.RtpCodecCapability[]>([
+	mediaCodecs: utils.deepFreeze<mediasoup.types.RouterRtpCodecCapability[]>([
 		{
 			kind: 'audio',
 			mimeType: 'audio/opus',

--- a/node/src/test/test-Router.ts
+++ b/node/src/test/test-Router.ts
@@ -6,13 +6,13 @@ import { InvalidStateError, UnsupportedError } from '../errors';
 import * as utils from '../utils';
 
 type TestContext = {
-	mediaCodecs: mediasoup.types.RtpCodecCapability[];
-	unsupportedMediaCodecs: mediasoup.types.RtpCodecCapability[];
+	mediaCodecs: mediasoup.types.RouterRtpCodecCapability[];
+	unsupportedMediaCodecs: mediasoup.types.RouterRtpCodecCapability[];
 	worker?: mediasoup.types.Worker;
 };
 
 const ctx: TestContext = {
-	mediaCodecs: utils.deepFreeze<mediasoup.types.RtpCodecCapability[]>([
+	mediaCodecs: utils.deepFreeze<mediasoup.types.RouterRtpCodecCapability[]>([
 		{
 			kind: 'audio',
 			mimeType: 'audio/opus',
@@ -41,7 +41,7 @@ const ctx: TestContext = {
 		},
 	]),
 	unsupportedMediaCodecs: utils.deepFreeze<
-		mediasoup.types.RtpCodecCapability[]
+		mediasoup.types.RouterRtpCodecCapability[]
 	>([
 		{
 			kind: 'audio',

--- a/node/src/test/test-WebRtcTransport.ts
+++ b/node/src/test/test-WebRtcTransport.ts
@@ -16,13 +16,13 @@ import * as FbsTransport from '../fbs/transport';
 import * as FbsWebRtcTransport from '../fbs/web-rtc-transport';
 
 type TestContext = {
-	mediaCodecs: mediasoup.types.RtpCodecCapability[];
+	mediaCodecs: mediasoup.types.RouterRtpCodecCapability[];
 	worker?: mediasoup.types.Worker;
 	router?: mediasoup.types.Router;
 };
 
 const ctx: TestContext = {
-	mediaCodecs: utils.deepFreeze<mediasoup.types.RtpCodecCapability[]>([
+	mediaCodecs: utils.deepFreeze<mediasoup.types.RouterRtpCodecCapability[]>([
 		{
 			kind: 'audio',
 			mimeType: 'audio/opus',

--- a/node/src/test/test-ortc.ts
+++ b/node/src/test/test-ortc.ts
@@ -3,7 +3,7 @@ import * as ortc from '../ortc';
 import { UnsupportedError } from '../errors';
 
 test('generateRouterRtpCapabilities() succeeds', () => {
-	const mediaCodecs: mediasoup.types.RtpCodecCapability[] = [
+	const mediaCodecs: mediasoup.types.RouterRtpCodecCapability[] = [
 		{
 			kind: 'audio',
 			mimeType: 'audio/opus',
@@ -119,7 +119,7 @@ test('generateRouterRtpCapabilities() succeeds', () => {
 });
 
 test('generateRouterRtpCapabilities() with unsupported codecs throws UnsupportedError', () => {
-	let mediaCodecs: mediasoup.types.RtpCodecCapability[];
+	let mediaCodecs: mediasoup.types.RouterRtpCodecCapability[];
 
 	mediaCodecs = [
 		{
@@ -149,7 +149,7 @@ test('generateRouterRtpCapabilities() with unsupported codecs throws Unsupported
 });
 
 test('generateRouterRtpCapabilities() with too many codecs throws', () => {
-	const mediaCodecs: mediasoup.types.RtpCodecCapability[] = [];
+	const mediaCodecs: mediasoup.types.RouterRtpCodecCapability[] = [];
 
 	for (let i = 0; i < 100; ++i) {
 		mediaCodecs.push({
@@ -166,7 +166,7 @@ test('generateRouterRtpCapabilities() with too many codecs throws', () => {
 });
 
 test('getProducerRtpParametersMapping(), getConsumableRtpParameters(), getConsumerRtpParameters() and getPipeConsumerRtpParameters() succeed', () => {
-	const mediaCodecs: mediasoup.types.RtpCodecCapability[] = [
+	const mediaCodecs: mediasoup.types.RouterRtpCodecCapability[] = [
 		{
 			kind: 'audio',
 			mimeType: 'audio/opus',
@@ -509,7 +509,7 @@ test('getProducerRtpParametersMapping(), getConsumableRtpParameters(), getConsum
 });
 
 test('getProducerRtpParametersMapping() with incompatible params throws UnsupportedError', () => {
-	const mediaCodecs: mediasoup.types.RtpCodecCapability[] = [
+	const mediaCodecs: mediasoup.types.RouterRtpCodecCapability[] = [
 		{
 			kind: 'audio',
 			mimeType: 'audio/opus',

--- a/worker/src/RTC/Codecs/AV1.cpp
+++ b/worker/src/RTC/Codecs/AV1.cpp
@@ -4,7 +4,7 @@
 
 #include "Logger.hpp"
 #include "RTC/Codecs/AV1.hpp"
-#include <limits> // std::numeric_limits()
+#include <limits> // std::numeric_limits
 
 namespace RTC
 {

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -9,7 +9,7 @@
 #ifdef MS_RTC_LOGGER_RTP
 #include "RTC/RtcLogger.hpp"
 #endif
-#include <limits> // std::numeric_limits()
+#include <limits> // std::numeric_limits
 
 namespace RTC
 {

--- a/worker/src/RTC/SCTP/packet/TLV.cpp
+++ b/worker/src/RTC/SCTP/packet/TLV.cpp
@@ -5,7 +5,7 @@
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include <cstring> // std::memmove()
-#include <limits>  // std::numeric_limits()
+#include <limits>  // std::numeric_limits
 
 namespace RTC
 {

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -11,7 +11,7 @@
 #ifdef MS_RTC_LOGGER_RTP
 #include "RTC/RtcLogger.hpp"
 #endif
-#include <limits> // std::numeric_limits()
+#include <limits> // std::numeric_limits
 
 namespace RTC
 {

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -10,7 +10,7 @@
 #ifdef MS_RTC_LOGGER_RTP
 #include "RTC/RtcLogger.hpp"
 #endif
-#include <limits> // std::numeric_limits()
+#include <limits> // std::numeric_limits
 
 namespace RTC
 {

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -10,7 +10,7 @@
 #ifdef MS_RTC_LOGGER_RTP
 #include "RTC/RtcLogger.hpp"
 #endif
-#include <limits> // std::numeric_limits()
+#include <limits> // std::numeric_limits
 
 namespace RTC
 {

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -6,7 +6,7 @@
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
 #include <libwebrtc/api/transport/network_types.h> // webrtc::TargetRateConstraints
-#include <limits>                                  // std::numeric_limits()
+#include <limits>                                  // std::numeric_limits
 
 namespace RTC
 {

--- a/worker/test/src/RTC/TestRateCalculator.cpp
+++ b/worker/test/src/RTC/TestRateCalculator.cpp
@@ -2,7 +2,7 @@
 #include "DepLibUV.hpp"
 #include "RTC/RateCalculator.hpp"
 #include <catch2/catch_test_macros.hpp>
-#include <limits> // std::numeric_limits()
+#include <limits> // std::numeric_limits
 #include <vector>
 
 using namespace RTC;

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -1,7 +1,7 @@
 #include "common.hpp"
 #include "RTC/SeqManager.hpp"
 #include <catch2/catch_test_macros.hpp>
-#include <limits> // std::numeric_limits()
+#include <limits> // std::numeric_limits
 #include <string>
 #include <vector>
 

--- a/worker/test/src/Utils/TestNumber.cpp
+++ b/worker/test/src/Utils/TestNumber.cpp
@@ -1,6 +1,7 @@
 #include "common.hpp"
 #include "Utils.hpp"
 #include <catch2/catch_test_macros.hpp>
+#include <limits> // std::numeric_limits
 
 using namespace Utils;
 


### PR DESCRIPTION
## Details

- Make `RtpCodecCapability.preferredPayloadType` mandatory. This is because it was mandatory in the already deprecated ORTC spec and because it's also mandatory in latest `mediasoup-client` 3.14.0, and this is because it makes sense that it's mandatory.
- The only case in which `preferredPayloadType` is optional is in the `mediaCodecs` given to `worker.createRouter()` and this is because, if `preferredPayloadType` is not given in a codec then mediasoup assigns a random one to it. So that's an obvious exception and not the general rule.
- So also add a new `RouterRtpCodecCapability` type in which `preferredPayloadType` is optional, and use it in `mediaCodecs` options in `worker.createRouter()` and also in `router.updateMediaCodecs()`.
- So also add a new `RouterRtpCapabilities` type in which `codecs` array has type `RouterRtpCodecCapability[]`, and use it in `supportedCapabilities.ts`. 
- And make `codecs` field in `RtpCapabilities` be `(RtpCodecCapability | RouterRtpCodecCapability)[]`.

### Note

This is a breaking change in the sense that if an application declares a variable `mediaCodecs: RtpCodecCapability[]` and introduces entries without `preferredPayloadType` then TS is gonna fail. But still this change makes sense.

## TODO

- [x] Document the new type in the website and update types in existing API (`worker.createRouter()`  and `router.updateMediaCodecs()`).
- [x] Announce the change in the forum.