### PR TITLE
Fix setting 2 byte header extension with value longer than 14 bytes

### DIFF
--- a/worker/include/Logger.hpp
+++ b/worker/include/Logger.hpp
@@ -365,7 +365,8 @@ public:
 		const char* spaces = (indentation == 1) ? "  " : \
 			((indentation == 2) ? "    " : \
 			((indentation == 3) ? "      " : \
-			((indentation == 4) ? "        " : ""))); \
+			((indentation == 4) ? "        " :\
+			((indentation == 5) ? "          " : "")))); \
 		const int loggerWritten = std::snprintf(Logger::buffer, Logger::BufferSize, "X%s" desc, spaces, ##__VA_ARGS__); \
 		Logger::channel->SendLog(Logger::buffer, static_cast<uint32_t>(loggerWritten)); \
 	} \
@@ -377,7 +378,8 @@ public:
 		const char* spaces = (indentation == 1) ? "  " : \
 			((indentation == 2) ? "    " : \
 			((indentation == 3) ? "      " : \
-			((indentation == 4) ? "        " : ""))); \
+			((indentation == 4) ? "        " :\
+			((indentation == 5) ? "          " : "")))); \
 		std::fprintf(stdout, "%s" desc _MS_LOG_SEPARATOR_CHAR_STD, spaces, ##__VA_ARGS__); \
 		std::fflush(stdout); \
 	} \

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -87,6 +87,7 @@ namespace RTC
 
 	public:
 		static const size_t HeaderSize{ 12 };
+
 		static bool IsRtp(const uint8_t* data, size_t len)
 		{
 			// NOTE: RtcpPacket::IsRtcp() must always be called before this method.
@@ -269,6 +270,11 @@ namespace RTC
 			this->videoOrientationExtensionId = id;
 		}
 
+		void SetAbsCaptureTimeExtensionId(uint8_t id)
+		{
+			this->absCaptureTimeExtensionId = id;
+		}
+
 		void SetPlayoutDelayExtensionId(uint8_t id)
 		{
 			this->playoutDelayExtensionId = id;
@@ -433,6 +439,34 @@ namespace RTC
 					break;
 				default:
 					rotation = 0;
+			}
+
+			return true;
+		}
+
+		bool ReadAbsCaptureTime(uint64_t& absCaptureTimestamp, int64_t& estimatedCaptureClockOffset) const
+		{
+			uint8_t extenLen;
+			uint8_t* extenValue = GetExtension(this->absCaptureTimeExtensionId, extenLen);
+
+			// Extension value can be 8 or 16 bytes depending on whether it contains
+			// estimated capture clock offset or not.
+			//
+			// https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time
+			if (!extenValue || (extenLen != 8u && extenLen != 16u))
+			{
+				return false;
+			}
+
+			absCaptureTimestamp = Utils::Byte::Get8Bytes(extenValue, 0);
+
+			if (extenLen == 16)
+			{
+				estimatedCaptureClockOffset = static_cast<int64_t>(Utils::Byte::Get8Bytes(extenValue, 8));
+			}
+			else
+			{
+				estimatedCaptureClockOffset = 0;
 			}
 
 			return true;
@@ -673,6 +707,7 @@ namespace RTC
 		uint8_t transportWideCc01ExtensionId{ 0u };
 		uint8_t ssrcAudioLevelExtensionId{ 0u };
 		uint8_t videoOrientationExtensionId{ 0u };
+		uint8_t absCaptureTimeExtensionId{ 0u };
 		uint8_t playoutDelayExtensionId{ 0u };
 		uint8_t dependencyDescriptorExtensionId{ 0u };
 		uint8_t* payload{ nullptr };

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1410,6 +1410,8 @@ namespace RTC
 			  static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::SSRC_AUDIO_LEVEL));
 			packet->SetVideoOrientationExtensionId(
 			  static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::VIDEO_ORIENTATION));
