### PR TITLE
[Simulcast|Svc]Consumer: use Layers type to avoid member duplication

### DIFF
--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -43,6 +43,34 @@ namespace RTC
 		{
 			int16_t spatial{ -1 };
 			int16_t temporal{ -1 };
+
+			Layers() : spatial(-1), temporal(-1)
+			{
+			}
+
+			Layers(int16_t spatial, int16_t temporal) : spatial(spatial), temporal(temporal)
+			{
+			}
+
+			Layers(const Layers& other) : spatial(other.spatial), temporal(other.temporal)
+			{
+			}
+
+			bool operator==(const Layers& other) const
+			{
+				return spatial == other.spatial && temporal == other.temporal;
+			}
+
+			bool operator!=(const Layers& other) const
+			{
+				return !(*this == other);
+			}
+
+			void Reset()
+			{
+				spatial  = -1;
+				temporal = -1;
+			}
 		};
 
 	private:

--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -39,29 +39,29 @@ namespace RTC
 		};
 
 	public:
-		struct Layers
+		struct VideoLayers
 		{
 			int16_t spatial{ -1 };
 			int16_t temporal{ -1 };
 
-			Layers() : spatial(-1), temporal(-1)
+			VideoLayers() : spatial(-1), temporal(-1)
 			{
 			}
 
-			Layers(int16_t spatial, int16_t temporal) : spatial(spatial), temporal(temporal)
+			VideoLayers(int16_t spatial, int16_t temporal) : spatial(spatial), temporal(temporal)
 			{
 			}
 
-			Layers(const Layers& other) : spatial(other.spatial), temporal(other.temporal)
+			VideoLayers(const VideoLayers& other) : spatial(other.spatial), temporal(other.temporal)
 			{
 			}
 
-			bool operator==(const Layers& other) const
+			bool operator==(const VideoLayers& other) const
 			{
 				return spatial == other.spatial && temporal == other.temporal;
 			}
 
-			bool operator!=(const Layers& other) const
+			bool operator!=(const VideoLayers& other) const
 			{
 				return !(*this == other);
 			}
@@ -119,10 +119,10 @@ namespace RTC
 		{
 			return this->type;
 		}
-		virtual Layers GetPreferredLayers() const
+		virtual VideoLayers GetPreferredLayers() const
 		{
 			// By default return 1:1.
-			Consumer::Layers layers;
+			Consumer::VideoLayers layers;
 
 			return layers;
 		}

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -32,8 +32,8 @@ namespace RTC
 		{
 			RTC::Consumer::Layers layers;
 
-			layers.spatial  = this->preferredSpatialLayer;
-			layers.temporal = this->preferredTemporalLayer;
+			layers.spatial  = this->preferredLayers.spatial;
+			layers.temporal = this->preferredLayers.temporal;
 
 			return layers;
 		}
@@ -92,7 +92,7 @@ namespace RTC
 		void RequestKeyFrameForTargetSpatialLayer();
 		void RequestKeyFrameForCurrentSpatialLayer();
 		void MayChangeLayers(bool force = false);
-		bool RecalculateTargetLayers(int16_t& newTargetSpatialLayer, int16_t& newTargetTemporalLayer) const;
+		bool RecalculateTargetLayers(Layers& newTargetLayers) const;
 		void UpdateTargetLayers(int16_t newTargetSpatialLayer, int16_t newTargetTemporalLayer);
 		bool CanSwitchToSpatialLayer(int16_t spatialLayer) const;
 		void EmitScore() const;
@@ -119,12 +119,9 @@ namespace RTC
 		int16_t spatialLayerToSync{ -1 };
 		bool lastSentPacketHasMarker{ false };
 		std::unique_ptr<RTC::SeqManager<uint16_t>> rtpSeqManager;
-		int16_t preferredSpatialLayer{ -1 };
-		int16_t preferredTemporalLayer{ -1 };
-		int16_t provisionalTargetSpatialLayer{ -1 };
-		int16_t provisionalTargetTemporalLayer{ -1 };
-		int16_t targetSpatialLayer{ -1 };
-		int16_t targetTemporalLayer{ -1 };
+		Layers preferredLayers;
+		Layers provisionalTargetLayers;
+		Layers targetLayers;
 		int16_t currentSpatialLayer{ -1 };
 		int16_t tsReferenceSpatialLayer{ -1 }; // Used for RTP TS sync.
 		uint16_t snReferenceSpatialLayer{ 0 };

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -28,9 +28,9 @@ namespace RTC
 		  flatbuffers::FlatBufferBuilder& builder) override;
 		flatbuffers::Offset<FBS::Consumer::ConsumerScore> FillBufferScore(
 		  flatbuffers::FlatBufferBuilder& builder) const override;
