### PR TITLE
Fix AV1 freezes due to wrong marker bit setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - AV1: Add support for DD extension header forwarding ([#1610](https://github.com/versatica/mediasoup/pull/1610)).
 - DependencyDescriptor: Update listener on RtpPacket clone ([#1618](https://github.com/versatica/mediasoup/pull/1618)).
+- AV1: Fix AV1 freezes due to wrong marker bit setting ([#1619](https://github.com/versatica/mediasoup/pull/1619)), thanks to @vpalmisano
+  for his investigation and suggestions.
 
 ### 3.19.3
 

--- a/worker/src/RTC/Codecs/AV1.cpp
+++ b/worker/src/RTC/Codecs/AV1.cpp
@@ -239,7 +239,7 @@ namespace RTC
 			}
 
 			// Set marker bit if needed.
-			if (packetSpatialLayer == tmpSpatialLayer && this->payloadDescriptor->endOfFrame)
+			if (this->payloadDescriptor->endOfFrame)
 			{
 				marker = true;
 			}


### PR DESCRIPTION
Somehow I missed this very well secified fact while reading around about marker bit setting:

https://aomediacodec.github.io/av1-rtp-spec/v1.0.0.html#rtp-header-marker

"The RTP header Marker bit MUST be set equal to 0 if the packet is not the
 last packet of the temporal unit, it SHOULD be set equal to 1 otherwise."

Fixes #1536