### PR TITLE
RtpPacket: add uniqueId

### DIFF
--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -87,6 +87,9 @@ namespace RTC
 
 	public:
 		static const size_t HeaderSize{ 12 };
+
+		thread_local static uint64_t nextUniqueId;
+
 		static bool IsRtp(const uint8_t* data, size_t len)
 		{
 			// NOTE: RtcpPacket::IsRtcp() must always be called before this method.
@@ -108,6 +111,7 @@ namespace RTC
 
 	private:
 		RtpPacket(
+		  uint64_t uniqueId,
 		  Header* header,
 		  HeaderExtension* headerExtension,
 		  const uint8_t* payload,
@@ -120,6 +124,11 @@ namespace RTC
 
 		void Dump(int indentation = 0) const;
 		flatbuffers::Offset<FBS::RtpPacket::Dump> FillBuffer(flatbuffers::FlatBufferBuilder& builder) const;
+
+		uint64_t GetUniqueId() const
+		{
+			return this->uniqueId;
+		}
 
 		const uint8_t* GetData() const
 		{
@@ -658,6 +667,9 @@ namespace RTC
 		void OnDependencyDescriptorUpdated(const uint8_t* data, size_t len);
 
 	private:
+		// Unique id to identify this packet when debugging (it shows up in Dump()
+		// and remains the same in cloned packets).
+		uint64_t uniqueId{ 0u };
 		Header* header{ nullptr };
 		uint8_t* csrcList{ nullptr };
 		HeaderExtension* headerExtension{ nullptr };

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #define MS_CLASS "RTC::RtpPacket"
 // #define MS_LOG_DEV_LEVEL 3
 // #define DUMP_PAYLOAD_DESCRIPTOR 1
@@ -14,6 +15,10 @@
 
 namespace RTC
 {
+	/* Class variables. */
+
+	thread_local uint64_t RtpPacket::nextUniqueId{ 0 };
+
 	/* Class methods. */
 
 	RtpPacket* RtpPacket::Parse(const uint8_t* data, size_t len)
@@ -126,20 +131,25 @@ namespace RTC
 		           payloadLength + size_t{ payloadPadding },
 		  "packet's computed size does not match received size");
 
-		return new RtpPacket(header, headerExtension, payload, payloadLength, payloadPadding, len);
+		auto uniqueId = RtpPacket::nextUniqueId++;
+
+		return new RtpPacket(
+		  uniqueId, header, headerExtension, payload, payloadLength, payloadPadding, len);
 	}
 
 	/* Instance methods. */
 
 	RtpPacket::RtpPacket(
+	  uint64_t uniqueId,
 	  Header* header,
 	  HeaderExtension* headerExtension,
 	  const uint8_t* payload,
 	  size_t payloadLength,
 	  uint8_t payloadPadding,
 	  size_t size)
-	  : header(header), headerExtension(headerExtension), payload(const_cast<uint8_t*>(payload)),
-	    payloadLength(payloadLength), payloadPadding(payloadPadding), size(size)
+	  : uniqueId(uniqueId), header(header), headerExtension(headerExtension),
+	    payload(const_cast<uint8_t*>(payload)), payloadLength(payloadLength),
+	    payloadPadding(payloadPadding), size(size)
 	{
 		MS_TRACE();
 
@@ -172,6 +182,7 @@ namespace RTC
 		MS_TRACE();
 
 		MS_DUMP_CLEAN(indentation, "<RtpPacket>");
+		MS_DUMP_CLEAN(indentation, "  unique id: %" PRIu64, this->uniqueId);
 		MS_DUMP_CLEAN(indentation, "  padding: %s", this->header->padding ? "true" : "false");
 		if (HasHeaderExtension())
 		{
@@ -792,7 +803,13 @@ namespace RTC
 
 		// Create the new RtpPacket instance and return it.
 		auto* packet = new RtpPacket(
-		  newHeader, newHeaderExtension, newPayload, this->payloadLength, this->payloadPadding, this->size);
+		  this->uniqueId,
+		  newHeader,
+		  newHeaderExtension,
+		  newPayload,
+		  this->payloadLength,
+		  this->payloadPadding,
+		  this->size);
 
 		// Keep already set extension ids.
 		packet->midExtensionId                  = this->midExtensionId;

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -183,7 +183,15 @@ namespace RTC
 
 		MS_DUMP_CLEAN(indentation, "<RtpPacket>");
 		MS_DUMP_CLEAN(indentation, "  unique id: %" PRIu64, this->uniqueId);
+		MS_DUMP_CLEAN(indentation, "  packet size: %zu bytes", GetSize());
+		MS_DUMP_CLEAN(indentation, "  sequence number: %" PRIu16, GetSequenceNumber());
+		MS_DUMP_CLEAN(indentation, "  timestamp: %" PRIu32, GetTimestamp());
+		MS_DUMP_CLEAN(indentation, "  marker: %s", HasMarker() ? "true" : "false");
+		MS_DUMP_CLEAN(indentation, "  payload type: %" PRIu8, GetPayloadType());
+		MS_DUMP_CLEAN(indentation, "  ssrc: %" PRIu32, GetSsrc());
+		MS_DUMP_CLEAN(indentation, "  csrc count: %" PRIu8, this->header->csrcCount);
 		MS_DUMP_CLEAN(indentation, "  padding: %s", this->header->padding ? "true" : "false");
+
 		if (HasHeaderExtension())
 		{
 			MS_DUMP_CLEAN(
@@ -192,14 +200,17 @@ namespace RTC
 			  GetHeaderExtensionId(),
 			  GetHeaderExtensionLength());
 		}
+
 		if (HasOneByteExtensions())
 		{
 			MS_DUMP_CLEAN(indentation, "  RFC5285 ext style: One-Byte Header");
 		}
+
 		if (HasTwoBytesExtensions())
 		{
 			MS_DUMP_CLEAN(indentation, "  RFC5285 ext style: Two-Bytes Header");
 		}
+
 		if (HasOneByteExtensions() || HasTwoBytesExtensions())
 		{
 			std::vector<std::string> extIds;
@@ -234,6 +245,7 @@ namespace RTC
 				MS_DUMP_CLEAN(indentation, "  RFC5285 ext ids: %s", extIdsStream.str().c_str());
 			}
 		}
+
 		if (this->midExtensionId != 0u)
 		{
 			std::string mid;
@@ -244,6 +256,7 @@ namespace RTC
 				  indentation, "  mid: extId:%" PRIu8 ", value:'%s'", this->midExtensionId, mid.c_str());
 			}
 		}
