### PR TITLE
Worker: modernize clang-format

### DIFF
--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -156,7 +156,7 @@ jobs:
         run: pip3 install --break-system-packages invoke
 
       # Run clang-format on macOS.
-      - if: ${{ startsWith(matrix.build.os, 'macos'}}
+      - if: ${{ startsWith(matrix.build.os, 'macos') }}
         name: invoke -r worker lint
         run: |
           brew install clang-format@21

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -159,6 +159,7 @@ jobs:
       - if: ${{ startsWith(matrix.build.os, 'macos') }}
         name: invoke -r worker lint
         run: |
+          npm ci --prefix worker/scripts
           brew install clang-format@21
           invoke -r worker lint
 

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -22,7 +22,6 @@ jobs:
           - os: ubuntu-22.04
             cc: gcc
             cxx: g++
-            run-lint: true
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -30,7 +29,6 @@ jobs:
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
-            run-lint: true
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -38,8 +36,6 @@ jobs:
           - os: ubuntu-22.04-arm
             cc: gcc
             cxx: g++
-            # No clang-format for ARM.
-            run-lint: false
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -48,7 +44,6 @@ jobs:
             cc: gcc
             cxx: g++
             pip-break-system-packages: true
-            run-lint: true
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -59,7 +54,6 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
-            run-lint: true
             run-test: true
             run-test-asan-address: true
             run-test-asan-undefined: true
@@ -70,8 +64,6 @@ jobs:
             cc: gcc
             cxx: g++
             pip-break-system-packages: true
-            # No clang-format for ARM.
-            run-lint: false
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -80,8 +72,6 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
-            # No clang-format for ARM.
-            run-lint: false
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -90,7 +80,6 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
-            run-lint: true
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -99,7 +88,6 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
-            run-lint: true
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -107,8 +95,6 @@ jobs:
           - os: windows-2022
             cc: cl
             cxx: cl
-            # No clang-format for Windows.
-            run-lint: false
             # Maybe some day we fix this.
             run-test: false
             # Address Sanitizer does not work on Windows.
@@ -118,8 +104,6 @@ jobs:
           - os: windows-2025
             cc: cl
             cxx: cl
-            # No clang-format for Windows.
-            run-lint: false
             # Maybe some day we fix this.
             run-test: false
             # Address Sanitizer does not work on Windows.
@@ -171,14 +155,12 @@ jobs:
         name: pip3 install --break-system-packages invoke
         run: pip3 install --break-system-packages invoke
 
-      # We need to install npm deps of worker/scripts/package.json.
-      - if: ${{ matrix.build.run-lint }}
-        name: npm ci --prefix worker/scripts
-        run: npm ci --prefix worker/scripts --foreground-scripts
-
-      - if: ${{ matrix.build.run-lint }}
+      # Run clang-format on macOS.
+      - if: ${{ startsWith(matrix.build.os, 'macos'}}
         name: invoke -r worker lint
-        run: invoke -r worker lint
+        run: |
+          brew install clang-format@21
+          invoke -r worker lint
 
       - name: invoke -r worker mediasoup-worker
         run: invoke -r worker mediasoup-worker

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -22,6 +22,7 @@ jobs:
           - os: ubuntu-22.04
             cc: gcc
             cxx: g++
+            run-lint: false
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -29,6 +30,7 @@ jobs:
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
+            run-lint: false
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -36,6 +38,8 @@ jobs:
           - os: ubuntu-22.04-arm
             cc: gcc
             cxx: g++
+            # No clang-format for ARM.
+            run-lint: false
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -44,6 +48,7 @@ jobs:
             cc: gcc
             cxx: g++
             pip-break-system-packages: true
+            run-lint: false
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -54,6 +59,7 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
+            run-lint: false
             run-test: true
             run-test-asan-address: true
             run-test-asan-undefined: true
@@ -64,6 +70,8 @@ jobs:
             cc: gcc
             cxx: g++
             pip-break-system-packages: true
+            # No clang-format for ARM.
+            run-lint: false
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -72,6 +80,8 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
+            # No clang-format for ARM.
+            run-lint: false
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -80,6 +90,7 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
+            run-lint: false
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -88,6 +99,8 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
+            # Run lint for the latest macos.
+            run-lint: true
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
@@ -95,6 +108,8 @@ jobs:
           - os: windows-2022
             cc: cl
             cxx: cl
+            # No clang-format for Windows.
+            run-lint: false
             # Maybe some day we fix this.
             run-test: false
             # Address Sanitizer does not work on Windows.
@@ -104,6 +119,8 @@ jobs:
           - os: windows-2025
             cc: cl
             cxx: cl
+            # No clang-format for Windows.
+            run-lint: false
             # Maybe some day we fix this.
             run-test: false
             # Address Sanitizer does not work on Windows.
@@ -156,7 +173,7 @@ jobs:
         run: pip3 install --break-system-packages invoke
 
       # Run clang-format on macOS.
-      - if: ${{ startsWith(matrix.build.os, 'macos') }}
+      - if: ${{ matrix.build.run-lint && startsWith(matrix.build.os, 'macos') }}
         name: invoke -r worker lint
         run: |
           npm ci --prefix worker/scripts

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -172,13 +172,27 @@ jobs:
         name: pip3 install --break-system-packages invoke
         run: pip3 install --break-system-packages invoke
 
-      # Run clang-format on macOS.
-      - if: ${{ matrix.build.run-lint && startsWith(matrix.build.os, 'macos') }}
-        name: invoke -r worker lint
+      # Fail if run-lint is set for non macos.
+      - if: ${{ matrix.build.run-lint && !startsWith(matrix.build.os, 'macos') }}
+        name: fail if run-lint is set for non macos
         run: |
-          npm ci --prefix worker/scripts
+          echo "run-lint set for non macos"
+          exit 1
+
+      # Install clang-format on macos.
+      - if: ${{ matrix.build.run-lint && startsWith(matrix.build.os, 'macos') }}
+        name: brew install clang-format@21
+        run: |
           brew install clang-format@21
-          invoke -r worker lint
+
+      # We need to install npm deps of worker/scripts/package.json.
+      - if: ${{ matrix.build.run-lint }}
+        name: npm ci --prefix worker/scripts
+        run: npm ci --prefix worker/scripts --foreground-scripts
+
+      - if: ${{ matrix.build.run-lint }}
+        name: invoke -r worker lint
+        run: invoke -r worker lint
 
       - name: invoke -r worker mediasoup-worker
         run: invoke -r worker mediasoup-worker

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -32,7 +32,7 @@ Runs both `lint:node` and `lint:worker` tasks.
 
 #### Install clang-format
 
-A specific clang-format version is required to be installed in the system, which is defined in [clang-format-mjs](../worker/scripts/clang-format-mjs).
+A specific clang-format version is required to be installed in the system, which is defined in [clang-format-mjs](../worker/scripts/clang-format.mjs).
 
 MacOS:
 

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -30,6 +30,22 @@ Creates a prebuilt of `mediasoup-worker` binary in the `worker/prebuild` folder.
 
 Runs both `lint:node` and `lint:worker` tasks.
 
+#### Install clang-format
+
+A specific clang-format version is required to be installed in the system, which is defined in [clang-format-mjs](../worker/scripts/clang-format-mjs).
+
+MacOS:
+
+```bash
+brew install clang-format-VERSION
+```
+
+Linux:
+
+```bash
+sudo apt-get install clang-format-VERSION
+```
+
 ### `npm run lint:node`
 
 Validates mediasoup TypeScript files using [ESLint](https://eslint.org), [Prettier](https://prettier.io) and [Knip](https://knip.dev/).
@@ -38,9 +54,13 @@ Validates mediasoup TypeScript files using [ESLint](https://eslint.org), [Pretti
 
 Validates mediasoup worker C++ files using [clang-format](https://clang.llvm.org/docs/ClangFormat.html). It invokes `invoke lint` below.
 
+See [Install clang-format](#install-clang-format) for requirements.
+
 ### `npm run format`
 
 Runs both `format:node` and `format:worker` tasks.
+
+See [Install clang-format](#install-clang-format) for requirements.
 
 ### `npm run format:node`
 
@@ -49,6 +69,8 @@ Format TypeScript and JavaScript code using [Prettier](https://prettier.io).
 ### `npm run format:worker`
 
 Rewrites mediasoup worker C++ files using [clang-format](https://clang.llvm.org/docs/ClangFormat.html). It invokes `invoke format` below.
+
+See [Install clang-format](#install-clang-format) for requirements.
 
 ### `npm run flatc`
 
@@ -196,9 +218,13 @@ Builds a Xcode project for the mediasoup worker subproject.
 
 Validates mediasoup worker C++ files using [clang-format](https://clang.llvm.org/docs/ClangFormat.html) and rules in `worker/.clang-format`.
 
+See [Install clang-format](#install-clang-format) for requirements.
+
 ### `invoke format`
 
 Rewrites mediasoup worker C++ files using [clang-format](https://clang.llvm.org/docs/ClangFormat.html).
+
+See [Install clang-format](#install-clang-format) for requirements.
 
 ### `invoke test`
 

--- a/worker/.clang-format
+++ b/worker/.clang-format
@@ -72,7 +72,7 @@ PenaltyBreakString: 20
 PenaltyExcessCharacter: 10
 PenaltyReturnTypeOnItsOwnLine: 1000
 PointerAlignment: Left
-ReflowComments: true
+ReflowComments: Always
 SortIncludes: CaseSensitive
 SpaceAfterCStyleCast: false
 SpaceAfterTemplateKeyword: false

--- a/worker/fuzzer/include/RTC/Codecs/FuzzerAV1.hpp
+++ b/worker/fuzzer/include/RTC/Codecs/FuzzerAV1.hpp
@@ -13,8 +13,8 @@ namespace Fuzzer
 			{
 				void Fuzz(const uint8_t* data, size_t len);
 			} // namespace AV1
-		}   // namespace Codecs
-	}     // namespace RTC
+		} // namespace Codecs
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/Codecs/FuzzerDependencyDescriptor.hpp
+++ b/worker/fuzzer/include/RTC/Codecs/FuzzerDependencyDescriptor.hpp
@@ -13,8 +13,8 @@ namespace Fuzzer
 			{
 				void Fuzz(const uint8_t* data, size_t len);
 			} // namespace DependencyDescriptor
-		}   // namespace Codecs
-	}     // namespace RTC
+		} // namespace Codecs
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/Codecs/FuzzerH264.hpp
+++ b/worker/fuzzer/include/RTC/Codecs/FuzzerH264.hpp
@@ -14,7 +14,7 @@ namespace Fuzzer
 				void Fuzz(const uint8_t* data, size_t len);
 			}
 		} // namespace Codecs
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/Codecs/FuzzerOpus.hpp
+++ b/worker/fuzzer/include/RTC/Codecs/FuzzerOpus.hpp
@@ -14,7 +14,7 @@ namespace Fuzzer
 				void Fuzz(const uint8_t* data, size_t len);
 			}
 		} // namespace Codecs
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/Codecs/FuzzerVP8.hpp
+++ b/worker/fuzzer/include/RTC/Codecs/FuzzerVP8.hpp
@@ -14,7 +14,7 @@ namespace Fuzzer
 				void Fuzz(const uint8_t* data, size_t len);
 			}
 		} // namespace Codecs
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/Codecs/FuzzerVP9.hpp
+++ b/worker/fuzzer/include/RTC/Codecs/FuzzerVP9.hpp
@@ -14,7 +14,7 @@ namespace Fuzzer
 				void Fuzz(const uint8_t* data, size_t len);
 			}
 		} // namespace Codecs
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/FuzzerDtlsTransport.hpp
+++ b/worker/fuzzer/include/RTC/FuzzerDtlsTransport.hpp
@@ -33,7 +33,7 @@ namespace Fuzzer
 
 			void Fuzz(const uint8_t* data, size_t len);
 		} // namespace DtlsTransport
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerBye.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerBye.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::ByePacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPs.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPs.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::Packet* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsAfb.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsAfb.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackPsAfbPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsFir.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsFir.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackPsFirPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsLei.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsLei.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackPsLeiPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsPli.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsPli.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackPsPliPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsRemb.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsRemb.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackPsRembPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsRpsi.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsRpsi.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackPsRpsiPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsSli.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsSli.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackPsSliPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsTst.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsTst.hpp
@@ -20,7 +20,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackPsTstrPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsVbcm.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsVbcm.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackPsVbcmPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtp.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtp.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::Packet* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpEcn.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpEcn.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackRtpEcnPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpNack.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpNack.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackRtpNackPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpSrReq.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpSrReq.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackRtpSrReqPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTllei.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTllei.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackRtpTlleiPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTmmb.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTmmb.hpp
@@ -20,7 +20,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackRtpTmmbrPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTransport.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTransport.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::FeedbackRtpTransportPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerPacket.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerPacket.hpp
@@ -14,7 +14,7 @@ namespace Fuzzer
 				void Fuzz(const uint8_t* data, size_t len);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerReceiverReport.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerReceiverReport.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::ReceiverReportPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerSdes.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerSdes.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::SdesPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerSenderReport.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerSenderReport.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::SenderReportPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerXr.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerXr.hpp
