### PR TITLE
`TransportTuple`: Generate hash based not only on remote IP:port but also on local IP:port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- `TransportTuple`: Generate hash based ont only on remote IP:port but also on local IP:port ([PR #1585](https://github.com/versatica/mediasoup/pull/1585)).
+- `TransportTuple`: Generate hash based ont only on remote IP:port but also on local IP:port ([PR #1586](https://github.com/versatica/mediasoup/pull/1586)).
 
 ### 3.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ### NEXT
 
+- `TransportTuple`: Generate hash based ont only on remote IP:port but also on local IP:port ([PR #1585](https://github.com/versatica/mediasoup/pull/1585)).
+
 ### 3.18.0
 
-- Node: Make `RtpCodecCapability.preferredPayloadType` mandatory and add `RouterRtpCodecCapability` type (in which `preferredPayloadType` is optional) and `RouterRtpCapabilities` type ([PR #15XX](https://github.com/versatica/mediasoup/pull/15XX)).
+- Node: Make `RtpCodecCapability.preferredPayloadType` mandatory and add `RouterRtpCodecCapability` type (in which `preferredPayloadType` is optional) and `RouterRtpCapabilities` type ([PR #1584](https://github.com/versatica/mediasoup/pull/1584)).
 
 ### 3.17.1
 

--- a/worker/include/RTC/TransportTuple.hpp
+++ b/worker/include/RTC/TransportTuple.hpp
@@ -20,7 +20,7 @@ namespace RTC
 		enum class Protocol : uint8_t
 		{
 			UDP = 1,
-			TCP
+			TCP = 2
 		};
 
 		static Protocol ProtocolFromFbs(FBS::Transport::Protocol protocol);
@@ -30,13 +30,13 @@ namespace RTC
 		TransportTuple(RTC::UdpSocket* udpSocket, const struct sockaddr* udpRemoteAddr)
 		  : udpSocket(udpSocket), udpRemoteAddr((struct sockaddr*)udpRemoteAddr), protocol(Protocol::UDP)
 		{
-			SetHash();
+			GenerateHash();
 		}
 
 		explicit TransportTuple(RTC::TcpConnection* tcpConnection)
 		  : tcpConnection(tcpConnection), protocol(Protocol::TCP)
 		{
-			SetHash();
+			GenerateHash();
 		}
 
 		explicit TransportTuple(const TransportTuple* tuple)
@@ -142,6 +142,8 @@ namespace RTC
 
 	private:
 		void SetHash();
+		void GenerateHash();
+		uint64_t GenerateFnv1aHash(const uint8_t* data, size_t size);
 
 	public:
 		uint64_t hash{ 0u };

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -405,6 +405,7 @@ test_sources = [
   'test/src/RTC/TestSharedRtpPacket.cpp',
   'test/src/RTC/TestSimpleConsumer.cpp',
   'test/src/RTC/TestTransportCongestionControlServer.cpp',
+  'test/src/RTC/TestTransportTuple.cpp',
   'test/src/RTC/TestTrendCalculator.cpp',
   'test/src/RTC/Codecs/TestDependencyDescriptor.cpp',
   'test/src/RTC/Codecs/TestVP8.cpp',

--- a/worker/src/RTC/TransportTuple.cpp
+++ b/worker/src/RTC/TransportTuple.cpp
@@ -3,7 +3,7 @@
 
 #include "RTC/TransportTuple.hpp"
 #include "Logger.hpp"
-#include <string>
+#include <vector>
 
 namespace RTC
 {
@@ -130,76 +130,60 @@ namespace RTC
 		MS_DUMP("</TransportTuple>");
 	}
 
-	/*
-	 * Hash for IPv4.
-	 *
-	 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 * |              PORT             |             IP                |
-	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 * |              IP               |                           |F|P|
-	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 *
-	 * Hash for IPv6.
-	 *
-	 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 * |              PORT             | IP[0] ^  IP[1] ^ IP[2] ^ IP[3]|
-	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 * |IP[0] ^  IP[1] ^ IP[2] ^ IP[3] |          IP[0] >> 16      |F|P|
-	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 */
-	void TransportTuple::SetHash()
+	void TransportTuple::GenerateHash()
 	{
 		MS_TRACE();
 
-		const struct sockaddr* remoteSockAddr = GetRemoteAddress();
+		const auto* localSockAddr  = GetLocalAddress();
+		const auto* remoteSockAddr = GetRemoteAddress();
 
-		switch (remoteSockAddr->sa_family)
+		std::vector<uint8_t> buffer;
+
+		auto appendSockAddr = [&](const sockaddr* addr)
 		{
-			case AF_INET:
+			if (addr->sa_family == AF_INET)
 			{
-				const auto* remoteSockAddrIn = reinterpret_cast<const struct sockaddr_in*>(remoteSockAddr);
+				const sockaddr_in* in = reinterpret_cast<const sockaddr_in*>(addr);
+				const uint8_t* ip     = reinterpret_cast<const uint8_t*>(&in->sin_addr.s_addr);
+				uint16_t port         = ntohs(in->sin_port);
 
-				const uint64_t address = ntohl(remoteSockAddrIn->sin_addr.s_addr);
-				const uint64_t port    = ntohs(remoteSockAddrIn->sin_port);
-
-				this->hash = port << 48;
-				this->hash |= address << 16;
-				this->hash |= 0x0000; // AF_INET.
-
-				break;
+				buffer.insert(buffer.end(), ip, ip + 4);
+				buffer.push_back((port >> 8) & 0xFF);
+				buffer.push_back(port & 0xFF);
 			}
-
-			case AF_INET6:
+			else if (addr->sa_family == AF_INET6)
 			{
-				const auto* remoteSockAddrIn6 = reinterpret_cast<const struct sockaddr_in6*>(remoteSockAddr);
-				const auto* a =
-				  reinterpret_cast<const uint32_t*>(std::addressof(remoteSockAddrIn6->sin6_addr));
+				const sockaddr_in6* in6 = reinterpret_cast<const sockaddr_in6*>(addr);
+				const uint8_t* ip       = reinterpret_cast<const uint8_t*>(&in6->sin6_addr);
+				uint16_t port           = ntohs(in6->sin6_port);
 
-				const auto address1 = a[0] ^ a[1] ^ a[2] ^ a[3];
-				const auto address2 = a[0];
-				const uint64_t port = ntohs(remoteSockAddrIn6->sin6_port);
-
-				this->hash = port << 48;
-				this->hash |= static_cast<uint64_t>(address1) << 16;
-				this->hash |= address2 >> 16 & 0xFFFC;
-				this->hash |= 0x0002; // AF_INET6.
-
-				break;
+				buffer.insert(buffer.end(), ip, ip + 16);
+				buffer.push_back((port >> 8) & 0xFF);
+				buffer.push_back(port & 0xFF);
 			}
+		};
+
+		appendSockAddr(localSockAddr);
+		appendSockAddr(remoteSockAddr);
+
+		buffer.push_back(static_cast<uint8_t>(this->protocol));
+
+		this->hash = GenerateFnv1aHash(buffer.data(), buffer.size());
+	}
+
+	uint64_t TransportTuple::GenerateFnv1aHash(const uint8_t* data, size_t size)
+	{
+		MS_TRACE();
+
+		const uint64_t fnvOffsetBasis = 14695981039346656037ull;
+		const uint64_t fnvPrime       = 1099511628211ull;
+		uint64_t hash                 = fnvOffsetBasis;
+
+		for (size_t i = 0; i < size; ++i)
+		{
+			hash = (hash ^ data[i]) * fnvPrime;
 		}
 
-		// Override least significant bit with protocol information:
-		// - If UDP, start with 0.
-		// - If TCP, start with 1.
-		if (this->protocol == Protocol::UDP)
-		{
-			this->hash |= 0x0000;
-		}
-		else
-		{
-			this->hash |= 0x0001;
-		}
+		return hash;
 	}
 } // namespace RTC

--- a/worker/test/src/RTC/TestTransportTuple.cpp
+++ b/worker/test/src/RTC/TestTransportTuple.cpp
@@ -1,0 +1,149 @@
+#include "common.hpp"
+#include "RTC/Transport.hpp"
+#include "RTC/TransportTuple.hpp"
+#include "RTC/UdpSocket.hpp"
+#include <uv.h>
+#include <catch2/catch_test_macros.hpp>
+
+using namespace RTC;
+
+class UdpSocketListener : public UdpSocket::Listener
+{
+public:
+	void OnUdpSocketPacketReceived(
+	  UdpSocket* /*socket*/,
+	  const uint8_t* /*data*/,
+	  size_t /*len*/,
+	  const struct sockaddr* /*remoteAddr*/) override
+	{
+	}
+};
+
+std::unique_ptr<UdpSocket> makeUdpSocket(const std::string& ip, uint16_t minPort, uint16_t maxPort)
+{
+	UdpSocketListener listener;
+	auto flags = Transport::SocketFlags{ .ipv6Only = false, .udpReusePort = false };
+	uint64_t portRangeHash{ 0u };
+	auto* udpSocket = new UdpSocket(
+	  std::addressof(listener), const_cast<std::string&>(ip), minPort, maxPort, flags, portRangeHash);
+
+	return std::unique_ptr<UdpSocket>(udpSocket);
+}
+
+std::unique_ptr<sockaddr> makeUdpSockAddr(int family, const std::string& ip, uint16_t port)
+{
+	if (family == AF_INET)
+	{
+		auto addr = std::make_unique<sockaddr_in>();
+
+		addr->sin_family = AF_INET;
+		addr->sin_port   = htons(port);
+
+		if (uv_inet_pton(AF_INET, ip.c_str(), std::addressof(addr->sin_addr)) != 0)
+		{
+			throw std::runtime_error("invalid IPv4 address");
+		}
+
+		return std::unique_ptr<sockaddr>(reinterpret_cast<sockaddr*>(addr.release()));
+	}
+	else if (family == AF_INET6)
+	{
+		auto addr6         = std::make_unique<sockaddr_in6>();
+		addr6->sin6_family = AF_INET6;
+		addr6->sin6_port   = htons(port);
+
+		if (uv_inet_pton(AF_INET6, ip.c_str(), std::addressof(addr6->sin6_addr)) != 0)
+		{
+			throw std::runtime_error("invalid IPv6 address");
+		}
+
+		return std::unique_ptr<sockaddr>(reinterpret_cast<sockaddr*>(addr6.release()));
+	}
+	else
+	{
+		throw std::runtime_error("invalid network family");
+	}
+}
+
+SCENARIO("TransportTuples have unique hashes", "[transporttuple]")
+{
+	SECTION("2 tuples with same local and remote IP:port have the same hash")
+	{
+		auto udpSocket      = makeUdpSocket("0.0.0.0", 10000, 50000);
+		auto udpRemoteAddr1 = makeUdpSockAddr(AF_INET, "1.2.3.4", 1234);
+		auto udpRemoteAddr2 = makeUdpSockAddr(AF_INET, "1.2.3.4", 1234);
+
+		TransportTuple udpTuple1(udpSocket.get(), udpRemoteAddr1.get());
+		TransportTuple udpTuple2(udpSocket.get(), udpRemoteAddr2.get());
+
+		REQUIRE(udpTuple1.hash == udpTuple2.hash);
+	}
+
+	SECTION(
+	  "2 tuples with same local IP:port, same remote IP and different remote port have different hashes")
+	{
+		auto udpSocket      = makeUdpSocket("0.0.0.0", 10000, 50000);
+		auto udpRemoteAddr1 = makeUdpSockAddr(AF_INET, "1.2.3.4", 10001);
+		auto udpRemoteAddr2 = makeUdpSockAddr(AF_INET, "1.2.3.4", 10002);
+
+		TransportTuple udpTuple1(udpSocket.get(), udpRemoteAddr1.get());
+		TransportTuple udpTuple2(udpSocket.get(), udpRemoteAddr2.get());
+
+		REQUIRE(udpTuple1.hash != udpTuple2.hash);
+
+		for (uint16_t remotePort{ 1 }; remotePort < 65535; ++remotePort)
+		{
+			// SKip if same port as the one in udpRemoteAddr1.
+			if (remotePort == 10001)
+			{
+				continue;
+			}
+
+			auto udpRemoteAddr3 = makeUdpSockAddr(AF_INET, "1.2.3.4", remotePort);
+
+			TransportTuple udpTuple3(udpSocket.get(), udpRemoteAddr3.get());
+
+			REQUIRE(udpTuple1.hash != udpTuple3.hash);
+		}
+	}
+
+	SECTION(
+	  "2 tuples with same local IP:port, different remote IP and same remote port have different hashes")
+	{
+		auto udpSocket      = makeUdpSocket("0.0.0.0", 10000, 50000);
+		auto udpRemoteAddr1 = makeUdpSockAddr(AF_INET, "1.2.3.4", 10001);
+		auto udpRemoteAddr2 = makeUdpSockAddr(AF_INET, "1.2.3.5", 10001);
+
+		TransportTuple udpTuple1(udpSocket.get(), udpRemoteAddr1.get());
+		TransportTuple udpTuple2(udpSocket.get(), udpRemoteAddr2.get());
+
+		REQUIRE(udpTuple1.hash != udpTuple2.hash);
+	}
+
+	SECTION(
+	  "2 tuples with same remote IP:port, same local IP and different local port have different hashes")
+	{
+		auto udpSocket1     = makeUdpSocket("0.0.0.0", 10000, 20000);
+		auto udpSocket2     = makeUdpSocket("0.0.0.0", 30000, 40000);
+		auto udpRemoteAddr1 = makeUdpSockAddr(AF_INET, "5.4.3.2", 22222);
+		auto udpRemoteAddr2 = makeUdpSockAddr(AF_INET, "5.4.3.2", 22222);
+
+		TransportTuple udpTuple1(udpSocket1.get(), udpRemoteAddr1.get());
+		TransportTuple udpTuple2(udpSocket2.get(), udpRemoteAddr2.get());
+
+		REQUIRE(udpTuple1.hash != udpTuple2.hash);
+	}
+
+	SECTION(
+	  "2 tuples with same local IP:port, same remote IP and different remote port have different hashes")
+	{
+		auto udpSocket      = makeUdpSocket("0.0.0.0", 10000, 50000);
+		auto udpRemoteAddr1 = makeUdpSockAddr(AF_INET, "1.2.3.4", 40001);
+		auto udpRemoteAddr2 = makeUdpSockAddr(AF_INET, "1.2.3.4", 40002);
+
+		TransportTuple udpTuple1(udpSocket.get(), udpRemoteAddr1.get());
+		TransportTuple udpTuple2(udpSocket.get(), udpRemoteAddr2.get());
+
+		REQUIRE(udpTuple1.hash != udpTuple2.hash);
+	}
+}


### PR DESCRIPTION
## Details

- See related issue in https://github.com/versatica/mediasoup/issues/1585#issuecomment-3163590173.
  - **NOTE:** This PR doesn't fix that issue completely. A new PR will complete it.
- The thing is that if mediasoup is listening in 2 public IPs A and B, a client behind a router may reach both A and B from the same public source IP:port.
- So the hash of the tuple must depend **also** on the local IP:port.
- Tests added.