### PR TITLE
`router.pipeToRouter()` can now connect two `Routers` in the same `Worker`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,13 +3,13 @@
 ### NEXT
 
 - Node: Improve worker binary location detection ([PR #1603](https://github.com/versatica/mediasoup/pull/1603)).
+- `router.pipeToRouter()` can now connect two `Routers` in the same `Worker` if `keepId` is set to `false` ([PR #1604](https://github.com/versatica/mediasoup/pull/1604)).
 
 ### 3.18.1
 
 - `TransportTuple`: Generate hash based not only on remote IP:port but also on local IP:port ([PR #1586](https://github.com/versatica/mediasoup/pull/1586)).
 - `IceServer`: Only update selected tuple if the new Binding request has ICE renomination ([PR #1587](https://github.com/versatica/mediasoup/pull/1587), credits to @pangsimon).
 - Fix installation in paths with spaces ([PR #1596](https://github.com/versatica/mediasoup/pull/1596), thanks to @ShuzhaoFeng for reporting and helping with this issue).
-- `router.pipeToRouter()` can now connect two `Routers` in the same `Worker` if `keepId` is set to `false` ([PR #1604](https://github.com/versatica/mediasoup/pull/1604)).
 
 ### 3.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 - `TransportTuple`: Generate hash based not only on remote IP:port but also on local IP:port ([PR #1586](https://github.com/versatica/mediasoup/pull/1586)).
 - `IceServer`: Only update selected tuple if the new Binding request has ICE renomination ([PR #1587](https://github.com/versatica/mediasoup/pull/1587), credits to @pangsimon).
 - Fix installation in paths with spaces ([PR #1596](https://github.com/versatica/mediasoup/pull/1596), thanks to @ShuzhaoFeng for reporting and helping with this issue).
-- `router.pipeToRouter()` can now connect two `Routers` in the same `Worker` ([PR #1604](https://github.com/versatica/mediasoup/pull/1604)).
+- `router.pipeToRouter()` can now connect two `Routers` in the same `Worker` if `keepId` is set to `false` ([PR #1604](https://github.com/versatica/mediasoup/pull/1604)).
 
 ### 3.18.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - `TransportTuple`: Generate hash based not only on remote IP:port but also on local IP:port ([PR #1586](https://github.com/versatica/mediasoup/pull/1586)).
 - `IceServer`: Only update selected tuple if the new Binding request has ICE renomination ([PR #1587](https://github.com/versatica/mediasoup/pull/1587), credits to @pangsimon).
 - Fix installation in paths with spaces ([PR #1596](https://github.com/versatica/mediasoup/pull/1596), thanks to @ShuzhaoFeng for reporting and helping with this issue).
+- `router.pipeToRouter()` can now connect two `Routers` in the same `Worker` ([PR #1604](https://github.com/versatica/mediasoup/pull/1604)).
 
 ### 3.18.0
 

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -1088,7 +1088,8 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 				});
 
 				pipeProducer = await remotePipeTransport!.produce({
-					id: producer.id,
+					// Generate a new id for the pipeProducer.
+					id: utils.generateUUIDv4(),
 					kind: pipeConsumer.kind,
 					rtpParameters: pipeConsumer.rtpParameters,
 					paused: pipeConsumer.producerPaused,
@@ -1145,7 +1146,8 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 				});
 
 				pipeDataProducer = await remotePipeTransport!.produceData({
-					id: dataProducer.id,
+					// Generate a new id for the pipeDataProducer.
+					id: utils.generateUUIDv4(),
 					sctpStreamParameters: pipeDataConsumer.sctpStreamParameters,
 					label: pipeDataConsumer.label,
 					protocol: pipeDataConsumer.protocol,

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -924,6 +924,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 		producerId,
 		dataProducerId,
 		router,
+		keepId = true,
 		listenInfo,
 		listenIp,
 		enableSctp = true,
@@ -1088,8 +1089,8 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 				});
 
 				pipeProducer = await remotePipeTransport!.produce({
-					// Generate a new id for the pipeProducer.
-					id: utils.generateUUIDv4(),
+					// If requested, generate a new id for the pipeProducer.
+					id: keepId ? producer.id : utils.generateUUIDv4(),
 					kind: pipeConsumer.kind,
 					rtpParameters: pipeConsumer.rtpParameters,
 					paused: pipeConsumer.producerPaused,
@@ -1146,8 +1147,8 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 				});
 
 				pipeDataProducer = await remotePipeTransport!.produceData({
-					// Generate a new id for the pipeDataProducer.
-					id: utils.generateUUIDv4(),
+					// If requested, generate a new id for the pipeDataProducer.
+					id: keepId ? dataProducer.id : utils.generateUUIDv4(),
 					sctpStreamParameters: pipeDataConsumer.sctpStreamParameters,
 					label: pipeDataConsumer.label,
 					protocol: pipeDataConsumer.protocol,

--- a/node/src/RouterTypes.ts
+++ b/node/src/RouterTypes.ts
@@ -66,6 +66,16 @@ export type PipeToRouterOptions = {
 	router: Router;
 
 	/**
+	 * Whether the `id` of the returned Producer or DataProducer should be the
+	 * same than the `id` of the original Producer or DataProducer. Default true.
+	 *
+	 * @remarks
+	 * - If set to true, then the origin router and target router cannot be in the
+	 *   same worker (if so, `pipeToRouter()` with throw).
+	 */
+	keepId?: boolean;
+
+	/**
 	 * Create a SCTP association. Default true.
 	 */
 	enableSctp?: boolean;

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -902,7 +902,7 @@ test('producer.close() is transmitted to pipe Consumer', async () => {
 	expect(videoConsumer.closed).toBe(true);
 }, 2000);
 
-test('router.pipeToRouter() does not fail if both Routers belong to the same Worker', async () => {
+test('router.pipeToRouter() with keepId: true fails if both Routers belong to the same Worker', async () => {
 	const router1bis = await ctx.worker1!.createRouter({
 		mediaCodecs: ctx.mediaCodecs,
 	});
@@ -911,8 +911,24 @@ test('router.pipeToRouter() does not fail if both Routers belong to the same Wor
 		ctx.router1!.pipeToRouter({
 			producerId: ctx.videoProducer!.id,
 			router: router1bis,
+			// Default value is true.
+			keepId: true,
 		})
-	).resolves.toBeDefined();
+	).rejects.toThrow(Error);
+}, 2000);
+
+test('router.pipeToRouter() with keepId: false does not fail if both Routers belong to the same Worker', async () => {
+	const router1bis = await ctx.worker1!.createRouter({
+		mediaCodecs: ctx.mediaCodecs,
+	});
+
+	const { pipeProducer } = await ctx.router1!.pipeToRouter({
+		producerId: ctx.videoProducer!.id,
+		router: router1bis,
+		keepId: false,
+	});
+
+	expect(pipeProducer!.id).not.toBe(ctx.videoProducer!.id);
 }, 2000);
 
 test('router.pipeToRouter() succeeds with data', async () => {

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -288,7 +288,7 @@ test('router.pipeToRouter() succeeds with audio', async () => {
 	});
 	expect(pipeConsumer.appData).toEqual({});
 
-	expect(typeof pipeProducer.id).toBe('string');
+	expect(pipeProducer.id).toBe(ctx.audioProducer!.id);
 	expect(pipeProducer.closed).toBe(false);
 	expect(pipeProducer.kind).toBe('audio');
 	expect(typeof pipeProducer.rtpParameters).toBe('object');
@@ -411,7 +411,7 @@ test('router.pipeToRouter() succeeds with video', async () => {
 	});
 	expect(pipeConsumer.appData).toEqual({});
 
-	expect(typeof pipeProducer.id).toBe('string');
+	expect(pipeProducer.id).toBe(ctx.videoProducer!.id);
 	expect(pipeProducer.closed).toBe(false);
 	expect(pipeProducer.kind).toBe('video');
 	expect(typeof pipeProducer.rtpParameters).toBe('object');

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -966,7 +966,7 @@ test('router.pipeToRouter() succeeds with data', async () => {
 	expect(pipeDataConsumer.label).toBe('foo');
 	expect(pipeDataConsumer.protocol).toBe('bar');
 
-	expect(typeof pipeDataProducer.id).toBe('string');
+	expect(pipeDataProducer.id).toBe(ctx.dataProducer!.id);
 	expect(pipeDataProducer.closed).toBe(false);
 	expect(pipeDataProducer.type).toBe('sctp');
 	expect(typeof pipeDataProducer.sctpStreamParameters).toBe('object');

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -288,7 +288,7 @@ test('router.pipeToRouter() succeeds with audio', async () => {
 	});
 	expect(pipeConsumer.appData).toEqual({});
 
-	expect(pipeProducer.id).toBe(ctx.audioProducer!.id);
+	expect(typeof pipeProducer.id).toBe('string');
 	expect(pipeProducer.closed).toBe(false);
 	expect(pipeProducer.kind).toBe('audio');
 	expect(typeof pipeProducer.rtpParameters).toBe('object');
@@ -411,7 +411,7 @@ test('router.pipeToRouter() succeeds with video', async () => {
 	});
 	expect(pipeConsumer.appData).toEqual({});
 
-	expect(pipeProducer.id).toBe(ctx.videoProducer!.id);
+	expect(typeof pipeProducer.id).toBe('string');
 	expect(pipeProducer.closed).toBe(false);
 	expect(pipeProducer.kind).toBe('video');
 	expect(typeof pipeProducer.rtpParameters).toBe('object');
@@ -758,13 +758,13 @@ test('router.createPipeTransport() with fixed port succeeds', async () => {
 }, 2000);
 
 test('transport.consume() for a pipe Producer succeeds', async () => {
-	await ctx.router1!.pipeToRouter({
+	const { pipeProducer } = await ctx.router1!.pipeToRouter({
 		producerId: ctx.videoProducer!.id,
 		router: ctx.router2!,
 	});
 
 	const videoConsumer = await ctx.webRtcTransport2!.consume({
-		producerId: ctx.videoProducer!.id,
+		producerId: pipeProducer!.id,
 		rtpCapabilities: ctx.consumerDeviceCapabilities,
 	});
 
@@ -840,7 +840,7 @@ test('producer.pause() and producer.resume() are transmitted to pipe Consumer', 
 	});
 
 	const videoConsumer = await ctx.webRtcTransport2!.consume({
-		producerId: ctx.videoProducer!.id,
+		producerId: pipeVideoProducer!.id,
 		rtpCapabilities: ctx.consumerDeviceCapabilities,
 	});
 
@@ -881,13 +881,13 @@ test('producer.pause() and producer.resume() are transmitted to pipe Consumer', 
 }, 2000);
 
 test('producer.close() is transmitted to pipe Consumer', async () => {
-	await ctx.router1!.pipeToRouter({
+	const { pipeProducer } = await ctx.router1!.pipeToRouter({
 		producerId: ctx.videoProducer!.id,
 		router: ctx.router2!,
 	});
 
 	const videoConsumer = await ctx.webRtcTransport2!.consume({
-		producerId: ctx.videoProducer!.id,
+		producerId: pipeProducer!.id,
 		rtpCapabilities: ctx.consumerDeviceCapabilities,
 	});
 
@@ -902,7 +902,7 @@ test('producer.close() is transmitted to pipe Consumer', async () => {
 	expect(videoConsumer.closed).toBe(true);
 }, 2000);
 
-test('router.pipeToRouter() fails if both Routers belong to the same Worker', async () => {
+test('router.pipeToRouter() does not fail if both Routers belong to the same Worker', async () => {
 	const router1bis = await ctx.worker1!.createRouter({
 		mediaCodecs: ctx.mediaCodecs,
 	});
@@ -912,7 +912,7 @@ test('router.pipeToRouter() fails if both Routers belong to the same Worker', as
 			producerId: ctx.videoProducer!.id,
 			router: router1bis,
 		})
-	).rejects.toThrow(Error);
+	).resolves.toBeDefined();
 }, 2000);
 
 test('router.pipeToRouter() succeeds with data', async () => {
@@ -950,7 +950,7 @@ test('router.pipeToRouter() succeeds with data', async () => {
 	expect(pipeDataConsumer.label).toBe('foo');
 	expect(pipeDataConsumer.protocol).toBe('bar');
 
-	expect(pipeDataProducer.id).toBe(ctx.dataProducer!.id);
+	expect(typeof pipeDataProducer.id).toBe('string');
 	expect(pipeDataProducer.closed).toBe(false);
 	expect(pipeDataProducer.type).toBe('sctp');
 	expect(typeof pipeDataProducer.sctpStreamParameters).toBe('object');
@@ -963,13 +963,13 @@ test('router.pipeToRouter() succeeds with data', async () => {
 }, 2000);
 
 test('transport.dataConsume() for a pipe DataProducer succeeds', async () => {
-	await ctx.router1!.pipeToRouter({
+	const { pipeDataProducer } = await ctx.router1!.pipeToRouter({
 		dataProducerId: ctx.dataProducer!.id,
 		router: ctx.router2!,
 	});
 
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: pipeDataProducer!.id,
 	});
 
 	expect(typeof dataConsumer.id).toBe('string');
@@ -985,13 +985,13 @@ test('transport.dataConsume() for a pipe DataProducer succeeds', async () => {
 }, 2000);
 
 test('dataProducer.close() is transmitted to pipe DataConsumer', async () => {
-	await ctx.router1!.pipeToRouter({
+	const { pipeDataProducer } = await ctx.router1!.pipeToRouter({
 		dataProducerId: ctx.dataProducer!.id,
 		router: ctx.router2!,
 	});
 
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
-		dataProducerId: ctx.dataProducer!.id,
+		dataProducerId: pipeDataProducer!.id,
 	});
 
 	ctx.dataProducer!.close();

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # NEXT
 
+- `router.pipe_producer_to_router()` and `router.pipe_data_producer_to_router()` can now connect two `Routers` in the same `Worker` (PR #1604).
+
 # 0.20.0
 
 - Make `parameters` and `rtcp_feedback` optional in `RtpCodecParameters` and `RtpCodecCapability` during deserialization (PR #1597).

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # NEXT
 
-- `router.pipe_producer_to_router()` and `router.pipe_data_producer_to_router()` can now connect two `Routers` in the same `Worker` (PR #1604).
+- `router.pipe_producer_to_router()` and `router.pipe_data_producer_to_router()` can now connect two `Routers` in the same `Worker` if `keep_id` is set to `false` (PR #1604).
 
 # 0.20.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # NEXT
 
-- `router.pipe_producer_to_router()` and `router.pipe_data_producer_to_router()` can now connect two `Routers` in the same `Worker` if `keep_id` is set to `false (PR #1604).
+- `router.pipe_producer_to_router()` and `router.pipe_data_producer_to_router()` can now connect two `Routers` in the same `Worker` if `keep_id` is set to `false` (PR #1604).
 
 # 0.20.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # NEXT
 
-- `router.pipe_producer_to_router()` and `router.pipe_data_producer_to_router()` can now connect two `Routers` in the same `Worker` if `keep_id` is set to `false` (PR #1604).
+- `router.pipe_producer_to_router()` and `router.pipe_data_producer_to_router()` can now connect two `Routers` in the same `Worker` if `keep_id` is set to `false (PR #1604).
 
 # 0.20.0
 

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -184,9 +184,6 @@ pub struct PipeProducerToRouterPair {
 /// Error that caused [`Router::pipe_producer_to_router()`] to fail.
 #[derive(Debug, Error)]
 pub enum PipeProducerToRouterError {
-    /// Destination router must be different
-    #[error("Destination router must be different")]
-    SameRouter,
     /// Producer with specified id not found
     #[error("Producer with id \"{0}\" not found")]
     ProducerNotFound(ProducerId),
@@ -240,9 +237,6 @@ pub struct PipeDataProducerToRouterPair {
 /// Error that caused [`Router::pipe_data_producer_to_router()`] to fail.
 #[derive(Debug, Error)]
 pub enum PipeDataProducerToRouterError {
-    /// Destination router must be different
-    #[error("Destination router must be different")]
-    SameRouter,
     /// Data producer with specified id not found
     #[error("Data producer with id \"{0}\" not found")]
     DataProducerNotFound(DataProducerId),
@@ -1083,10 +1077,6 @@ impl Router {
     ) -> Result<PipeProducerToRouterPair, PipeProducerToRouterError> {
         debug!("pipe_producer_to_router()");
 
-        if pipe_to_router_options.router.id() == self.id() {
-            return Err(PipeProducerToRouterError::SameRouter);
-        }
-
         let producer = match self
             .inner
             .producers
@@ -1116,7 +1106,8 @@ impl Router {
             .remote
             .produce({
                 let mut producer_options = ProducerOptions::new_pipe_transport(
-                    producer_id,
+                    // Generate a new id for the pipeProducer.
+                    ProducerId::new(),
                     pipe_consumer.kind(),
                     pipe_consumer.rtp_parameters().clone(),
                 );
@@ -1293,10 +1284,6 @@ impl Router {
     ) -> Result<PipeDataProducerToRouterPair, PipeDataProducerToRouterError> {
         debug!("pipe_data_producer_to_router()");
 
-        if pipe_to_router_options.router.id() == self.id() {
-            return Err(PipeDataProducerToRouterError::SameRouter);
-        }
-
         let data_producer = match self
             .inner
             .data_producers
@@ -1325,7 +1312,8 @@ impl Router {
             .remote
             .produce_data({
                 let mut producer_options = DataProducerOptions::new_pipe_transport(
-                    data_producer_id,
+                    // Generate a new id for the pipeDataProducer.
+                    DataProducerId::new(),
                     // We've created `DataConsumer` with SCTP above, so this should never panic
                     pipe_data_consumer.sctp_stream_parameters().unwrap(),
                 );

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -170,12 +170,6 @@ impl PipeToRouterOptions {
             enable_srtp: false,
         }
     }
-
-    /// Set `keep_id`.
-    pub fn with_keep_id(mut self, keep: bool) -> Self {
-        self.keep_id = keep;
-        self
-    }
 }
 
 /// Container for pipe consumer and pipe producer pair.

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -1097,9 +1097,13 @@ impl Router {
     ) -> Result<PipeProducerToRouterPair, PipeProducerToRouterError> {
         debug!("pipe_producer_to_router()");
 
-        let PipeToRouterOptions { keep_id, .. } = pipe_to_router_options;
+        let PipeToRouterOptions {
+            ref router,
+            keep_id,
+            ..
+        } = pipe_to_router_options;
 
-        if keep_id && pipe_to_router_options.router.id() == self.id() {
+        if keep_id && router.id() == self.id() {
             return Err(PipeProducerToRouterError::SameRouter);
         }
 
@@ -1314,9 +1318,13 @@ impl Router {
     ) -> Result<PipeDataProducerToRouterPair, PipeDataProducerToRouterError> {
         debug!("pipe_data_producer_to_router()");
 
-        let PipeToRouterOptions { keep_id, .. } = pipe_to_router_options;
+        let PipeToRouterOptions {
+            ref router,
+            keep_id,
+            ..
+        } = pipe_to_router_options;
 
-        if keep_id && pipe_to_router_options.router.id() == self.id() {
+        if keep_id && router.id() == self.id() {
             return Err(PipeDataProducerToRouterError::SameRouter);
         }
 

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -119,6 +119,13 @@ impl Default for RouterOptions {
 pub struct PipeToRouterOptions {
     /// Target Router instance.
     pub router: Router,
+    /// Whether the `id` of the returned Producer or DataProducer should be the
+    /// same than the `id` of the original Producer or DataProducer. Default true.
+    ///
+    /// # Note
+    /// If set to true, then the origin router and target router cannot be in the
+    /// same worker.
+    pub keep_id: bool,
     /// IP used in the PipeTransport pair.
     ///
     /// Default `{ protocol: 'udp', ip: '127.0.0.1' }`.
@@ -145,6 +152,7 @@ impl PipeToRouterOptions {
     pub fn new(router: Router) -> Self {
         Self {
             router,
+            keep_id: true,
             listen_info: ListenInfo {
                 protocol: Protocol::Udp,
                 ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
@@ -161,6 +169,12 @@ impl PipeToRouterOptions {
             enable_rtx: false,
             enable_srtp: false,
         }
+    }
+
+    /// Set `keep_id`.
+    pub fn with_keep_id(mut self, keep: bool) -> Self {
+        self.keep_id = keep;
+        self
     }
 }
 
@@ -184,6 +198,9 @@ pub struct PipeProducerToRouterPair {
 /// Error that caused [`Router::pipe_producer_to_router()`] to fail.
 #[derive(Debug, Error)]
 pub enum PipeProducerToRouterError {
+    /// Destination router must be different
+    #[error("Destination router must be different")]
+    SameRouter,
     /// Producer with specified id not found
     #[error("Producer with id \"{0}\" not found")]
     ProducerNotFound(ProducerId),
@@ -237,6 +254,9 @@ pub struct PipeDataProducerToRouterPair {
 /// Error that caused [`Router::pipe_data_producer_to_router()`] to fail.
 #[derive(Debug, Error)]
 pub enum PipeDataProducerToRouterError {
+    /// Destination router must be different
+    #[error("Destination router must be different")]
+    SameRouter,
     /// Data producer with specified id not found
     #[error("Data producer with id \"{0}\" not found")]
     DataProducerNotFound(DataProducerId),
@@ -1077,6 +1097,12 @@ impl Router {
     ) -> Result<PipeProducerToRouterPair, PipeProducerToRouterError> {
         debug!("pipe_producer_to_router()");
 
+        let PipeToRouterOptions { keep_id, .. } = pipe_to_router_options;
+
+        if keep_id && pipe_to_router_options.router.id() == self.id() {
+            return Err(PipeProducerToRouterError::SameRouter);
+        }
+
         let producer = match self
             .inner
             .producers
@@ -1106,8 +1132,12 @@ impl Router {
             .remote
             .produce({
                 let mut producer_options = ProducerOptions::new_pipe_transport(
-                    // Generate a new id for the pipeProducer.
-                    ProducerId::new(),
+                    // Generate a new id for the pipeProducer if requested.
+                    if keep_id {
+                        producer_id
+                    } else {
+                        ProducerId::new()
+                    },
                     pipe_consumer.kind(),
                     pipe_consumer.rtp_parameters().clone(),
                 );
@@ -1284,6 +1314,12 @@ impl Router {
     ) -> Result<PipeDataProducerToRouterPair, PipeDataProducerToRouterError> {
         debug!("pipe_data_producer_to_router()");
 
+        let PipeToRouterOptions { keep_id, .. } = pipe_to_router_options;
+
+        if keep_id && pipe_to_router_options.router.id() == self.id() {
+            return Err(PipeDataProducerToRouterError::SameRouter);
+        }
+
         let data_producer = match self
             .inner
             .data_producers
@@ -1312,8 +1348,12 @@ impl Router {
             .remote
             .produce_data({
                 let mut producer_options = DataProducerOptions::new_pipe_transport(
-                    // Generate a new id for the pipeDataProducer.
-                    DataProducerId::new(),
+                    // Generate a new id for the pipeDataProducer if requested.
+                    if keep_id {
+                        data_producer_id
+                    } else {
+                        DataProducerId::new()
+                    },
                     // We've created `DataConsumer` with SCTP above, so this should never panic
                     pipe_data_consumer.sctp_stream_parameters().unwrap(),
                 );
@@ -1497,6 +1537,7 @@ impl Router {
     ) -> Result<PipeTransportPair, RequestError> {
         let PipeToRouterOptions {
             router,
+            keep_id: _,
             listen_info,
             enable_sctp,
             num_sctp_streams,

--- a/rust/src/router/pipe_transport/tests.rs
+++ b/rust/src/router/pipe_transport/tests.rs
@@ -137,7 +137,10 @@ fn producer_close_is_transmitted_to_pipe_consumer() {
             .await
             .expect("Failed to produce video");
 
-        let PipeProducerToRouterPair { pipe_producer, .. } = router1
+        let PipeProducerToRouterPair {
+            pipe_producer,
+            pipe_consumer: _,
+        } = router1
             .pipe_producer_to_router(
                 video_producer.id(),
                 PipeToRouterOptions::new(router2.clone()),
@@ -179,7 +182,8 @@ fn data_producer_close_is_transmitted_to_pipe_data_consumer() {
             .expect("Failed to produce data");
 
         let PipeDataProducerToRouterPair {
-            pipe_data_producer, ..
+            pipe_data_producer,
+            pipe_data_consumer: _,
         } = router1
             .pipe_data_producer_to_router(
                 data_producer.id(),

--- a/rust/src/router/pipe_transport/tests.rs
+++ b/rust/src/router/pipe_transport/tests.rs
@@ -2,7 +2,10 @@ use crate::consumer::ConsumerOptions;
 use crate::data_consumer::DataConsumerOptions;
 use crate::data_producer::DataProducerOptions;
 use crate::producer::ProducerOptions;
-use crate::router::{PipeToRouterOptions, Router, RouterOptions};
+use crate::router::{
+    PipeDataProducerToRouterPair, PipeProducerToRouterPair, PipeToRouterOptions, Router,
+    RouterOptions,
+};
 use crate::transport::Transport;
 use crate::webrtc_transport::{
     WebRtcTransport, WebRtcTransportListenInfos, WebRtcTransportOptions,
@@ -134,7 +137,7 @@ fn producer_close_is_transmitted_to_pipe_consumer() {
             .await
             .expect("Failed to produce video");
 
-        router1
+        let PipeProducerToRouterPair { pipe_producer, .. } = router1
             .pipe_producer_to_router(
                 video_producer.id(),
                 PipeToRouterOptions::new(router2.clone()),
@@ -142,9 +145,11 @@ fn producer_close_is_transmitted_to_pipe_consumer() {
             .await
             .expect("Failed to pipe video producer to router");
 
+        let pipe_producer = pipe_producer.into_inner();
+
         let video_consumer = transport2
             .consume(ConsumerOptions::new(
-                video_producer.id(),
+                pipe_producer.id(),
                 consumer_device_capabilities(),
             ))
             .await
@@ -173,7 +178,9 @@ fn data_producer_close_is_transmitted_to_pipe_data_consumer() {
             .await
             .expect("Failed to produce data");
 
-        router1
+        let PipeDataProducerToRouterPair {
+            pipe_data_producer, ..
+        } = router1
             .pipe_data_producer_to_router(
                 data_producer.id(),
                 PipeToRouterOptions::new(router2.clone()),
@@ -181,8 +188,10 @@ fn data_producer_close_is_transmitted_to_pipe_data_consumer() {
             .await
             .expect("Failed to pipe data producer to router");
 
+        let pipe_data_producer = pipe_data_producer.into_inner();
+
         let data_consumer = transport2
-            .consume_data(DataConsumerOptions::new_sctp(data_producer.id()))
+            .consume_data(DataConsumerOptions::new_sctp(pipe_data_producer.id()))
             .await
             .expect("Failed to create data consumer");
 

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -293,8 +293,8 @@ fn pipe_to_router_succeeds_with_audio() {
             .expect("Failed to produce audio");
 
         let PipeProducerToRouterPair {
-            pipe_consumer,
             pipe_producer,
+            pipe_consumer,
         } = router1
             .pipe_producer_to_router(
                 audio_producer.id(),
@@ -372,6 +372,7 @@ fn pipe_to_router_succeeds_with_audio() {
         );
         assert_eq!(pipe_consumer.app_data().downcast_ref::<()>().unwrap(), &());
 
+        assert_eq!(pipe_producer.id(), audio_producer.id());
         assert_eq!(pipe_producer.kind(), MediaKind::Audio);
         assert_eq!(pipe_producer.rtp_parameters().mid, None);
         assert_eq!(
@@ -442,8 +443,8 @@ fn pipe_to_router_succeeds_with_video() {
             .expect("Failed to pause video producer");
 
         let PipeProducerToRouterPair {
-            pipe_consumer,
             pipe_producer,
+            pipe_consumer,
         } = router1
             .pipe_producer_to_router(
                 video_producer.id(),
@@ -518,6 +519,7 @@ fn pipe_to_router_succeeds_with_video() {
         );
         assert_eq!(pipe_consumer.app_data().downcast_ref::<()>().unwrap(), &());
 
+        assert_eq!(pipe_producer.id(), video_producer.id());
         assert_eq!(pipe_producer.kind(), MediaKind::Video);
         assert_eq!(pipe_producer.rtp_parameters().mid, None);
         assert_eq!(
@@ -607,7 +609,10 @@ fn pipe_to_router_with_keep_id_false_does_not_fail_if_both_routers_belong_to_the
             .await
             .expect("Failed to produce video");
 
-        router1
+        let PipeProducerToRouterPair {
+            pipe_producer,
+            pipe_consumer: _,
+        } = router1
             .pipe_producer_to_router(video_producer.id(), {
                 let mut options = PipeToRouterOptions::new(router1bis.clone());
                 options.keep_id = false;
@@ -615,6 +620,10 @@ fn pipe_to_router_with_keep_id_false_does_not_fail_if_both_routers_belong_to_the
             })
             .await
             .expect("Failed to pipe producer to router");
+
+        let pipe_producer = pipe_producer.into_inner();
+
+        assert_ne!(pipe_producer.id(), video_producer.id());
     });
 }
 
@@ -1072,8 +1081,8 @@ fn pipe_to_router_succeeds_with_data() {
             .expect("Failed to produce data");
 
         let PipeDataProducerToRouterPair {
-            pipe_data_consumer,
             pipe_data_producer,
+            pipe_data_consumer,
         } = router1
             .pipe_data_producer_to_router(
                 data_producer.id(),
@@ -1143,7 +1152,8 @@ fn data_consume_for_pipe_data_producer_succeeds() {
             .expect("Failed to produce data");
 
         let PipeDataProducerToRouterPair {
-            pipe_data_producer, ..
+            pipe_data_producer,
+            pipe_data_consumer: _,
         } = router1
             .pipe_data_producer_to_router(
                 data_producer.id(),

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -608,10 +608,11 @@ fn pipe_to_router_with_keep_id_false_does_not_fail_if_both_routers_belong_to_the
             .expect("Failed to produce video");
 
         router1
-            .pipe_producer_to_router(
-                video_producer.id(),
-                PipeToRouterOptions::new(router1bis.clone()).with_keep_id(false),
-            )
+            .pipe_producer_to_router(video_producer.id(), {
+                let mut options = PipeToRouterOptions::new(router1bis.clone());
+                options.keep_id = false;
+                options
+            })
             .await
             .expect("Failed to pipe producer to router");
     });

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -9,6 +9,7 @@ use mediasoup::router::{
     PipeDataProducerToRouterPair, PipeProducerToRouterPair, PipeToRouterOptions, Router,
     RouterOptions,
 };
+use mediasoup::transport::ProduceError;
 use mediasoup::webrtc_transport::{
     WebRtcTransport, WebRtcTransportListenInfos, WebRtcTransportOptions,
 };
@@ -559,7 +560,40 @@ fn pipe_to_router_succeeds_with_video() {
 }
 
 #[test]
-fn pipe_to_router_fails_if_both_routers_belong_to_the_same_worker() {
+fn pipe_to_router_with_keep_id_true_fails_if_both_routers_belong_to_the_same_worker() {
+    future::block_on(async move {
+        let (worker1, _worker2, router1, _router2, transport1, _transport2) = init().await;
+
+        let router1bis = worker1
+            .create_router(RouterOptions::new(media_codecs()))
+            .await
+            .expect("Failed to create router");
+
+        let video_producer = transport1
+            .produce(video_producer_options())
+            .await
+            .expect("Failed to produce video");
+
+        let result = router1
+            .pipe_producer_to_router(
+                video_producer.id(),
+                PipeToRouterOptions::new(router1bis.clone()),
+            )
+            .await;
+
+        if let Err(PipeProducerToRouterError::ProduceFailed(ProduceError::Request(
+            RequestError::Response { reason },
+        ))) = result
+        {
+            assert!(reason.contains("already exists [method:transport.produce]"));
+        } else {
+            panic!("Unexpected result: {result:?}");
+        }
+    });
+}
+
+#[test]
+fn pipe_to_router_with_keep_id_false_does_not_fail_if_both_routers_belong_to_the_same_worker() {
     future::block_on(async move {
         let (worker1, _worker2, router1, _router2, transport1, _transport2) = init().await;
 
@@ -576,7 +610,7 @@ fn pipe_to_router_fails_if_both_routers_belong_to_the_same_worker() {
         router1
             .pipe_producer_to_router(
                 video_producer.id(),
-                PipeToRouterOptions::new(router1bis.clone()),
+                PipeToRouterOptions::new(router1bis.clone()).with_keep_id(false),
             )
             .await
             .expect("Failed to pipe producer to router");

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -1004,7 +1004,10 @@ fn producer_pause_resume_are_transmitted_to_pipe_consumer() {
             .await
             .expect("Failed to pause video producer");
 
-        let PipeProducerToRouterPair { pipe_producer, .. } = router1
+        let PipeProducerToRouterPair {
+            pipe_producer,
+            pipe_consumer: _,
+        } = router1
             .pipe_producer_to_router(
                 video_producer.id(),
                 PipeToRouterOptions::new(router2.clone()),

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -9,7 +9,6 @@ use mediasoup::router::{
     PipeDataProducerToRouterPair, PipeProducerToRouterPair, PipeToRouterOptions, Router,
     RouterOptions,
 };
-use mediasoup::transport::ProduceError;
 use mediasoup::webrtc_transport::{
     WebRtcTransport, WebRtcTransportListenInfos, WebRtcTransportOptions,
 };
@@ -372,7 +371,6 @@ fn pipe_to_router_succeeds_with_audio() {
         );
         assert_eq!(pipe_consumer.app_data().downcast_ref::<()>().unwrap(), &());
 
-        assert_eq!(pipe_producer.id(), audio_producer.id());
         assert_eq!(pipe_producer.kind(), MediaKind::Audio);
         assert_eq!(pipe_producer.rtp_parameters().mid, None);
         assert_eq!(
@@ -519,7 +517,6 @@ fn pipe_to_router_succeeds_with_video() {
         );
         assert_eq!(pipe_consumer.app_data().downcast_ref::<()>().unwrap(), &());
 
-        assert_eq!(pipe_producer.id(), video_producer.id());
         assert_eq!(pipe_producer.kind(), MediaKind::Video);
         assert_eq!(pipe_producer.rtp_parameters().mid, None);
         assert_eq!(
@@ -576,21 +573,13 @@ fn pipe_to_router_fails_if_both_routers_belong_to_the_same_worker() {
             .await
             .expect("Failed to produce video");
 
-        let result = router1
+        router1
             .pipe_producer_to_router(
                 video_producer.id(),
                 PipeToRouterOptions::new(router1bis.clone()),
             )
-            .await;
-
-        if let Err(PipeProducerToRouterError::ProduceFailed(ProduceError::Request(
-            RequestError::Response { reason },
-        ))) = result
-        {
-            assert!(reason.contains("already exists [method:transport.produce]"));
-        } else {
-            panic!("Unexpected result: {result:?}");
-        }
+            .await
+            .expect("Failed to pipe producer to router");
     });
 }
 
@@ -879,7 +868,7 @@ fn consume_for_pipe_producer_succeeds() {
             .await
             .expect("Failed to pause video producer");
 
-        router1
+        let PipeProducerToRouterPair { pipe_producer, .. } = router1
             .pipe_producer_to_router(
                 video_producer.id(),
                 PipeToRouterOptions::new(router2.clone()),
@@ -887,9 +876,11 @@ fn consume_for_pipe_producer_succeeds() {
             .await
             .expect("Failed to pipe video producer to router");
 
+        let pipe_video_producer = pipe_producer.into_inner();
+
         let video_consumer = transport2
             .consume(ConsumerOptions::new(
-                video_producer.id(),
+                pipe_video_producer.id(),
                 consumer_device_capabilities(),
             ))
             .await
@@ -969,7 +960,7 @@ fn producer_pause_resume_are_transmitted_to_pipe_consumer() {
             .await
             .expect("Failed to pause video producer");
 
-        router1
+        let PipeProducerToRouterPair { pipe_producer, .. } = router1
             .pipe_producer_to_router(
                 video_producer.id(),
                 PipeToRouterOptions::new(router2.clone()),
@@ -977,9 +968,11 @@ fn producer_pause_resume_are_transmitted_to_pipe_consumer() {
             .await
             .expect("Failed to pipe video producer to router");
 
+        let pipe_video_producer = pipe_producer.into_inner();
+
         let video_consumer = transport2
             .consume(ConsumerOptions::new(
-                video_producer.id(),
+                pipe_video_producer.id(),
                 consumer_device_capabilities(),
             ))
             .await
@@ -1088,7 +1081,6 @@ fn pipe_to_router_succeeds_with_data() {
         assert_eq!(pipe_data_consumer.label().as_str(), "foo");
         assert_eq!(pipe_data_consumer.protocol().as_str(), "bar");
 
-        assert_eq!(pipe_data_producer.id(), data_producer.id());
         assert_eq!(pipe_data_producer.r#type(), DataProducerType::Sctp);
         {
             let sctp_stream_parameters = pipe_data_producer.sctp_stream_parameters();
@@ -1115,7 +1107,9 @@ fn data_consume_for_pipe_data_producer_succeeds() {
             .await
             .expect("Failed to produce data");
 
-        router1
+        let PipeDataProducerToRouterPair {
+            pipe_data_producer, ..
+        } = router1
             .pipe_data_producer_to_router(
                 data_producer.id(),
                 PipeToRouterOptions::new(router2.clone()),
@@ -1123,8 +1117,10 @@ fn data_consume_for_pipe_data_producer_succeeds() {
             .await
             .expect("Failed to pipe data producer to router");
 
+        let pipe_data_producer = pipe_data_producer.into_inner();
+
         let data_consumer = transport2
-            .consume_data(DataConsumerOptions::new_sctp(data_producer.id()))
+            .consume_data(DataConsumerOptions::new_sctp(pipe_data_producer.id()))
             .await
             .expect("Failed to create data consumer");
 


### PR DESCRIPTION
## Details

- Fixes #1602
- Remove the limitation by which `router1.pipeToRouter({ router: router2, etc })` throws if both `router1` and `router2` are in the same `Worker`.
- The solution is very simple: When we `produce()` the internally created `pipeConsumer` into the target `router`, pass a random `producerId` instead of keeping the same `id` that the original `producer` has.
- This may break some applications if they assume that the generated `pipeProducer` has same `id` than the `original` producer. The application should obtain the new `id` from the `{ pipeProducer, pipeDataProducer }` returned by `pipeToRouter()` method.
- **In order to avoid breaking existing applications that assume that the `pipeProducer.id` is the same as the original `producer.id`**, this new behavior is disabled by default. To enable it, `keepId: false` must be passed to `pipeToRouter()`.

## TODO

- [x] Document the new `keepId` field and new behavior in the docs.
- [x] Remove or clarify the note in the docs: https://mediasoup.org/documentation/v3/mediasoup/api/#router-pipeToRouter
- [x] Make public announcement.