### PR TITLE
Revert marker changes vp9 av1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,6 @@
 
 - AV1: Add support for DD extension header forwarding ([#1610](https://github.com/versatica/mediasoup/pull/1610)).
 - DependencyDescriptor: Update listener on RtpPacket clone ([#1618](https://github.com/versatica/mediasoup/pull/1618)).
-- AV1: Fix AV1 freezes due to wrong marker bit setting ([#1619](https://github.com/versatica/mediasoup/pull/1619)), thanks to @vpalmisano
-  for his investigation and suggestions.
 
 ### 3.19.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,6 @@
 - DependencyDescriptor: Update listener on RtpPacket clone ([#1618](https://github.com/versatica/mediasoup/pull/1618)).
 - AV1: Fix AV1 freezes due to wrong marker bit setting ([#1619](https://github.com/versatica/mediasoup/pull/1619)), thanks to @vpalmisano
   for his investigation and suggestions.
-- VP9: Fix VP9 freezes due to wrong marker bit setting ([#1620](https://github.com/versatica/mediasoup/pull/1620)), thanks to @geirbakke
-  for reporting.
 
 ### 3.19.3
 

--- a/worker/src/RTC/Codecs/AV1.cpp
+++ b/worker/src/RTC/Codecs/AV1.cpp
@@ -239,12 +239,6 @@ namespace RTC
 			}
 
 			// Set marker bit if needed.
-			// NOTE: As per the spec the correct way to set the marker bit is:
-			// if (packetSpatialLayer == tmpSpatialLayer && this->payloadDescriptor->e)
-			// https://aomediacodec.github.io/av1-rtp-spec/v1.0.0.html#rtp-header-marker
-			// But that generates a lot of freezes when there is downlink packet loss.
-			// Issue may be in client side: https://issues.webrtc.org/issues/449408585
-			// Reference: https://github.com/versatica/mediasoup/issues/1536
 			if (this->payloadDescriptor->endOfFrame)
 			{
 				marker = true;

--- a/worker/src/RTC/Codecs/AV1.cpp
+++ b/worker/src/RTC/Codecs/AV1.cpp
@@ -239,7 +239,7 @@ namespace RTC
 			}
 
 			// Set marker bit if needed.
-			if (this->payloadDescriptor->endOfFrame)
+			if (packetSpatialLayer == tmpSpatialLayer && this->payloadDescriptor->endOfFrame)
 			{
 				marker = true;
 			}

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -381,12 +381,6 @@ namespace RTC
 			}
 
 			// Set marker bit if needed.
-			// NOTE: As per the spec the correct way to set the marker bit is:
-			// if (packetSpatialLayer == tmpSpatialLayer && this->payloadDescriptor->e)
-			// https://www.rfc-editor.org/rfc/rfc9628.html#name-rtp-header-usage
-			// But that generates a lot of freezes when there is downlink packet loss.
-			// Issue may be in client side: https://issues.webrtc.org/issues/449408585
-			// https://github.com/versatica/mediasoup/issues/1616
 			if (this->payloadDescriptor->e)
 			{
 				marker = true;

--- a/worker/src/RTC/Codecs/VP9.cpp
+++ b/worker/src/RTC/Codecs/VP9.cpp
@@ -381,7 +381,7 @@ namespace RTC
 			}
 
 			// Set marker bit if needed.
-			if (this->payloadDescriptor->e)
+			if (packetSpatialLayer == tmpSpatialLayer && this->payloadDescriptor->e)
 			{
 				marker = true;
 			}


### PR DESCRIPTION
The changes were wrong. By adding marker to every end of frame the receiver can only decode the lowest spatial layer...