### PR TITLE
[Rust] Don't re-expose types from main crate

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Make `parameters` and `rtcp_feedback` optional in `RtpCodecParameters` and `RtpCodecCapability` during deserialization (PR #1589).
 - Make codec `mime_type` case insensitive during deserialization (PR #1590).
+- Only expose `data_structures`, `rtp_parameters`, `sctp_parameters` and `srtp_parameters` through the `mediasoup-types` crate (PR #1591).
 
 # 0.19.1
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 # NEXT
 
-- Make `parameters` and `rtcp_feedback` optional in `RtpCodecParameters` and `RtpCodecCapability` during deserialization (PR #1589).
-- Make codec `mime_type` case insensitive during deserialization (PR #1590).
-- Only expose `data_structures`, `rtp_parameters`, `sctp_parameters` and `srtp_parameters` through the `mediasoup-types` crate (PR #1591).
+- Make `parameters` and `rtcp_feedback` optional in `RtpCodecParameters` and `RtpCodecCapability` during deserialization (PR #1597).
+- Make codec `mime_type` case insensitive during deserialization (PR #1599).
+- Only expose `data_structures`, `rtp_parameters`, `sctp_parameters` and `srtp_parameters` through the `mediasoup-types` crate (PR #1600).
 
 # 0.19.1
 

--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -49,8 +49,7 @@
 //! and are a good place to start until we have demo apps built in Rust).
 
 pub use mediasoup_types as types;
-#[deprecated(note = "Deprecated in favour of types::data_structures")]
-pub mod data_structures;
+mod data_structures;
 pub(crate) mod fbs;
 mod macros;
 mod messages;
@@ -58,14 +57,9 @@ mod messages;
 pub mod ortc;
 pub mod prelude;
 pub mod router;
-#[deprecated(note = "Deprecated in favour of types::rtp_parameters")]
-pub mod rtp_parameters;
-#[deprecated(note = "Deprecated in favour of types::scalability_modes")]
-pub mod scalability_modes;
-#[deprecated(note = "Deprecated in favour of types::sctp_parameters")]
-pub mod sctp_parameters;
-#[deprecated(note = "Deprecated in favour of types::srtp_parameters")]
-pub mod srtp_parameters;
+mod rtp_parameters;
+mod sctp_parameters;
+mod srtp_parameters;
 pub mod supported_rtp_capabilities;
 pub mod webrtc_server;
 pub mod worker;

--- a/rust/src/rtp_parameters.rs
+++ b/rust/src/rtp_parameters.rs
@@ -3,22 +3,10 @@
 
 use crate::fbs::{FromFbs, ToFbs, TryFromFbs};
 use mediasoup_sys::fbs::rtp_parameters;
-pub use mediasoup_types::rtp_parameters::*;
+use mediasoup_types::rtp_parameters::*;
 use std::borrow::Cow;
 use std::error::Error;
 use std::str::FromStr;
-use thiserror::Error;
-
-/// Error that caused [`MimeType`] parsing error.
-#[derive(Debug, Error, Eq, PartialEq)]
-pub enum ParseMimeTypeError {
-    /// Invalid MIME type input string
-    #[error("Invalid MIME type input string")]
-    InvalidInput,
-    /// Unknown MIME type
-    #[error("Unknown MIME type")]
-    UnknownMimeType,
-}
 
 impl<'a> TryFromFbs<'a> for RtpParameters {
     type FbsType = rtp_parameters::RtpParametersRef<'a>;

--- a/rust/src/sctp_parameters.rs
+++ b/rust/src/sctp_parameters.rs
@@ -2,7 +2,7 @@
 
 use crate::fbs::{FromFbs, ToFbs};
 use mediasoup_sys::fbs::sctp_parameters;
-pub use mediasoup_types::sctp_parameters::*;
+use mediasoup_types::sctp_parameters::*;
 
 impl ToFbs for NumSctpStreams {
     type FbsType = sctp_parameters::NumSctpStreams;

--- a/rust/src/srtp_parameters.rs
+++ b/rust/src/srtp_parameters.rs
@@ -2,7 +2,7 @@
 
 use crate::fbs::{FromFbs, ToFbs};
 use mediasoup_sys::fbs::srtp_parameters;
-pub use mediasoup_types::srtp_parameters::*;
+use mediasoup_types::srtp_parameters::*;
 
 impl FromFbs for SrtpParameters {
     type FbsType = srtp_parameters::SrtpParameters;


### PR DESCRIPTION
## Details

- Fixes #1598.
- Only expose `data_structures`, `rtp_parameters`, `sctp_parameters` and `srtp_parameters` through the `mediasoup-types` crate.