@@ -15,7 +15,7 @@ namespace Fuzzer
 				void Fuzz(::RTC::RTCP::ExtendedReportPacket* packet);
 			}
 		} // namespace RTCP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/SCTP/association/FuzzerStateCookie.hpp
+++ b/worker/fuzzer/include/RTC/SCTP/association/FuzzerStateCookie.hpp
@@ -14,7 +14,7 @@ namespace Fuzzer
 				void Fuzz(const uint8_t* data, size_t len);
 			}
 		} // namespace SCTP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/fuzzer/include/RTC/SCTP/packet/FuzzerPacket.hpp
+++ b/worker/fuzzer/include/RTC/SCTP/packet/FuzzerPacket.hpp
@@ -14,7 +14,7 @@ namespace Fuzzer
 				void Fuzz(const uint8_t* data, size_t len);
 			}
 		} // namespace SCTP
-	}   // namespace RTC
+	} // namespace RTC
 } // namespace Fuzzer
 
 #endif

--- a/worker/include/RTC/Codecs/H264.hpp
+++ b/worker/include/RTC/Codecs/H264.hpp
@@ -69,7 +69,7 @@ namespace RTC
 				}
 				bool Process(
 				  RTC::Codecs::EncodingContext* encodingContext, RTC::RtpPacket* packet, bool& marker) override;
