### PR TITLE
RtpPacket: update Dependency Descriptor listener on Clone()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - AV1: Add support for DD extension header forwarding ([#1610](https://github.com/versatica/mediasoup/pull/1610)).
+- DependencyDescriptor: Update listener on RtpPacket clone ([#1618](https://github.com/versatica/mediasoup/pull/1618)).
 
 ### 3.19.3
 

--- a/worker/include/RTC/Codecs/AV1.hpp
+++ b/worker/include/RTC/Codecs/AV1.hpp
@@ -36,6 +36,13 @@ namespace RTC
 				~PayloadDescriptor() override = default;
 
 				void Dump(int indentation = 0) const override;
+				void UpdateListener(Codecs::DependencyDescriptor::Listener* listener)
+				{
+					if (this->dependencyDescriptor)
+					{
+						this->dependencyDescriptor->UpdateListener(listener);
+					}
+				}
 				void Encode();
 				void Restore() const;
 				void UpdateActiveDecodeTargets(uint16_t spatialLayer, uint16_t temporalLayer);
@@ -110,6 +117,10 @@ namespace RTC
 				}
 				bool Process(
 				  RTC::Codecs::EncodingContext* encodingContext, RTC::RtpPacket* packet, bool& marker) override;
+				void RtpPacketCloned(RtpPacket* packet) override
+				{
+					this->payloadDescriptor->UpdateListener(packet);
+				};
 				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
 				{
 					return this->payloadDescriptor->GetEncoder();

--- a/worker/include/RTC/Codecs/DependencyDescriptor.hpp
+++ b/worker/include/RTC/Codecs/DependencyDescriptor.hpp
@@ -83,6 +83,7 @@ namespace RTC
 			  TemplateDependencyStructure* templateDependencyStructure);
 
 			void Dump(int indentation = 0) const;
+			void UpdateListener(DependencyDescriptor::Listener* listener);
 			const uint8_t* Serialize(uint8_t& len);
 			bool UpdateActiveDecodeTargets(uint32_t maxSpatialLayer, uint32_t maxTemporalLayer);
 

--- a/worker/include/RTC/Codecs/H264.hpp
+++ b/worker/include/RTC/Codecs/H264.hpp
@@ -69,6 +69,7 @@ namespace RTC
 				}
 				bool Process(
 				  RTC::Codecs::EncodingContext* encodingContext, RTC::RtpPacket* packet, bool& marker) override;
+				void RtpPacketCloned(RtpPacket* packet) override{};
 				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
 				{
 					return nullptr;

--- a/worker/include/RTC/Codecs/Opus.hpp
+++ b/worker/include/RTC/Codecs/Opus.hpp
@@ -4,7 +4,6 @@
 #include "common.hpp"
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
 #include "RTC/RtpPacket.hpp"
-#include "RTC/SeqManager.hpp"
 
 namespace RTC
 {
@@ -66,6 +65,7 @@ namespace RTC
 				}
 				bool Process(
 				  RTC::Codecs::EncodingContext* encodingContext, RTC::RtpPacket* packet, bool& marker) override;
+				void RtpPacketCloned(RtpPacket* packet) override{};
 				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
 				{
 					return nullptr;

--- a/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
+++ b/worker/include/RTC/Codecs/PayloadDescriptorHandler.hpp
@@ -223,6 +223,7 @@ namespace RTC
 			virtual void Dump(int indentation = 0) const = 0;
 			virtual bool Process(
 			  RTC::Codecs::EncodingContext* context, RTC::RtpPacket* packet, bool& marker) = 0;
+			virtual void RtpPacketCloned(RtpPacket* packet)                                = 0;
 			virtual std::unique_ptr<PayloadDescriptor::Encoder> GetEncoder() const         = 0;
 			virtual void Encode(RtpPacket* packet, PayloadDescriptor::Encoder* encoder)    = 0;
 			virtual void Restore(RtpPacket* packet)                                        = 0;

--- a/worker/include/RTC/Codecs/VP8.hpp
+++ b/worker/include/RTC/Codecs/VP8.hpp
@@ -147,6 +147,7 @@ namespace RTC
 				}
 				bool Process(
 				  RTC::Codecs::EncodingContext* encodingContext, RTC::RtpPacket* packet, bool& marker) override;
+				void RtpPacketCloned(RtpPacket* packet) override{};
 				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
 				{
 					return this->payloadDescriptor->GetEncoder();

--- a/worker/include/RTC/Codecs/VP9.hpp
+++ b/worker/include/RTC/Codecs/VP9.hpp
@@ -126,6 +126,7 @@ namespace RTC
 				}
 				bool Process(
 				  RTC::Codecs::EncodingContext* encodingContext, RTC::RtpPacket* packet, bool& marker) override;
+				void RtpPacketCloned(RtpPacket* packet) override{};
 				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
 				{
 					return nullptr;

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -16,7 +16,7 @@
 
 namespace RTC
 {
-	class RtpPacket : Codecs::DependencyDescriptor::Listener
+	class RtpPacket : public Codecs::DependencyDescriptor::Listener
 	{
 	public:
 		/* Struct for RTP header. */

--- a/worker/src/RTC/Codecs/DependencyDescriptor.cpp
+++ b/worker/src/RTC/Codecs/DependencyDescriptor.cpp
@@ -185,6 +185,11 @@ namespace RTC
 			MS_DUMP_CLEAN(indentation, "</DependencyDescriptor>");
 		}
 
+		void DependencyDescriptor::UpdateListener(DependencyDescriptor::Listener* listener)
+		{
+			this->listener = listener;
+		}
+
 		bool DependencyDescriptor::ReadMandatoryDescriptorFields()
 		{
 			MS_TRACE();

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -806,6 +806,12 @@ namespace RTC
 		packet->dependencyDescriptorExtensionId = this->dependencyDescriptorExtensionId;
 		// Assign the payload descriptor handler.
 		packet->payloadDescriptorHandler = this->payloadDescriptorHandler;
+
+		if (this->payloadDescriptorHandler)
+		{
+			packet->payloadDescriptorHandler->RtpPacketCloned(packet);
+		}
+
 		// Store allocated buffer.
 		packet->buffer = buffer;
 

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -45,12 +45,13 @@ public:
 	{
 		return true;
 	}
-
+	void RtpPacketCloned(RTC::RtpPacket* packet) override
+	{
+	}
 	std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
 	{
 		return nullptr;
 	}
-
 	void Encode(RtpPacket* /*packet*/, RTC::Codecs::PayloadDescriptor::Encoder* /*encoder*/) override
 	{
 	}

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -54,6 +54,19 @@ static void CheckRtxPacket(RtpPacket* rtxPacket, RtpPacket* origPacket)
 	REQUIRE(rtxPacket->HasMarker() == origPacket->HasMarker());
 }
 
+static void ParseAV1RtpPacket(
+  RtpPacket* packet,
+  std::unique_ptr<Codecs::DependencyDescriptor::TemplateDependencyStructure>& templateDependencyStructure)
+{
+	std::unique_ptr<Codecs::DependencyDescriptor> dependencyDescriptor;
+	packet->ReadDependencyDescriptor(dependencyDescriptor, templateDependencyStructure);
+	REQUIRE(dependencyDescriptor);
+
+	auto* payloadDescriptor        = Codecs::AV1::Parse(dependencyDescriptor);
+	auto* payloadDescriptorHandler = new Codecs::AV1::PayloadDescriptorHandler(payloadDescriptor);
+	packet->SetPayloadDescriptorHandler(payloadDescriptorHandler);
+}
+
 SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstreamsend]")
 {
 	class TestRtpStreamListener : public RtpStreamSend::Listener
@@ -557,29 +570,6 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstreamsend
 
 		/*
 		 * <DependencyDescriptor>
-		 * 	 startOfFrame: false
-		 * 	 endOfFrame: true
-		 * 	 frameDependencyTemplateId: 0
-		 * 	 frameNumber: 1
-		 * 	 templateId: 0
-		 * 	 spatialLayer: 0
-		 * 	 temporalLayer: 0
-		 * 	</DependencyDescriptor>
-		 */
-		uint8_t rtpBuffer2[] =
-		{
-			0x90, 0xAD, 0x56, 0xA8,
-			0x8D, 0x76, 0xF5, 0x02,
-			0xDD, 0xD5, 0x4C, 0xB9,
-			0xBE, 0xDE, 0x00, 0x04,
-			0x22, 0x8A, 0x03, 0xE5,
-			0xD0, 0x00, 0x31, 0x00,
-			0x17, 0xC2, 0x40, 0x00,
-			0x01, 0x40, 0x31, 0x00
-		};
-
-		/*
-		 * <DependencyDescriptor>
 		 * 	 startOfFrame: true
 		 * 	 endOfFrame: true
 		 * 	 frameDependencyTemplateId: 2
@@ -589,7 +579,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstreamsend
 		 * 	 spatialLayer: 0
 		 * 	</DependencyDescriptor>
 		 */
-		uint8_t rtpBuffer3[] =
+		uint8_t rtpBuffer2[] =
 		{
 			0x90, 0xAD, 0x56, 0xA9,
 			0x8D, 0x77, 0x02, 0xB8,
@@ -599,6 +589,29 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstreamsend
 			0x31, 0x00, 0x18, 0x40,
 			0x31, 0xC2, 0xC2, 0x00,
 			0x02, 0x00, 0x00, 0x00
+		};
+
+		/*
+		 * <DependencyDescriptor>
+		 * 	 startOfFrame: false
+		 * 	 endOfFrame: true
+		 * 	 frameDependencyTemplateId: 0
+		 * 	 frameNumber: 1
+		 * 	 templateId: 0
+		 * 	 spatialLayer: 0
+		 * 	 temporalLayer: 0
+		 * 	</DependencyDescriptor>
+		 */
+		uint8_t rtpBuffer3[] =
+		{
+			0x90, 0xAD, 0x56, 0xA8,
+			0x8D, 0x76, 0xF5, 0x02,
+			0xDD, 0xD5, 0x4C, 0xB9,
+			0xBE, 0xDE, 0x00, 0x04,
+			0x22, 0x8A, 0x03, 0xE5,
+			0xD0, 0x00, 0x31, 0x00,
+			0x17, 0xC2, 0x40, 0x00,
+			0x01, 0x40, 0x31, 0x00
 		};
 		// clang-format on
 
@@ -655,47 +668,41 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstreamsend
 		std::unique_ptr<Codecs::DependencyDescriptor::TemplateDependencyStructure> templateDependencyStructure;
 
 		// Parse the first packet for the shake of having the template dependency structure.
-		std::unique_ptr<Codecs::DependencyDescriptor> dependencyDescriptor1;
-		packet1->ReadDependencyDescriptor(dependencyDescriptor1, templateDependencyStructure);
-		REQUIRE(dependencyDescriptor1);
-
-		auto* payloadDescriptor1        = Codecs::AV1::Parse(dependencyDescriptor1);
-		auto* payloadDescriptorHandler1 = new Codecs::AV1::PayloadDescriptorHandler(payloadDescriptor1);
-		packet1->SetPayloadDescriptorHandler(payloadDescriptorHandler1);
+		ParseAV1RtpPacket(packet1.get(), templateDependencyStructure);
+		// Parse the second packet.
+		ParseAV1RtpPacket(packet2.get(), templateDependencyStructure);
 
 		bool marker    = false;
 		bool forwarded = false;
 
-		// Parse the second packet.
-		std::unique_ptr<Codecs::DependencyDescriptor> dependencyDescriptor2;
-		packet2->ReadDependencyDescriptor(dependencyDescriptor2, templateDependencyStructure);
-		REQUIRE(dependencyDescriptor2);
-
-		auto* payloadDescriptor2        = Codecs::AV1::Parse(dependencyDescriptor2);
-		auto* payloadDescriptorHandler2 = new Codecs::AV1::PayloadDescriptorHandler(payloadDescriptor2);
-		packet2->SetPayloadDescriptorHandler(payloadDescriptorHandler2);
-
 		// Process the second packet for context1.
 		forwarded = packet2->ProcessPayload(&context1, marker);
-		REQUIRE(forwarded);
-		REQUIRE(context1.GetCurrentSpatialLayer() == 0);
-		REQUIRE(context1.GetCurrentTemporalLayer() == 0);
+		REQUIRE(!forwarded);
 
 		// Process the second packet with context2.
 		forwarded = packet2->ProcessPayload(&context2, marker);
 		REQUIRE(forwarded);
 		REQUIRE(context2.GetCurrentSpatialLayer() == 0);
-		REQUIRE(context2.GetCurrentTemporalLayer() == 0);
+		REQUIRE(context2.GetCurrentTemporalLayer() == 1);
 
 		// Parse the third packet
-		std::unique_ptr<Codecs::DependencyDescriptor> dependencyDescriptor3;
+		ParseAV1RtpPacket(packet3.get(), templateDependencyStructure);
 
-		packet3->ReadDependencyDescriptor(dependencyDescriptor3, templateDependencyStructure);
-		REQUIRE(dependencyDescriptor3);
+		// Process the third packet with context1 and verify current spatial layers.
+		forwarded = packet3->ProcessPayload(&context1, marker);
+		REQUIRE(forwarded);
+		REQUIRE(context1.GetCurrentSpatialLayer() == 0);
+		REQUIRE(context1.GetCurrentTemporalLayer() == 0);
 
-		auto* payloadDescriptor3        = Codecs::AV1::Parse(dependencyDescriptor3);
-		auto* payloadDescriptorHandler3 = new Codecs::AV1::PayloadDescriptorHandler(payloadDescriptor3);
-		packet3->SetPayloadDescriptorHandler(payloadDescriptorHandler3);
+		RTC::SharedRtpPacket sharedPacket;
+
+		packet3->SetSsrc(params1.ssrc);
+		// Whenever packet3 is Nacked on stream1, it must always be set a
+		// 00000001 (S0_T1) active decode target bitmas.
+		auto result = stream1->ReceivePacket(packet3.get(), sharedPacket);
+
+		REQUIRE(result == RTC::RtpStreamSend::ReceivePacketResult::ACCEPTED_AND_STORED);
+		sharedPacket.Assign(packet3.get());
 
 		// Process the third packet with context2 and verify current spatial layers.
 		forwarded = packet3->ProcessPayload(&context2, marker);
@@ -703,33 +710,19 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstreamsend
 		REQUIRE(context2.GetCurrentSpatialLayer() == 0);
 		REQUIRE(context2.GetCurrentTemporalLayer() == 1);
 
-		// Process the second packet with context2.
-		// This way packet2 will contain an active decode target bitmask
-		// of 11 (S0T1_S0T0)
-		forwarded = packet2->ProcessPayload(&context2, marker);
-		REQUIRE(context2.GetCurrentSpatialLayer() == 0);
-		REQUIRE(context2.GetCurrentTemporalLayer() == 1);
-		REQUIRE(forwarded);
+		packet3->SetSsrc(params2.ssrc);
 
-		// Receive the second packet in the first stream.
-		SendRtpPacket({ { stream1.get(), params1.ssrc } }, packet2.get());
-
-		// Process the second packet with context1.
-		forwarded = packet2->ProcessPayload(&context1, marker);
-		REQUIRE(forwarded);
-		REQUIRE(context1.GetCurrentSpatialLayer() == 0);
-		REQUIRE(context1.GetCurrentTemporalLayer() == 0);
-
-		// Receive the second packet in the second stream.
-		SendRtpPacket({ { stream2.get(), params2.ssrc } }, packet2.get());
+		// Whenever packet3 is Nacked on stream2, it must always be set a
+		// 00000011 (S0_T1) active decode target bitmas.
+		stream2->ReceivePacket(packet3.get(), sharedPacket);
 
 		// Create a NACK item that requests the third packet.
 		RTCP::FeedbackRtpNackPacket nackPacket(0, params1.ssrc);
-		auto* nackItem = new RTCP::FeedbackRtpNackItem(2, 0b0000000000000000);
+		auto* nackItem = new RTCP::FeedbackRtpNackItem(3, 0b0000000000000000);
 
 		nackPacket.AddItem(nackItem);
 
-		REQUIRE(nackItem->GetPacketId() == 2);
+		REQUIRE(nackItem->GetPacketId() == 3);
 		REQUIRE(nackItem->GetLostPacketBitmask() == 0b0000000000000000);
 
 		// Process the NACK packet on stream1.
@@ -744,7 +737,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstreamsend
 
 		packet->ReadDependencyDescriptor(dependencyDescriptor4, templateDependencyStructure);
 		REQUIRE(dependencyDescriptor4);
-		REQUIRE(dependencyDescriptor4->activeDecodeTargetsBitmask == 0b0000000000000011);
+		REQUIRE(dependencyDescriptor4->activeDecodeTargetsBitmask == 0b0000000000000001);
 
 		// Process the NACK packet on stream2.
 		stream2->ReceiveNack(&nackPacket);
@@ -758,7 +751,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstreamsend
 
 		packet->ReadDependencyDescriptor(dependencyDescriptor5, templateDependencyStructure);
 		REQUIRE(dependencyDescriptor5);
-		REQUIRE(dependencyDescriptor5->activeDecodeTargetsBitmask == 0b0000000000000001);
+		REQUIRE(dependencyDescriptor5->activeDecodeTargetsBitmask == 0b0000000000000011);
 	}
 
 	SECTION("packets get retransmitted as long as they don't exceed MaxRetransmissionDelayForVideoMs")


### PR DESCRIPTION
The outgoing RTP packet is not the original packet which parsed the Dependency Decriptor, hence the cloned packet (the packet being sent) needs to be set as the new listener
 of Dependency Descriptor.