### PR TITLE
Worker: Fix missing system header include

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - `RtxStream`: Don't check if RTP timestamp moved backwards ([PR #1668](https://github.com/versatica/mediasoup/pull/1668), credits to @Lynnworld).
 - Fix RTX packets containing non yet seen RTP packets being discarded ([PR #1653](https://github.com/versatica/mediasoup/pull/1653), credits to @penguinol, @mengbieting and @Lynnworld).
+- Worker: Fix missing system header include, which fails in GCC 15.
 
 ### 3.19.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 - `RtxStream`: Don't check if RTP timestamp moved backwards ([PR #1668](https://github.com/versatica/mediasoup/pull/1668), credits to @Lynnworld).
 - Fix RTX packets containing non yet seen RTP packets being discarded ([PR #1653](https://github.com/versatica/mediasoup/pull/1653), credits to @penguinol, @mengbieting and @Lynnworld).
-- Worker: Fix missing system header include, which fails in GCC 15.
+- Worker: Fix missing system header include, which fails in GCC 15 ([PR #1679](https://github.com/versatica/mediasoup/pull/1679), credits to @upisfree).
 
 ### 3.19.12
 

--- a/worker/deps/libwebrtc/libwebrtc/api/network_state_predictor.h
+++ b/worker/deps/libwebrtc/libwebrtc/api/network_state_predictor.h
@@ -14,6 +14,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 namespace webrtc {
 


### PR DESCRIPTION
Fixes #1678

Since GCC 15, C++ programs that use standard library components without including the right headers will no longer compile.

NOTE: This does not fail in Ubuntu 25 with GCC 15.

```txt
The Meson build system
Version: 1.9.1
Source dir: /foo bar/mediasoup/worker
Build dir: /foo bar/mediasoup/worker/out/Release/build
Build type: native build
Project name: mediasoup-worker
Project version: undefined
C compiler for the host machine: gcc (gcc 15.0.1 "gcc (Ubuntu 15-20250404-0ubuntu1) 15.0.1 20250404 (experimental) [master r15-9193-g08e803aa9be]")
C linker for the host machine: gcc ld.bfd 2.44
C++ compiler for the host machine: g++ (gcc 15.0.1 "g++ (Ubuntu 15-20250404-0ubuntu1) 15.0.1 20250404 (experimental) [master r15-9193-g08e803aa9be]")
C++ linker for the host machine: g++ ld.bfd 2.44
Host machine cpu family: aarch64
Host machine cpu: aarch64
Checking for function "strtoull_l" : YES
```

Anyways this PR is totally legitimate regardless it fails in Ubuntu or not.