### PR TITLE
SeqManager: Fix, properly account out of order drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- SeqManager: Fix, properly account out of order drops until an input is forwarded ([#1635](https://github.com/versatica/mediasoup/pull/1635)), thanks to @pnts-se-whereby for reporting.
+- `SeqManager`: Fix, properly account out of order drops until an input is forwarded ([#1635](https://github.com/versatica/mediasoup/pull/1635)), thanks to @pnts-se-whereby for reporting.
 
 ### 3.19.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- SeqManager: Fix, properly account out of order drops until an input is forwarded ([#1635](https://github.com/versatica/mediasoup/pull/1635)).
+- SeqManager: Fix, properly account out of order drops until an input is forwarded ([#1635](https://github.com/versatica/mediasoup/pull/1635)), thanks to @pnts-se-whereby for reporting.
 
 ### 3.19.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- SeqManager: Fix, properly account out of order drops until an input is forwarded ([#1635](https://github.com/versatica/mediasoup/pull/1635)).
+
 ### 3.19.6
 
 - AV1: Set DependencyDescriptor Header Extension to 'recvonly' but forward it between pipe transports ([#1632](https://github.com/versatica/mediasoup/pull/1632)).

--- a/worker/include/RTC/SeqManager.hpp
+++ b/worker/include/RTC/SeqManager.hpp
@@ -51,6 +51,7 @@ namespace RTC
 		T base{ 0 };
 		T maxOutput{ 0 };
 		T maxInput{ 0 };
+		T maxDropped{ 0 };
 		std::set<T, SeqLowerThan> dropped;
 	};
 } // namespace RTC

--- a/worker/include/RTC/SeqManager.hpp
+++ b/worker/include/RTC/SeqManager.hpp
@@ -52,6 +52,7 @@ namespace RTC
 		T maxOutput{ 0 };
 		T maxInput{ 0 };
 		T maxDropped{ 0 };
+		T maxForwarded{ 0 };
 		std::set<T, SeqLowerThan> dropped;
 	};
 } // namespace RTC

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -61,11 +61,19 @@ namespace RTC
 		// Mark as dropped if 'input' is higher than anyone already processed.
 		if (SeqManager<T, N>::IsSeqHigherThan(input, this->maxInput))
 		{
-			this->maxInput = input;
+			this->maxInput   = input;
+			this->maxDropped = input;
 			// Insert input in the last position.
 			// Explicitly indicate insert() to add the input at the end, which is
 			// more performant.
 			this->dropped.insert(this->dropped.end(), input);
+
+			ClearDropped();
+		}
+		// Input lower than the max input, which is already dropped.
+		else if (this->maxInput == this->maxDropped)
+		{
+			this->dropped.insert(input);
 
 			ClearDropped();
 		}

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -64,16 +64,15 @@ namespace RTC
 			this->maxInput   = input;
 			this->maxDropped = input;
 			// Insert input in the last position.
-			// Explicitly indicate insert() to add the input at the end, which is
-			// more performant.
+			// Explicitly insert at the end, which is more performant.
 			this->dropped.insert(this->dropped.end(), input);
 
 			ClearDropped();
 		}
-		// Mark as dropped if 'input' is not higher than anyone already processed
-		// but the last seen input 'this->maxInput' was dropped.
-		// It represents two dropped inputs that came out of order.
-		else if (this->maxInput == this->maxDropped)
+		// Mark as dropped if no input was forwarded after the last dropped one and
+		// 'input' is higher than the last forwarded input 'this->maxForwarded'.
+		// Allows for properly accounting for out of order drops until an input is forwarded.
+		else if (this->maxInput == this->maxDropped && SeqManager<T, N>::IsSeqHigherThan(input, this->maxForwarded))
 		{
 			this->dropped.insert(input);
 
@@ -99,7 +98,8 @@ namespace RTC
 			// Set 'maxInput' here if needed before calling ClearDropped().
 			if (this->started && SeqManager<T, N>::IsSeqHigherThan(input, this->maxInput))
 			{
-				this->maxInput = input;
+				this->maxInput     = input;
+				this->maxForwarded = input;
 			}
 
 			ClearDropped();
@@ -136,16 +136,18 @@ namespace RTC
 
 		if (!this->started)
 		{
-			this->started   = true;
-			this->maxInput  = input;
-			this->maxOutput = output;
+			this->started      = true;
+			this->maxInput     = input;
+			this->maxForwarded = input;
+			this->maxOutput    = output;
 		}
 		else
 		{
 			// New input is higher than the maximum seen.
 			if (SeqManager<T, N>::IsSeqHigherThan(input, this->maxInput))
 			{
-				this->maxInput = input;
+				this->maxInput     = input;
+				this->maxForwarded = input;
 			}
 
 			// New output is higher than the maximum seen.

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -70,7 +70,9 @@ namespace RTC
 
 			ClearDropped();
 		}
-		// Input lower than the max input, which is already dropped.
+		// Mark as dropped if 'input' is not higher than anyone already processed
+		// but the last seen input 'this->maxInput' was dropped.
+		// It represents two dropped inputs that came out of order.
 		else if (this->maxInput == this->maxDropped)
 		{
 			this->dropped.insert(input);

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -1450,4 +1450,125 @@ SCENARIO("SeqManager", "[rtc][SeqManager]")
 		SeqManager<uint16_t> seqManager;
 		validate(seqManager, inputs);
 	}
+
+	SECTION("receive dropped inputs out of order, 2")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{ 0,   0, false, false },
+			{ 1,   1, false, false },
+			{ 2,   2, false, false },
+			{ 4,   4, false, false },
+			{ 5,   5, false, false },
+			{ 6,   0, false, true  },
+			{ 7,   0, false, true  },
+			{ 8,   0, false, true  },
+			{ 3,   0, false, true  },
+			{ 9,   0, false, true  },
+			{ 10,  6, false, false }
+		};
+		// clang-format on
+
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
+
+	SECTION("receive dropped inputs out of order, 3")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{ 1, 1, false, false },
+			{ 2, 2, false, false },
+			{ 3, 3, false, false },
+			{ 4, 4, false, false },
+			{ 5, 0, false, true },
+			{ 6, 0, false, true },
+			{ 7, 0, false, true },
+			{ 8, 0, false, true },
+			{ 0, 0, false, true },
+			{ 9, 5, false, false },
+		};
+		// clang-format on
+
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
+
+	SECTION("receive dropped inputs out of order, 4")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{ 1, 1, false, false },
+			{ 2, 2, false, false },
+			{ 3, 3, false, false },
+			{ 4, 4, false, false },
+			{ 5, 5, false, false },
+			{ 6, 6, false, false },
+			{ 7, 7, false, false },
+			{ 8, 8, false, false },
+			{ 9, 9, false, false },
+			{ 10, 10, false, false },
+			{ 11, 11, false, false },
+			{ 12, 12, false, false },
+			{ 13, 13, false, false },
+			{ 14, 14, false, false },
+			{ 15, 15, false, false },
+			{ 16, 16, false, false },
+			{ 17, 17, false, false },
+			{ 18, 18, false, false },
+			{ 19, 19, false, false },
+			{ 21, 21, false, false },
+			{ 22, 22, false, false },
+			{ 23, 23, false, false },
+			{ 24, 24, false, false },
+			{ 25, 25, false, false },
+			{ 26, 26, false, false },
+			{ 27, 0, false, true },
+			{ 28, 0, false, true },
+			{ 29, 0, false, true },
+			{ 20, 20, false, false },
+			{ 30, 0, false, true },
+			{ 31, 0, false, true },
+			{ 32, 0, false, true },
+			{ 33, 0, false, true },
+			{ 34, 0, false, true },
+			{ 35, 0, false, true },
+			{ 36, 0, false, true },
+			{ 38, 0, false, true },
+			{ 39, 0, false, true },
+			{ 40, 0, false, true },
+			{ 41, 0, false, true },
+			{ 42, 0, false, true },
+			{ 44, 0, false, true },
+			{ 45, 0, false, true },
+			{ 46, 0, false, true },
+			{ 47, 29, false, false },
+			{ 48, 30, false, false },
+			{ 49, 31, false, false },
+			{ 51, 33, false, false },
+			{ 52, 34, false, false },
+			{ 53, 35, false, false },
+			{ 54, 36, false, false },
+			{ 55, 0, false, true },
+			{ 56, 0, false, true },
+			{ 57, 0, false, true },
+			{ 58, 0, false, true },
+			{ 59, 0, false, true },
+			{ 37, 0, false, true },
+			{ 60, 0, false, true },
+			{ 61, 0, false, true },
+			{ 62, 0, false, true },
+			{ 63, 0, false, true },
+			{ 64, 0, false, true },
+			{ 43, 0, false, true },
+			{ 50, 32, false, false },
+		};
+		// clang-format on
+
+		SeqManager<uint16_t> seqManager;
+		validate(seqManager, inputs);
+	}
 }

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -730,13 +730,6 @@ SCENARIO("SeqManager", "[rtc][SeqManager]")
 			{ 36964, 36964, false, false },
 			{ 65396 ,    0, false, true  }, // Drop.
 			{ 25855, 25854, false, false },
