### PR TITLE
[Node] Improve worker location detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Node: Improve worker binary location detection ([PR #1603](https://github.com/versatica/mediasoup/pull/1603)).
+
 ### 3.18.1
 
 - `TransportTuple`: Generate hash based not only on remote IP:port but also on local IP:port ([PR #1586](https://github.com/versatica/mediasoup/pull/1586)).

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -650,9 +650,8 @@ function getWorkerBin(): string {
 		);
 	} catch (error) {
 		logger.warn(
-			`getWorkerBin() | require.resolve('mediasoup') failed: ${error}`
+			`getWorkerBin() | require.resolve('mediasoup') failed, using __dirname: ${error}`
 		);
-		logger.debug('getWorkerBin() | using __dirname');
 
 		// mediasoup module path is two folders above this file.
 		mediasoupModulePath = path.join(__dirname, '..', '..');

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -32,33 +32,10 @@ import * as FbsWorker from './fbs/worker';
 import * as FbsTransport from './fbs/transport';
 import { Protocol as FbsTransportProtocol } from './fbs/transport/protocol';
 
-// If env MEDIASOUP_WORKER_BIN is given, use it as worker binary.
-// Otherwise if env MEDIASOUP_BUILDTYPE is 'Debug' use the Debug binary.
-// Otherwise use the Release binary.
-export const workerBin = process.env['MEDIASOUP_WORKER_BIN']
-	? process.env['MEDIASOUP_WORKER_BIN']
-	: process.env['MEDIASOUP_BUILDTYPE'] === 'Debug'
-		? path.join(
-				__dirname,
-				'..',
-				'..',
-				'worker',
-				'out',
-				'Debug',
-				'mediasoup-worker'
-			)
-		: path.join(
-				__dirname,
-				'..',
-				'..',
-				'worker',
-				'out',
-				'Release',
-				'mediasoup-worker'
-			);
-
 const logger = new Logger('Worker');
 const workerLogger = new Logger('Worker');
+
+export const workerBin: string = getWorkerBin();
 
 export class WorkerImpl<WorkerAppData extends AppData = AppData>
 	extends EnhancedEventEmitter<WorkerEvents>
@@ -644,4 +621,59 @@ function parseWorkerDumpResponse(binary: FbsWorker.DumpResponse): WorkerDump {
 	}
 
 	return dump;
+}
+
+function getWorkerBin(): string {
+	// If MEDIASOUP_WORKER_BIN env is given, use it as worker binary.
+	if (process.env['MEDIASOUP_WORKER_BIN']) {
+		logger.debug(
+			`getWorkerBin() | using MEDIASOUP_WORKER_BIN environment variable: ${process.env['MEDIASOUP_WORKER_BIN']}`
+		);
+
+		return process.env['MEDIASOUP_WORKER_BIN'];
+	}
+
+	// Obtain the path of the mediasoup module.
+	let mediasoupModulePath: string | undefined;
+
+	try {
+		// NOTE: This will throw `MODULE_NOT_FOUND` if mediasoup is installed
+		// globally.
+		mediasoupModulePath = require.resolve('mediasoup');
+
+		// NOTE: Returned path will include 'node/lib/index.js' since that's the
+		// main entry point in package.json, so remove it.
+		mediasoupModulePath = path.join(
+			path.dirname(mediasoupModulePath),
+			'..',
+			'..'
+		);
+	} catch (error) {
+		logger.warn(
+			`getWorkerBin() | require.resolve('mediasoup') failed: ${error}`
+		);
+		logger.debug('getWorkerBin() | using __dirname');
+
+		// mediasoup module path is two folders above this file.
+		mediasoupModulePath = path.join(__dirname, '..', '..');
+	}
+
+	// If env MEDIASOUP_BUILDTYPE is 'Debug' use the Debug binary. Otherwise use
+	// the Release binary.
+	const buildType: 'Release' | 'Debug' =
+		process.env['MEDIASOUP_BUILDTYPE'] === 'Debug' ? 'Debug' : 'Release';
+
+	const workerBinPath = path.join(
+		mediasoupModulePath,
+		'worker',
+		'out',
+		buildType,
+		'mediasoup-worker'
+	);
+
+	logger.debug(
+		`getWorkerBin() | detected worker binary path: ${workerBinPath}`
+	);
+
+	return workerBinPath;
 }


### PR DESCRIPTION
## Details

- Fixes #1601
- Use `require.resolve('mediasoup')` to get the path of mediasoup module and, from there, compute the location of the worker binary.
- This prevents mediasoup from failing to spawn the worker binary when the Node application uses webpack or rollup and bundles the source code (including mediasoup dependency) into a `dist/` folder.
- As fallback mechanism, use the previous `__dirname` solution.