### PR TITLE
RateCalculator: do not retrieve current time if not needed

### DIFF
--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -199,12 +199,12 @@ namespace RTC
 
 	void RtpDataCounter::Update(RTC::RtpPacket* packet)
 	{
-		const uint64_t nowMs = DepLibUV::GetTimeMs();
-
 		this->packets++;
 
 		if (!this->ignorePaddingOnlyPackets || packet->GetPayloadLength() > 0)
 		{
+			const uint64_t nowMs = DepLibUV::GetTimeMs();
+
 			this->rate.Update(packet->GetSize(), nowMs);
 		}
 	}


### PR DESCRIPTION
Nothing relevant. Just do not call `DepLibUV::GetTimeMs()` when not needed.