### PR TITLE
Require Node >= 22

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -41,6 +41,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
+      - name: Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -44,7 +44,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: 24
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - CI: Remove `macos-13` hosts.
 - VP8: Fix keyframe detection if "extended" bit is not set ([PR #1612](https://github.com/versatica/mediasoup/pull/1612), credits to @nifigase).
 - CI: Remove `node-20` GitHub actions.
+- Require Node.js >= 22 ([PR #1614](https://github.com/versatica/mediasoup/pull/1614)).
 
 ### 3.19.2
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
 				"typescript-eslint": "^8.44.1"
 			},
 			"engines": {
-				"node": ">=20"
+				"node": ">=22"
 			},
 			"funding": {
 				"type": "opencollective",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
 		"worker/tasks.py"
 	],
 	"engines": {
-		"node": ">=20"
+		"node": ">=22"
 	},
 	"keywords": [
 		"webrtc",


### PR DESCRIPTION
- [x] package.json: engines field.
- [x] Installation and Requirements in the website.


> - Maybe also in README of the project (not sure).

It's not there and I've never missed it anyway. IMO we don't need to put it there.

> Remove the --force in npm ci in mediasoup-node.yaml (not sure if in there or in other projects, if so there is a self-explanatory note on the line).

It was already removed.