### PR TITLE
VP8 keyframe detect fix for non-extended payloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - CI: Remove `macos-13` hosts.
+- VP8: Fix keyframe detection if "extended" bit is not set ([PR #1612](https://github.com/versatica/mediasoup/pull/1612), credits to @nifigase).
 
 ### 3.19.2
 

--- a/worker/src/RTC/Codecs/VP8.cpp
+++ b/worker/src/RTC/Codecs/VP8.cpp
@@ -117,7 +117,7 @@ namespace RTC
 				(len >= ++offset + 1) &&
 				payloadDescriptor->start &&
 				payloadDescriptor->partitionIndex == 0 &&
-				(!(data[offset] & 0x01)) //inverse Keyframe bit
+				(!(data[offset] & 0x01)) // Inverse Keyframe bit.
 			)
 			// clang-format on
 			{

--- a/worker/src/RTC/Codecs/VP8.cpp
+++ b/worker/src/RTC/Codecs/VP8.cpp
@@ -32,13 +32,7 @@ namespace RTC
 			payloadDescriptor->start          = (byte >> 4) & 0x01;
 			payloadDescriptor->partitionIndex = byte & 0x07;
 
-			if (!payloadDescriptor->extended)
-			{
-				MS_WARN_DEV("ignoring invalid payload (1)");
-
-				return nullptr;
-			}
-			else
+			if (payloadDescriptor->extended)
 			{
 				if (len < ++offset + 1)
 				{
@@ -123,7 +117,7 @@ namespace RTC
 				(len >= ++offset + 1) &&
 				payloadDescriptor->start &&
 				payloadDescriptor->partitionIndex == 0 &&
-				(!(data[offset] & 0x01))
+				(!(data[offset] & 0x01)) //inverse Keyframe bit
 			)
 			// clang-format on
 			{

--- a/worker/test/src/RTC/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP8.cpp
@@ -243,7 +243,7 @@ SCENARIO("parse VP8 payload descriptor", "[codecs][vp8]")
 		REQUIRE_FALSE(payloadDescriptor);
 	}
 
-	SECTION("parse payload descriptor. X flag is not set")
+	SECTION("parse payload descriptor. X flag is not set, no keyframe")
 	{
 		/** VP8 Payload Descriptor
 		 *
@@ -252,24 +252,95 @@ SCENARIO("parse VP8 payload descriptor", "[codecs][vp8]")
 		 * 0 = N bit: Reference frame
 		 * 1 = S bit: Start of VP8 partition
 		 * Part Id: 0
-		 * 1 = I bit: Picture ID byte present
-		 * 0 = L bit: TL0PICIDX byte not present
-		 * 0 = T bit: TID (temporal layer index) byte not present
-		 * 0 = K bit: TID/KEYIDX byte not present
-		 * 0000 = Reserved A: 0
-		 * 0001 0001 = Picture Id: 17
+		 * 000000 = Size0 | H | VER
+		 * 1 = P bit: Inverse Keyframe
 		 */
 
 		// clang-format off
 		uint8_t buffer[] =
 		{
-			0x50, 0x80, 0x11
+			0x50, 0x01
 		};
 		// clang-format on
 
 		auto* payloadDescriptor = Codecs::VP8::Parse(buffer, sizeof(buffer));
 
-		REQUIRE_FALSE(payloadDescriptor);
+		REQUIRE(payloadDescriptor);
+
+		REQUIRE(payloadDescriptor->extended == 0);
+		REQUIRE(payloadDescriptor->nonReference == 0);
+		REQUIRE(payloadDescriptor->start == 1);
+		REQUIRE(payloadDescriptor->partitionIndex == 0);
+
+		// optional field flags.
+		REQUIRE(payloadDescriptor->i == 0);
+		REQUIRE(payloadDescriptor->l == 0);
+		REQUIRE(payloadDescriptor->t == 0);
+		REQUIRE(payloadDescriptor->k == 0);
+
+		// optional fields.
+		REQUIRE(payloadDescriptor->pictureId == 0);
+		REQUIRE(payloadDescriptor->tl0PictureIndex == 0);
+		REQUIRE(payloadDescriptor->tlIndex == 0);
+		REQUIRE(payloadDescriptor->y == 0);
+		REQUIRE(payloadDescriptor->keyIndex == 0);
+
+		REQUIRE(payloadDescriptor->isKeyFrame == false);
+		REQUIRE(payloadDescriptor->hasPictureId == false);
+		REQUIRE(payloadDescriptor->hasOneBytePictureId == false);
+		REQUIRE(payloadDescriptor->hasTwoBytesPictureId == false);
+		REQUIRE(payloadDescriptor->hasTl0PictureIndex == false);
+		REQUIRE(payloadDescriptor->hasTlIndex == false);
+	}
+
+	SECTION("parse payload descriptor. X flag is not set, keyframe")
+	{
+		/** VP8 Payload Descriptor
+		 *
+		 * 0 = X bit: Extended control bits present (I L T K)
+		 * 1 = R bit: Reserved for future use (Error should be zero)
+		 * 0 = N bit: Reference frame
+		 * 1 = S bit: Start of VP8 partition
+		 * Part Id: 0
+		 * 000000 = Size0 | H | VER
+		 * 0 = P bit: Inverse Keyframe
+		 */
+
+		// clang-format off
+		uint8_t buffer[] =
+		{
+			0x50, 0x00
+		};
+		// clang-format on
+
+		auto* payloadDescriptor = Codecs::VP8::Parse(buffer, sizeof(buffer));
+
+		REQUIRE(payloadDescriptor);
+
+		REQUIRE(payloadDescriptor->extended == 0);
+		REQUIRE(payloadDescriptor->nonReference == 0);
+		REQUIRE(payloadDescriptor->start == 1);
+		REQUIRE(payloadDescriptor->partitionIndex == 0);
+
+		// optional field flags.
+		REQUIRE(payloadDescriptor->i == 0);
+		REQUIRE(payloadDescriptor->l == 0);
+		REQUIRE(payloadDescriptor->t == 0);
+		REQUIRE(payloadDescriptor->k == 0);
+
+		// optional fields.
+		REQUIRE(payloadDescriptor->pictureId == 0);
+		REQUIRE(payloadDescriptor->tl0PictureIndex == 0);
+		REQUIRE(payloadDescriptor->tlIndex == 0);
+		REQUIRE(payloadDescriptor->y == 0);
+		REQUIRE(payloadDescriptor->keyIndex == 0);
+
+		REQUIRE(payloadDescriptor->isKeyFrame == true);
+		REQUIRE(payloadDescriptor->hasPictureId == false);
+		REQUIRE(payloadDescriptor->hasOneBytePictureId == false);
+		REQUIRE(payloadDescriptor->hasTwoBytesPictureId == false);
+		REQUIRE(payloadDescriptor->hasTl0PictureIndex == false);
+		REQUIRE(payloadDescriptor->hasTlIndex == false);
 	}
 }
 

--- a/worker/test/src/RTC/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP8.cpp
@@ -322,7 +322,7 @@ SCENARIO("parse VP8 payload descriptor", "[codecs][vp8]")
 		REQUIRE(payloadDescriptor->start == 1);
 		REQUIRE(payloadDescriptor->partitionIndex == 0);
 
-		// optional field flags.
+		// Optional field flags.
 		REQUIRE(payloadDescriptor->i == 0);
 		REQUIRE(payloadDescriptor->l == 0);
 		REQUIRE(payloadDescriptor->t == 0);

--- a/worker/test/src/RTC/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/Codecs/TestVP8.cpp
@@ -272,7 +272,7 @@ SCENARIO("parse VP8 payload descriptor", "[codecs][vp8]")
 		REQUIRE(payloadDescriptor->start == 1);
 		REQUIRE(payloadDescriptor->partitionIndex == 0);
 
-		// optional field flags.
+		// Optional field flags.
 		REQUIRE(payloadDescriptor->i == 0);
 		REQUIRE(payloadDescriptor->l == 0);
 		REQUIRE(payloadDescriptor->t == 0);


### PR DESCRIPTION
I faced the following issue with modern chrome (139.0.7258.127) sending simulcast video in VP8.
Mediasoup fails to detect keyframes: VP8 payload parser ignores whole payload if "extended" bit is not set https://datatracker.ietf.org/doc/html/rfc7741#section-4.2
Chrome may send packets with no extended control bits. But even in this case "payload header" with inverse keyframe flag is present in packet, according to RFC: https://datatracker.ietf.org/doc/html/rfc7741#section-4.3