-				void RtpPacketCloned(RtpPacket* packet) override{};
+				void RtpPacketCloned(RtpPacket* packet) override {};
 				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
 				{
 					return nullptr;

--- a/worker/include/RTC/Codecs/Opus.hpp
+++ b/worker/include/RTC/Codecs/Opus.hpp
@@ -65,7 +65,7 @@ namespace RTC
 				}
 				bool Process(
 				  RTC::Codecs::EncodingContext* encodingContext, RTC::RtpPacket* packet, bool& marker) override;
-				void RtpPacketCloned(RtpPacket* packet) override{};
+				void RtpPacketCloned(RtpPacket* packet) override {};
 				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
 				{
 					return nullptr;

--- a/worker/include/RTC/Codecs/VP8.hpp
+++ b/worker/include/RTC/Codecs/VP8.hpp
@@ -147,7 +147,7 @@ namespace RTC
 				}
 				bool Process(
 				  RTC::Codecs::EncodingContext* encodingContext, RTC::RtpPacket* packet, bool& marker) override;
-				void RtpPacketCloned(RtpPacket* packet) override{};
+				void RtpPacketCloned(RtpPacket* packet) override {};
 				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
 				{
 					return this->payloadDescriptor->GetEncoder();

--- a/worker/include/RTC/Codecs/VP9.hpp
+++ b/worker/include/RTC/Codecs/VP9.hpp
@@ -126,7 +126,7 @@ namespace RTC
 				}
 				bool Process(
 				  RTC::Codecs::EncodingContext* encodingContext, RTC::RtpPacket* packet, bool& marker) override;
