### PR TITLE
RtpPacket: add abs-capture-time RTP extension API

### DIFF
--- a/worker/include/Logger.hpp
+++ b/worker/include/Logger.hpp
@@ -365,7 +365,8 @@ public:
 		const char* spaces = (indentation == 1) ? "  " : \
 			((indentation == 2) ? "    " : \
 			((indentation == 3) ? "      " : \
-			((indentation == 4) ? "        " : ""))); \
+			((indentation == 4) ? "        " :\
+			((indentation == 5) ? "          " : "")))); \
 		const int loggerWritten = std::snprintf(Logger::buffer, Logger::BufferSize, "X%s" desc, spaces, ##__VA_ARGS__); \
 		Logger::channel->SendLog(Logger::buffer, static_cast<uint32_t>(loggerWritten)); \
 	} \
@@ -377,7 +378,8 @@ public:
 		const char* spaces = (indentation == 1) ? "  " : \
 			((indentation == 2) ? "    " : \
 			((indentation == 3) ? "      " : \
-			((indentation == 4) ? "        " : ""))); \
+			((indentation == 4) ? "        " :\
+			((indentation == 5) ? "          " : "")))); \
 		std::fprintf(stdout, "%s" desc _MS_LOG_SEPARATOR_CHAR_STD, spaces, ##__VA_ARGS__); \
 		std::fflush(stdout); \
 	} \

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -87,6 +87,7 @@ namespace RTC
 
 	public:
 		static const size_t HeaderSize{ 12 };
+
 		static bool IsRtp(const uint8_t* data, size_t len)
 		{
 			// NOTE: RtcpPacket::IsRtcp() must always be called before this method.
@@ -269,6 +270,11 @@ namespace RTC
 			this->videoOrientationExtensionId = id;
 		}
 
+		void SetAbsCaptureTimeExtensionId(uint8_t id)
+		{
+			this->absCaptureTimeExtensionId = id;
+		}
+
 		void SetPlayoutDelayExtensionId(uint8_t id)
 		{
 			this->playoutDelayExtensionId = id;
@@ -433,6 +439,34 @@ namespace RTC
 					break;
 				default:
 					rotation = 0;
+			}
+
+			return true;
+		}
+
+		bool ReadAbsCaptureTime(uint64_t& absCaptureTimestamp, int64_t& estimatedCaptureClockOffset) const
+		{
+			uint8_t extenLen;
+			uint8_t* extenValue = GetExtension(this->absCaptureTimeExtensionId, extenLen);
+
+			// Extension value can be 8 or 16 bytes depending on whether it contains
+			// estimated capture clock offset or not.
+			//
+			// https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time
+			if (!extenValue || (extenLen != 8u && extenLen != 16u))
+			{
+				return false;
+			}
+
+			absCaptureTimestamp = Utils::Byte::Get8Bytes(extenValue, 0);
+
+			if (extenLen == 16)
+			{
+				estimatedCaptureClockOffset = static_cast<int64_t>(Utils::Byte::Get8Bytes(extenValue, 8));
+			}
+			else
+			{
+				estimatedCaptureClockOffset = 0;
 			}
 
 			return true;
@@ -673,6 +707,7 @@ namespace RTC
 		uint8_t transportWideCc01ExtensionId{ 0u };
 		uint8_t ssrcAudioLevelExtensionId{ 0u };
 		uint8_t videoOrientationExtensionId{ 0u };
+		uint8_t absCaptureTimeExtensionId{ 0u };
 		uint8_t playoutDelayExtensionId{ 0u };
 		uint8_t dependencyDescriptorExtensionId{ 0u };
 		uint8_t* payload{ nullptr };

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1410,6 +1410,8 @@ namespace RTC
 			  static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::SSRC_AUDIO_LEVEL));
 			packet->SetVideoOrientationExtensionId(
 			  static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::VIDEO_ORIENTATION));
