### PR TITLE
`IceServer`: Only update selected tuple if the new Binding request has ICE re-nomination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - `TransportTuple`: Generate hash based ont only on remote IP:port but also on local IP:port ([PR #1586](https://github.com/versatica/mediasoup/pull/1586)).
+- `IceServer`: Only update selected tuple if the new Binding request has ICE renomination ([PR #1587](https://github.com/versatica/mediasoup/pull/1587), credits to @pangsimon).
 
 ### 3.18.0
 

--- a/worker/src/RTC/IceServer.cpp
+++ b/worker/src/RTC/IceServer.cpp
@@ -747,7 +747,9 @@ namespace RTC
 					// Store the tuple.
 					auto* storedTuple = AddTuple(tuple);
 
-					if ((hasNomination && nomination > this->remoteNomination) || !hasNomination)
+					// When in completed state, only set current tuple as selected tuple
+					// if the request has nomination.
+					if (hasNomination && nomination > this->remoteNomination)
 					{
 						// Mark it as selected tuple.
 						SetSelectedTuple(storedTuple);

--- a/worker/src/RTC/IceServer.cpp
+++ b/worker/src/RTC/IceServer.cpp
@@ -747,8 +747,8 @@ namespace RTC
 					// Store the tuple.
 					auto* storedTuple = AddTuple(tuple);
 
-					// When in completed state, only set current tuple as selected tuple
-					// if the request has nomination.
+					// When in completed state, only update selected tuple if there is ICE
+					// nomination.
 					if (hasNomination && nomination > this->remoteNomination)
 					{
 						// Mark it as selected tuple.


### PR DESCRIPTION
## Details

- Fixes #1585
- Credits to @pangsimon.