### PR TITLE
Rust: Remove unused `Notification` enum

### DIFF
--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -501,12 +501,6 @@ impl Inner {
         &self,
         buffer_worker_messages_guard: BufferMessagesGuard,
     ) -> io::Result<()> {
-        #[derive(Deserialize)]
-        #[serde(tag = "event", rename_all = "lowercase")]
-        enum Notification {
-            Running,
-        }
-
         let (sender, receiver) = async_oneshot::oneshot();
         let id = self.id;
         let sender = Mutex::new(Some(sender));


### PR DESCRIPTION
## Details

- Fixes #1593
- Such a `Notification` enum is not used anywhere.
- AFAIS this "running" notification was intended to mimic the behavior in Node where the worker sends a "running" notification to Node layer once it's ready. But AFAIK that has never been needed in mediasoup Rust.