-		RTC::Consumer::Layers GetPreferredLayers() const override
+		RTC::Consumer::VideoLayers GetPreferredLayers() const override
 		{
-			RTC::Consumer::Layers layers;
+			RTC::Consumer::VideoLayers layers;
 
 			layers.spatial  = this->preferredLayers.spatial;
 			layers.temporal = this->preferredLayers.temporal;
@@ -92,7 +92,7 @@ namespace RTC
 		void RequestKeyFrameForTargetSpatialLayer();
 		void RequestKeyFrameForCurrentSpatialLayer();
 		void MayChangeLayers(bool force = false);
-		bool RecalculateTargetLayers(Layers& newTargetLayers) const;
+		bool RecalculateTargetLayers(VideoLayers& newTargetLayers) const;
 		void UpdateTargetLayers(int16_t newTargetSpatialLayer, int16_t newTargetTemporalLayer);
 		bool CanSwitchToSpatialLayer(int16_t spatialLayer) const;
 		void EmitScore() const;
@@ -119,9 +119,9 @@ namespace RTC
 		int16_t spatialLayerToSync{ -1 };
 		bool lastSentPacketHasMarker{ false };
 		std::unique_ptr<RTC::SeqManager<uint16_t>> rtpSeqManager;
-		Layers preferredLayers;
-		Layers provisionalTargetLayers;
-		Layers targetLayers;
+		VideoLayers preferredLayers;
+		VideoLayers provisionalTargetLayers;
+		VideoLayers targetLayers;
 		int16_t currentSpatialLayer{ -1 };
 		int16_t tsReferenceSpatialLayer{ -1 }; // Used for RTP TS sync.
 		uint16_t snReferenceSpatialLayer{ 0 };

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -31,8 +31,8 @@ namespace RTC
 		{
 			RTC::Consumer::Layers layers;
 
-			layers.spatial  = this->preferredSpatialLayer;
-			layers.temporal = this->preferredTemporalLayer;
+			layers.spatial  = this->preferredLayers.spatial;
+			layers.temporal = this->preferredLayers.temporal;
 
 			return layers;
 		}
@@ -103,10 +103,8 @@ namespace RTC
 		RTC::RtpStreamRecv* producerRtpStream{ nullptr };
 		bool syncRequired{ false };
 		std::unique_ptr<RTC::SeqManager<uint16_t>> rtpSeqManager;
-		int16_t preferredSpatialLayer{ -1 };
-		int16_t preferredTemporalLayer{ -1 };
-		int16_t provisionalTargetSpatialLayer{ -1 };
-		int16_t provisionalTargetTemporalLayer{ -1 };
+		Layers preferredLayers;
+		Layers provisionalTargetLayers;
 		std::unique_ptr<RTC::Codecs::EncodingContext> encodingContext;
 		// Last time we moved to lower spatial layer due to BWE.
 		uint64_t lastBweDowngradeAtMs{ 0u };

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -27,9 +27,9 @@ namespace RTC
 		  flatbuffers::FlatBufferBuilder& builder) override;
 		flatbuffers::Offset<FBS::Consumer::ConsumerScore> FillBufferScore(
 		  flatbuffers::FlatBufferBuilder& builder) const override;
-		RTC::Consumer::Layers GetPreferredLayers() const override
+		RTC::Consumer::VideoLayers GetPreferredLayers() const override
 		{
-			RTC::Consumer::Layers layers;
+			RTC::Consumer::VideoLayers layers;
 
 			layers.spatial  = this->preferredLayers.spatial;
 			layers.temporal = this->preferredLayers.temporal;
@@ -103,8 +103,8 @@ namespace RTC
 		RTC::RtpStreamRecv* producerRtpStream{ nullptr };
 		bool syncRequired{ false };
 		std::unique_ptr<RTC::SeqManager<uint16_t>> rtpSeqManager;
-		Layers preferredLayers;
-		Layers provisionalTargetLayers;
+		VideoLayers preferredLayers;
+		VideoLayers provisionalTargetLayers;
 		std::unique_ptr<RTC::Codecs::EncodingContext> encodingContext;
 		// Last time we moved to lower spatial layer due to BWE.
 		uint64_t lastBweDowngradeAtMs{ 0u };

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -1585,7 +1585,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		Layers newTargetLayers;
+		VideoLayers newTargetLayers;
 
 		if (RecalculateTargetLayers(newTargetLayers))
 		{
@@ -1608,7 +1608,7 @@ namespace RTC
 		}
 	}
 
-	bool SimulcastConsumer::RecalculateTargetLayers(Layers& newTargetLayers) const
+	bool SimulcastConsumer::RecalculateTargetLayers(VideoLayers& newTargetLayers) const
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -61,33 +61,33 @@ namespace RTC
 		{
 			const auto* preferredLayers = data->preferredLayers();
 
-			this->preferredSpatialLayer = preferredLayers->spatialLayer();
+			this->preferredLayers.spatial = preferredLayers->spatialLayer();
 
-			if (this->preferredSpatialLayer > encoding.spatialLayers - 1)
+			if (this->preferredLayers.spatial > encoding.spatialLayers - 1)
 			{
-				this->preferredSpatialLayer = static_cast<int16_t>(encoding.spatialLayers - 1);
+				this->preferredLayers.spatial = static_cast<int16_t>(encoding.spatialLayers - 1);
 			}
 
 			if (preferredLayers->temporalLayer().has_value())
 			{
-				this->preferredTemporalLayer = preferredLayers->temporalLayer().value();
+				this->preferredLayers.temporal = preferredLayers->temporalLayer().value();
 
-				if (this->preferredTemporalLayer > encoding.temporalLayers - 1)
+				if (this->preferredLayers.temporal > encoding.temporalLayers - 1)
 				{
-					this->preferredTemporalLayer = static_cast<int16_t>(encoding.temporalLayers - 1);
+					this->preferredLayers.temporal = static_cast<int16_t>(encoding.temporalLayers - 1);
 				}
 			}
 			else
 			{
-				this->preferredTemporalLayer = static_cast<int16_t>(encoding.temporalLayers - 1);
+				this->preferredLayers.temporal = static_cast<int16_t>(encoding.temporalLayers - 1);
 			}
 		}
 		else
 		{
 			// Initially set preferredSpatialLayer and preferredTemporalLayer to the
 			// maximum value.
-			this->preferredSpatialLayer  = static_cast<int16_t>(encoding.spatialLayers - 1);
-			this->preferredTemporalLayer = static_cast<int16_t>(encoding.temporalLayers - 1);
+			this->preferredLayers.spatial  = static_cast<int16_t>(encoding.spatialLayers - 1);
+			this->preferredLayers.temporal = static_cast<int16_t>(encoding.temporalLayers - 1);
 		}
 
 		// Reserve space for the Producer RTP streams by filling all the possible
@@ -156,11 +156,11 @@ namespace RTC
 		  builder,
 		  base,
 		  &rtpStreams,
-		  this->preferredSpatialLayer,
-		  this->targetSpatialLayer,
+		  this->preferredLayers.spatial,
+		  this->targetLayers.spatial,
 		  this->currentSpatialLayer,