+			packet->SetAbsCaptureTimeExtensionId(
+			  static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::ABS_CAPTURE_TIME));
 			packet->SetPlayoutDelayExtensionId(
 			  static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::PLAYOUT_DELAY));
 			packet->SetDependencyDescriptorExtensionId(

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #define MS_CLASS "RTC::RtpPacket"
 // #define MS_LOG_DEV_LEVEL 3
 // #define DUMP_PAYLOAD_DESCRIPTOR 1
@@ -126,7 +127,8 @@ namespace RTC
 		           payloadLength + size_t{ payloadPadding },
 		  "packet's computed size does not match received size");
 
-		return new RtpPacket(header, headerExtension, payload, payloadLength, payloadPadding, len);
+		return new RtpPacket(
+		  header, headerExtension, payload, payloadLength, payloadPadding, len);
 	}
 
 	/* Instance methods. */
@@ -138,8 +140,9 @@ namespace RTC
 	  size_t payloadLength,
 	  uint8_t payloadPadding,
 	  size_t size)
-	  : header(header), headerExtension(headerExtension), payload(const_cast<uint8_t*>(payload)),
-	    payloadLength(payloadLength), payloadPadding(payloadPadding), size(size)
+	  : header(header), headerExtension(headerExtension),
+	    payload(const_cast<uint8_t*>(payload)), payloadLength(payloadLength),
+	    payloadPadding(payloadPadding), size(size)
 	{
 		MS_TRACE();
 
@@ -172,7 +175,15 @@ namespace RTC
 		MS_TRACE();
 
 		MS_DUMP_CLEAN(indentation, "<RtpPacket>");
+		MS_DUMP_CLEAN(indentation, "  packet size: %zu bytes", GetSize());
+		MS_DUMP_CLEAN(indentation, "  sequence number: %" PRIu16, GetSequenceNumber());
+		MS_DUMP_CLEAN(indentation, "  timestamp: %" PRIu32, GetTimestamp());
+		MS_DUMP_CLEAN(indentation, "  marker: %s", HasMarker() ? "true" : "false");
+		MS_DUMP_CLEAN(indentation, "  payload type: %" PRIu8, GetPayloadType());
+		MS_DUMP_CLEAN(indentation, "  ssrc: %" PRIu32, GetSsrc());
+		MS_DUMP_CLEAN(indentation, "  csrc count: %" PRIu8, this->header->csrcCount);
 		MS_DUMP_CLEAN(indentation, "  padding: %s", this->header->padding ? "true" : "false");
+
 		if (HasHeaderExtension())
 		{
 			MS_DUMP_CLEAN(
@@ -181,14 +192,17 @@ namespace RTC
 			  GetHeaderExtensionId(),
 			  GetHeaderExtensionLength());
 		}
+
 		if (HasOneByteExtensions())
 		{
 			MS_DUMP_CLEAN(indentation, "  RFC5285 ext style: One-Byte Header");
 		}
+
 		if (HasTwoBytesExtensions())
 		{
 			MS_DUMP_CLEAN(indentation, "  RFC5285 ext style: Two-Bytes Header");
 		}
+
 		if (HasOneByteExtensions() || HasTwoBytesExtensions())
 		{
 			std::vector<std::string> extIds;
@@ -223,6 +237,7 @@ namespace RTC
 				MS_DUMP_CLEAN(indentation, "  RFC5285 ext ids: %s", extIdsStream.str().c_str());
 			}
 		}
+
 		if (this->midExtensionId != 0u)
 		{
 			std::string mid;
@@ -233,6 +248,7 @@ namespace RTC
 				  indentation, "  mid: extId:%" PRIu8 ", value:'%s'", this->midExtensionId, mid.c_str());
 			}
 		}
+
 		if (this->ridExtensionId != 0u)
 		{
 			std::string rid;
@@ -243,6 +259,7 @@ namespace RTC
 				  indentation, "  rid: extId:%" PRIu8 ", value:'%s'", this->ridExtensionId, rid.c_str());
 			}
 		}
+
 		if (this->rridExtensionId != 0u)
 		{
 			std::string rid;
@@ -253,10 +270,12 @@ namespace RTC
 				  indentation, "  rrid: extId:%" PRIu8 ", value:'%s'", this->rridExtensionId, rid.c_str());
 			}
 		}
