### PR TITLE
Rust, deadlock problem caused by 'paused' and 'producer_paused' in 'consumer.rs'

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - `router.pipe_producer_to_router()` and `router.pipe_data_producer_to_router()` can now connect two `Routers` in the same `Worker` if `keep_id` is set to `false` (PR #1604).
 - Updates from mediasoup TypeScript `3.18.1.=3.19.0`.
+- Ensure that the order of acquiring the `paused` and `producer_paused` locks in `consumer.rs` is consistent at all times to avoid deadlock.
 
 # 0.20.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - `router.pipe_producer_to_router()` and `router.pipe_data_producer_to_router()` can now connect two `Routers` in the same `Worker` if `keep_id` is set to `false` (PR #1604).
 - Updates from mediasoup TypeScript `3.18.1.=3.19.0`.
-- Ensure that the order of acquiring the `paused` and `producer_paused` locks in `consumer.rs` is consistent at all times to avoid deadlock.
+- Ensure that the order of acquiring the `paused` and `producer_paused` locks in `consumer.rs` is consistent at all times to avoid deadlock (PR #1605).
 
 # 0.20.0
 

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -880,9 +880,13 @@ impl Consumer {
                             }
                         }
                         Notification::ProducerPause => {
-                            let mut producer_paused = producer_paused.lock();
-                            let paused = *paused.lock();
-                            *producer_paused = true;
+                            let paused = {
+                                let paused = paused.lock();
+                                let mut producer_paused = producer_paused.lock();
+                                *producer_paused = true;
+
+                                *paused
+                            };
 
                             handlers.producer_pause.call_simple();
 
@@ -891,9 +895,13 @@ impl Consumer {
                             }
                         }
                         Notification::ProducerResume => {
-                            let mut producer_paused = producer_paused.lock();
-                            let paused = *paused.lock();
-                            *producer_paused = false;
+                            let paused = {
+                                let paused = paused.lock();
+                                let mut producer_paused = producer_paused.lock();
+                                *producer_paused = false;
+
+                                *paused
+                            };
 
                             handlers.producer_resume.call_simple();
 
@@ -1121,9 +1129,13 @@ impl Consumer {
             .request(self.id(), ConsumerPauseRequest {})
             .await?;
 
-        let mut paused = self.inner.paused.lock();
-        let was_paused = *paused || *self.inner.producer_paused.lock();
-        *paused = true;
+        let was_paused = {
+            let mut paused = self.inner.paused.lock();
+            let was_paused = *paused || *self.inner.producer_paused.lock();
+            *paused = true;
+
+            was_paused
+        };
 
         if !was_paused {
             self.inner.handlers.pause.call_simple();
@@ -1141,9 +1153,13 @@ impl Consumer {
             .request(self.id(), ConsumerResumeRequest {})
             .await?;
 
-        let mut paused = self.inner.paused.lock();
-        let was_paused = *paused || *self.inner.producer_paused.lock();
-        *paused = false;
+        let was_paused = {
+            let mut paused = self.inner.paused.lock();
+            let was_paused = *paused || *self.inner.producer_paused.lock();
+            *paused = false;
+
+            was_paused
+        };
 
         if was_paused {
             self.inner.handlers.resume.call_simple();


### PR DESCRIPTION
[Rust] Fixed the deadlock problem caused by inconsistent acquisition order of 'paused' and 'producer_paused', and released early before the 'call_simple()'.