+			packet->SetAbsCaptureTimeExtensionId(
+			  static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::ABS_CAPTURE_TIME));
 			packet->SetPlayoutDelayExtensionId(
 			  static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::PLAYOUT_DELAY));
 			packet->SetDependencyDescriptorExtensionId(

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -1,3 +1,4 @@
+#include <cstdint>
 #define MS_CLASS "RTC::RtpPacket"
 // #define MS_LOG_DEV_LEVEL 3
 // #define DUMP_PAYLOAD_DESCRIPTOR 1
@@ -172,7 +173,15 @@ namespace RTC
 		MS_TRACE();
 
 		MS_DUMP_CLEAN(indentation, "<RtpPacket>");
+		MS_DUMP_CLEAN(indentation, "  packet size: %zu bytes", GetSize());
+		MS_DUMP_CLEAN(indentation, "  sequence number: %" PRIu16, GetSequenceNumber());
+		MS_DUMP_CLEAN(indentation, "  timestamp: %" PRIu32, GetTimestamp());
+		MS_DUMP_CLEAN(indentation, "  marker: %s", HasMarker() ? "true" : "false");
+		MS_DUMP_CLEAN(indentation, "  payload type: %" PRIu8, GetPayloadType());
+		MS_DUMP_CLEAN(indentation, "  ssrc: %" PRIu32, GetSsrc());
+		MS_DUMP_CLEAN(indentation, "  csrc count: %" PRIu8, this->header->csrcCount);
 		MS_DUMP_CLEAN(indentation, "  padding: %s", this->header->padding ? "true" : "false");
+
 		if (HasHeaderExtension())
 		{
 			MS_DUMP_CLEAN(
@@ -181,14 +190,17 @@ namespace RTC
 			  GetHeaderExtensionId(),
 			  GetHeaderExtensionLength());
 		}
+
 		if (HasOneByteExtensions())
 		{
 			MS_DUMP_CLEAN(indentation, "  RFC5285 ext style: One-Byte Header");
 		}
+
 		if (HasTwoBytesExtensions())
 		{
 			MS_DUMP_CLEAN(indentation, "  RFC5285 ext style: Two-Bytes Header");
 		}
+
 		if (HasOneByteExtensions() || HasTwoBytesExtensions())
 		{
 			std::vector<std::string> extIds;
@@ -223,6 +235,7 @@ namespace RTC
 				MS_DUMP_CLEAN(indentation, "  RFC5285 ext ids: %s", extIdsStream.str().c_str());
 			}
 		}
+
 		if (this->midExtensionId != 0u)
 		{
 			std::string mid;
@@ -233,6 +246,7 @@ namespace RTC
 				  indentation, "  mid: extId:%" PRIu8 ", value:'%s'", this->midExtensionId, mid.c_str());
 			}
 		}
+
 		if (this->ridExtensionId != 0u)
 		{
 			std::string rid;
@@ -243,6 +257,7 @@ namespace RTC
 				  indentation, "  rid: extId:%" PRIu8 ", value:'%s'", this->ridExtensionId, rid.c_str());
 			}
 		}
+
 		if (this->rridExtensionId != 0u)
 		{
 			std::string rid;
@@ -253,10 +268,12 @@ namespace RTC
 				  indentation, "  rrid: extId:%" PRIu8 ", value:'%s'", this->rridExtensionId, rid.c_str());
 			}
 		}
+
 		if (this->absSendTimeExtensionId != 0u)
 		{
 			MS_DUMP_CLEAN(indentation, "  absSendTime: extId:%" PRIu8, this->absSendTimeExtensionId);
 		}
+
 		if (this->transportWideCc01ExtensionId != 0u)
 		{
 			uint16_t wideSeqNumber{ 0 };
@@ -270,6 +287,7 @@ namespace RTC
 				  wideSeqNumber);
 			}
 		}
+
 		if (this->ssrcAudioLevelExtensionId != 0u)
 		{
 			uint8_t volume{ 0 };
@@ -285,6 +303,7 @@ namespace RTC
 				  voice ? "true" : "false");
 			}
 		}
+
 		if (this->videoOrientationExtensionId != 0u)
 		{
 			bool camera{ false };
@@ -302,6 +321,24 @@ namespace RTC
 				  rotation);
 			}
 		}
+
+		if (this->absCaptureTimeExtensionId != 0u)
+		{
+			uint64_t absCaptureTimestamp{ 0u };
+			int64_t estimatedCaptureClockOffset{ 0 };
+
+			if (ReadAbsCaptureTime(absCaptureTimestamp, estimatedCaptureClockOffset))
+			{
+				MS_DUMP_CLEAN(
+				  indentation,
+				  "  absCaptureTime: extId:%" PRIu8 ", absCaptureTimestamp:%" PRIu64
+				  ", estimatedCaptureClockOffset:%" PRId64,
+				  this->absCaptureTimeExtensionId,
+				  absCaptureTimestamp,
+				  estimatedCaptureClockOffset);
+			}
+		}
+
 		if (this->playoutDelayExtensionId != 0u)
 		{
 			uint16_t minDelay{ 0 };
@@ -312,11 +349,12 @@ namespace RTC
 				MS_DUMP_CLEAN(
 				  indentation,
 				  "  playoutDelay: extId:%" PRIu8 ", minDelay:%" PRIu16 ", maxDelay:%" PRIu16,
-				  this->videoOrientationExtensionId,
+				  this->playoutDelayExtensionId,
 				  minDelay,
 				  maxDelay);
 			}
 		}
+
 		if (this->dependencyDescriptorExtensionId != 0u)
 		{
 			uint8_t extenLen;
@@ -332,18 +370,12 @@ namespace RTC
 			}
 		}
 