+
 		if (this->absSendTimeExtensionId != 0u)
 		{
 			MS_DUMP_CLEAN(indentation, "  absSendTime: extId:%" PRIu8, this->absSendTimeExtensionId);
 		}
+
 		if (this->transportWideCc01ExtensionId != 0u)
 		{
 			uint16_t wideSeqNumber{ 0 };
@@ -270,6 +289,7 @@ namespace RTC
 				  wideSeqNumber);
 			}
 		}
+
 		if (this->ssrcAudioLevelExtensionId != 0u)
 		{
 			uint8_t volume{ 0 };
@@ -285,6 +305,7 @@ namespace RTC
 				  voice ? "true" : "false");
 			}
 		}
+
 		if (this->videoOrientationExtensionId != 0u)
 		{
 			bool camera{ false };
@@ -302,6 +323,24 @@ namespace RTC
 				  rotation);
 			}
 		}
+
+		if (this->absCaptureTimeExtensionId != 0u)
+		{
+			uint64_t absCaptureTimestamp{ 0u };
+			int64_t estimatedCaptureClockOffset{ 0 };
+
+			if (ReadAbsCaptureTime(absCaptureTimestamp, estimatedCaptureClockOffset))
+			{
+				MS_DUMP_CLEAN(
+				  indentation,
+				  "  absCaptureTime: extId:%" PRIu8 ", absCaptureTimestamp:%" PRIu64
+				  ", estimatedCaptureClockOffset:%" PRId64,
+				  this->absCaptureTimeExtensionId,
+				  absCaptureTimestamp,
+				  estimatedCaptureClockOffset);
+			}
+		}
+
 		if (this->playoutDelayExtensionId != 0u)
 		{
 			uint16_t minDelay{ 0 };
@@ -312,11 +351,12 @@ namespace RTC
 				MS_DUMP_CLEAN(
 				  indentation,
 				  "  playoutDelay: extId:%" PRIu8 ", minDelay:%" PRIu16 ", maxDelay:%" PRIu16,
-				  this->videoOrientationExtensionId,
+				  this->playoutDelayExtensionId,
 				  minDelay,
 				  maxDelay);
 			}
 		}
+
 		if (this->dependencyDescriptorExtensionId != 0u)
 		{
 			uint8_t extenLen;
@@ -332,18 +372,12 @@ namespace RTC
 			}
 		}
 
-		MS_DUMP_CLEAN(indentation, "  csrc count: %" PRIu8, this->header->csrcCount);
-		MS_DUMP_CLEAN(indentation, "  marker: %s", HasMarker() ? "true" : "false");
-		MS_DUMP_CLEAN(indentation, "  payload type: %" PRIu8, GetPayloadType());
-		MS_DUMP_CLEAN(indentation, "  sequence number: %" PRIu16, GetSequenceNumber());
-		MS_DUMP_CLEAN(indentation, "  timestamp: %" PRIu32, GetTimestamp());
-		MS_DUMP_CLEAN(indentation, "  ssrc: %" PRIu32, GetSsrc());
 		MS_DUMP_CLEAN(indentation, "  payload size: %zu bytes", GetPayloadLength());
 		if (this->header->padding != 0u)
 		{
 			MS_DUMP_CLEAN(indentation, "  padding size: %" PRIu8 " bytes", this->payloadPadding);
 		}
-		MS_DUMP_CLEAN(indentation, "  packet size: %zu bytes", GetSize());
+
 		MS_DUMP_CLEAN(indentation, "  spatial layer: %" PRIu8, GetSpatialLayer());
 		MS_DUMP_CLEAN(indentation, "  temporal layer: %" PRIu8, GetTemporalLayer());
 #ifdef DUMP_PAYLOAD_DESCRIPTOR
@@ -423,6 +457,7 @@ namespace RTC
 		this->transportWideCc01ExtensionId    = 0u;
 		this->ssrcAudioLevelExtensionId       = 0u;
 		this->videoOrientationExtensionId     = 0u;
