### PR TITLE
Test receive rtx before corresponding rtp

### DIFF
--- a/worker/test/src/RTC/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/TestRtpStreamRecv.cpp
@@ -174,7 +174,7 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 		REQUIRE(listener.nackedSeqNumbers.empty());
 	}
 
-	SECTION("Receive RTX before corresponding RTP")
+	SECTION("receive RTX before corresponding RTP")
 	{
 		RtpStreamRecvListener listener;
 		RtpStreamRecv rtpStream(&listener, params, SendNackDelay, UseRtpInactivityCheck);

--- a/worker/test/src/RTC/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/TestRtpStreamRecv.cpp
@@ -124,11 +124,12 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 	{
 		0x80, 0x01, 0x00, 0x01,
 		0x00, 0x00, 0x00, 0x04,
-		0x00, 0x00, 0x00, 0x05
+		0x00, 0x00, 0x00, 0x05,
+		0x00, 0x00, 0x00, 0x00 // Extra space for RTX encoding.
 	};
 	// clang-format on
 
-	std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, sizeof(buffer)) };
+	std::unique_ptr<RtpPacket> packet{ RtpPacket::Parse(buffer, 12) };
 
 	if (!packet)
 	{

--- a/worker/test/src/RTC/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/TestRtpStreamRecv.cpp
@@ -137,11 +137,13 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 
 	RtpStream::Params params;
 
-	params.ssrc      = packet->GetSsrc();
-	params.clockRate = 90000;
-	params.useNack   = true;
-	params.usePli    = true;
-	params.useFir    = false;
+	params.ssrc           = packet->GetSsrc();
+	params.rtxSsrc        = 1234;
+	params.rtxPayloadType = 96;
+	params.clockRate      = 90000;
+	params.useNack        = true;
+	params.usePli         = true;
+	params.useFir         = false;
 
 	SECTION("NACK one packet")
 	{
@@ -170,6 +172,37 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 		rtpStream.ReceivePacket(packet.get());
 
 		REQUIRE(listener.nackedSeqNumbers.empty());
+	}
+
+	SECTION("Receive RTX before corresponding RTP")
+	{
+		RtpStreamRecvListener listener;
+		RtpStreamRecv rtpStream(&listener, params, SendNackDelay, UseRtpInactivityCheck);
+
+		packet->SetSequenceNumber(1);
+		rtpStream.ReceivePacket(packet.get());
+
+		packet->SetSequenceNumber(2);
+		rtpStream.ReceivePacket(packet.get());
+
+		packet->SetSequenceNumber(3);
+		rtpStream.ReceivePacket(packet.get());
+
+		packet->SetSequenceNumber(4);
+		rtpStream.ReceivePacket(packet.get());
+
+		packet->SetSequenceNumber(5);
+		rtpStream.ReceivePacket(packet.get());
+
+		auto originalSsrc        = packet->GetSsrc();
+		auto originalPayloadType = packet->GetPayloadType();
+
+		packet->SetSequenceNumber(6);
+		packet->RtxEncode(params.rtxPayloadType, params.rtxSsrc, 1000 /*seq=*/);
+
+		REQUIRE(rtpStream.ReceiveRtxPacket(packet.get()));
+
+		packet->RtxDecode(originalPayloadType, originalSsrc);
 	}
 
 	SECTION("wrapping sequence numbers")

--- a/worker/test/src/RTC/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/TestRtpStreamRecv.cpp
@@ -194,6 +194,8 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream]")
 		packet->SetSequenceNumber(5);
 		rtpStream.ReceivePacket(packet.get());
 
+		// Sequence number 6 arrives via RTX before the original RTP packet.
+
 		auto originalSsrc        = packet->GetSsrc();
 		auto originalPayloadType = packet->GetPayloadType();
 


### PR DESCRIPTION
This test which is defined in https://github.com/versatica/mediasoup/issues/906 description demonstrates that https://github.com/versatica/mediasoup/pull/1653 fixes it. The test fails in v3 and succeeds in that branch.

NOTE: This PR targets https://github.com/versatica/mediasoup/pull/1653. It will be part of that branch once merged.