### PR TITLE
Logger: allow for up to 5 indents in MS_DUMP_CLEAN

### DIFF
--- a/worker/include/Logger.hpp
+++ b/worker/include/Logger.hpp
@@ -365,7 +365,8 @@ public:
 		const char* spaces = (indentation == 1) ? "  " : \
 			((indentation == 2) ? "    " : \
 			((indentation == 3) ? "      " : \
-			((indentation == 4) ? "        " : ""))); \
+			((indentation == 4) ? "        " :\
+			((indentation == 5) ? "          " : "")))); \
 		const int loggerWritten = std::snprintf(Logger::buffer, Logger::BufferSize, "X%s" desc, spaces, ##__VA_ARGS__); \
 		Logger::channel->SendLog(Logger::buffer, static_cast<uint32_t>(loggerWritten)); \
 	} \
@@ -377,7 +378,8 @@ public:
 		const char* spaces = (indentation == 1) ? "  " : \
 			((indentation == 2) ? "    " : \
 			((indentation == 3) ? "      " : \
-			((indentation == 4) ? "        " : ""))); \
+			((indentation == 4) ? "        " :\
+			((indentation == 5) ? "          " : "")))); \
 		std::fprintf(stdout, "%s" desc _MS_LOG_SEPARATOR_CHAR_STD, spaces, ##__VA_ARGS__); \
 		std::fflush(stdout); \
 	} \


### PR DESCRIPTION
I've found this needed while adding some testing logs.