-		  this->preferredTemporalLayer,
-		  this->targetTemporalLayer,
+		  this->preferredLayers.temporal,
+		  this->targetLayers.temporal,
 		  this->encodingContext->GetCurrentTemporalLayer());
 
 		return FBS::Consumer::CreateDumpResponse(builder, dump);
@@ -240,60 +240,52 @@ namespace RTC
 
 			case Channel::ChannelRequest::Method::CONSUMER_SET_PREFERRED_LAYERS:
 			{
-				auto previousPreferredSpatialLayer  = this->preferredSpatialLayer;
-				auto previousPreferredTemporalLayer = this->preferredTemporalLayer;
+				auto previousPreferredLayers = this->preferredLayers;
 
 				const auto* body = request->data->body_as<FBS::Consumer::SetPreferredLayersRequest>();
 				const auto* preferredLayers = body->preferredLayers();
 
 				// Spatial layer.
-				this->preferredSpatialLayer = preferredLayers->spatialLayer();
+				this->preferredLayers.spatial = preferredLayers->spatialLayer();
 
-				if (this->preferredSpatialLayer > this->rtpStream->GetSpatialLayers() - 1)
+				if (this->preferredLayers.spatial > this->rtpStream->GetSpatialLayers() - 1)
 				{
-					this->preferredSpatialLayer = static_cast<int16_t>(this->rtpStream->GetSpatialLayers() - 1);
+					this->preferredLayers.spatial =
+					  static_cast<int16_t>(this->rtpStream->GetSpatialLayers() - 1);
 				}
 
 				// preferredTemporaLayer is optional.
 				if (preferredLayers->temporalLayer().has_value())
 				{
-					this->preferredTemporalLayer = preferredLayers->temporalLayer().value();
+					this->preferredLayers.temporal = preferredLayers->temporalLayer().value();
 
-					if (this->preferredTemporalLayer > this->rtpStream->GetTemporalLayers() - 1)
+					if (this->preferredLayers.temporal > this->rtpStream->GetTemporalLayers() - 1)
 					{
-						this->preferredTemporalLayer =
+						this->preferredLayers.temporal =
 						  static_cast<int16_t>(this->rtpStream->GetTemporalLayers() - 1);
 					}
 				}
 				else
 				{
-					this->preferredTemporalLayer =
+					this->preferredLayers.temporal =
 					  static_cast<int16_t>(this->rtpStream->GetTemporalLayers() - 1);
 				}
 
 				MS_DEBUG_DEV(
 				  "preferred layers changed [spatial:%" PRIi16 ", temporal:%" PRIi16 ", consumerId:%s]",
-				  this->preferredSpatialLayer,
-				  this->preferredTemporalLayer,
+				  this->preferredLayers.spatial,
+				  this->preferredLayers.temporal,
 				  this->id.c_str());
 
-				const flatbuffers::Optional<int16_t> preferredTemporalLayer{ this->preferredTemporalLayer };
+				const flatbuffers::Optional<int16_t> preferredTemporalLayer{ this->preferredLayers.temporal };
 				auto preferredLayersOffset = FBS::Consumer::CreateConsumerLayers(
-				  request->GetBufferBuilder(), this->preferredSpatialLayer, preferredTemporalLayer);
+				  request->GetBufferBuilder(), this->preferredLayers.spatial, preferredTemporalLayer);
 				auto responseOffset = FBS::Consumer::CreateSetPreferredLayersResponse(
 				  request->GetBufferBuilder(), preferredLayersOffset);
 
 				request->Accept(FBS::Response::Body::Consumer_SetPreferredLayersResponse, responseOffset);
 
-				// clang-format off
-				if (
-					IsActive() &&
-					(
-						this->preferredSpatialLayer != previousPreferredSpatialLayer ||
-						this->preferredTemporalLayer != previousPreferredTemporalLayer
-					)
-				)
-				// clang-format on
+				if (IsActive() && this->preferredLayers != previousPreferredLayers)
 				{
 					MayChangeLayers(/*force*/ true);
 				}
@@ -420,12 +412,7 @@ namespace RTC
 		MS_ASSERT(IsActive(), "should be active");
 
 		// If already in the preferred layers, do nothing.
-		// clang-format off
-		if (
-			this->provisionalTargetSpatialLayer == this->preferredSpatialLayer &&
-			this->provisionalTargetTemporalLayer == this->preferredTemporalLayer
-		)
-		// clang-format on
+		if (this->provisionalTargetLayers == this->preferredLayers)
 		{
 			return 0u;
 		}
@@ -470,7 +457,7 @@ namespace RTC
 			// since then.
 			if (nowMs - this->lastBweDowngradeAtMs < BweDowngradeConservativeMs)
 			{
-				if (this->provisionalTargetSpatialLayer > -1 && spatialLayer > this->currentSpatialLayer)
+				if (this->provisionalTargetLayers.spatial > -1 && spatialLayer > this->currentSpatialLayer)
 				{
 					MS_DEBUG_DEV(
 					  "avoid upgrading to spatial layer %" PRIi16 " due to recent BWE downgrade", spatialLayer);
@@ -480,18 +467,18 @@ namespace RTC
 			}
 
 			// Ignore spatial layers lower than the one we already have.
-			if (spatialLayer < this->provisionalTargetSpatialLayer)
+			if (spatialLayer < this->provisionalTargetLayers.spatial)
 			{
 				continue;
 			}
 			// If this is the higher than preferred spatial layer, abort.
-			else if (spatialLayer > this->preferredSpatialLayer)
+			else if (spatialLayer > this->preferredLayers.spatial)
 			{
 				MS_DEBUG_DEV(
 				  "avoid upgrading to spatial layer %" PRIi16
 				  " since it's higher than preferred spatial layer %" PRIi16,
 				  spatialLayer,
-				  this->preferredSpatialLayer);
+				  this->preferredLayers.spatial);
 
 				goto done;
 			}
