### PR TITLE
Only look up the RTP packet’s RID extension if the packet doesn’t have MID extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Only look up the RTP packet’s RID extension if the packet doesn’t have MID extension ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 3.19.11
 
 - Node: Add `workerBin` optional field in `createWorker()` ([PR #1660](https://github.com/versatica/mediasoup/pull/1660)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Only look up the RTP packet’s RID extension if the packet doesn’t have MID extension ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Only look up the RTP packet’s RID extension if the packet doesn’t have MID extension ([PR #1666](https://github.com/versatica/mediasoup/pull/1666)).
 
 ### 3.19.11
 

--- a/worker/src/RTC/RtpListener.cpp
+++ b/worker/src/RTC/RtpListener.cpp
@@ -216,13 +216,22 @@ namespace RTC
 				auto* producer = it->second;
 
 				// Fill the ssrc table.
-				// NOTE: Here we may override an existing key with same SSRC but it's ok.
 
+				MS_DEBUG_DEV(
+				  "inserting entry in ssrcTable [mid:%s, ssrc:%" PRIu32 ", producerId:%s]",
+				  mid.c_str(),
+				  packet->GetSsrc(),
+				  producer.id.c_str());
+
+				// NOTE: Here we may override an existing key with same SSRC but it's ok.
 				if (this->ssrcTable.find(packet->GetSsrc()) != this->ssrcTable.end())
 				{
 					MS_WARN_TAG(
 					  rtp,
-					  "a Producer with ssrc %" PRIu32 " already exists in the ssrcTable, overriding it anyway");
+					  "a Producer with ssrc %" PRIu32
+					  " already exists in the ssrcTable, overriding it anyway [mid:%s]",
+					  packet->GetSsrc(),
+					  mid.c_str());
 				}
 
 				this->ssrcTable[packet->GetSsrc()] = producer;
@@ -242,12 +251,22 @@ namespace RTC
 				auto* producer = it->second;
 
 				// Fill the ssrc table.
+
+				MS_DEBUG_DEV(
+				  "inserting entry in ssrcTable [rid:%s, ssrc:%" PRIu32 ", producerId:%s]",
+				  rid.c_str(),
+				  packet->GetSsrc(),
+				  producer.id.c_str());
+
 				// NOTE: Here we may override an existing key with same SSRC but it's ok.
 				if (this->ssrcTable.find(packet->GetSsrc()) != this->ssrcTable.end())
 				{
 					MS_WARN_TAG(
 					  rtp,
-					  "a Producer with ssrc %" PRIu32 " already exists in the ssrcTable, overriding it anyway");
+					  "a Producer with ssrc %" PRIu32
+					  " already exists in the ssrcTable, overriding it anyway  [rid:%s]",
+					  packet->GetSsrc(),
+					  rid.c_str());
 				}
 
 				this->ssrcTable[packet->GetSsrc()] = producer;

--- a/worker/src/RTC/RtpListener.cpp
+++ b/worker/src/RTC/RtpListener.cpp
@@ -217,11 +217,12 @@ namespace RTC
 
 				// Fill the ssrc table.
 
-				MS_DEBUG_DEV(
+				// TODO: Change this to MS_DEBUG_DEV().
+				MS_DUMP(
 				  "inserting entry in ssrcTable [mid:%s, ssrc:%" PRIu32 ", producerId:%s]",
 				  mid.c_str(),
 				  packet->GetSsrc(),
-				  producer.id.c_str());
+				  producer->id.c_str());
 
 				// NOTE: Here we may override an existing key with same SSRC but it's ok.
 				if (this->ssrcTable.find(packet->GetSsrc()) != this->ssrcTable.end())
@@ -252,11 +253,12 @@ namespace RTC
 
 				// Fill the ssrc table.
 