-				void RtpPacketCloned(RtpPacket* packet) override{};
+				void RtpPacketCloned(RtpPacket* packet) override {};
 				std::unique_ptr<RTC::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
 				{
 					return nullptr;

--- a/worker/include/RTC/PipeTransport.hpp
+++ b/worker/include/RTC/PipeTransport.hpp
@@ -75,9 +75,7 @@ namespace RTC
 		RTC::SrtpSession* srtpSendSession{ nullptr };
 		// Others.
 		ListenInfo listenInfo;
-		struct sockaddr_storage remoteAddrStorage
-		{
-		};
+		struct sockaddr_storage remoteAddrStorage{};
 		bool rtx{ false };
 		std::string srtpKey;
 		std::string srtpKeyBase64;

--- a/worker/include/RTC/PlainTransport.hpp
+++ b/worker/include/RTC/PlainTransport.hpp
@@ -76,12 +76,8 @@ namespace RTC
 		ListenInfo rtcpListenInfo;
 		bool rtcpMux{ true };
 		bool comedia{ false };
-		struct sockaddr_storage remoteAddrStorage
-		{
-		};
-		struct sockaddr_storage rtcpRemoteAddrStorage
-		{
-		};
+		struct sockaddr_storage remoteAddrStorage{};
+		struct sockaddr_storage rtcpRemoteAddrStorage{};
 		RTC::SrtpSession::CryptoSuite srtpCryptoSuite{
 			RTC::SrtpSession::CryptoSuite::AES_CM_128_HMAC_SHA1_80
 		};

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -78,7 +78,7 @@ namespace RTC
 		/* Struct for replacing and setting header extensions. */
 		struct GenericExtension
 		{
-			GenericExtension(uint8_t id, uint8_t len, uint8_t* value) : id(id), len(len), value(value){};
+			GenericExtension(uint8_t id, uint8_t len, uint8_t* value) : id(id), len(len), value(value) {};
 
 			uint8_t id;
 			uint8_t len;

--- a/worker/include/RTC/TransportTuple.hpp
+++ b/worker/include/RTC/TransportTuple.hpp
@@ -155,9 +155,7 @@ namespace RTC
 		RTC::TcpConnection* tcpConnection{ nullptr };
 		std::string localAnnouncedAddress;
 		// Others.
-		struct sockaddr_storage udpRemoteAddrStorage
-		{
-		};
+		struct sockaddr_storage udpRemoteAddrStorage{};
 		Protocol protocol;
 	};
 } // namespace RTC

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -74,9 +74,7 @@ namespace Utils
 
 		static struct sockaddr_storage CopyAddress(const struct sockaddr* addr)
 		{
-			struct sockaddr_storage copiedAddr
-			{
-			};
+			struct sockaddr_storage copiedAddr{};
 
 			switch (addr->sa_family)
 			{

--- a/worker/include/handles/TcpConnectionHandle.hpp
+++ b/worker/include/handles/TcpConnectionHandle.hpp
@@ -132,9 +132,7 @@ protected:
 	size_t bufferDataLen{ 0u };
 	std::string localIp;
 	uint16_t localPort{ 0u };
-	struct sockaddr_storage peerAddr
-	{
-	};
+	struct sockaddr_storage peerAddr{};
 	std::string peerIp;
 	uint16_t peerPort{ 0u };
 

--- a/worker/include/handles/TcpServerHandle.hpp
+++ b/worker/include/handles/TcpServerHandle.hpp
@@ -64,9 +64,7 @@ public:
 	void OnTcpConnectionClosed(TcpConnectionHandle* connection) override;
 
 protected:
-	struct sockaddr_storage localAddr
-	{
-	};
+	struct sockaddr_storage localAddr{};
 	std::string localIp;
 	uint16_t localPort{ 0u };
 

--- a/worker/include/handles/UdpSocketHandle.hpp
+++ b/worker/include/handles/UdpSocketHandle.hpp
@@ -94,9 +94,7 @@ protected:
 	  const uint8_t* data, size_t len, const struct sockaddr* addr) = 0;
 
 protected:
-	struct sockaddr_storage localAddr
-	{
-	};
+	struct sockaddr_storage localAddr{};
 	std::string localIp;
 	uint16_t localPort{ 0u };
 

--- a/worker/scripts/clang-format.mjs
+++ b/worker/scripts/clang-format.mjs
@@ -1,13 +1,27 @@
 import { execSync } from 'node:child_process';
 import { glob } from 'glob';
-import clangFormat from 'clang-format';
 
+const REQUIRED_CLANG_FORMAT_VERSION = 21;
 const task = process.argv.slice(2).join(' ');
+
+let clangFormatBinary = 'clang-format';
 
 void run();
 
 async function run() {
-	const clangFormatNativeBinary = clangFormat.getNativeBinary();
+	if (!process.env.MEDIASOUP_CLANG_FORMAT_BINARY) {
+		logInfo(
+			'MEDIASOUP_CLANG_FORMAT_BINARY not specified, using "clang-format"'
+		);
+	} else {
+		clangFormatBinary = process.env.MEDIASOUP_CLANG_FORMAT_BINARY;
+		logInfo(
+			`MEDIASOUP_CLANG_FORMAT_BINARY specified, using "${clangFormatBinary}"`
+		);
+	}
+
+	checkClangFormatVersion(REQUIRED_CLANG_FORMAT_VERSION);
+
 	const workerFiles = await glob([
 		'../src/**/*.cpp',
 		'../include/**/*.hpp',
@@ -20,18 +34,14 @@ async function run() {
 	switch (task) {
 		case 'lint': {
 			executeCmd(
-				`"${clangFormatNativeBinary}" --Werror --dry-run ${workerFiles.join(
-					' '
-				)}`
+				`"${clangFormatBinary}" --Werror --dry-run ${workerFiles.join(' ')}`
 			);
 
 			break;
 		}
 
 		case 'format': {
-			executeCmd(
-				`"${clangFormatNativeBinary}" --Werror -i ${workerFiles.join(' ')}`
-			);
+			executeCmd(`"${clangFormatBinary}" --Werror -i ${workerFiles.join(' ')}`);
 
 			break;
 		}
@@ -54,7 +64,6 @@ function executeCmd(command) {
 	}
 }
 
-// eslint-disable-next-line no-unused-vars
 function logInfo(message) {
 	// eslint-disable-next-line no-console
 	console.log(`clang-format.mjs \x1b[36m[INFO] [${task}]\x1b[0m`, message);
@@ -73,4 +82,44 @@ function logError(message) {
 
 function exitWithError() {
 	process.exit(1);
+}
+
+function getClangFormatVersion() {
+	try {
+		// Run the command and capture the output.
+		const output = execSync(`${clangFormatBinary} --version`, {
+			encoding: 'utf-8',
+		});
+
+		// Extract the mayor version number from the output.
+		const match = output.match(/version (\d+)/);
+
+		if (match && match[1]) {
+			return parseInt(match[1], 10);
+		} else {
+			logError(`Unable to parse clang-format version: ${output}`);
+			exitWithError();
+		}
+	} catch (error) {
+		logError(`Error executing clang-format --version: ${error.message}`);
+		exitWithError();
+	}
+}
+
+function checkClangFormatVersion(requiredVersion) {
+	try {
+		const version = getClangFormatVersion();
+
+		if (version === requiredVersion) {
+			logInfo(`clang-format version is the required one (${requiredVersion})`);
+		} else {
+			logInfo(
+				`clang-format version (${version}) is not the required one (${requiredVersion})`
+			);
+			exitWithError();
+		}
+	} catch (error) {
+		logInfo(`Failed to check clang-format version: ${error.message}`);
+		exitWithError();
+	}
 }

--- a/worker/scripts/package-lock.json
+++ b/worker/scripts/package-lock.json
@@ -8,7 +8,6 @@
 			"name": "mediasoup-worker-dev-tools",
 			"version": "0.0.1",
 			"dependencies": {
-				"clang-format": "^1.8.0",
 				"glob": "^11.0.3"
 			}
 		},
@@ -74,71 +73,6 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
-		"node_modules/async": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-			"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
-		},
-		"node_modules/balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-		},
-		"node_modules/clang-format": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.8.0.tgz",
-			"integrity": "sha512-pK8gzfu55/lHzIpQ1givIbWfn3eXnU7SfxqIwVgnn5jEM6j4ZJYjpFqFs4iSBPNedzRMmfjYjuQhu657WAXHXw==",
-			"dependencies": {
-				"async": "^3.2.3",
-				"glob": "^7.0.0",
-				"resolve": "^1.1.6"
-			},
-			"bin": {
-				"check-clang-format": "bin/check-clang-format.js",
-				"clang-format": "index.js",
-				"git-clang-format": "bin/git-clang-format"
-			}
-		},
-		"node_modules/clang-format/node_modules/brace-expansion": {
-			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-			"license": "MIT",
-			"dependencies": {
-				"balanced-match": "^1.0.0",
-				"concat-map": "0.0.1"
-			}
-		},
-		"node_modules/clang-format/node_modules/glob": {
-			"version": "7.2.3",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-			"dependencies": {
-				"fs.realpath": "^1.0.0",
-				"inflight": "^1.0.4",
-				"inherits": "2",
-				"minimatch": "^3.1.1",
-				"once": "^1.3.0",
-				"path-is-absolute": "^1.0.0"
-			},
-			"engines": {
-				"node": "*"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/clang-format/node_modules/minimatch": {
-			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-			"dependencies": {
-				"brace-expansion": "^1.1.7"
-			},
-			"engines": {
-				"node": "*"
-			}
-		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -156,11 +90,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"license": "MIT"
-		},
-		"node_modules/concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
@@ -204,16 +133,6 @@
 				"url": "https://github.com/sponsors/isaacs"
 			}
 		},
-		"node_modules/fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-		},
-		"node_modules/function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-		},
 		"node_modules/glob": {
 			"version": "11.0.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
@@ -235,42 +154,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"dependencies": {
-				"function-bind": "^1.1.1"
-			},
-			"engines": {
-				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"dependencies": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"node_modules/inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"node_modules/is-core-module": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-			"integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
-			"dependencies": {
-				"has": "^1.0.3"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/is-fullwidth-code-point": {
@@ -336,27 +219,11 @@
 				"node": ">=16 || 14 >=14.17"
 			}
 		},
-		"node_modules/once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dependencies": {
-				"wrappy": "1"
-			}
-		},
 		"node_modules/package-json-from-dist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
 			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
 			"license": "BlueOak-1.0.0"
-		},
-		"node_modules/path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
@@ -366,11 +233,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
 		},
 		"node_modules/path-scurry": {
 			"version": "2.0.0",
@@ -386,18 +248,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"dependencies": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/shebang-command": {
@@ -634,11 +484,6 @@
 			"engines": {
 				"node": ">=8"
 			}
-		},
-		"node_modules/wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		}
 	},
 	"dependencies": {
@@ -678,58 +523,6 @@
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.1.tgz",
 			"integrity": "sha512-bN798gFfQX+viw3R7yrGWRqnrN2oRkEkUjjl4JNn4E8GxxbjtG3FbrEIIY3l8/hrwUwIeCZvi4QuOTP4MErVug=="
 		},