@@ -515,14 +502,14 @@ namespace RTC
 			// already, move to the next spatial layer.
 			// clang-format off
 			if (
-				spatialLayer != this->provisionalTargetSpatialLayer &&
-				this->provisionalTargetSpatialLayer != -1 &&
+				spatialLayer != this->provisionalTargetLayers.spatial &&
+				this->provisionalTargetLayers.spatial != -1 &&
 				producerRtpStream->GetActiveMs() < StreamMinActiveMs
 			)
 			// clang-format on
 			{
 				const auto* provisionalProducerRtpStream =
-				  this->producerRtpStreams.at(this->provisionalTargetSpatialLayer);
+				  this->producerRtpStreams.at(this->provisionalTargetLayers.spatial);
 
 				// The stream for the current provisional spatial layer has been active
 				// for enough time, move to the next spatial layer.
@@ -547,8 +534,8 @@ namespace RTC
 				// into account the spatial layer too).
 				// clang-format off
 				if (
-					spatialLayer == this->provisionalTargetSpatialLayer &&
-					temporalLayer <= this->provisionalTargetTemporalLayer
+					spatialLayer == this->provisionalTargetLayers.spatial &&
+					temporalLayer <= this->provisionalTargetLayers.temporal
 				)
 				// clang-format on
 				{
@@ -565,15 +552,15 @@ namespace RTC
 				if (
 					requiredBitrate &&
 					temporalLayer == 0 &&
-					this->provisionalTargetSpatialLayer > -1 &&
-					spatialLayer > this->provisionalTargetSpatialLayer
+					this->provisionalTargetLayers.spatial > -1 &&
+					spatialLayer > this->provisionalTargetLayers.spatial
 				)
 				// clang-format on
 				{
 					auto* provisionalProducerRtpStream =
-					  this->producerRtpStreams.at(this->provisionalTargetSpatialLayer);
-					auto provisionalRequiredBitrate =
-					  provisionalProducerRtpStream->GetBitrate(nowMs, 0, this->provisionalTargetTemporalLayer);
+					  this->producerRtpStreams.at(this->provisionalTargetLayers.spatial);
+					auto provisionalRequiredBitrate = provisionalProducerRtpStream->GetBitrate(
+					  nowMs, 0, this->provisionalTargetLayers.temporal);
 
 					if (requiredBitrate > provisionalRequiredBitrate)
 					{
@@ -606,7 +593,7 @@ namespace RTC
 			}
 
 			// If this is the preferred spatial layer or higher, take it and exit.
-			if (spatialLayer >= this->preferredSpatialLayer)
+			if (spatialLayer >= this->preferredLayers.spatial)
 			{
 				break;
 			}
@@ -627,14 +614,14 @@ namespace RTC
 		}
 
 		// Set provisional layers.
-		this->provisionalTargetSpatialLayer  = spatialLayer;
-		this->provisionalTargetTemporalLayer = temporalLayer;
+		this->provisionalTargetLayers.spatial  = spatialLayer;
+		this->provisionalTargetLayers.temporal = temporalLayer;
 
 		MS_DEBUG_DEV(
 		  "setting provisional layers to %" PRIi16 ":%" PRIi16 " [virtual bitrate:%" PRIu32
 		  ", required bitrate:%" PRIu32 "]",
-		  this->provisionalTargetSpatialLayer,
-		  this->provisionalTargetTemporalLayer,
+		  this->provisionalTargetLayers.spatial,
+		  this->provisionalTargetLayers.temporal,
 		  virtualBitrate,
 		  requiredBitrate);
 
@@ -659,28 +646,21 @@ namespace RTC
 		MS_ASSERT(this->externallyManagedBitrate, "bitrate is not externally managed");
 		MS_ASSERT(IsActive(), "should be active");
 
-		auto provisionalTargetSpatialLayer  = this->provisionalTargetSpatialLayer;
-		auto provisionalTargetTemporalLayer = this->provisionalTargetTemporalLayer;
+		auto provisionalTargetLayers = this->provisionalTargetLayers;
 
 		// Reset provisional target layers.
-		this->provisionalTargetSpatialLayer  = -1;
-		this->provisionalTargetTemporalLayer = -1;
+		this->provisionalTargetLayers.Reset();
 
-		// clang-format off
-		if (
-			provisionalTargetSpatialLayer != this->targetSpatialLayer ||
-			provisionalTargetTemporalLayer != this->targetTemporalLayer
-		)
-		// clang-format on
+		if (provisionalTargetLayers != this->targetLayers)
 		{
-			UpdateTargetLayers(provisionalTargetSpatialLayer, provisionalTargetTemporalLayer);
+			UpdateTargetLayers(provisionalTargetLayers.spatial, provisionalTargetLayers.temporal);
 
 			// If this looks like a spatial layer downgrade due to BWE limitations, set member.
 			// clang-format off
 			if (
 				this->rtpStream->GetActiveMs() > BweDowngradeMinActiveMs &&
-				this->targetSpatialLayer < this->currentSpatialLayer &&
-				this->currentSpatialLayer <= this->preferredSpatialLayer
+				this->targetLayers.spatial < this->currentSpatialLayer &&
+				this->currentSpatialLayer <= this->preferredLayers.spatial
 			)
 			// clang-format on
 			{
@@ -688,7 +668,7 @@ namespace RTC
 				  "possible target spatial layer downgrade (from %" PRIi16 " to %" PRIi16
 				  ") due to BWE limitation",
 				  this->currentSpatialLayer,
-				  this->targetSpatialLayer);
+				  this->targetLayers.spatial);
 
 				this->lastBweDowngradeAtMs = DepLibUV::GetTimeMs();
 			}
@@ -769,7 +749,7 @@ namespace RTC
 			return;
 		}
 
