### PR TITLE
Refactor: Use nullToUndefined for optional FlatBuffers fields

### DIFF
--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -629,7 +629,7 @@ function parseTraceEventData(
 		timestamp: Number(trace.timestamp()),
 		direction:
 			trace.direction() === FbsTraceDirection.DIRECTION_IN ? 'in' : 'out',
-		info: info?.unpack(),
+		info: fbsUtils.nullToUndefined(info?.unpack()),
 	};
 }
 

--- a/node/src/Producer.ts
+++ b/node/src/Producer.ts
@@ -519,11 +519,7 @@ function parseProducerDump(data: FbsProducer.DumpResponse): ProducerDump {
 		kind: data.kind() === FbsRtpParameters.MediaKind.AUDIO ? 'audio' : 'video',
 		type: producerTypeFromFbs(data.type()),
 		rtpParameters: parseRtpParameters(data.rtpParameters()!),
-		// NOTE: optional values are represented with null instead of undefined.
-		// TODO: Make flatbuffers TS return undefined instead of null.
-		rtpMapping: data.rtpMapping()?.unpack(),
-		// NOTE: optional values are represented with null instead of undefined.
-		// TODO: Make flatbuffers TS return undefined instead of null.
+		rtpMapping: fbsUtils.nullToUndefined(data.rtpMapping()?.unpack()),
 		rtpStreams:
 			data.rtpStreamsLength() > 0
 				? fbsUtils.parseVector(data, 'rtpStreams', rtpStream =>
@@ -573,6 +569,6 @@ function parseTraceEventData(
 		timestamp: Number(trace.timestamp()),
 		direction:
 			trace.direction() === FbsTraceDirection.DIRECTION_IN ? 'in' : 'out',
-		info: info?.unpack(),
+				info: fbsUtils.nullToUndefined(info?.unpack()),
 	};
 }

--- a/node/src/fbsUtils.ts
+++ b/node/src/fbsUtils.ts
@@ -120,3 +120,12 @@ export function parseStringStringArrayVector(
 
 	return array;
 }
+
+/**
+ * Convert FlatBuffers null to TypeScript undefined.
+ * FlatBuffers TypeScript implementation returns null for optional values,
+ * but TypeScript best practices prefer undefined for missing values.
+ */
+export function nullToUndefined<T>(value: T | null): T | undefined {
+	return value === null ? undefined : value;
+}


### PR DESCRIPTION
This PR improves FlatBuffers null handling by introducing a type-safe utility function and applying it consistently across the codebase.