### PR TITLE
Worker: Perf, avoid dynamic memory allocation in TransportTuple hash

### DIFF
--- a/worker/src/RTC/TransportTuple.cpp
+++ b/worker/src/RTC/TransportTuple.cpp
@@ -3,6 +3,7 @@
 
 #include "RTC/TransportTuple.hpp"
 #include "Logger.hpp"
+#include <cstring> // std::memcpy()
 
 namespace RTC
 {

--- a/worker/src/RTC/TransportTuple.cpp
+++ b/worker/src/RTC/TransportTuple.cpp
@@ -3,7 +3,6 @@
 
 #include "RTC/TransportTuple.hpp"
 #include "Logger.hpp"
-#include <array>
 
 namespace RTC
 {
@@ -155,10 +154,8 @@ namespace RTC
 
 		// Maximum buffer length for two IPv6 addresses and ports plus protocol.
 		static constexpr size_t BufferSize = ((16 + 2) * 2) + 1;
-		std::array<uint8_t, BufferSize> buffer{};
-		// NOTE: Windows cannot deduce the type if using 'auto'.
-		// NOLINTNEXTLINE (hicpp-use-auto)
-		std::array<uint8_t, BufferSize>::iterator it = buffer.begin();
+		uint8_t buffer[BufferSize]         = {};
+		size_t idx                         = 0;
 
 		auto appendSockAddr = [&](const sockaddr* addr)
 		{
@@ -168,11 +165,10 @@ namespace RTC
 				const auto* ip      = reinterpret_cast<const uint8_t*>(&in->sin_addr.s_addr);
 				const uint16_t port = ntohs(in->sin_port);
 
-				it  = std::copy(ip, ip + 4, it);
-				*it = (port >> 8) & 0xFF;
-				it++;
-				*it = port & 0xFF;
-				it++;
+				std::memcpy(buffer + idx, ip, 4);
+				idx += 4;
+				buffer[idx++] = (port >> 8) & 0xFF;
+				buffer[idx++] = port & 0xFF;
 			}
 			else if (addr->sa_family == AF_INET6)
 			{
@@ -180,19 +176,18 @@ namespace RTC
 				const auto* ip      = reinterpret_cast<const uint8_t*>(&in6->sin6_addr);
 				const uint16_t port = ntohs(in6->sin6_port);
 
-				it  = std::copy(ip, ip + 16, it);
-				*it = (port >> 8) & 0xFF;
-				it++;
-				*it = port & 0xFF;
-				it++;
+				std::memcpy(buffer + idx, ip, 16);
+				idx += 16;
+				buffer[idx++] = (port >> 8) & 0xFF;
+				buffer[idx++] = port & 0xFF;
 			}
 		};
 
 		appendSockAddr(localSockAddr);
 		appendSockAddr(remoteSockAddr);
 
-		*it = static_cast<uint8_t>(this->protocol);
+		buffer[idx] = static_cast<uint8_t>(this->protocol);
 
-		this->hash = TransportTuple::GenerateFnv1aHash(buffer.data(), buffer.size());
+		this->hash = TransportTuple::GenerateFnv1aHash(buffer, idx + 1);
 	}
 } // namespace RTC

--- a/worker/src/RTC/TransportTuple.cpp
+++ b/worker/src/RTC/TransportTuple.cpp
@@ -153,7 +153,10 @@ namespace RTC
 		const auto* localSockAddr  = GetLocalAddress();
 		const auto* remoteSockAddr = GetRemoteAddress();
 
