### PR TITLE
Add jitter in Consumer 'outbound-rtp' stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Add `jitter` in `Consumer` 'outbound-rtp' stats ([PR #1654](https://github.com/versatica/mediasoup/pull/1654)).
+
 ### 3.19.9
 
 - Fix RTCP packets lost in stats ([PR #1651](https://github.com/versatica/mediasoup/pull/1651)).

--- a/node/src/rtpStreamStatsFbsUtils.ts
+++ b/node/src/rtpStreamStatsFbsUtils.ts
@@ -31,7 +31,6 @@ export function parseRtpStreamRecvStats(
 	return {
 		...base,
 		type: 'inbound-rtp',
-		jitter: recvStats.jitter(),
 		byteCount: Number(recvStats.byteCount()),
 		packetCount: Number(recvStats.packetCount()),
 		bitrate: Number(recvStats.bitrate()),
@@ -72,6 +71,7 @@ function parseBaseStreamStats(
 		mimeType: binary.mimeType()!,
 		packetsLost: Number(binary.packetsLost()),
 		fractionLost: Number(binary.fractionLost()),
+		jitter: Number(binary.jitter()),
 		packetsDiscarded: Number(binary.packetsDiscarded()),
 		packetsRetransmitted: Number(binary.packetsRetransmitted()),
 		packetsRepaired: Number(binary.packetsRepaired()),
@@ -79,11 +79,11 @@ function parseBaseStreamStats(
 		nackPacketCount: Number(binary.nackPacketCount()),
 		pliCount: Number(binary.pliCount()),
 		firCount: Number(binary.firCount()),
-		score: binary.score(),
 		roundTripTime: binary.roundTripTime(),
 		rtxPacketsDiscarded: binary.rtxPacketsDiscarded()
 			? Number(binary.rtxPacketsDiscarded())
 			: undefined,
+		score: binary.score(),
 	};
 }
 

--- a/node/src/rtpStreamStatsTypes.ts
+++ b/node/src/rtpStreamStatsTypes.ts
@@ -1,6 +1,5 @@
 export type RtpStreamRecvStats = BaseRtpStreamStats & {
 	type: string;
-	jitter: number;
 	packetCount: number;
 	byteCount: number;
 	bitrate: number;
@@ -23,6 +22,7 @@ export type BaseRtpStreamStats = {
 	mimeType: string;
 	packetsLost: number;
 	fractionLost: number;
+	jitter: number;
 	packetsDiscarded: number;
 	packetsRetransmitted: number;
 	packetsRepaired: number;
@@ -30,9 +30,9 @@ export type BaseRtpStreamStats = {
 	nackPacketCount: number;
 	pliCount: number;
 	firCount: number;
-	score: number;
 	roundTripTime?: number;
 	rtxPacketsDiscarded?: number;
+	score: number;
 };
 
 export type BitrateByLayer = { [key: string]: number };

--- a/rust/src/router/consumer.rs
+++ b/rust/src/router/consumer.rs
@@ -398,6 +398,7 @@ pub struct ConsumerStat {
     pub mime_type: MimeType,
     pub packets_lost: i32,
     pub fraction_lost: u8,
+    pub jitter: u32,
     pub packets_discarded: u64,
     pub packets_retransmitted: u64,
     pub packets_repaired: u64,
@@ -405,11 +406,12 @@ pub struct ConsumerStat {
     pub nack_packet_count: u64,
     pub pli_count: u64,
     pub fir_count: u64,
-    pub score: u8,
     pub packet_count: u64,
     pub byte_count: u64,
     pub bitrate: u32,
     pub round_trip_time: Option<f32>,
+    pub rtx_packets_discarded: Option<u64>,
+    pub score: u8,
 }
 
 impl FromFbs for ConsumerStat {
@@ -432,6 +434,7 @@ impl FromFbs for ConsumerStat {
             mime_type: base.mime_type.to_string().parse().unwrap(),
             packets_lost: base.packets_lost,
             fraction_lost: base.fraction_lost,
+            jitter: base.jitter,
             packets_discarded: base.packets_discarded,
             packets_retransmitted: base.packets_retransmitted,
             packets_repaired: base.packets_repaired,
@@ -439,11 +442,12 @@ impl FromFbs for ConsumerStat {
             nack_packet_count: base.nack_packet_count,
             pli_count: base.pli_count,
             fir_count: base.fir_count,
-            score: base.score,
             packet_count: stats.packet_count,
             byte_count: stats.byte_count,
             bitrate: stats.bitrate,
             round_trip_time: Some(base.round_trip_time),
+            rtx_packets_discarded: Some(base.rtx_packets_discarded),
+            score: base.score,
         }
     }
 }

--- a/rust/src/router/producer.rs
+++ b/rust/src/router/producer.rs
@@ -300,6 +300,7 @@ pub struct ProducerStat {
     pub mime_type: MimeType,
     pub packets_lost: i32,
     pub fraction_lost: u8,
+    pub jitter: u32,
     pub packets_discarded: u64,
     pub packets_retransmitted: u64,
     pub packets_repaired: u64,
@@ -307,14 +308,13 @@ pub struct ProducerStat {
     pub nack_packet_count: u64,
     pub pli_count: u64,
     pub fir_count: u64,
-    pub score: u8,
     pub packet_count: u64,
     pub byte_count: u64,
     pub bitrate: u32,
     pub round_trip_time: Option<f32>,
     pub rtx_packets_discarded: Option<u64>,
+    pub score: u8,
     // RtpStreamRecv specific.
-    pub jitter: u32,
     pub bitrate_by_layer: Vec<BitrateByLayer>,
 }
 
@@ -339,6 +339,7 @@ impl FromFbs for ProducerStat {
             mime_type: base.mime_type.to_string().parse().unwrap(),
             packets_lost: base.packets_lost,
             fraction_lost: base.fraction_lost,
+            jitter: base.jitter,
             packets_discarded: base.packets_discarded,
             packets_retransmitted: base.packets_retransmitted,
             packets_repaired: base.packets_repaired,
@@ -346,13 +347,12 @@ impl FromFbs for ProducerStat {
             nack_packet_count: base.nack_packet_count,
             pli_count: base.pli_count,
             fir_count: base.fir_count,
-            score: base.score,
             packet_count: stats.packet_count,
             byte_count: stats.byte_count,
             bitrate: stats.bitrate,
             round_trip_time: Some(base.round_trip_time),
             rtx_packets_discarded: Some(base.rtx_packets_discarded),
-            jitter: stats.jitter,
+            score: base.score,
             bitrate_by_layer: stats
                 .bitrate_by_layer
                 .iter()

--- a/worker/fbs/rtpStream.fbs
+++ b/worker/fbs/rtpStream.fbs
@@ -50,6 +50,7 @@ table BaseStats {
     mime_type: string (required);
     packets_lost: int32;
     fraction_lost: uint8;
+    jitter: uint32;
     packets_discarded: uint64;
     packets_retransmitted: uint64;
     packets_repaired: uint64;
@@ -57,16 +58,15 @@ table BaseStats {
     nack_packet_count: uint64;
     pli_count: uint64;
     fir_count: uint64;
-    score: uint8;
     rid: string;
     rtx_ssrc: uint32 = null;
     rtx_packets_discarded: uint64;
     round_trip_time: float;
+    score: uint8;
 }
 
 table RecvStats {
     base: Stats (required);
-    jitter: uint32;
     packet_count: uint64;
     byte_count: uint64;
     bitrate: uint32;

--- a/worker/include/RTC/RtpStream.hpp
+++ b/worker/include/RTC/RtpStream.hpp
@@ -199,6 +199,9 @@ namespace RTC
 		uint64_t maxPacketMs{ 0u };
 		int32_t packetsLost{ 0 };
 		uint8_t fractionLost{ 0u };
+		// Jitter in RTP timestamp units. As per spec it's kept as floating value
+		// although it's exposed as integer in the stats.
+		float jitter{ 0 };
 		size_t packetsDiscarded{ 0u };
 		size_t packetsRetransmitted{ 0u };
 		size_t packetsRepaired{ 0u };

--- a/worker/include/RTC/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RtpStreamRecv.hpp
@@ -119,9 +119,6 @@ namespace RTC
 		uint64_t lastSrReceived{ 0u };
 		// Relative transit time for prev packet.
 		int32_t transit{ 0u };
-		// Jitter in RTP timestamp units. As per spec it's kept as floating value
-		// although it's exposed as integer in the stats.
-		float jitter{ 0 };
 		uint8_t firSeqNumber{ 0u };
 		int32_t reportedPacketsLost{ 0 };
 		std::unique_ptr<RTC::NackGenerator> nackGenerator;

--- a/worker/src/RTC/RtpStream.cpp
+++ b/worker/src/RTC/RtpStream.cpp
@@ -68,6 +68,7 @@ namespace RTC
 		  this->params.mimeType.ToString().c_str(),
 		  this->packetsLost,
 		  this->fractionLost,
+		  this->jitter,
 		  this->packetsDiscarded,
 		  this->packetsRetransmitted,
 		  this->packetsRepaired,
@@ -75,12 +76,12 @@ namespace RTC
 		  this->nackPacketCount,
 		  this->pliCount,
 		  this->firCount,
-		  this->score,
 		  !this->params.rid.empty() ? this->params.rid.c_str() : nullptr,
 		  this->params.rtxSsrc ? flatbuffers::Optional<uint32_t>(this->params.rtxSsrc)
 		                       : flatbuffers::nullopt,
 		  this->rtxStream ? this->rtxStream->GetPacketsDiscarded() : 0,
-		  this->rtt > 0.0f ? this->rtt : 0);
+		  this->rtt > 0.0f ? this->rtt : 0,
+		  this->score);
 
 		return FBS::RtpStream::CreateStats(
 		  builder, FBS::RtpStream::StatsData::BaseStats, baseStats.Union());

--- a/worker/src/RTC/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RtpStreamRecv.cpp
@@ -252,7 +252,6 @@ namespace RTC
 		auto stats = FBS::RtpStream::CreateRecvStatsDirect(
 		  builder,
 		  baseStats,
-		  static_cast<uint32_t>(this->jitter),
 		  this->transmissionCounter.GetPacketCount(),
 		  this->transmissionCounter.GetBytes(),
 		  this->transmissionCounter.GetBitrate(nowMs),

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -313,6 +313,7 @@ namespace RTC
 
 		this->packetsLost  = report->GetTotalLost();
 		this->fractionLost = report->GetFractionLost();
+		this->jitter       = static_cast<float>(report->GetJitter());
 
 		// Update the score with the received RR.
 		UpdateScore(report);
@@ -405,6 +406,9 @@ namespace RTC
 		{
 			this->retransmissionBuffer->Clear();
 		}
+
+		// Reset jitter.
+		this->jitter = 0;
 	}
 
 	void RtpStreamSend::Resume()


### PR DESCRIPTION
# Details

- Fixes #1652
- Read jitter from last received RTCP Receiver Report and add it to 'outbound-rtp' stats.

<img width="732" height="1666" alt="CleanShot 2025-11-13 at 14 36 30" src="https://github.com/user-attachments/assets/24d6a103-2b98-4dae-9f03-5c5196bca819" />

(red arrows point to the new things)