### PR TITLE
Make dependency descriptor header sendrecv

### DIFF
--- a/node/src/supportedRtpCapabilities.ts
+++ b/node/src/supportedRtpCapabilities.ts
@@ -266,7 +266,7 @@ const supportedRtpCapabilities: RouterRtpCapabilities = {
 			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
 			preferredId: 8,
 			preferredEncrypt: false,
-			direction: 'recvonly',
+			direction: 'sendrecv',
 		},
 		{
 			kind: 'audio',

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -368,13 +368,12 @@ test('router.pipeToRouter() succeeds with video', async () => {
 		},
 	]);
 	expect(pipeConsumer.rtpParameters.headerExtensions).toEqual([
-		// TODO: Enable when DD is sendrecv.
-		// {
-		// 	uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
-		// 	id: 8,
-		// 	encrypt: false,
-		// 	parameters: {},
-		// },
+		{
+		 	uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+		 	id: 8,
+		 	encrypt: false,
+		 	parameters: {},
+		},
 		{
 			uri: 'urn:3gpp:video-orientation',
 			id: 11,
@@ -429,13 +428,12 @@ test('router.pipeToRouter() succeeds with video', async () => {
 		},
 	]);
 	expect(pipeProducer.rtpParameters.headerExtensions).toEqual([
-		// TODO: Enable when DD is sendrecv.
-		// {
-		// 	uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
-		// 	id: 8,
-		// 	encrypt: false,
-		// 	parameters: {},
-		// },
+		{
+		 	uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+		 	id: 8,
+		 	encrypt: false,
+		 	parameters: {},
+		},
 		{
 			uri: 'urn:3gpp:video-orientation',
 			id: 11,
@@ -544,13 +542,12 @@ test('router.createPipeTransport() with enableRtx succeeds', async () => {
 		},
 	]);
 	expect(pipeConsumer.rtpParameters.headerExtensions).toEqual([
-		// TODO: Enable when DD is sendrecv.
-		// {
-		// 	uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
-		// 	id: 8,
-		// 	encrypt: false,
-		// 	parameters: {},
-		// },
+		{
+		 	uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+		 	id: 8,
+		 	encrypt: false,
+		 	parameters: {},
+		},
 		{
 			uri: 'urn:3gpp:video-orientation',
 			id: 11,

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -369,10 +369,10 @@ test('router.pipeToRouter() succeeds with video', async () => {
 	]);
 	expect(pipeConsumer.rtpParameters.headerExtensions).toEqual([
 		{
-		 	uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
-		 	id: 8,
-		 	encrypt: false,
-		 	parameters: {},
+			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+			id: 8,
+			encrypt: false,
+			parameters: {},
 		},
 		{
 			uri: 'urn:3gpp:video-orientation',
@@ -429,10 +429,10 @@ test('router.pipeToRouter() succeeds with video', async () => {
 	]);
 	expect(pipeProducer.rtpParameters.headerExtensions).toEqual([
 		{
-		 	uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
-		 	id: 8,
-		 	encrypt: false,
-		 	parameters: {},
+			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+			id: 8,
+			encrypt: false,
+			parameters: {},
 		},
 		{
 			uri: 'urn:3gpp:video-orientation',
@@ -543,10 +543,10 @@ test('router.createPipeTransport() with enableRtx succeeds', async () => {
 	]);
 	expect(pipeConsumer.rtpParameters.headerExtensions).toEqual([
 		{
-		 	uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
-		 	id: 8,
-		 	encrypt: false,
-		 	parameters: {},
+			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+			id: 8,
+			encrypt: false,
+			parameters: {},
 		},
 		{
 			uri: 'urn:3gpp:video-orientation',


### PR DESCRIPTION
We need to make the dependency descriptor header sendrecv, otherwise producers created inside piped transports will not forward the required header and the consumers will not receive any AV1 packet.