+
 		if (this->ridExtensionId != 0u)
 		{
 			std::string rid;
@@ -254,6 +267,7 @@ namespace RTC
 				  indentation, "  rid: extId:%" PRIu8 ", value:'%s'", this->ridExtensionId, rid.c_str());
 			}
 		}
+
 		if (this->rridExtensionId != 0u)
 		{
 			std::string rid;
@@ -264,10 +278,12 @@ namespace RTC
 				  indentation, "  rrid: extId:%" PRIu8 ", value:'%s'", this->rridExtensionId, rid.c_str());
 			}
 		}
+
 		if (this->absSendTimeExtensionId != 0u)
 		{
 			MS_DUMP_CLEAN(indentation, "  absSendTime: extId:%" PRIu8, this->absSendTimeExtensionId);
 		}
+
 		if (this->transportWideCc01ExtensionId != 0u)
 		{
 			uint16_t wideSeqNumber{ 0 };
@@ -281,6 +297,7 @@ namespace RTC
 				  wideSeqNumber);
 			}
 		}
+
 		if (this->ssrcAudioLevelExtensionId != 0u)
 		{
 			uint8_t volume{ 0 };
@@ -296,6 +313,7 @@ namespace RTC
 				  voice ? "true" : "false");
 			}
 		}
+
 		if (this->videoOrientationExtensionId != 0u)
 		{
 			bool camera{ false };
@@ -313,6 +331,7 @@ namespace RTC
 				  rotation);
 			}
 		}
+
 		if (this->playoutDelayExtensionId != 0u)
 		{
 			uint16_t minDelay{ 0 };
@@ -328,6 +347,7 @@ namespace RTC
 				  maxDelay);
 			}
 		}
+
 		if (this->dependencyDescriptorExtensionId != 0u)
 		{
 			uint8_t extenLen;
@@ -343,18 +363,12 @@ namespace RTC
 			}
 		}
 
-		MS_DUMP_CLEAN(indentation, "  csrc count: %" PRIu8, this->header->csrcCount);
-		MS_DUMP_CLEAN(indentation, "  marker: %s", HasMarker() ? "true" : "false");
-		MS_DUMP_CLEAN(indentation, "  payload type: %" PRIu8, GetPayloadType());
-		MS_DUMP_CLEAN(indentation, "  sequence number: %" PRIu16, GetSequenceNumber());
-		MS_DUMP_CLEAN(indentation, "  timestamp: %" PRIu32, GetTimestamp());
-		MS_DUMP_CLEAN(indentation, "  ssrc: %" PRIu32, GetSsrc());
 		MS_DUMP_CLEAN(indentation, "  payload size: %zu bytes", GetPayloadLength());
 		if (this->header->padding != 0u)
 		{
 			MS_DUMP_CLEAN(indentation, "  padding size: %" PRIu8 " bytes", this->payloadPadding);
 		}
-		MS_DUMP_CLEAN(indentation, "  packet size: %zu bytes", GetSize());
+
 		MS_DUMP_CLEAN(indentation, "  spatial layer: %" PRIu8, GetSpatialLayer());
 		MS_DUMP_CLEAN(indentation, "  temporal layer: %" PRIu8, GetTemporalLayer());
 #ifdef DUMP_PAYLOAD_DESCRIPTOR


### PR DESCRIPTION
The problem is that **obviously** such an `uniqueId` is lost when sending the RTP packet through a pipe transport, which was the purpose of this PR... but anyway...

Bonus track: Improve order of items in `RtpPacket::Dump()`