-		"async": {
-			"version": "3.2.5",
-			"resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
-			"integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg=="
-		},
-		"balanced-match": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
-		},
-		"clang-format": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.8.0.tgz",
-			"integrity": "sha512-pK8gzfu55/lHzIpQ1givIbWfn3eXnU7SfxqIwVgnn5jEM6j4ZJYjpFqFs4iSBPNedzRMmfjYjuQhu657WAXHXw==",
-			"requires": {
-				"async": "^3.2.3",
-				"glob": "^7.0.0",
-				"resolve": "^1.1.6"
-			},
-			"dependencies": {
-				"brace-expansion": {
-					"version": "1.1.12",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-					"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
-					"requires": {
-						"balanced-match": "^1.0.0",
-						"concat-map": "0.0.1"
-					}
-				},
-				"glob": {
-					"version": "7.2.3",
-					"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-					"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
-					"requires": {
-						"fs.realpath": "^1.0.0",
-						"inflight": "^1.0.4",
-						"inherits": "2",
-						"minimatch": "^3.1.1",
-						"once": "^1.3.0",
-						"path-is-absolute": "^1.0.0"
-					}
-				},
-				"minimatch": {
-					"version": "3.1.2",
-					"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-					"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-					"requires": {
-						"brace-expansion": "^1.1.7"
-					}
-				}
-			}
-		},
 		"color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -742,11 +535,6 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-		},
-		"concat-map": {
-			"version": "0.0.1",
-			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-			"integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
 		},
 		"cross-spawn": {
 			"version": "7.0.6",
@@ -777,16 +565,6 @@
 				"signal-exit": "^4.0.1"
 			}
 		},
-		"fs.realpath": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-			"integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-		},
-		"function-bind": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
-		},
 		"glob": {
 			"version": "11.0.3",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-11.0.3.tgz",
@@ -798,36 +576,6 @@
 				"minipass": "^7.1.2",
 				"package-json-from-dist": "^1.0.0",
 				"path-scurry": "^2.0.0"
-			}
-		},
-		"has": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
-			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
-			"requires": {
-				"function-bind": "^1.1.1"
-			}
-		},
-		"inflight": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-			"integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-			"requires": {
-				"once": "^1.3.0",
-				"wrappy": "1"
-			}
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"is-core-module": {
-			"version": "2.8.0",
-			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.8.0.tgz",
-			"integrity": "sha512-vd15qHsaqrRL7dtH6QNuy0ndJmRDrS9HAM1CAiSifNUFv4x1a0CCVsj18hJ1mShxIG6T2i1sO78MkP56r0nYRw==",
-			"requires": {
-				"has": "^1.0.3"
 			}
 		},
 		"is-fullwidth-code-point": {
@@ -866,33 +614,15 @@
 			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
 			"integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw=="
 		},
-		"once": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"requires": {
-				"wrappy": "1"
-			}
-		},
 		"package-json-from-dist": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
 			"integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="
 		},
-		"path-is-absolute": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
-		},
 		"path-key": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
-		},
-		"path-parse": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
-			"integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
 		},
 		"path-scurry": {
 			"version": "2.0.0",
@@ -901,15 +631,6 @@
 			"requires": {
 				"lru-cache": "^11.0.0",
 				"minipass": "^7.1.2"
-			}
-		},
-		"resolve": {
-			"version": "1.20.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
-			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
-			"requires": {
-				"is-core-module": "^2.2.0",
-				"path-parse": "^1.0.6"
 			}
 		},
 		"shebang-command": {
@@ -1058,11 +779,6 @@
 					}
 				}
 			}
-		},
-		"wrappy": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		}
 	}
 }