-				MS_DEBUG_DEV(
+				// TODO: Change this to MS_DEBUG_DEV().
+				MS_DUMP(
 				  "inserting entry in ssrcTable [rid:%s, ssrc:%" PRIu32 ", producerId:%s]",
 				  rid.c_str(),
 				  packet->GetSsrc(),
-				  producer.id.c_str());
+				  producer->id.c_str());
 
 				// NOTE: Here we may override an existing key with same SSRC but it's ok.
 				if (this->ssrcTable.find(packet->GetSsrc()) != this->ssrcTable.end())

--- a/worker/src/RTC/RtpListener.cpp
+++ b/worker/src/RTC/RtpListener.cpp
@@ -217,6 +217,14 @@ namespace RTC
 
 				// Fill the ssrc table.
 				// NOTE: Here we may override an existing key with same SSRC but it's ok.
+
+				if (this->ssrcTable.find(packet->GetSsrc()) != this->ssrcTable.end())
+				{
+					MS_WARN_TAG(
+					  rtp,
+					  "a Producer with ssrc %" PRIu32 " already exists in the ssrcTable, overriding it anyway");
+				}
+
 				this->ssrcTable[packet->GetSsrc()] = producer;
 
 				return producer;
@@ -235,6 +243,13 @@ namespace RTC
 
 				// Fill the ssrc table.
 				// NOTE: Here we may override an existing key with same SSRC but it's ok.
+				if (this->ssrcTable.find(packet->GetSsrc()) != this->ssrcTable.end())
+				{
+					MS_WARN_TAG(
+					  rtp,
+					  "a Producer with ssrc %" PRIu32 " already exists in the ssrcTable, overriding it anyway");
+				}
+
 				this->ssrcTable[packet->GetSsrc()] = producer;
 
 				return producer;

--- a/worker/src/RTC/RtpListener.cpp
+++ b/worker/src/RTC/RtpListener.cpp
@@ -217,8 +217,7 @@ namespace RTC
 
 				// Fill the ssrc table.
 
