### PR TITLE
Meson: use c11 for C subprojects

### DIFF
--- a/worker/meson.build
+++ b/worker/meson.build
@@ -2,9 +2,9 @@ project(
   'mediasoup-worker',
   ['c', 'cpp'],
   default_options : [
-    'warning_level=1',
     'cpp_std=c++17',
     'default_library=static',
+    'warning_level=1',
   ],
   meson_version: '>= 1.1.0',
 )
@@ -243,25 +243,28 @@ common_sources = [
   'src/RTC/SCTP/packet/errorCauses/UnknownErrorCause.cpp',
 ]
 
-openssl_proj = subproject(
-  'openssl',
-  default_options: [
-    'warning_level=0',
-  ],
-)
-
 libuv_proj = subproject(
   'libuv',
   default_options: [
+    'c_std=c11',
     'warning_level=0',
     'build_tests=false',
     'build_benchmarks=false',
   ],
 )
 
+openssl_proj = subproject(
+  'openssl',
+  default_options: [
+    'c_std=c11',
+    'warning_level=0',
+  ],
+)
+
 libsrtp3_proj = subproject(
   'libsrtp3',
   default_options: [
+    'c_std=c11',
     'warning_level=0',
     'crypto-library=openssl',
     'crypto-library-kdf=disabled',
@@ -272,6 +275,7 @@ libsrtp3_proj = subproject(
 usrsctp_proj = subproject(
   'usrsctp',
   default_options: [
+    'c_std=c11',
     'warning_level=0',
     'sctp_build_programs=false',
   ],
@@ -295,6 +299,7 @@ catch2_proj = subproject(
 flatbuffers_proj = subproject(
   'flatbuffers',
   default_options: [
+    'c_std=c11',
     'warning_level=0',
   ],
 )

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -256,7 +256,7 @@ libuv_proj = subproject(
 openssl_proj = subproject(
   'openssl',
   default_options: [
-    'c_std=c11',
+    'c_std=gnu11',
     'warning_level=0',
   ],
 )


### PR DESCRIPTION
# Details

- WIP (or not WIP, it depends on whether it makes sense or not).
- Fixes #1636


## Notes

If no C `std` is given, both gcc and clang use gnu11 or gnu17 (depending their version) as default. so I'm not sure this PR should exist. I mean, gcc and clang rely by default in gnuNN, why should we change that and force c11 to compile some C subprojects in mediasoup?

I mean, why are we doing this instead of letting gcc and clang use their defaults if the Meson subproject doesn't specify a C standard? For example OpenSSL's `meson.build` specifies `s_std:gnu11` but others such as libuv or libsrtp don't do it. Why should we force it to be `c11` or whatever? Why should we avoid `gnu11` or `gnu17` C standards when they are **the default** C standards used by gcc and clang if the project doesn't define a specific standard? Why should we decide this if the developers of those libraries don't even decide it and instead rely on the default choice of gcc and glang?