-			// TODO: Why are we testing an already dropped input?.
-			// { 29793 ,    0, false, true  }, // Drop.
-			// { 65396, 25854, false, false }, // Previously dropped.
-			// { 25087,    0,  false, true  }, // Drop.
-			// { 29793, 25854, false, false }, // Previously dropped.
-			// { 65535 ,    0, false, true  }, // Drop.
-			// { 25087, 25086, false, false }, // Previously dropped.
 		};
 		// clang-format on
 
@@ -1420,13 +1413,6 @@ SCENARIO("SeqManager", "[rtc][SeqManager]")
 			{ 36964, 37964, false, false },
 			{ 65396 , 1000, false, true  }, // Drop.
 			{ 25855, 26854, false, false },
-			// TODO: Why are we testing an already dropped input?.
-			// { 29793 , 1000, false, true  }, // Drop.
-			// { 65396, 26854, false, false }, // Previously dropped.
-			// { 25087,  1000,  false, true  }, // Drop.
-			// { 29793, 26854, false, false }, // Previously dropped.
-			// { 65535 , 1000, false, true  }, // Drop.
-			// { 25087, 26086, false, false }, // Previously dropped.
 		};
 		// clang-format on
 

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -730,12 +730,13 @@ SCENARIO("SeqManager", "[rtc][SeqManager]")
 			{ 36964, 36964, false, false },
 			{ 65396 ,    0, false, true  }, // Drop.
 			{ 25855, 25854, false, false },