-				// TODO: Change this to MS_DEBUG_DEV().
-				MS_DUMP(
+				MS_DEBUG_DEV(
 				  "inserting entry in ssrcTable [mid:%s, ssrc:%" PRIu32 ", producerId:%s]",
 				  mid.c_str(),
 				  packet->GetSsrc(),
@@ -253,8 +252,7 @@ namespace RTC
 
 				// Fill the ssrc table.
 
-				// TODO: Change this to MS_DEBUG_DEV().
-				MS_DUMP(
+				MS_DEBUG_DEV(
 				  "inserting entry in ssrcTable [rid:%s, ssrc:%" PRIu32 ", producerId:%s]",
 				  rid.c_str(),
 				  packet->GetSsrc(),

--- a/worker/src/RTC/RtpListener.cpp
+++ b/worker/src/RTC/RtpListener.cpp
@@ -200,45 +200,44 @@ namespace RTC
 			}
 		}
 
+		bool hasMid{ false };
+		std::string mid;
+		std::string rid;
+
 		// Otherwise lookup into the MID table.
+		if (packet->ReadMid(mid))
 		{
-			std::string mid;
+			hasMid = true;
 
-			if (packet->ReadMid(mid))
+			auto it = this->midTable.find(mid);
+
+			if (it != this->midTable.end())
 			{
-				auto it = this->midTable.find(mid);
+				auto* producer = it->second;
 
-				if (it != this->midTable.end())
-				{
-					auto* producer = it->second;
+				// Fill the ssrc table.
+				// NOTE: We may be overriding an exiting SSRC here, but we don't care.
+				this->ssrcTable[packet->GetSsrc()] = producer;
 
-					// Fill the ssrc table.
-					// NOTE: We may be overriding an exiting SSRC here, but we don't care.
-					this->ssrcTable[packet->GetSsrc()] = producer;
-
-					return producer;
-				}
+				return producer;
 			}
 		}
 
-		// Otherwise lookup into the RID table.
+		// Otherwise lookup into the RID table but only do it if the packet doesn't
+		// have MID extension.
+		if (!hasMid && packet->ReadRid(rid))
 		{
-			std::string rid;
+			auto it = this->ridTable.find(rid);
 
-			if (packet->ReadRid(rid))
+			if (it != this->ridTable.end())
 			{
-				auto it = this->ridTable.find(rid);
+				auto* producer = it->second;
 
-				if (it != this->ridTable.end())
-				{
-					auto* producer = it->second;
+				// Fill the ssrc table.
+				// NOTE: We may be overriding an exiting SSRC here, but we don't care.
+				this->ssrcTable[packet->GetSsrc()] = producer;
 
-					// Fill the ssrc table.
-					// NOTE: We may be overriding an exiting SSRC here, but we don't care.
-					this->ssrcTable[packet->GetSsrc()] = producer;
-
-					return producer;
-				}
+				return producer;
 			}
 		}
 

--- a/worker/src/RTC/RtpListener.cpp
+++ b/worker/src/RTC/RtpListener.cpp
@@ -216,7 +216,7 @@ namespace RTC
 				auto* producer = it->second;
 
 				// Fill the ssrc table.
-				// NOTE: We may be overriding an exiting SSRC here, but we don't care.
+				// NOTE: Here we may override an existing key with same SSRC but it's ok.
 				this->ssrcTable[packet->GetSsrc()] = producer;
 
 				return producer;
@@ -234,7 +234,7 @@ namespace RTC
 				auto* producer = it->second;
 
 				// Fill the ssrc table.
-				// NOTE: We may be overriding an exiting SSRC here, but we don't care.
+				// NOTE: Here we may override an existing key with same SSRC but it's ok.
 				this->ssrcTable[packet->GetSsrc()] = producer;
 
 				return producer;


### PR DESCRIPTION
# Details

- When a RTP packet is received by `RtpListener.getProducer(packet)`, and assuming that the packet's SSRC is not yet in the `ssrcTable`, only read the RID extension of the packet if it doesn't have MID extension.
- It fixes a bug exposed in the forum here: https://mediasoup.discourse.group/t/producer-simulcast-ssrc-mixed-up-race-condition/6917/16
- Thanks [Hugo Mallet](https://mediasoup.discourse.group/u/hugo) for reporting the issue.

## The problem

- Imagine client sends simulcast in 2 producers A and B.
- Producer A has MID "A" and 2 RIDs "r0" and "r1".
- Producer B has MID "B" and 2 RIDs "r0" and "r1".
- After a while, Producer A is closed in mediasoup server but not in the client which keeps sending packets from its local Producer A.
- When a packet from Producer A arrives, `RtpListener` won't find it in its `ssrcTable`, neither in its `midTable`. However it will find it in the `ridTable` because both Producers have same RID values, so the `ridTable` contains entries in the `ridTable` with keys "r0" and "r1" and value pointing to Producer 2 (because Producer 2 was created after Producer 1 so its `rid` values override the previous ones of Producer 1, this is ok and expected).
- And hence `RtpListener` will do this: `this->ssrcTable[packet->GetSsrc()] = producer`, and from now on all packets from Producer 1 will be identified as packets of Producer 2 in `RtpListener` and hence a new `RtpStreamRecv` will be created in Producer 2 and it will forward those wrong packets to its Consumers, producing frozen video and different and unexpected issues.

## The solution

- Once Producer 1 has been closed in mediasoup server, there are no entries in the tables of `RtpListener` pointing to it.
- Then a late packet of Producer 1 arrives to mediasoup (or maybe client didn't really close its Producer 1).
- `RtpListener` cannot find an entry in `ssrcTable` neither in `midTable`.
- When it comes to look for an entry in `ridTable`, now we won't do it because the packet also contains MID extension so it should have been identified in the block before when looking in the `midTable`. But it's not in the `midTable` because Producer 1 was closed in mediasoup server.

## Rationale

- All RTP packets that include RID extension also include MID extension.
- Of course, client needs to negotiate MID and RID.
- If a client sends RID without MID and creates different Producers in the same Transport with same RID values, then it has a problem, but it's not a realistic scenario at all.