### PR TITLE
Fix VP9 freezes due to wrong marker bit setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - AV1: Add support for DD extension header forwarding ([#1610](https://github.com/versatica/mediasoup/pull/1610)).
 - DependencyDescriptor: Update listener on RtpPacket clone ([#1618](https://github.com/versatica/mediasoup/pull/1618)).
+- VP9: Fix VP9 freezes due to wrong marker bit setting ([#1620](https://github.com/versatica/mediasoup/pull/1620)), thanks to @geirbakke
+  for reporting.
 
 ### 3.19.3
 

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -381,7 +381,7 @@ namespace RTC
 			}
 
 			// Set marker bit if needed.
-			if (packetSpatialLayer == tmpSpatialLayer && this->payloadDescriptor->e)
+			if (this->payloadDescriptor->e)
 			{
 				marker = true;
 			}


### PR DESCRIPTION
Fixes #1616

Even though the spec says:

"This bit MUST be set to one for the final packet of the highest spatial-layer frame (the final packet of the picture) "

Since the receiver endpoint does not know which is the highest spatial-layer we are sending, marker flag must be set for every final packet of frame.

Tests demonstrate this reduces freezes massively.