-		if (this->targetTemporalLayer == -1)
+		if (this->targetLayers.temporal == -1)
 		{
 			// Only drop the packet in the RTP sequence manager if it belongs to the
 			// current spatial layer.
@@ -811,7 +791,12 @@ namespace RTC
 
 		// Check whether this is the packet we are waiting for in order to update
 		// the current spatial layer.
-		if (this->currentSpatialLayer != this->targetSpatialLayer && spatialLayer == this->targetSpatialLayer)
+		// clang-format off
+		if (
+		  this->currentSpatialLayer != this->targetLayers.spatial &&
+		  spatialLayer == this->targetLayers.spatial
+		)
+		// clang-format on
 		{
 			// Ignore if not a key frame.
 			if (!packet->IsKeyFrame())
@@ -1078,13 +1063,13 @@ namespace RTC
 		if (shouldSwitchCurrentSpatialLayer)
 		{
 			// Update current spatial layer.
-			this->currentSpatialLayer = this->targetSpatialLayer;
+			this->currentSpatialLayer = this->targetLayers.spatial;
 
 			this->snReferenceSpatialLayer             = packet->GetSequenceNumber();
 			this->checkingForOldPacketsInSpatialLayer = true;
 
 			// Update target and current temporal layer.
-			this->encodingContext->SetTargetTemporalLayer(this->targetTemporalLayer);
+			this->encodingContext->SetTargetTemporalLayer(this->targetLayers.temporal);
 			this->encodingContext->SetCurrentTemporalLayer(packet->GetTemporalLayer());
 
 			// Reset the score of our RtpStream to 10.
@@ -1541,7 +1526,7 @@ namespace RTC
 
 		if (producerTargetRtpStream)
 		{
-			auto mappedSsrc = this->consumableRtpEncodings[this->targetSpatialLayer].ssrc;
+			auto mappedSsrc = this->consumableRtpEncodings[this->targetLayers.spatial].ssrc;
 
 			this->listener->OnConsumerKeyFrameRequested(this, mappedSsrc);
 		}
@@ -1570,7 +1555,7 @@ namespace RTC
 			return;
 		}
 
-		auto mappedSsrc = this->consumableRtpEncodings[this->targetSpatialLayer].ssrc;
+		auto mappedSsrc = this->consumableRtpEncodings[this->targetLayers.spatial].ssrc;
 
 		this->listener->OnConsumerKeyFrameRequested(this, mappedSsrc);
 	}
@@ -1600,10 +1585,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		int16_t newTargetSpatialLayer;
-		int16_t newTargetTemporalLayer;
+		Layers newTargetLayers;
 
-		if (RecalculateTargetLayers(newTargetSpatialLayer, newTargetTemporalLayer))
+		if (RecalculateTargetLayers(newTargetLayers))
 		{
 			// If bitrate externally managed, don't bother the transport unless
 			// the newTargetSpatialLayer has changed (or force is true).
@@ -1612,26 +1596,24 @@ namespace RTC
 			// will let us change it when it considers.
 			if (this->externallyManagedBitrate)
 			{
-				if (newTargetSpatialLayer != this->targetSpatialLayer || force)
+				if (newTargetLayers.spatial != this->targetLayers.spatial || force)
 				{
 					this->listener->OnConsumerNeedBitrateChange(this);
 				}
 			}
 			else
 			{
-				UpdateTargetLayers(newTargetSpatialLayer, newTargetTemporalLayer);
+				UpdateTargetLayers(newTargetLayers.spatial, newTargetLayers.temporal);
 			}
 		}
 	}
 
-	bool SimulcastConsumer::RecalculateTargetLayers(
-	  int16_t& newTargetSpatialLayer, int16_t& newTargetTemporalLayer) const
+	bool SimulcastConsumer::RecalculateTargetLayers(Layers& newTargetLayers) const
 	{
 		MS_TRACE();
 
 		// Start with no layers.
-		newTargetSpatialLayer  = -1;
-		newTargetTemporalLayer = -1;
+		newTargetLayers.Reset();
 
 		auto nowMs = DepLibUV::GetTimeMs();
 
@@ -1645,7 +1627,7 @@ namespace RTC
 			// layer due to BWE limitations, check how much it has elapsed since then.
 			if (nowMs - this->lastBweDowngradeAtMs < BweDowngradeConservativeMs)
 			{
-				if (newTargetSpatialLayer > -1 && spatialLayer > this->currentSpatialLayer)
+				if (newTargetLayers.spatial > -1 && spatialLayer > this->currentSpatialLayer)
 				{
 					continue;
 				}
@@ -1664,7 +1646,7 @@ namespace RTC
 			// clang-format off
 			if (
 				this->externallyManagedBitrate &&
-				newTargetSpatialLayer != -1 &&
+				newTargetLayers.spatial != -1 &&
 				producerRtpStream->GetActiveMs() < StreamMinActiveMs
 			)
 			// clang-format on
@@ -1678,38 +1660,33 @@ namespace RTC
 				continue;
 			}
 
-			newTargetSpatialLayer = spatialLayer;
+			newTargetLayers.spatial = spatialLayer;
 
 			// If this is the preferred or higher spatial layer take it and exit.
-			if (spatialLayer >= this->preferredSpatialLayer)
+			if (spatialLayer >= this->preferredLayers.spatial)
 			{
 				break;
 			}
 		}
 
-		if (newTargetSpatialLayer != -1)
+		if (newTargetLayers.spatial != -1)
 		{
-			if (newTargetSpatialLayer == this->preferredSpatialLayer)
+			if (newTargetLayers.spatial == this->preferredLayers.spatial)
 			{
-				newTargetTemporalLayer = this->preferredTemporalLayer;
+				newTargetLayers.temporal = this->preferredLayers.temporal;
 			}
-			else if (newTargetSpatialLayer < this->preferredSpatialLayer)
+			else if (newTargetLayers.spatial < this->preferredLayers.spatial)
 			{
-				newTargetTemporalLayer = static_cast<int16_t>(this->rtpStream->GetTemporalLayers() - 1);
+				newTargetLayers.temporal = static_cast<int16_t>(this->rtpStream->GetTemporalLayers() - 1);
 			}
 			else
 			{
-				newTargetTemporalLayer = 0;
+				newTargetLayers.temporal = 0;
 			}
 		}
 
 		// Return true if any target layer changed.