-		MS_DUMP_CLEAN(indentation, "  csrc count: %" PRIu8, this->header->csrcCount);
-		MS_DUMP_CLEAN(indentation, "  marker: %s", HasMarker() ? "true" : "false");
-		MS_DUMP_CLEAN(indentation, "  payload type: %" PRIu8, GetPayloadType());
-		MS_DUMP_CLEAN(indentation, "  sequence number: %" PRIu16, GetSequenceNumber());
-		MS_DUMP_CLEAN(indentation, "  timestamp: %" PRIu32, GetTimestamp());
-		MS_DUMP_CLEAN(indentation, "  ssrc: %" PRIu32, GetSsrc());
 		MS_DUMP_CLEAN(indentation, "  payload size: %zu bytes", GetPayloadLength());
 		if (this->header->padding != 0u)
 		{
 			MS_DUMP_CLEAN(indentation, "  padding size: %" PRIu8 " bytes", this->payloadPadding);
 		}
-		MS_DUMP_CLEAN(indentation, "  packet size: %zu bytes", GetSize());
+
 		MS_DUMP_CLEAN(indentation, "  spatial layer: %" PRIu8, GetSpatialLayer());
 		MS_DUMP_CLEAN(indentation, "  temporal layer: %" PRIu8, GetTemporalLayer());
 #ifdef DUMP_PAYLOAD_DESCRIPTOR
@@ -423,6 +455,7 @@ namespace RTC
 		this->transportWideCc01ExtensionId    = 0u;
 		this->ssrcAudioLevelExtensionId       = 0u;
 		this->videoOrientationExtensionId     = 0u;
+		this->absCaptureTimeExtensionId       = 0u;
 		this->playoutDelayExtensionId         = 0u;
 		this->dependencyDescriptorExtensionId = 0u;
 
@@ -802,6 +835,7 @@ namespace RTC
 		packet->transportWideCc01ExtensionId    = this->transportWideCc01ExtensionId;
 		packet->ssrcAudioLevelExtensionId       = this->ssrcAudioLevelExtensionId;
 		packet->videoOrientationExtensionId     = this->videoOrientationExtensionId;
+		packet->absCaptureTimeExtensionId       = this->absCaptureTimeExtensionId;
 		packet->playoutDelayExtensionId         = this->playoutDelayExtensionId;
 		packet->dependencyDescriptorExtensionId = this->dependencyDescriptorExtensionId;
 		// Assign the payload descriptor handler.

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -697,6 +697,12 @@ namespace RTC
 					  producerRtpHeaderExtensionIds.transportWideCc01;
 				}
 
+				if (producerRtpHeaderExtensionIds.absCaptureTime != 0u)
+				{
+					this->recvRtpHeaderExtensionIds.absCaptureTime =
+					  producerRtpHeaderExtensionIds.absCaptureTime;
+				}
+
 				// Create status response.
 				auto responseOffset = FBS::Transport::CreateProduceResponse(
 				  request->GetBufferBuilder(), FBS::RtpParameters::Type(producer->GetType()));
@@ -1562,6 +1568,7 @@ namespace RTC
 		packet->SetRepairedRidExtensionId(this->recvRtpHeaderExtensionIds.rrid);
 		packet->SetAbsSendTimeExtensionId(this->recvRtpHeaderExtensionIds.absSendTime);
 		packet->SetTransportWideCc01ExtensionId(this->recvRtpHeaderExtensionIds.transportWideCc01);
+		packet->SetAbsCaptureTimeExtensionId(this->recvRtpHeaderExtensionIds.absCaptureTime);
 
 		auto nowMs = DepLibUV::GetTimeMs();
 

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -538,7 +538,6 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetPayloadLength() == 12);
 		REQUIRE(packet->GetPayloadPadding() == 4);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
-		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
 
@@ -607,7 +606,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		packet->SetExtensions(1, extensions);
 
-		REQUIRE(packet->GetSize() == 60); // Takinng into account padding in header extension.
+		REQUIRE(packet->GetSize() == 60); // Taking into account padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
 		REQUIRE(packet->GetHeaderExtensionLength() == 28); // 25 + 3 bytes for padding.
@@ -782,7 +781,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		packet->SetExtensions(2, extensions);
 
-		REQUIRE(packet->GetSize() == 72); // Takinng into account padding in header extension.
+		REQUIRE(packet->GetSize() == 72); // Taking into account padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0b0001000000000000);
 		REQUIRE(packet->GetHeaderExtensionLength() == 40); // 39 + 1 byte for padding.

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -507,6 +507,14 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00
 		};
 		// clang-format on
@@ -529,6 +537,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
 		REQUIRE(packet->GetPayloadPadding() == 4);