--- a/worker/scripts/package.json
+++ b/worker/scripts/package.json
@@ -7,7 +7,6 @@
 		"format": "node clang-format.mjs format"
 	},
 	"dependencies": {
-		"clang-format": "^1.8.0",
 		"glob": "^11.0.3"
 	}
 }

--- a/worker/src/RTC/AudioLevelObserver.cpp
+++ b/worker/src/RTC/AudioLevelObserver.cpp
@@ -177,8 +177,9 @@ namespace RTC
 
 			for (; idx < this->maxEntries && rit != mapDBovsProducer.crend(); ++idx, ++rit)
 			{
-				volumes.emplace_back(FBS::AudioLevelObserver::CreateVolumeDirect(
-				  this->shared->channelNotifier->GetBufferBuilder(), rit->second->id.c_str(), rit->first));
+				volumes.emplace_back(
+				  FBS::AudioLevelObserver::CreateVolumeDirect(
+				    this->shared->channelNotifier->GetBufferBuilder(), rit->second->id.c_str(), rit->first));
 			}
 
 			auto notification = FBS::AudioLevelObserver::CreateVolumesNotificationDirect(

--- a/worker/src/RTC/NackGenerator.cpp
+++ b/worker/src/RTC/NackGenerator.cpp
@@ -200,13 +200,14 @@ namespace RTC
 				continue;
 			}
 
-			this->nackList.emplace(std::make_pair(
-			  seq,
-			  NackInfo{
-			    DepLibUV::GetTimeMs(),
+			this->nackList.emplace(
+			  std::make_pair(
 			    seq,
-			    seq,
-			  }));
+			    NackInfo{
+			      DepLibUV::GetTimeMs(),
+			      seq,
+			      seq,
+			    }));
 		}
 	}
 

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -47,9 +47,7 @@ namespace RTC
 
 		int err;
 		const int family = Utils::IP::GetFamily(ip);
-		struct sockaddr_storage bindAddr
-		{
-		};
+		struct sockaddr_storage bindAddr{};
 		uv_handle_t* uvHandle{ nullptr };
 		std::string protocolStr;
 		const uint8_t bitFlags = ConvertSocketFlags(flags, protocol, family);
@@ -262,9 +260,7 @@ namespace RTC
 
 		int err;
 		const int family = Utils::IP::GetFamily(ip);
-		struct sockaddr_storage bindAddr
-		{
-		};
+		struct sockaddr_storage bindAddr{};
 		std::string protocolStr;
 
 		switch (protocol)

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -278,13 +278,14 @@ namespace RTC
 
 		for (const auto& encodingMapping : this->rtpMapping.encodings)
 		{
-			encodings.emplace_back(FBS::RtpParameters::CreateEncodingMappingDirect(
-			  builder,
-			  encodingMapping.rid.c_str(),
-			  encodingMapping.ssrc != 0u ? flatbuffers::Optional<uint32_t>(encodingMapping.ssrc)
-			                             : flatbuffers::nullopt,
-			  nullptr, /* capability mode. NOTE: Present in NODE*/
-			  encodingMapping.mappedSsrc));
+			encodings.emplace_back(
+			  FBS::RtpParameters::CreateEncodingMappingDirect(
+			    builder,
+			    encodingMapping.rid.c_str(),
+			    encodingMapping.ssrc != 0u ? flatbuffers::Optional<uint32_t>(encodingMapping.ssrc)
+			                               : flatbuffers::nullopt,
+			    nullptr, /* capability mode. NOTE: Present in NODE*/
+			    encodingMapping.mappedSsrc));
 		}
 
 		// Build rtpMapping.
@@ -1532,12 +1533,13 @@ namespace RTC
 				continue;
 			}
 
-			scores.emplace_back(FBS::Producer::CreateScoreDirect(
-			  this->shared->channelNotifier->GetBufferBuilder(),
-			  rtpStream->GetEncodingIdx(),
-			  rtpStream->GetSsrc(),
-			  !rtpStream->GetRid().empty() ? rtpStream->GetRid().c_str() : nullptr,
-			  rtpStream->GetScore()));
+			scores.emplace_back(
+			  FBS::Producer::CreateScoreDirect(
+			    this->shared->channelNotifier->GetBufferBuilder(),
+			    rtpStream->GetEncodingIdx(),
+			    rtpStream->GetSsrc(),
+			    !rtpStream->GetRid().empty() ? rtpStream->GetRid().c_str() : nullptr,
+			    rtpStream->GetScore()));
 		}
 
 		auto notification = FBS::Producer::CreateScoreNotificationDirect(

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -164,8 +164,9 @@ namespace RTC
 				dataConsumerIds.emplace_back(builder.CreateString(dataConsumer->id));
 			}
 
-			mapDataProducerIdDataConsumerIds.emplace_back(FBS::Common::CreateStringStringArrayDirect(
-			  builder, dataProducer->id.c_str(), &dataConsumerIds));
+			mapDataProducerIdDataConsumerIds.emplace_back(
+			  FBS::Common::CreateStringStringArrayDirect(
+			    builder, dataProducer->id.c_str(), &dataConsumerIds));
 		}
 
 		// Add mapDataConsumerIdDataProducerId.
@@ -177,8 +178,9 @@ namespace RTC
 			auto* dataConsumer = kv.first;
 			auto* dataProducer = kv.second;
 