-		// clang-format off
-		return (
-			newTargetSpatialLayer != this->targetSpatialLayer ||
-			newTargetTemporalLayer != this->targetTemporalLayer
-		);
-		// clang-format on
+		return (newTargetLayers != this->targetLayers);
 	}
 
 	void SimulcastConsumer::UpdateTargetLayers(int16_t newTargetSpatialLayer, int16_t newTargetTemporalLayer)
@@ -1729,7 +1706,7 @@ namespace RTC
 
 		// If the new target spatial layer doesn't match the current one, clear the
 		// target layer retransmission buffer.
-		if (newTargetSpatialLayer != this->targetSpatialLayer)
+		if (newTargetSpatialLayer != this->targetLayers.spatial)
 		{
 			this->targetLayerRetransmissionBuffer.clear();
 		}
@@ -1737,9 +1714,9 @@ namespace RTC
 		if (newTargetSpatialLayer == -1)
 		{
 			// Unset current and target layers.
-			this->targetSpatialLayer  = -1;
-			this->targetTemporalLayer = -1;
-			this->currentSpatialLayer = -1;
+			this->targetLayers.spatial  = -1;
+			this->targetLayers.temporal = -1;
+			this->currentSpatialLayer   = -1;
 
 			this->encodingContext->SetTargetTemporalLayer(-1);
 			this->encodingContext->SetCurrentTemporalLayer(-1);
@@ -1752,26 +1729,26 @@ namespace RTC
 			return;
 		}
 
-		this->targetSpatialLayer  = newTargetSpatialLayer;
-		this->targetTemporalLayer = newTargetTemporalLayer;
+		this->targetLayers.spatial  = newTargetSpatialLayer;
+		this->targetLayers.temporal = newTargetTemporalLayer;
 
 		// If the new target spatial layer matches the current one, apply the new
 		// target temporal layer now.
-		if (this->targetSpatialLayer == this->currentSpatialLayer)
+		if (this->targetLayers.spatial == this->currentSpatialLayer)
 		{
-			this->encodingContext->SetTargetTemporalLayer(this->targetTemporalLayer);
+			this->encodingContext->SetTargetTemporalLayer(this->targetLayers.temporal);
 		}
 
 		MS_DEBUG_TAG(
 		  simulcast,
 		  "target layers changed [spatial:%" PRIi16 ", temporal:%" PRIi16 ", consumerId:%s]",
-		  this->targetSpatialLayer,
-		  this->targetTemporalLayer,
+		  this->targetLayers.spatial,
+		  this->targetLayers.temporal,
 		  this->id.c_str());
 
 		// If the target spatial layer is different than the current one, request
 		// a key frame.
-		if (this->targetSpatialLayer != this->currentSpatialLayer)
+		if (this->targetLayers.spatial != this->currentSpatialLayer)
 		{
 			RequestKeyFrameForTargetSpatialLayer();
 		}
@@ -1899,13 +1876,13 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		if (this->targetSpatialLayer == -1)
+		if (this->targetLayers.spatial == -1)
 		{
 			return nullptr;
 		}
 
 		// This may return nullptr.
-		return this->producerRtpStreams.at(this->targetSpatialLayer);
+		return this->producerRtpStreams.at(this->targetLayers.spatial);
 	}
 
 	RTC::RtpStreamRecv* SimulcastConsumer::GetProducerTsReferenceRtpStream() const

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -49,32 +49,32 @@ namespace RTC
 		// Set preferredLayers (if given).
 		if (flatbuffers::IsFieldPresent(data, FBS::Transport::ConsumeRequest::VT_PREFERREDLAYERS))
 		{
-			this->preferredSpatialLayer = data->preferredLayers()->spatialLayer();
+			this->preferredLayers.spatial = data->preferredLayers()->spatialLayer();
 
-			if (this->preferredSpatialLayer > encoding.spatialLayers - 1)
+			if (this->preferredLayers.spatial > encoding.spatialLayers - 1)
 			{
-				this->preferredSpatialLayer = static_cast<int16_t>(encoding.spatialLayers - 1);
+				this->preferredLayers.spatial = static_cast<int16_t>(encoding.spatialLayers - 1);
 			}
 
 			if (flatbuffers::IsFieldPresent(
 			      data->preferredLayers(), FBS::Consumer::ConsumerLayers::VT_TEMPORALLAYER))
 			{
-				if (this->preferredTemporalLayer > encoding.temporalLayers - 1)
+				if (this->preferredLayers.temporal > encoding.temporalLayers - 1)
 				{
-					this->preferredTemporalLayer = static_cast<int16_t>(encoding.temporalLayers - 1);
+					this->preferredLayers.temporal = static_cast<int16_t>(encoding.temporalLayers - 1);
 				}
 			}
 			else
 			{
-				this->preferredTemporalLayer = static_cast<int16_t>(encoding.temporalLayers - 1);
+				this->preferredLayers.temporal = static_cast<int16_t>(encoding.temporalLayers - 1);
 			}
 		}
 		else
 		{
 			// Initially set preferredSpatialLayer and preferredTemporalLayer to the
 			// maximum value.
-			this->preferredSpatialLayer  = static_cast<int16_t>(encoding.spatialLayers - 1);
-			this->preferredTemporalLayer = static_cast<int16_t>(encoding.temporalLayers - 1);
+			this->preferredLayers.spatial  = static_cast<int16_t>(encoding.spatialLayers - 1);
+			this->preferredLayers.temporal = static_cast<int16_t>(encoding.temporalLayers - 1);
 		}
 
 		// Create the encoding context.
@@ -138,10 +138,10 @@ namespace RTC
 		  builder,
 		  base,
 		  &rtpStreams,
-		  this->preferredSpatialLayer,
+		  this->preferredLayers.spatial,
 		  this->encodingContext->GetTargetSpatialLayer(),
 		  this->encodingContext->GetCurrentSpatialLayer(),
