### PR TITLE
[Rust] Make `parameters` and `rtcp_feedback` optional in `RtpCodecParameters` and `RtpCodecCapability` during deserialization

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # NEXT
 
+- Make `parameters` and `rtcp_feedback` optional in `RtpCodecParameters` and `RtpCodecCapability` during deserialization.
+
 # 0.19.1
 
 - Fix installation in paths with spaces (PR #1596).

--- a/rust/types/src/rtp_parameters.rs
+++ b/rust/types/src/rtp_parameters.rs
@@ -427,8 +427,10 @@ pub enum RtpCodecCapability {
         channels: NonZeroU8,
         /// Codec specific parameters. Some parameters (such as `packetization-mode` and
         /// `profile-level-id` in H264 or `profile-id` in VP9) are critical for codec matching.
+        #[serde(default)]
         parameters: RtpCodecParametersParameters,
         /// Transport layer and codec-specific feedback messages for this codec.
+        #[serde(default)]
         rtcp_feedback: Vec<RtcpFeedback>,
     },
     /// Video codec capability
@@ -443,8 +445,10 @@ pub enum RtpCodecCapability {
         clock_rate: NonZeroU32,
         /// Codec specific parameters. Some parameters (such as `packetization-mode` and
         /// `profile-level-id` in H264 or `profile-id` in VP9) are critical for codec matching.
+        #[serde(default)]
         parameters: RtpCodecParametersParameters,
         /// Transport layer and codec-specific feedback messages for this codec.
+        #[serde(default)]
         rtcp_feedback: Vec<RtcpFeedback>,
     },
 }
@@ -762,8 +766,10 @@ pub enum RtpCodecParameters {
         /// Codec-specific parameters available for signaling. Some parameters (such as
         /// `packetization-mode` and `profile-level-id` in H264 or `profile-id` in VP9) are critical for
         /// codec matching.
+        #[serde(default)]
         parameters: RtpCodecParametersParameters,
         /// Transport layer and codec-specific feedback messages for this codec.
+        #[serde(default)]
         rtcp_feedback: Vec<RtcpFeedback>,
     },
     /// Video codec
@@ -778,8 +784,10 @@ pub enum RtpCodecParameters {
         /// Codec-specific parameters available for signaling. Some parameters (such as
         /// `packetization-mode` and `profile-level-id` in H264 or `profile-id` in VP9) are critical for
         /// codec matching.
+        #[serde(default)]
         parameters: RtpCodecParametersParameters,
         /// Transport layer and codec-specific feedback messages for this codec.
+        #[serde(default)]
         rtcp_feedback: Vec<RtcpFeedback>,
     },
 }


### PR DESCRIPTION
## Details

- Fixes #1589

## TODO

- Should I also add `#[serde(default)]` above `parameters` and `rtcp_feedback` fields in `RtpCodecCapabilityFinalized` type?