+		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() + packet->GetPayloadPadding() - 1] == 4);
 		REQUIRE(packet->GetPayload()[0] == 0x11);
 		REQUIRE(packet->GetPayload()[packet->GetPayloadLength() - 1] == 0xCC);
@@ -588,12 +597,20 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value2 // value
 		);
 
+		uint8_t value3[] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77 };
+
+		extensions.emplace_back(
+		  5,     // id
+		  8,     // len
+		  value3 // value
+		);
+
 		packet->SetExtensions(1, extensions);
 
-		REQUIRE(packet->GetSize() == 52); // 49 + 3 bytes for padding in header extension.
+		REQUIRE(packet->GetSize() == 60); // Takinng into account padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0xBEDE);
-		REQUIRE(packet->GetHeaderExtensionLength() == 20); // 17 + 3 bytes for padding.
+		REQUIRE(packet->GetHeaderExtensionLength() == 28); // 25 + 3 bytes for padding.
 		REQUIRE(packet->HasOneByteExtensions() == true);
 		REQUIRE(packet->HasTwoBytesExtensions() == false);
 		REQUIRE(packet->GetPayloadLength() == 12);
@@ -613,15 +630,18 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetExtension(2, extenLen));
 		REQUIRE(packet->HasExtension(2) == true);
 		REQUIRE(extenLen == 11);
+		REQUIRE(packet->GetExtension(5, extenLen));
+		REQUIRE(packet->HasExtension(5) == true);
+		REQUIRE(extenLen == 8);
 
 		extensions.clear();
 
-		uint8_t value3[] = { 0x01, 0x02, 0x03, 0x04 };
+		uint8_t value4[] = { 0x01, 0x02, 0x03, 0x04 };
 
 		extensions.emplace_back(
 		  14,    // id
 		  4,     // len
-		  value3 // value
+		  value4 // value
 		);
 
 		packet->SetExtensions(1, extensions);
@@ -671,6 +691,12 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 			0x99, 0xaa, 0xbb, 0xcc,
 			0x00, 0x00, 0x00, 0x04, // 4 padding bytes
 			// Extra buffer
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
+			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,
 			0x00, 0x00, 0x00, 0x00,
@@ -745,12 +771,21 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value2 // value
 		);
 
+		uint8_t value3[] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+			                   0x01, 0x12, 0x23, 0x34, 0x45, 0x56, 0x67, 0x78 };
+
+		extensions.emplace_back(
+		  5,     // id
+		  16,    // len
+		  value3 // value
+		);
+
 		packet->SetExtensions(2, extensions);
 
-		REQUIRE(packet->GetSize() == 52); // 51 + 1 byte for padding in header extension.
+		REQUIRE(packet->GetSize() == 72); // Takinng into account padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
 		REQUIRE(packet->GetHeaderExtensionId() == 0b0001000000000000);
-		REQUIRE(packet->GetHeaderExtensionLength() == 20); // 19 + 1 byte for padding.
+		REQUIRE(packet->GetHeaderExtensionLength() == 40); // 39 + 1 byte for padding.
 		REQUIRE(packet->HasOneByteExtensions() == false);
 		REQUIRE(packet->HasTwoBytesExtensions() == true);
 		REQUIRE(packet->GetPayloadLength() == 12);
@@ -778,15 +813,18 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		REQUIRE(packet->GetExtension(22, extenLen));
 		REQUIRE(packet->HasExtension(22) == true);
 		REQUIRE(extenLen == 11);
+		REQUIRE(packet->GetExtension(5, extenLen));
+		REQUIRE(packet->HasExtension(5) == true);
+		REQUIRE(extenLen == 16);
 
 		extensions.clear();
 
-		uint8_t value3[] = { 0x01, 0x02, 0x03, 0x04 };
+		uint8_t value4[] = { 0x01, 0x02, 0x03, 0x04 };
 
 		extensions.emplace_back(
 		  24,    // id
 		  4,     // len
-		  value3 // value
+		  value4 // value
 		);
 
 		packet->SetExtensions(2, extensions);


### PR DESCRIPTION
Because of course we accepted an external PR that didn't do it: https://github.com/versatica/mediasoup/pull/761

Result:
```
<RtpPacket>
  packet size: 645 bytes
  sequence number: 24612
  timestamp: 2233432389
  marker: false
  payload type: 101
  ssrc: 447540820
  csrc count: 0
  padding: false
  header extension: id:48862, length:36
  RFC5285 ext style: One-Byte Header
  RFC5285 ext ids: 1,4,5,13
  mid: extId:1, value:'0'
  absSendTime: extId:4
  transportWideCc01: extId:5, value:0
  absCaptureTime: extId:13, absCaptureTimestamp:17050879188517931008, estimatedCaptureClockOffset:0
  payload size: 593 bytes
  spatial layer: 0
  temporal layer: 2
</RtpPacket>
```
