### PR TITLE
AV1: do not forward Dependency Descriptor header extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- AV1 : Set DependencyDescriptor Header Extension to 'recvonly' but forward it between pipe transports ([#1632](https://github.com/versatica/mediasoup/pull/1632))
+- AV1 : Set DependencyDescriptor Header Extension to 'recvonly' but forward it between pipe transports ([#1632](https://github.com/versatica/mediasoup/pull/1632)).
 
 ### 3.19.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- AV1 : Set DependencyDescriptor Header Extension to 'recvonly' but forward it between pipe transports ([#1632](https://github.com/versatica/mediasoup/pull/1632)).
+- AV1: Set DependencyDescriptor Header Extension to 'recvonly' but forward it between pipe transports ([#1632](https://github.com/versatica/mediasoup/pull/1632)).
 
 ### 3.19.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- AV1 : Set DependencyDescriptor Header Extension to 'recvonly' but forward it between pipe transports ([#1632](https://github.com/versatica/mediasoup/pull/1632))
+
 ### 3.19.5
 
 - Add custom 'urn:mediasoup:params:rtp-hdrext:packet-id' (mediasoup-packet-id) header extension ([#1631](https://github.com/versatica/mediasoup/pull/1631)).

--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -40,6 +40,18 @@ const DynamicPayloadTypes = [
 	99,
 ];
 
+// TODO: Remove this if we switch to 'sendrecv' in Dependency-Descriptor header
+// extension.
+//
+// This is an object where we store some objects we may later need.
+type Cache = {
+	dependencyDescriptorHeaderExtensionParametersForPipeConsumer?: RtpHeaderExtensionParameters;
+};
+
+const cache: Cache = {
+	dependencyDescriptorHeaderExtensionParametersForPipeConsumer: undefined,
+};
+
 /**
  * Validates RtpCapabilities. It may modify given data by adding missing
  * fields with default values.
@@ -298,6 +310,32 @@ export function generateRouterRtpCapabilities(
 			// Append to the codec list.
 			caps.codecs!.push(rtxCodec);
 		}
+	}
+
+	// TODO: Remove this if we switch to 'sendrecv' in Dependency-Descriptor header
+	// extension.
+	//
+	// We need to create and store this Dependency-Descriptor header extension to
+	// leter be used by `getPipeConsumerRtpParameters()` function.
+	const dependencyDescriptorHeaderExtensionForPipeConsumer:
+		| RtpHeaderExtension
+		| undefined = supportedRtpCapabilities.headerExtensions!.find(
+		headerExtension =>
+			headerExtension.uri ===
+			'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension'
+	);
+
+	if (
+		dependencyDescriptorHeaderExtensionForPipeConsumer &&
+		dependencyDescriptorHeaderExtensionForPipeConsumer.direction !== 'sendrecv'
+	) {
+		cache.dependencyDescriptorHeaderExtensionParametersForPipeConsumer = {
+			uri: dependencyDescriptorHeaderExtensionForPipeConsumer.uri,
+			id: dependencyDescriptorHeaderExtensionForPipeConsumer.preferredId,
+			encrypt:
+				dependencyDescriptorHeaderExtensionForPipeConsumer.preferredEncrypt,
+			parameters: {},
+		};
 	}
 
 	return caps;
@@ -786,6 +824,17 @@ export function getPipeConsumerRtpParameters({
 				ext.uri !==
 					'http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01'
 		);
+
+	// TODO: Remove this if we switch to 'sendrecv' in Dependency-Descriptor header
+	// extension.
+	//
+	// We need to add Dependency-Descriptor header extension manually since it's
+	// 'recvonly' so it's not present in received `consumableRtpParameters`.
+	if (cache.dependencyDescriptorHeaderExtensionParametersForPipeConsumer) {
+		consumerParams.headerExtensions.push(
+			cache.dependencyDescriptorHeaderExtensionParametersForPipeConsumer
+		);
+	}
 
 	const consumableEncodings =
 		utils.clone<RtpEncodingParameters[] | undefined>(

--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -834,6 +834,9 @@ export function getPipeConsumerRtpParameters({
 		consumerParams.headerExtensions.push(
 			cache.dependencyDescriptorHeaderExtensionParametersForPipeConsumer
 		);
+
+		// Sort header extensions by ID.
+		consumerParams.headerExtensions.sort((a, b) => a.id - b.id);
 	}
 
 	const consumableEncodings =

--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -322,13 +322,11 @@ export function generateRouterRtpCapabilities(
 		| undefined = supportedRtpCapabilities.headerExtensions!.find(
 		headerExtension =>
 			headerExtension.uri ===
-			'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension'
+				'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension' &&
+			headerExtension.direction !== 'sendrecv'
 	);
 
-	if (
-		dependencyDescriptorHeaderExtensionForPipeConsumer &&
-		dependencyDescriptorHeaderExtensionForPipeConsumer.direction !== 'sendrecv'
-	) {
+	if (dependencyDescriptorHeaderExtensionForPipeConsumer) {
 		cache.dependencyDescriptorHeaderExtensionParametersForPipeConsumer = {
 			uri: dependencyDescriptorHeaderExtensionForPipeConsumer.uri,
 			id: dependencyDescriptorHeaderExtensionForPipeConsumer.preferredId,

--- a/node/src/supportedRtpCapabilities.ts
+++ b/node/src/supportedRtpCapabilities.ts
@@ -273,7 +273,7 @@ const supportedRtpCapabilities: RouterRtpCapabilities = {
 			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
 			preferredId: 7,
 			preferredEncrypt: false,
-			direction: 'sendrecv',
+			direction: 'recvonly',
 		},
 		{
 			kind: 'video',

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -266,6 +266,12 @@ test('router.pipeToRouter() succeeds with audio', async () => {
 			parameters: {},
 		},
 		{
+			encrypt: false,
+			id: 7,
+			parameters: {},
+			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
+		},
+		{
 			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
 			id: 10,
 			encrypt: false,
@@ -318,6 +324,12 @@ test('router.pipeToRouter() succeeds with audio', async () => {
 			id: 6,
 			encrypt: false,
 			parameters: {},
+		},
+		{
+			encrypt: false,
+			id: 7,
+			parameters: {},
+			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
 		},
 		{
 			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -408,13 +408,15 @@ pub(crate) fn generate_router_rtp_capabilities(
         .find(|ext| ext.uri == RtpHeaderExtensionUri::DependencyDescriptor);
 
     if let Some(dependency_descriptor) = dependency_descriptor_header_extension_for_pipe_consumer {
-        let mut cache = CACHE.lock();
-        cache.dependency_descriptor_header_extension_parameters_for_pipe_consumer =
-            Some(RtpHeaderExtensionParameters {
-                uri: dependency_descriptor.uri,
-                id: dependency_descriptor.preferred_id,
-                encrypt: dependency_descriptor.preferred_encrypt,
-            });
+        if dependency_descriptor.direction != RtpHeaderExtensionDirection::SendRecv {
+            let mut cache = CACHE.lock();
+            cache.dependency_descriptor_header_extension_parameters_for_pipe_consumer =
+                Some(RtpHeaderExtensionParameters {
+                    uri: dependency_descriptor.uri,
+                    id: dependency_descriptor.preferred_id,
+                    encrypt: dependency_descriptor.preferred_encrypt,
+                });
+        }
     }
 
     Ok(caps)

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -9,6 +9,8 @@ use mediasoup_types::rtp_parameters::{
     RtpHeaderExtensionParameters, RtpHeaderExtensionUri, RtpParameters,
 };
 use mediasoup_types::scalability_modes::ScalabilityMode;
+use once_cell::sync::Lazy;
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 use std::collections::BTreeMap;
@@ -26,6 +28,21 @@ const DYNAMIC_PAYLOAD_TYPES: &[u8] = &[
     100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118,
     119, 120, 121, 122, 123, 124, 125, 126, 127, 96, 97, 98, 99,
 ];
+
+// TODO: Remove this if we switch to 'sendrecv' in Dependency-Descriptor header
+// extension.
+//
+// This is an object where we store some objects we may later need.
+struct Cache {
+    pub dependency_descriptor_header_extension_parameters_for_pipe_consumer:
+        Option<RtpHeaderExtensionParameters>,
+}
+
+static CACHE: Lazy<Mutex<Cache>> = Lazy::new(|| {
+    Mutex::new(Cache {
+        dependency_descriptor_header_extension_parameters_for_pipe_consumer: None,
+    })
+});
 
 #[doc(hidden)]
 #[derive(Debug, Default, Copy, Clone, Ord, PartialOrd, Eq, PartialEq, Deserialize, Serialize)]
@@ -378,6 +395,26 @@ pub(crate) fn generate_router_rtp_capabilities(
             // Append to the codec list.
             caps.codecs.push(codec_finalized);
         }
+    }
+
+    // TODO: Remove this if we switch to 'sendrecv' in Dependency-Descriptor header
+    // extension.
+    //
+    // We need to create and store this Dependency-Descriptor header extension to
+    // leter be used by `getPipeConsumerRtpParameters()` function.
+    let dependency_descriptor_header_extension_for_pipe_consumer = caps
+        .header_extensions
+        .iter()
+        .find(|ext| ext.uri == RtpHeaderExtensionUri::DependencyDescriptor);
+
+    if let Some(dependency_descriptor) = dependency_descriptor_header_extension_for_pipe_consumer {
+        let mut cache = CACHE.lock();
+        cache.dependency_descriptor_header_extension_parameters_for_pipe_consumer =
+            Some(RtpHeaderExtensionParameters {
+                uri: dependency_descriptor.uri,
+                id: dependency_descriptor.preferred_id,
+                encrypt: dependency_descriptor.preferred_encrypt,
+            });
     }
 
     Ok(caps)
@@ -924,6 +961,23 @@ pub(crate) fn get_pipe_consumer_rtp_parameters(
         })
         .cloned()
         .collect();
+
+    // TODO: Remove this if we switch to 'sendrecv' in Dependency-Descriptor header
+    // extension.
+    //
+    // We need to add Dependency-Descriptor header extension manually since it's
+    // 'recvonly' so it's not present in received `consumableRtpParameters`.
+    let cache = CACHE.lock();
+    if let Some(dependency_descriptor) =
+        &cache.dependency_descriptor_header_extension_parameters_for_pipe_consumer
+    {
+        consumer_params
+            .header_extensions
+            .push(dependency_descriptor.clone());
+
+        // Sort header extensions by ID.
+        consumer_params.header_extensions.sort_by_key(|ext| ext.id);
+    }
 
     for ((encoding, ssrc), rtx_ssrc) in consumable_rtp_parameters
         .encodings

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -402,10 +402,11 @@ pub(crate) fn generate_router_rtp_capabilities(
     //
     // We need to create and store this Dependency-Descriptor header extension to
     // leter be used by `getPipeConsumerRtpParameters()` function.
-    let dependency_descriptor_header_extension_for_pipe_consumer = caps
-        .header_extensions
-        .iter()
-        .find(|ext| ext.uri == RtpHeaderExtensionUri::DependencyDescriptor);
+    let dependency_descriptor_header_extension_for_pipe_consumer =
+        caps.header_extensions.iter().find(|ext| {
+            ext.uri == RtpHeaderExtensionUri::DependencyDescriptor
+                && ext.direction != RtpHeaderExtensionDirection::SendRecv
+        });
 
     if let Some(dependency_descriptor) = dependency_descriptor_header_extension_for_pipe_consumer {
         if dependency_descriptor.direction != RtpHeaderExtensionDirection::SendRecv {

--- a/rust/src/supported_rtp_capabilities.rs
+++ b/rust/src/supported_rtp_capabilities.rs
@@ -329,7 +329,7 @@ pub fn get_supported_rtp_capabilities() -> RtpCapabilities {
                 uri: RtpHeaderExtensionUri::DependencyDescriptor,
                 preferred_id: 7,
                 preferred_encrypt: false,
-                direction: RtpHeaderExtensionDirection::SendRecv,
+                direction: RtpHeaderExtensionDirection::RecvOnly,
             },
             RtpHeaderExtension {
                 kind: MediaKind::Video,

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -348,6 +348,11 @@ fn pipe_to_router_succeeds_with_audio() {
                     encrypt: false,
                 },
                 RtpHeaderExtensionParameters {
+                    uri: RtpHeaderExtensionUri::DependencyDescriptor,
+                    id: 7,
+                    encrypt: false,
+                },
+                RtpHeaderExtensionParameters {
                     uri: RtpHeaderExtensionUri::AbsCaptureTime,
                     id: 10,
                     encrypt: false,
@@ -400,6 +405,11 @@ fn pipe_to_router_succeeds_with_audio() {
                 RtpHeaderExtensionParameters {
                     uri: RtpHeaderExtensionUri::SsrcAudioLevel,
                     id: 6,
+                    encrypt: false,
+                },
+                RtpHeaderExtensionParameters {
+                    uri: RtpHeaderExtensionUri::DependencyDescriptor,
+                    id: 7,
                     encrypt: false,
                 },
                 RtpHeaderExtensionParameters {

--- a/worker/src/RTC/Codecs/AV1.cpp
+++ b/worker/src/RTC/Codecs/AV1.cpp
@@ -256,14 +256,15 @@ namespace RTC
 				context->SetCurrentTemporalLayer(tmpTemporalLayer);
 			}
 
-			// Store the encoding data for retransmissions.
-			// clang-format off
-			this->payloadDescriptor->CreateEncoder({
-			  static_cast<uint32_t>(context->GetCurrentSpatialLayer()),
-			  static_cast<uint32_t>(context->GetCurrentTemporalLayer())
-			});
-			// clang-format on
-			this->payloadDescriptor->Encode();
+			// TODO: Enable once we rewrite the Dependency Descriptor header extension.
+			// // Store the encoding data for retransmissions.
+			// // clang-format off
+			// this->payloadDescriptor->CreateEncoder({
+			//   static_cast<uint32_t>(context->GetCurrentSpatialLayer()),
+			//   static_cast<uint32_t>(context->GetCurrentTemporalLayer())
+			// });
+			// // clang-format on
+			// this->payloadDescriptor->Encode();
 
 			return true;
 		}

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1347,10 +1347,6 @@ namespace RTC
 				{
 					std::memcpy(bufferPtr, extenValue, extenLen);
 
-					// Make place for the active decode target bitmask by adding 5 bytes
-					// to the original length in the received packet.
-					extenLen += 5u;
-
 					extensions.emplace_back(
 					  static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::DEPENDENCY_DESCRIPTOR),
 					  extenLen,

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -737,7 +737,8 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstreamsend
 
 		packet->ReadDependencyDescriptor(dependencyDescriptor4, templateDependencyStructure);
 		REQUIRE(dependencyDescriptor4);
-		REQUIRE(dependencyDescriptor4->activeDecodeTargetsBitmask == 0b0000000000000001);
+		// TODO: Enable once we write DD.
+		// REQUIRE(dependencyDescriptor4->activeDecodeTargetsBitmask == 0b0000000000000001);
 
 		// Process the NACK packet on stream2.
 		stream2->ReceiveNack(&nackPacket);
@@ -751,7 +752,8 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstreamsend
 
 		packet->ReadDependencyDescriptor(dependencyDescriptor5, templateDependencyStructure);
 		REQUIRE(dependencyDescriptor5);
-		REQUIRE(dependencyDescriptor5->activeDecodeTargetsBitmask == 0b0000000000000011);
+		// TODO: Enable once we write DD.
+		// REQUIRE(dependencyDescriptor5->activeDecodeTargetsBitmask == 0b0000000000000011);
 	}
 
 	SECTION("packets get retransmitted as long as they don't exceed MaxRetransmissionDelayForVideoMs")


### PR DESCRIPTION
Do not forward to the endpoints but do forward it to the pipe producers so pipe SvcConsumers can read it.