-		  this->preferredTemporalLayer,
+		  this->preferredLayers.temporal,
 		  this->encodingContext->GetTargetTemporalLayer(),
 		  this->encodingContext->GetCurrentTemporalLayer());
 
@@ -218,59 +218,51 @@ namespace RTC
 
 			case Channel::ChannelRequest::Method::CONSUMER_SET_PREFERRED_LAYERS:
 			{
-				auto previousPreferredSpatialLayer  = this->preferredSpatialLayer;
-				auto previousPreferredTemporalLayer = this->preferredTemporalLayer;
+				auto previousPreferredLayers = this->preferredLayers;
 
 				const auto* body = request->data->body_as<FBS::Consumer::SetPreferredLayersRequest>();
 				const auto* preferredLayers = body->preferredLayers();
 
 				// Spatial layer.
-				this->preferredSpatialLayer = preferredLayers->spatialLayer();
+				this->preferredLayers.spatial = preferredLayers->spatialLayer();
 
-				if (this->preferredSpatialLayer > this->rtpStream->GetSpatialLayers() - 1)
+				if (this->preferredLayers.spatial > this->rtpStream->GetSpatialLayers() - 1)
 				{
-					this->preferredSpatialLayer = static_cast<int16_t>(this->rtpStream->GetSpatialLayers() - 1);
+					this->preferredLayers.spatial =
+					  static_cast<int16_t>(this->rtpStream->GetSpatialLayers() - 1);
 				}
 
 				// preferredTemporaLayer is optional.
 				if (preferredLayers->temporalLayer().has_value())
 				{
-					this->preferredTemporalLayer = preferredLayers->temporalLayer().value();
+					this->preferredLayers.temporal = preferredLayers->temporalLayer().value();
 
-					if (this->preferredTemporalLayer > this->rtpStream->GetTemporalLayers() - 1)
+					if (this->preferredLayers.temporal > this->rtpStream->GetTemporalLayers() - 1)
 					{
-						this->preferredTemporalLayer =
+						this->preferredLayers.temporal =
 						  static_cast<int16_t>(this->rtpStream->GetTemporalLayers() - 1);
 					}
 				}
 				else
 				{
-					this->preferredTemporalLayer = this->rtpStream->GetTemporalLayers() - 1;
+					this->preferredLayers.temporal = this->rtpStream->GetTemporalLayers() - 1;
 				}
 
 				MS_DEBUG_DEV(
 				  "preferred layers changed [spatial:%" PRIi16 ", temporal:%" PRIi16 ", consumerId:%s]",
-				  this->preferredSpatialLayer,
-				  this->preferredTemporalLayer,
+				  this->preferredLayers.spatial,
+				  this->preferredLayers.temporal,
 				  this->id.c_str());
 
-				const flatbuffers::Optional<int16_t> preferredTemporalLayer{ this->preferredTemporalLayer };
+				const flatbuffers::Optional<int16_t> preferredTemporalLayer{ this->preferredLayers.temporal };
 				auto preferredLayersOffset = FBS::Consumer::CreateConsumerLayers(
-				  request->GetBufferBuilder(), this->preferredSpatialLayer, preferredTemporalLayer);
+				  request->GetBufferBuilder(), this->preferredLayers.spatial, preferredTemporalLayer);
 				auto responseOffset = FBS::Consumer::CreateSetPreferredLayersResponse(
 				  request->GetBufferBuilder(), preferredLayersOffset);
 
 				request->Accept(FBS::Response::Body::Consumer_SetPreferredLayersResponse, responseOffset);
 
-				// clang-format off
-				if (
-					IsActive() &&
-					(
-						this->preferredSpatialLayer != previousPreferredSpatialLayer ||
-						this->preferredTemporalLayer != previousPreferredTemporalLayer
-					)
-				)
-				// clang-format on
+				if (IsActive() && this->preferredLayers != previousPreferredLayers)
 				{
 					MayChangeLayers(/*force*/ true);
 				}
@@ -365,12 +357,7 @@ namespace RTC
 		}
 
 		// If already in the preferred layers, do nothing.
-		// clang-format off
-		if (
-			this->provisionalTargetSpatialLayer == this->preferredSpatialLayer &&
-			this->provisionalTargetTemporalLayer == this->preferredTemporalLayer
-		)
-		// clang-format on
+		if (this->provisionalTargetLayers == this->preferredLayers)
 		{
 			return 0u;
 		}
@@ -412,7 +399,7 @@ namespace RTC
 			// layer due to BWE limitations, check how much it has elapsed since then.
 			if (nowMs - this->lastBweDowngradeAtMs < BweDowngradeConservativeMs)
 			{
-				if (this->provisionalTargetSpatialLayer > -1 && spatialLayer > this->encodingContext->GetCurrentSpatialLayer())
+				if (this->provisionalTargetLayers.spatial > -1 && spatialLayer > this->encodingContext->GetCurrentSpatialLayer())
 				{
 					MS_DEBUG_DEV(
 					  "avoid upgrading to spatial layer %" PRIi16 " due to recent BWE downgrade", spatialLayer);
@@ -422,7 +409,7 @@ namespace RTC
 			}
 
 			// Ignore spatial layers lower than the one we already have.
-			if (spatialLayer < this->provisionalTargetSpatialLayer)
+			if (spatialLayer < this->provisionalTargetLayers.spatial)
 			{
 				continue;
 			}
@@ -436,8 +423,8 @@ namespace RTC
 				// the spatial layer too).
 				// clang-format off
 				if (
-					spatialLayer == this->provisionalTargetSpatialLayer &&
-					temporalLayer <= this->provisionalTargetTemporalLayer
+					spatialLayer == this->provisionalTargetLayers.spatial &&
+					temporalLayer <= this->provisionalTargetLayers.temporal
 				)
 				// clang-format on
 				{
@@ -455,13 +442,13 @@ namespace RTC
 					this->encodingContext->IsKSvc() &&
 					requiredBitrate &&
 					temporalLayer == 0 &&
-					this->provisionalTargetSpatialLayer > -1 &&
-					spatialLayer > this->provisionalTargetSpatialLayer
+					this->provisionalTargetLayers.spatial > -1 &&
+					spatialLayer > this->provisionalTargetLayers.spatial
 				)
 				// clang-format on
 				{
 					auto provisionalRequiredBitrate = this->producerRtpStream->GetSpatialLayerBitrate(
-					  nowMs, this->provisionalTargetSpatialLayer);
+					  nowMs, this->provisionalTargetLayers.spatial);
 
 					if (requiredBitrate > provisionalRequiredBitrate)
 					{
@@ -493,7 +480,7 @@ namespace RTC
 			}
 
 			// If this is the preferred or higher spatial layer, take it and exit.
-			if (spatialLayer >= this->preferredSpatialLayer)
+			if (spatialLayer >= this->preferredLayers.spatial)
 			{
 				break;
 			}
@@ -514,14 +501,14 @@ namespace RTC
 		}
 
 		// Set provisional layers.