+		this->absCaptureTimeExtensionId       = 0u;
 		this->playoutDelayExtensionId         = 0u;
 		this->dependencyDescriptorExtensionId = 0u;
 
@@ -792,7 +827,12 @@ namespace RTC
 
 		// Create the new RtpPacket instance and return it.
 		auto* packet = new RtpPacket(
-		  newHeader, newHeaderExtension, newPayload, this->payloadLength, this->payloadPadding, this->size);
+		  newHeader,
+		  newHeaderExtension,
+		  newPayload,
+		  this->payloadLength,
+		  this->payloadPadding,
+		  this->size);
 
 		// Keep already set extension ids.
 		packet->midExtensionId                  = this->midExtensionId;
@@ -802,6 +842,7 @@ namespace RTC
 		packet->transportWideCc01ExtensionId    = this->transportWideCc01ExtensionId;
 		packet->ssrcAudioLevelExtensionId       = this->ssrcAudioLevelExtensionId;
 		packet->videoOrientationExtensionId     = this->videoOrientationExtensionId;
+		packet->absCaptureTimeExtensionId       = this->absCaptureTimeExtensionId;
 		packet->playoutDelayExtensionId         = this->playoutDelayExtensionId;
 		packet->dependencyDescriptorExtensionId = this->dependencyDescriptorExtensionId;
 		// Assign the payload descriptor handler.

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -1,3 +1,7 @@
+// TODO: REMOVE
+#define MS_CLASS "TestRtpPacket"
+#include "Logger.hpp"
+
 #include "common.hpp"
 #include "helpers.hpp"
 #include "RTC/RtpPacket.hpp"
@@ -529,6 +533,9 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
 		REQUIRE(packet->GetPayloadPadding() == 4);
+		MS_DUMP("---- test set One-Byte header extensions 1");
+		MS_DUMP_DATA(packet->GetPayload(), packet->GetPayloadLength() + 4);
+		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
@@ -588,16 +595,26 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value2 // value
 		);
 
+		uint8_t value3[] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77 };
+
+		extensions.emplace_back(
+		  5,     // id
+		  8,     // len
+		  value3 // value
+		);
+
 		packet->SetExtensions(1, extensions);
 
-		REQUIRE(packet->GetSize() == 52); // 49 + 3 bytes for padding in header extension.
+		REQUIRE(packet->GetSize() == 60); // Takinng into account padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
-		REQUIRE(packet->GetHeaderExtensionLength() == 20); // 17 + 3 bytes for padding.
+		REQUIRE(packet->GetHeaderExtensionLength() == 28); // 25 + 3 bytes for padding.
 		REQUIRE(packet->HasOneByteExtensions() == true);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
 		REQUIRE(packet->GetPayloadPadding() == 4);
+		MS_DUMP("---- test set One-Byte header extensions 2");
+		MS_DUMP_DATA(packet->GetPayload(), packet->GetPayloadLength() + 4);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
@@ -613,15 +630,18 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetExtension(2, extenLen));
 		REQUIRE(packet->HasExtension(2) == true);
 		REQUIRE(extenLen == 11);
+		REQUIRE(packet->GetExtension(5, extenLen));
+		REQUIRE(packet->HasExtension(5) == true);
+		REQUIRE(extenLen == 8);
 
 		extensions.clear();
 
-		uint8_t value3[] = { 0x01, 0x02, 0x03, 0x04 };
+		uint8_t value4[] = { 0x01, 0x02, 0x03, 0x04 };
 
 		extensions.emplace_back(
 		  14,    // id
 		  4,     // len
-		  value3 // value
+		  value4 // value
 		);
 
 		packet->SetExtensions(1, extensions);
@@ -634,6 +654,8 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
 		REQUIRE(packet->GetPayloadPadding() == 4);
+		MS_DUMP("---- test set One-Byte header extensions 3");
+		MS_DUMP_DATA(packet->GetPayload(), packet->GetPayloadLength() + 4);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
@@ -700,6 +722,8 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
 		REQUIRE(packet->GetPayloadPadding() == 4);
