### PR TITLE
`RtxStream`: Don't check if RTP timestamp moved backwards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- `RtxStream`: Don't check if RTP timestamp moved backwards ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX), credits to @Lynnworld).
+- `RtxStream`: Don't check if RTP timestamp moved backwards ([PR #1668](https://github.com/versatica/mediasoup/pull/1668), credits to @Lynnworld).
 
 ### 3.19.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- `RtxStream`: Don't check if RTP timestamp moved backwards ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX), credits to @Lynnworld).
+
 ### 3.19.12
 
 - Only look up the RTP packet’s RID extension if the packet doesn’t have MID extension ([PR #1666](https://github.com/versatica/mediasoup/pull/1666)).

--- a/worker/src/RTC/RtxStream.cpp
+++ b/worker/src/RTC/RtxStream.cpp
@@ -186,23 +186,6 @@ namespace RTC
 			}
 
 			this->maxSeq = seq;
-
-			// Timestamp moved backwards despite in-order sequence number. Likely
-			// caused by prolonged Producer inactivity (e.g., overnight pause).
-			if (Utils::Number<uint32_t>::IsLowerThan(packet->GetTimestamp(), this->maxPacketTs))
-			{
-				MS_DEBUG_TAG(
-				  rtx,
-				  "timestamp moved backwards, updating [ssrc:%" PRIu32 ", seq:%" PRIu16
-				  ", old maxPacketTs:%" PRIu32 ", new maxPacketTs:%" PRIu32 "]",
-				  packet->GetSsrc(),
-				  packet->GetSequenceNumber(),
-				  this->maxPacketTs,
-				  packet->GetTimestamp());
-
-				this->maxPacketTs = packet->GetTimestamp();
-				this->maxPacketMs = DepLibUV::GetTimeMs();
-			}
 		}
 		// Too old packet received (older than the allowed misorder).
 		// Or to new packet (more than acceptable dropout).


### PR DESCRIPTION
# Details

- Fixes #1667
- Don't check if RTP timestamp moved backwards because timestamp in a RTX packet is the original media packet's timestamp, so it's normal to see a value lower than computed `maxPacketTs`.
- Credits to @Lynnworld.