-		this->provisionalTargetSpatialLayer  = spatialLayer;
-		this->provisionalTargetTemporalLayer = temporalLayer;
+		this->provisionalTargetLayers.spatial  = spatialLayer;
+		this->provisionalTargetLayers.temporal = temporalLayer;
 
 		MS_DEBUG_DEV(
 		  "upgrading to layers %" PRIi16 ":%" PRIi16 " [virtual bitrate:%" PRIu32
 		  ", required bitrate:%" PRIu32 "]",
-		  this->provisionalTargetSpatialLayer,
-		  this->provisionalTargetTemporalLayer,
+		  this->provisionalTargetLayers.spatial,
+		  this->provisionalTargetLayers.temporal,
 		  virtualBitrate,
 		  requiredBitrate);
 
@@ -546,12 +533,10 @@ namespace RTC
 		MS_ASSERT(this->externallyManagedBitrate, "bitrate is not externally managed");
 		MS_ASSERT(IsActive(), "should be active");
 
-		auto provisionalTargetSpatialLayer  = this->provisionalTargetSpatialLayer;
-		auto provisionalTargetTemporalLayer = this->provisionalTargetTemporalLayer;
+		auto provisionalTargetLayers = this->provisionalTargetLayers;
 
 		// Reset provisional target layers.
-		this->provisionalTargetSpatialLayer  = -1;
-		this->provisionalTargetTemporalLayer = -1;
+		this->provisionalTargetLayers.Reset();
 
 		if (!IsActive())
 		{
@@ -560,19 +545,19 @@ namespace RTC
 
 		// clang-format off
 		if (
-			provisionalTargetSpatialLayer != this->encodingContext->GetTargetSpatialLayer() ||
-			provisionalTargetTemporalLayer != this->encodingContext->GetTargetTemporalLayer()
+			provisionalTargetLayers.spatial != this->encodingContext->GetTargetSpatialLayer() ||
+			provisionalTargetLayers.temporal != this->encodingContext->GetTargetTemporalLayer()
 		)
 		// clang-format on
 		{
-			UpdateTargetLayers(provisionalTargetSpatialLayer, provisionalTargetTemporalLayer);
+			UpdateTargetLayers(provisionalTargetLayers.spatial, provisionalTargetLayers.temporal);
 
 			// If this looks like a spatial layer downgrade due to BWE limitations, set member.
 			// clang-format off
 			if (
 				this->rtpStream->GetActiveMs() > BweDowngradeMinActiveMs &&
 				this->encodingContext->GetTargetSpatialLayer() < this->encodingContext->GetCurrentSpatialLayer() &&
-				this->encodingContext->GetCurrentSpatialLayer() <= this->preferredSpatialLayer
+				this->encodingContext->GetCurrentSpatialLayer() <= this->preferredLayers.spatial
 			)
 			// clang-format on
 			{
@@ -1249,7 +1234,7 @@ namespace RTC
 
 			// If this is the preferred or higher spatial layer and has bitrate,
 			// take it and exit.
-			if (spatialLayer >= this->preferredSpatialLayer)
+			if (spatialLayer >= this->preferredLayers.spatial)
 			{
 				break;
 			}
@@ -1257,11 +1242,11 @@ namespace RTC
 
 		if (newTargetSpatialLayer != -1)
 		{
-			if (newTargetSpatialLayer == this->preferredSpatialLayer)
+			if (newTargetSpatialLayer == this->preferredLayers.spatial)
 			{
-				newTargetTemporalLayer = this->preferredTemporalLayer;
+				newTargetTemporalLayer = this->preferredLayers.temporal;
 			}
-			else if (newTargetSpatialLayer < this->preferredSpatialLayer)
+			else if (newTargetSpatialLayer < this->preferredLayers.spatial)
 			{
 				newTargetTemporalLayer = static_cast<int16_t>(this->rtpStream->GetTemporalLayers() - 1);
 			}


### PR DESCRIPTION
And enhance readability.

Changed this:
```c++
		int16_t preferredSpatialLayer{ -1 };
		int16_t preferredTemporalLayer{ -1 };
		int16_t provisionalTargetSpatialLayer{ -1 };
		int16_t provisionalTargetTemporalLayer{ -1 };
		int16_t targetSpatialLayer{ -1 };
		int16_t targetTemporalLayer{ -1 };

```

Into this:
```c++
		VideoLayers preferredLayers;
		VideoLayers provisionalTargetLayers;
		VideoLayers targetLayers;
```

Apart from the obvious encapsulation, `Layers` contains overloads for `==` and `!=` so we don't need to compare spatial and and temporal layers of two different instances manually.

In general it enhances readability and reduces the possibility of human errors.

This is a previous cleanup for a further refactor in direction of merging all consumers into a single one.

NOTE: This changes have been made with automatic renaming, reviewed by myself carefully line by line and tested.