-			mapDataConsumerIdDataProducerId.emplace_back(FBS::Common::CreateStringStringDirect(
-			  builder, dataConsumer->id.c_str(), dataProducer->id.c_str()));
+			mapDataConsumerIdDataProducerId.emplace_back(
+			  FBS::Common::CreateStringStringDirect(
+			    builder, dataConsumer->id.c_str(), dataProducer->id.c_str()));
 		}
 
 		return FBS::Router::CreateDumpResponseDirect(

--- a/worker/src/RTC/RtpDictionaries/Parameters.cpp
+++ b/worker/src/RTC/RtpDictionaries/Parameters.cpp
@@ -38,8 +38,9 @@ namespace RTC
 				{
 					auto valueOffset = FBS::RtpParameters::CreateInteger32(builder, value.integerValue);
 
-					parameters.emplace_back(FBS::RtpParameters::CreateParameterDirect(
-					  builder, key.c_str(), FBS::RtpParameters::Value::Integer32, valueOffset.Union()));
+					parameters.emplace_back(
+					  FBS::RtpParameters::CreateParameterDirect(
+					    builder, key.c_str(), FBS::RtpParameters::Value::Integer32, valueOffset.Union()));
 
 					break;
 				}
@@ -48,8 +49,9 @@ namespace RTC
 				{
 					auto valueOffset = FBS::RtpParameters::CreateDouble(builder, value.doubleValue);
 
-					parameters.emplace_back(FBS::RtpParameters::CreateParameterDirect(
-					  builder, key.c_str(), FBS::RtpParameters::Value::Double, valueOffset.Union()));
+					parameters.emplace_back(
+					  FBS::RtpParameters::CreateParameterDirect(
+					    builder, key.c_str(), FBS::RtpParameters::Value::Double, valueOffset.Union()));
 
 					break;
 				}
@@ -59,8 +61,9 @@ namespace RTC
 					auto valueOffset =
 					  FBS::RtpParameters::CreateStringDirect(builder, value.stringValue.c_str());
 
-					parameters.emplace_back(FBS::RtpParameters::CreateParameterDirect(
-					  builder, key.c_str(), FBS::RtpParameters::Value::String, valueOffset.Union()));
+					parameters.emplace_back(
+					  FBS::RtpParameters::CreateParameterDirect(
+					    builder, key.c_str(), FBS::RtpParameters::Value::String, valueOffset.Union()));
 
 					break;
 				}
@@ -70,8 +73,9 @@ namespace RTC
 					auto valueOffset =
 					  FBS::RtpParameters::CreateInteger32ArrayDirect(builder, &value.arrayOfIntegers);
 
-					parameters.emplace_back(FBS::RtpParameters::CreateParameterDirect(
-					  builder, key.c_str(), FBS::RtpParameters::Value::Integer32Array, valueOffset.Union()));
+					parameters.emplace_back(
+					  FBS::RtpParameters::CreateParameterDirect(
+					    builder, key.c_str(), FBS::RtpParameters::Value::Integer32Array, valueOffset.Union()));
 
 					break;
 				}

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -247,8 +247,9 @@ namespace RTC
 				{
 					auto layer = std::to_string(sIdx) + "." + std::to_string(tIdx);
 
-					bitrateByLayer.emplace_back(FBS::RtpStream::CreateBitrateByLayerDirect(
-					  builder, layer.c_str(), GetBitrate(nowMs, sIdx, tIdx)));
+					bitrateByLayer.emplace_back(
+					  FBS::RtpStream::CreateBitrateByLayerDirect(
+					    builder, layer.c_str(), GetBitrate(nowMs, sIdx, tIdx)));
 				}
 			}
 		}

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -160,9 +160,7 @@ namespace RTC
 		// This ensures that the usrsctp close call deletes the association. This
 		// prevents usrsctp from calling the global send callback with references to
 		// this class as the address.
-		struct linger lingerOpt
-		{
-		}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+		struct linger lingerOpt{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 		lingerOpt.l_onoff  = 1;
 		lingerOpt.l_linger = 0;
@@ -177,9 +175,7 @@ namespace RTC
 		}
 
 		// Set SCTP_ENABLE_STREAM_RESET.
-		struct sctp_assoc_value av
-		{
-		}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+		struct sctp_assoc_value av{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 		av.assoc_value =
 		  SCTP_ENABLE_RESET_STREAM_REQ | SCTP_ENABLE_RESET_ASSOC_REQ | SCTP_ENABLE_CHANGE_ASSOC_REQ;
@@ -206,9 +202,7 @@ namespace RTC
 		}
 
 		// Enable events.
-		struct sctp_event event
-		{
-		}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+		struct sctp_event event{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 		std::memset(&event, 0, sizeof(event));
 		event.se_on = 1;
@@ -228,9 +222,7 @@ namespace RTC
 		}
 
 		// Init message.
-		struct sctp_initmsg initmsg
-		{
-		}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+		struct sctp_initmsg initmsg{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 		std::memset(&initmsg, 0, sizeof(initmsg));
 		initmsg.sinit_num_ostreams  = this->os;
@@ -246,9 +238,7 @@ namespace RTC
 		}
 
 		// Server side.