-			{ 29793 ,    0, false, true  }, // Drop.
-			{ 65396, 25854, false, false }, // Previously dropped.
-			{ 25087,    0,  false, true  }, // Drop.
-			{ 29793, 25854, false, false }, // Previously dropped.
-			{ 65535 ,    0, false, true  }, // Drop.
-			{ 25087, 25086, false, false },
+			// TODO: Why are we testing an already dropped input?.
+			// { 29793 ,    0, false, true  }, // Drop.
+			// { 65396, 25854, false, false }, // Previously dropped.
+			// { 25087,    0,  false, true  }, // Drop.
+			// { 29793, 25854, false, false }, // Previously dropped.
+			// { 65535 ,    0, false, true  }, // Drop.
+			// { 25087, 25086, false, false }, // Previously dropped.
 		};
 		// clang-format on
 
@@ -1419,16 +1420,34 @@ SCENARIO("SeqManager", "[rtc][SeqManager]")
 			{ 36964, 37964, false, false },
 			{ 65396 , 1000, false, true  }, // Drop.
 			{ 25855, 26854, false, false },
-			{ 29793 , 1000, false, true  }, // Drop.
-			{ 65396, 26854, false, false }, // Previously dropped.
-			{ 25087,  1000,  false, true  }, // Drop.
-			{ 29793, 26854, false, false }, // Previously dropped.
-			{ 65535 , 1000, false, true  }, // Drop.
-			{ 25087, 26086, false, false },
+			// TODO: Why are we testing an already dropped input?.
+			// { 29793 , 1000, false, true  }, // Drop.
+			// { 65396, 26854, false, false }, // Previously dropped.
+			// { 25087,  1000,  false, true  }, // Drop.
+			// { 29793, 26854, false, false }, // Previously dropped.
+			// { 65535 , 1000, false, true  }, // Drop.
+			// { 25087, 26086, false, false }, // Previously dropped.
 		};
 		// clang-format on
 
 		SeqManager<uint16_t> seqManager(/*initialOutput*/ 1000);
+		validate(seqManager, inputs);
+	}
+
+	// https://github.com/versatica/mediasoup/issues/1615
+	SECTION("receive dropped inputs out of order")
+	{
+		// clang-format off
+		std::vector<TestSeqManagerInput<uint16_t>> inputs =
+		{
+			{ 0, 0, false, false },
+			{ 2, 0, false, true  },
+			{ 1, 0, false, true  },
+			{ 3, 1, false, false  },
+		};
+		// clang-format on
+
+		SeqManager<uint16_t> seqManager;
 		validate(seqManager, inputs);
 	}
 }


### PR DESCRIPTION
Fixes #1615

Current implementation does only consider dropped inputs when they are higher than the highest input seen.

Before this PR ❌

|input|output|drop|
|-|-|-|
|0|0||
|2||x|
|1||x|
|3|2||

Due to this issue, we were generating a lot of sequence number jumps (considered packet loss at receiver side, which generated unnecessary and unprocessable NACK requests) when RTP is received out of order to the producer and many packets are being discarded in consumer (ie: SVC, targeting low layers).

The following solution allows for properly accounting out of order drops until a newer input is forwarded.

After this PR ✅ 

|input|output|drop|
|-|-|-|
|0|0||
|2||x|
|1||x|
|3|1||