-		std::vector<uint8_t> buffer;
+		// Maximum buffer length for two IPv6 addresses and ports plus protocol.
+		static constexpr size_t BufferSize = ((16 + 2) * 2) + 1;
+		std::array<uint8_t, BufferSize> buffer{};
+		auto* it = buffer.begin();
 
 		auto appendSockAddr = [&](const sockaddr* addr)
 		{
@@ -163,9 +166,9 @@ namespace RTC
 				const auto* ip      = reinterpret_cast<const uint8_t*>(&in->sin_addr.s_addr);
 				const uint16_t port = ntohs(in->sin_port);
 
-				buffer.insert(buffer.end(), ip, ip + 4);
-				buffer.push_back((port >> 8) & 0xFF);
-				buffer.push_back(port & 0xFF);
+				it    = std::copy(ip, ip + 4, it);
+				*it++ = (port >> 8) & 0xFF;
+				*it++ = port & 0xFF;
 			}
 			else if (addr->sa_family == AF_INET6)
 			{
@@ -173,16 +176,16 @@ namespace RTC
 				const auto* ip      = reinterpret_cast<const uint8_t*>(&in6->sin6_addr);
 				const uint16_t port = ntohs(in6->sin6_port);
 
-				buffer.insert(buffer.end(), ip, ip + 16);
-				buffer.push_back((port >> 8) & 0xFF);
-				buffer.push_back(port & 0xFF);
+				it    = std::copy(ip, ip + 16, it);
+				*it++ = (port >> 8) & 0xFF;
+				*it++ = port & 0xFF;
 			}
 		};
 
 		appendSockAddr(localSockAddr);
 		appendSockAddr(remoteSockAddr);
 
-		buffer.push_back(static_cast<uint8_t>(this->protocol));
+		*it = static_cast<uint8_t>(this->protocol);
 
 		this->hash = TransportTuple::GenerateFnv1aHash(buffer.data(), buffer.size());
 	}

--- a/worker/src/RTC/TransportTuple.cpp
+++ b/worker/src/RTC/TransportTuple.cpp
@@ -156,7 +156,9 @@ namespace RTC
 		// Maximum buffer length for two IPv6 addresses and ports plus protocol.
 		static constexpr size_t BufferSize = ((16 + 2) * 2) + 1;
 		std::array<uint8_t, BufferSize> buffer{};
-		auto* it = buffer.begin();
+		// NOTE: Windows cannot deduce the type if using 'auto'.
+		// NOLINTNEXTLINE (hicpp-use-auto)
+		std::array<uint8_t, BufferSize>::iterator it = buffer.begin();
 
 		auto appendSockAddr = [&](const sockaddr* addr)
 		{
@@ -166,9 +168,11 @@ namespace RTC
 				const auto* ip      = reinterpret_cast<const uint8_t*>(&in->sin_addr.s_addr);
 				const uint16_t port = ntohs(in->sin_port);
 
-				it    = std::copy(ip, ip + 4, it);
-				*it++ = (port >> 8) & 0xFF;
-				*it++ = port & 0xFF;
+				it  = std::copy(ip, ip + 4, it);
+				*it = (port >> 8) & 0xFF;
+				it++;
+				*it = port & 0xFF;
+				it++;
 			}
 			else if (addr->sa_family == AF_INET6)
 			{
@@ -176,9 +180,11 @@ namespace RTC
 				const auto* ip      = reinterpret_cast<const uint8_t*>(&in6->sin6_addr);
 				const uint16_t port = ntohs(in6->sin6_port);
 
-				it    = std::copy(ip, ip + 16, it);
-				*it++ = (port >> 8) & 0xFF;
-				*it++ = port & 0xFF;
+				it  = std::copy(ip, ip + 16, it);
+				*it = (port >> 8) & 0xFF;
+				it++;
+				*it = port & 0xFF;
+				it++;
 			}
 		};
 

--- a/worker/src/RTC/TransportTuple.cpp
+++ b/worker/src/RTC/TransportTuple.cpp
@@ -3,7 +3,7 @@
 
 #include "RTC/TransportTuple.hpp"
 #include "Logger.hpp"
-#include <vector>
+#include <array>
 
 namespace RTC
 {


### PR DESCRIPTION
For every packet arriving from network we are generating a tuple, and upon creation we create its hash.

Before this PR we were using a `std::vector` which we later fill it with the tuple info. This generates dynamic memory allocation which must later be released.

This PR makes use of `std::array` with a fixed length (we know it in advance), so we store the info only in the stack.

This only change improves CPU performance in a little more than 1%.

Before `TransportTuple::GenerateHash()` took around 1.4%:
<img width="775" height="85" alt="Screenshot 2025-11-26 at 15 28 25" src="https://github.com/user-attachments/assets/ac7e5e40-0075-4df4-967f-a545415ae2fb" />

After  `TransportTuple::GenerateHash()` takes around 0.2%:
<img width="625" height="20" alt="Screenshot 2025-11-26 at 15 17 35" src="https://github.com/user-attachments/assets/397da425-7b0b-4fb5-a1ae-0c6a8bb2abdb" />