-		struct sockaddr_conn sconn
-		{
-		}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+		struct sockaddr_conn sconn{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 		std::memset(&sconn, 0, sizeof(sconn));
 		sconn.sconn_family = AF_CONN;
@@ -309,9 +299,7 @@ namespace RTC
 		try
 		{
 			int ret;
-			struct sockaddr_conn rconn
-			{
-			}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+			struct sockaddr_conn rconn{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 			std::memset(&rconn, 0, sizeof(rconn));
 			rconn.sconn_family = AF_CONN;
@@ -407,9 +395,7 @@ namespace RTC
 		const auto& parameters = dataConsumer->GetSctpStreamParameters();
 
 		// Fill sctp_sendv_spa.
-		struct sctp_sendv_spa spa
-		{
-		}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+		struct sctp_sendv_spa spa{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 		std::memset(&spa, 0, sizeof(spa));
 		spa.sendv_flags             = SCTP_SEND_SNDINFO_VALID;
@@ -547,9 +533,7 @@ namespace RTC
 		}
 
 		int ret;
-		struct sctp_assoc_value av
-		{
-		}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+		struct sctp_assoc_value av{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 		socklen_t len = sizeof(av);
 
 		ret = usrsctp_getsockopt(this->socket, IPPROTO_SCTP, SCTP_RECONFIG_SUPPORTED, &av, &len);
@@ -647,9 +631,7 @@ namespace RTC
 			return;
 		}
 
-		struct sctp_add_streams sas
-		{
-		}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+		struct sctp_add_streams sas{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 		std::memset(&sas, 0, sizeof(sas));
 		sas.sas_instrms  = 0;

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -29,8 +29,9 @@ namespace RTC
 	  uint32_t maxOutgoingBitrate,
 	  uint32_t minOutgoingBitrate)
 	  : listener(listener), bweType(bweType),
-	    initialAvailableBitrate(std::max<uint32_t>(
-	      initialAvailableBitrate, RTC::TransportCongestionControlMinOutgoingBitrate)),
+	    initialAvailableBitrate(
+	      std::max<uint32_t>(
+	        initialAvailableBitrate, RTC::TransportCongestionControlMinOutgoingBitrate)),
 	    maxOutgoingBitrate(maxOutgoingBitrate), minOutgoingBitrate(minOutgoingBitrate)
 	{
 		MS_TRACE();
@@ -162,7 +163,7 @@ namespace RTC
 		}
 
 		// Notify the transport feedback adapter about the sent packet.
-		rtc::SentPacket const sentPacket(packetInfo.transport_sequence_number, nowMs);
+		const rtc::SentPacket sentPacket(packetInfo.transport_sequence_number, nowMs);
 		this->rtpTransportControllerSend->OnSentPacket(sentPacket, packetInfo.length);
 	}
 

--- a/worker/src/RTC/WebRtcServer.cpp
+++ b/worker/src/RTC/WebRtcServer.cpp
@@ -269,13 +269,15 @@ namespace RTC
 		{
 			if (item.udpSocket)
 			{
-				udpSockets.emplace_back(FBS::WebRtcServer::CreateIpPortDirect(
-				  builder, item.udpSocket->GetLocalIp().c_str(), item.udpSocket->GetLocalPort()));
+				udpSockets.emplace_back(
+				  FBS::WebRtcServer::CreateIpPortDirect(
+				    builder, item.udpSocket->GetLocalIp().c_str(), item.udpSocket->GetLocalPort()));
 			}
 			else if (item.tcpServer)
 			{
-				tcpServers.emplace_back(FBS::WebRtcServer::CreateIpPortDirect(
-				  builder, item.tcpServer->GetLocalIp().c_str(), item.tcpServer->GetLocalPort()));
+				tcpServers.emplace_back(
+				  FBS::WebRtcServer::CreateIpPortDirect(
+				    builder, item.tcpServer->GetLocalIp().c_str(), item.tcpServer->GetLocalPort()));
 			}
 		}
 
@@ -295,8 +297,9 @@ namespace RTC
 			const auto& localIceUsernameFragment = kv.first;
 			const auto* webRtcTransport          = kv.second;
 
-			localIceUsernameFragments.emplace_back(FBS::WebRtcServer::CreateIceUserNameFragmentDirect(
-			  builder, localIceUsernameFragment.c_str(), webRtcTransport->id.c_str()));
+			localIceUsernameFragments.emplace_back(
+			  FBS::WebRtcServer::CreateIceUserNameFragmentDirect(
+			    builder, localIceUsernameFragment.c_str(), webRtcTransport->id.c_str()));
 		}
 
 		// Add tupleHashes.

--- a/worker/src/Utils/File.cpp
+++ b/worker/src/Utils/File.cpp
@@ -8,7 +8,7 @@
 #include <sys/stat.h> // stat()
 #ifdef _WIN32
 #include <io.h>
-#define __S_ISTYPE(mode, mask) (((mode)&_S_IFMT) == (mask))
+#define __S_ISTYPE(mode, mask) (((mode) & _S_IFMT) == (mask))
 #define S_ISREG(mode) __S_ISTYPE((mode), _S_IFREG)
 #else
 #include <unistd.h> // access(), R_OK
@@ -20,9 +20,7 @@ namespace Utils
 	{
 		MS_TRACE();
 
-		struct stat fileStat
-		{
-		}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+		struct stat fileStat{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 		int err;
 
 		// Ensure the given file exists.

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -181,9 +181,7 @@ void IgnoreSignals()
 	MS_TRACE();
 
 	int err;
-	struct sigaction act
-	{
-	}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+	struct sigaction act{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 	// clang-format off
 	absl::flat_hash_map<std::string, int> const ignoredSignals =

--- a/worker/test/include/RTC/SCTP/common.hpp
+++ b/worker/test/include/RTC/SCTP/common.hpp
@@ -25,6 +25,7 @@ extern thread_local uint8_t ThrowBuffer[66665];
 
 void resetBuffers();
 
+// clang-format off
 #define CHECK_PACKET(                                                                              \
   /*const Packet**/ packet,                                                                        \
   /*const uint8_t**/ buffer,                                                                       \
@@ -203,5 +204,6 @@ void resetBuffers();
 		REQUIRE_THROWS_AS(errorCause->Clone(ThrowBuffer, length - 1), MediaSoupError);                 \
 	}                                                                                                \
 	while (false)
+// clang-format on
 
 #endif

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -36,7 +36,7 @@ struct TestNackGeneratorInput
 class TestPayloadDescriptorHandler : public Codecs::PayloadDescriptorHandler
 {
 public:
-	explicit TestPayloadDescriptorHandler(bool isKeyFrame) : isKeyFrame(isKeyFrame){};
+	explicit TestPayloadDescriptorHandler(bool isKeyFrame) : isKeyFrame(isKeyFrame) {};
 	~TestPayloadDescriptorHandler() override = default;
 	void Dump(int indentation = 0) const override
 	{

--- a/worker/test/src/RTC/TestSimpleConsumer.cpp
+++ b/worker/test/src/RTC/TestSimpleConsumer.cpp
@@ -46,10 +46,10 @@ class ConsumerListener : public Consumer::Listener
 	void OnConsumerRetransmitRtpPacket(RTC::Consumer* consumer, RTC::RtpPacket* packet) final
 	{
 	}
-	void OnConsumerKeyFrameRequested(RTC::Consumer* consumer, uint32_t mappedSsrc) final{};
-	void OnConsumerNeedBitrateChange(RTC::Consumer* consumer) final{};
-	void OnConsumerNeedZeroBitrate(RTC::Consumer* consumer) final{};
-	void OnConsumerProducerClosed(RTC::Consumer* consumer) final{};
+	void OnConsumerKeyFrameRequested(RTC::Consumer* consumer, uint32_t mappedSsrc) final {};
+	void OnConsumerNeedBitrateChange(RTC::Consumer* consumer) final {};
+	void OnConsumerNeedZeroBitrate(RTC::Consumer* consumer) final {};
+	void OnConsumerProducerClosed(RTC::Consumer* consumer) final {};
 
 public:
 	// Verifies that the given number of packets have been sent,


### PR DESCRIPTION
We were using a very old clang-format out of npm [clang-format package](https://www.npmjs.com/package/clang-format) which is out of date.

Use a modern clang-format and define a specific version (21) to be run .

Also just run lint GH action for macos. We are not trying to test clang-format on different OS.