+		MS_DUMP("---- test set Two-Byte header extensions 1");
+		MS_DUMP_DATA(packet->GetPayload(), packet->GetPayloadLength() + 4);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
@@ -716,6 +740,8 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasTwoBytesExtensions() == true);
 		REQUIRE(packet->GetPayloadLength() == 12);
 		REQUIRE(packet->GetPayloadPadding() == 4);
+		MS_DUMP("---- test set Two-Byte header extensions 2");
+		MS_DUMP_DATA(packet->GetPayload(), packet->GetPayloadLength() + 4);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
@@ -745,16 +771,33 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value2 // value
 		);
 
+		// uint8_t value3[] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x01, 0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78 };
+
+		// extensions.emplace_back(
+		//   5,     // id
+		//   16,    // len
+		//   value3 // value
+		// );
+		uint8_t value3[] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x01, 0x12, 0x23, 0x34, 0x45, 0x56, 0x67 };
+
+		extensions.emplace_back(
+		  5,     // id
+		  14,    // len
+		  value3 // value
+		);
+
 		packet->SetExtensions(2, extensions);
 
-		REQUIRE(packet->GetSize() == 52); // 51 + 1 byte for padding in header extension.
+		// REQUIRE(packet->GetSize() == 72); // Takinng into account padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0b0001000000000000);
-		REQUIRE(packet->GetHeaderExtensionLength() == 20); // 19 + 1 byte for padding.
+		// REQUIRE(packet->GetHeaderExtensionLength() == 40); // 39 + 1 byte for padding.
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == true);
 		REQUIRE(packet->GetPayloadLength() == 12);
 		REQUIRE(packet->GetPayloadPadding() == 4);
+		MS_DUMP("---- test set Two-Byte header extensions 3");
+		MS_DUMP_DATA(packet->GetPayload(), packet->GetPayloadLength() + 4);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
@@ -778,20 +821,23 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetExtension(22, extenLen));
 		REQUIRE(packet->HasExtension(22) == true);
 		REQUIRE(extenLen == 11);
+		REQUIRE(packet->GetExtension(5, extenLen));
+		REQUIRE(packet->HasExtension(5) == true);
+		// REQUIRE(extenLen == 16);
 
 		extensions.clear();
 
-		uint8_t value3[] = { 0x01, 0x02, 0x03, 0x04 };
+		uint8_t value4[] = { 0x01, 0x02, 0x03, 0x04 };
 
 		extensions.emplace_back(
 		  24,    // id
 		  4,     // len
-		  value3 // value
+		  value4 // value
 		);
 
 		packet->SetExtensions(2, extensions);
 
-		REQUIRE(packet->GetSize() == 40);
+		// REQUIRE(packet->GetSize() == 40);
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0b0001000000000000);
 		REQUIRE(packet->GetHeaderExtensionLength() == 8);
@@ -799,6 +845,8 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasTwoBytesExtensions() == true);
 		REQUIRE(packet->GetPayloadLength() == 12);
 		REQUIRE(packet->GetPayloadPadding() == 4);
+		MS_DUMP("---- test set Two-Byte header extensions 4");
+		MS_DUMP_DATA(packet->GetPayload(), packet->GetPayloadLength() + 4);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);


### PR DESCRIPTION
# Details

- This PR was intended to dump abs-capture-time extension in `RtpPacket::Dump()`.
- But amazingly, while extending tests, I found a bug: settings extensions in a `RtpPacket` with an extension value > 14 bytes **FAILS**.
- It fails using both 1 byte extensions and 2 bytes extensions.
  - Unrelated, but remember that when using 1 byte extensions, max value length is 16 since there is 1 byte for indicating the length of the value, but its value 0 corresponds to 1 byte of value length, so its max value 15 means 16 bytes of value length. Anyway this is unrelated because the bug happens with extension values > 14.
- This PR replaces PR https://github.com/versatica/mediasoup/pull/1627

## WIP

This PR doesn't fix yet the issue but it adds some logs that should show the problem. Just run `MEDIASOUP_TEST_TAGS=[rtp] make test` in `worker/` folder.