### PR TITLE
Create `RtpPacket::ExtensionsType` enum

### DIFF
--- a/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
@@ -125,13 +125,13 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	  value2 // value
 	);
 
-	packet->SetExtensions(1, extensions);
-	packet->SetExtensions(2, extensions);
+	packet->SetExtensions(::RTC::RtpPacket::ExtensionType::OneByteExtension, extensions);
+	packet->SetExtensions(::RTC::RtpPacket::ExtensionType::TwoBytesExtension, extensions);
 
 	extensions.clear();
 
-	packet->SetExtensions(2, extensions);
-	packet->SetExtensions(1, extensions);
+	packet->SetExtensions(::RTC::RtpPacket::ExtensionType::TwoBytesExtension, extensions);
+	packet->SetExtensions(::RTC::RtpPacket::ExtensionType::OneByteExtension, extensions);
 
 	uint8_t value3[] = { 0x01, 0x02, 0x03 };
 
@@ -159,8 +159,8 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	  value3 // value
 	);
 
-	packet->SetExtensions(2, extensions);
-	packet->SetExtensions(1, extensions);
+	packet->SetExtensions(::RTC::RtpPacket::ExtensionType::TwoBytesExtension, extensions);
+	packet->SetExtensions(::RTC::RtpPacket::ExtensionType::OneByteExtension, extensions);
 
 	packet->SetAbsSendTimeExtensionId(13);
 	packet->HasExtension(13);

--- a/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerRtpPacket.cpp
@@ -125,13 +125,13 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	  value2 // value
 	);
 
-	packet->SetExtensions(::RTC::RtpPacket::ExtensionType::OneByteExtension, extensions);
-	packet->SetExtensions(::RTC::RtpPacket::ExtensionType::TwoBytesExtension, extensions);
+	packet->SetExtensions(::RTC::RtpPacket::ExtensionsType::OneByte, extensions);
+	packet->SetExtensions(::RTC::RtpPacket::ExtensionsType::TwoBytes, extensions);
 
 	extensions.clear();
 
-	packet->SetExtensions(::RTC::RtpPacket::ExtensionType::TwoBytesExtension, extensions);
-	packet->SetExtensions(::RTC::RtpPacket::ExtensionType::OneByteExtension, extensions);
+	packet->SetExtensions(::RTC::RtpPacket::ExtensionsType::TwoBytes, extensions);
+	packet->SetExtensions(::RTC::RtpPacket::ExtensionsType::OneByte, extensions);
 
 	uint8_t value3[] = { 0x01, 0x02, 0x03 };
 
@@ -159,8 +159,8 @@ void Fuzzer::RTC::RtpPacket::Fuzz(const uint8_t* data, size_t len)
 	  value3 // value
 	);
 
-	packet->SetExtensions(::RTC::RtpPacket::ExtensionType::TwoBytesExtension, extensions);
-	packet->SetExtensions(::RTC::RtpPacket::ExtensionType::OneByteExtension, extensions);
+	packet->SetExtensions(::RTC::RtpPacket::ExtensionsType::TwoBytes, extensions);
+	packet->SetExtensions(::RTC::RtpPacket::ExtensionsType::OneByte, extensions);
 
 	packet->SetAbsSendTimeExtensionId(13);
 	packet->HasExtension(13);

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -51,6 +51,13 @@ namespace RTC
 			uint8_t value[1];
 		};
 
+	public:
+		enum class ExtensionType : uint8_t
+		{
+			OneByteExtension  = 1,
+			TwoBytesExtension = 2
+		};
+
 	private:
 		/* Struct for One-Byte extension. */
 		struct OneByteExtension
@@ -198,7 +205,7 @@ namespace RTC
 		}
 
 		// After calling this method, all the extension ids are reset to 0.
-		void SetExtensions(uint8_t type, const std::vector<GenericExtension>& extensions);
+		void SetExtensions(ExtensionType type, const std::vector<GenericExtension>& extensions);
 
 		uint16_t GetHeaderExtensionId() const
 		{

--- a/worker/include/RTC/RtpPacket.hpp
+++ b/worker/include/RTC/RtpPacket.hpp
@@ -52,10 +52,10 @@ namespace RTC
 		};
 
 	public:
-		enum class ExtensionType : uint8_t
+		enum class ExtensionsType : uint8_t
 		{
-			OneByteExtension  = 1,
-			TwoBytesExtension = 2
+			OneByte  = 1,
+			TwoBytes = 2
 		};
 
 	private:
@@ -205,7 +205,7 @@ namespace RTC
 		}
 
 		// After calling this method, all the extension ids are reset to 0.
-		void SetExtensions(ExtensionType type, const std::vector<GenericExtension>& extensions);
+		void SetExtensions(ExtensionsType type, const std::vector<GenericExtension>& extensions);
 
 		uint16_t GetHeaderExtensionId() const
 		{

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1,14 +1,13 @@
-#include "RTC/RtpPacket.hpp"
 #define MS_CLASS "RTC::Producer"
 // #define MS_LOG_DEV_LEVEL 3
 
+#include "RTC/Producer.hpp"
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include "Utils.hpp"
 #include "RTC/Codecs/Tools.hpp"
 #include "RTC/Consts.hpp"
-#include "RTC/Producer.hpp"
 #include "RTC/RTCP/Feedback.hpp"
 #include "RTC/RTCP/XrReceiverReferenceTime.hpp"
 #ifdef MS_RTC_LOGGER_RTP

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1,13 +1,14 @@
+#include "RTC/RtpPacket.hpp"
 #define MS_CLASS "RTC::Producer"
 // #define MS_LOG_DEV_LEVEL 3
 
-#include "RTC/Producer.hpp"
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include "Utils.hpp"
 #include "RTC/Codecs/Tools.hpp"
 #include "RTC/Consts.hpp"
+#include "RTC/Producer.hpp"
 #include "RTC/RTCP/Feedback.hpp"
 #include "RTC/RTCP/XrReceiverReferenceTime.hpp"
 #ifdef MS_RTC_LOGGER_RTP
@@ -1433,7 +1434,9 @@ namespace RTC
 			// Set the new extensions into the packet.
 			// Use 1-byte or 2-bytes type depending on the highest extension id and
 			// length we are introducing in the packet.
-			const uint8_t type = highestExtenId <= 14 && highestExtenLen <= 16 ? 1 : 2;
+			const auto type = highestExtenId <= 14 && highestExtenLen <= 16
+			                    ? RTC::RtpPacket::ExtensionType::OneByteExtension
+			                    : RTC::RtpPacket::ExtensionType::TwoBytesExtension;
 
 			MS_DEBUG_DEV(
 			  "using %" PRIu8 " byte(s) header extensions [highestExtenId:%" PRIu8

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1434,8 +1434,8 @@ namespace RTC
 			// Use 1-byte or 2-bytes type depending on the highest extension id and
 			// length we are introducing in the packet.
 			const auto type = highestExtenId <= 14 && highestExtenLen <= 16
-			                    ? RTC::RtpPacket::ExtensionType::OneByteExtension
-			                    : RTC::RtpPacket::ExtensionType::TwoBytesExtension;
+			                    ? RTC::RtpPacket::ExtensionsType::OneByte
+			                    : RTC::RtpPacket::ExtensionsType::TwoBytes;
 
 			MS_DEBUG_DEV(
 			  "using %" PRIu8 " byte(s) header extensions [highestExtenId:%" PRIu8

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -473,10 +473,6 @@ namespace RTC
 
 	void RtpPacket::SetExtensions(ExtensionType type, const std::vector<GenericExtension>& extensions)
 	{
-		MS_ASSERT(
-		  type == ExtensionType::OneByteExtension || type == ExtensionType::TwoBytesExtension,
-		  "type must be 1 or 2");
-
 		// Reset extension ids.
 		this->midExtensionId                  = 0u;
 		this->ridExtensionId                  = 0u;

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -471,9 +471,11 @@ namespace RTC
 		                        : flatbuffers::nullopt);
 	}
 
-	void RtpPacket::SetExtensions(uint8_t type, const std::vector<GenericExtension>& extensions)
+	void RtpPacket::SetExtensions(ExtensionType type, const std::vector<GenericExtension>& extensions)
 	{
-		MS_ASSERT(type == 1u || type == 2u, "type must be 1 or 2");
+		MS_ASSERT(
+		  type == ExtensionType::OneByteExtension || type == ExtensionType::TwoBytesExtension,
+		  "type must be 1 or 2");
 
 		// Reset extension ids.
 		this->midExtensionId                  = 0u;
@@ -494,24 +496,24 @@ namespace RTC
 
 		// If One-Byte is requested and the packet already has One-Byte extensions,
 		// keep the header extension id.
-		if (type == 1u && HasOneByteExtensions())
+		if (type == ExtensionType::OneByteExtension && HasOneByteExtensions())
 		{
 			// Nothing to do.
 		}
 		// If Two-Bytes is requested and the packet already has Two-Bytes extensions,
 		// keep the header extension id.
-		else if (type == 2u && HasTwoBytesExtensions())
+		else if (type == ExtensionType::TwoBytesExtension && HasTwoBytesExtensions())
 		{
 			// Nothing to do.
 		}
 		// Otherwise, if there is header extension of non matching type, modify its id.
 		else if (this->headerExtension)
 		{
-			if (type == 1u)
+			if (type == ExtensionType::OneByteExtension)
 			{
 				this->headerExtension->id = htons(0xBEDE);
 			}
-			else if (type == 2u)
+			else if (type == ExtensionType::TwoBytesExtension)
 			{
 				this->headerExtension->id = htons(0b0001000000000000);
 			}
@@ -522,7 +524,7 @@ namespace RTC
 
 		for (const auto& extension : extensions)
 		{
-			if (type == 1u)
+			if (type == ExtensionType::OneByteExtension)
 			{
 				if (extension.id == 0 || extension.id > 14 || extension.len == 0 || extension.len > 16)
 				{
@@ -531,7 +533,7 @@ namespace RTC
 
 				extensionsTotalSize += (1 + extension.len);
 			}
-			else if (type == 2u)
+			else if (type == ExtensionType::TwoBytesExtension)
 			{
 				if (extension.id == 0)
 				{
@@ -588,11 +590,11 @@ namespace RTC
 			this->size += shift;
 
 			// Set the header extension id.
-			if (type == 1u)
+			if (type == ExtensionType::OneByteExtension)
 			{
 				this->headerExtension->id = htons(0xBEDE);
 			}
-			else if (type == 2u)
+			else if (type == ExtensionType::TwoBytesExtension)
 			{
 				this->headerExtension->id = htons(0b0001000000000000);
 			}
@@ -606,7 +608,7 @@ namespace RTC
 
 		for (const auto& extension : extensions)
 		{
-			if (type == 1u)
+			if (type == ExtensionType::OneByteExtension)
 			{
 				if (extension.id == 0 || extension.id > 14 || extension.len == 0 || extension.len > 16)
 				{
@@ -622,7 +624,7 @@ namespace RTC
 				std::memmove(ptr, extension.value, extension.len);
 				ptr += extension.len;
 			}
-			else if (type == 2u)
+			else if (type == ExtensionType::TwoBytesExtension)
 			{
 				if (extension.id == 0)
 				{

--- a/worker/src/RTC/RtpPacket.cpp
+++ b/worker/src/RTC/RtpPacket.cpp
@@ -471,7 +471,7 @@ namespace RTC
 		                        : flatbuffers::nullopt);
 	}
 
-	void RtpPacket::SetExtensions(ExtensionType type, const std::vector<GenericExtension>& extensions)
+	void RtpPacket::SetExtensions(ExtensionsType type, const std::vector<GenericExtension>& extensions)
 	{
 		// Reset extension ids.
 		this->midExtensionId                  = 0u;
@@ -492,24 +492,24 @@ namespace RTC
 
 		// If One-Byte is requested and the packet already has One-Byte extensions,
 		// keep the header extension id.
-		if (type == ExtensionType::OneByteExtension && HasOneByteExtensions())
+		if (type == ExtensionsType::OneByte && HasOneByteExtensions())
 		{
 			// Nothing to do.
 		}
 		// If Two-Bytes is requested and the packet already has Two-Bytes extensions,
 		// keep the header extension id.
-		else if (type == ExtensionType::TwoBytesExtension && HasTwoBytesExtensions())
+		else if (type == ExtensionsType::TwoBytes && HasTwoBytesExtensions())
 		{
 			// Nothing to do.
 		}
 		// Otherwise, if there is header extension of non matching type, modify its id.
 		else if (this->headerExtension)
 		{
-			if (type == ExtensionType::OneByteExtension)
+			if (type == ExtensionsType::OneByte)
 			{
 				this->headerExtension->id = htons(0xBEDE);
 			}
-			else if (type == ExtensionType::TwoBytesExtension)
+			else if (type == ExtensionsType::TwoBytes)
 			{
 				this->headerExtension->id = htons(0b0001000000000000);
 			}
@@ -520,7 +520,7 @@ namespace RTC
 
 		for (const auto& extension : extensions)
 		{
-			if (type == ExtensionType::OneByteExtension)
+			if (type == ExtensionsType::OneByte)
 			{
 				if (extension.id == 0 || extension.id > 14 || extension.len == 0 || extension.len > 16)
 				{
@@ -529,7 +529,7 @@ namespace RTC
 
 				extensionsTotalSize += (1 + extension.len);
 			}
-			else if (type == ExtensionType::TwoBytesExtension)
+			else if (type == ExtensionsType::TwoBytes)
 			{
 				if (extension.id == 0)
 				{
@@ -586,11 +586,11 @@ namespace RTC
 			this->size += shift;
 
 			// Set the header extension id.
-			if (type == ExtensionType::OneByteExtension)
+			if (type == ExtensionsType::OneByte)
 			{
 				this->headerExtension->id = htons(0xBEDE);
 			}
-			else if (type == ExtensionType::TwoBytesExtension)
+			else if (type == ExtensionsType::TwoBytes)
 			{
 				this->headerExtension->id = htons(0b0001000000000000);
 			}
@@ -604,7 +604,7 @@ namespace RTC
 
 		for (const auto& extension : extensions)
 		{
-			if (type == ExtensionType::OneByteExtension)
+			if (type == ExtensionsType::OneByte)
 			{
 				if (extension.id == 0 || extension.id > 14 || extension.len == 0 || extension.len > 16)
 				{
@@ -620,7 +620,7 @@ namespace RTC
 				std::memmove(ptr, extension.value, extension.len);
 				ptr += extension.len;
 			}
-			else if (type == ExtensionType::TwoBytesExtension)
+			else if (type == ExtensionsType::TwoBytes)
 			{
 				if (extension.id == 0)
 				{

--- a/worker/src/RTC/RtpProbationGenerator.cpp
+++ b/worker/src/RTC/RtpProbationGenerator.cpp
@@ -106,7 +106,7 @@ namespace RTC
 		}
 
 		// Set the extensions into the packet using One-Byte format.
-		this->probationPacket->SetExtensions(RTC::RtpPacket::ExtensionType::OneByteExtension, extensions);
+		this->probationPacket->SetExtensions(RTC::RtpPacket::ExtensionsType::OneByte, extensions);
 
 		// Set our urn:ietf:params:rtp-hdrext:sdes:mid extension id.
 		this->probationPacket->SetMidExtensionId(

--- a/worker/src/RTC/RtpProbationGenerator.cpp
+++ b/worker/src/RTC/RtpProbationGenerator.cpp
@@ -106,7 +106,7 @@ namespace RTC
 		}
 
 		// Set the extensions into the packet using One-Byte format.
-		this->probationPacket->SetExtensions(1, extensions);
+		this->probationPacket->SetExtensions(RTC::RtpPacket::ExtensionType::OneByteExtension, extensions);
 
 		// Set our urn:ietf:params:rtp-hdrext:sdes:mid extension id.
 		this->probationPacket->SetMidExtensionId(

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -544,7 +544,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		extensions.clear();
 
-		packet->SetExtensions(RtpPacket::ExtensionType::OneByteExtension, extensions);
+		packet->SetExtensions(RtpPacket::ExtensionsType::OneByte, extensions);
 
 		REQUIRE(packet->GetSize() == 32);
 		REQUIRE(packet->HasHeaderExtension() == true);
@@ -605,7 +605,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value3 // value
 		);
 
-		packet->SetExtensions(RtpPacket::ExtensionType::OneByteExtension, extensions);
+		packet->SetExtensions(RtpPacket::ExtensionsType::OneByte, extensions);
 
 		REQUIRE(packet->GetSize() == 60); // Taking into account padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
@@ -644,7 +644,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value4 // value
 		);
 
-		packet->SetExtensions(RtpPacket::ExtensionType::OneByteExtension, extensions);
+		packet->SetExtensions(RtpPacket::ExtensionsType::OneByte, extensions);
 
 		REQUIRE(packet->GetSize() == 40);
 		REQUIRE(packet->HasHeaderExtension() == true);
@@ -732,7 +732,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		extensions.clear();
 
-		packet->SetExtensions(RtpPacket::ExtensionType::TwoBytesExtension, extensions);
+		packet->SetExtensions(RtpPacket::ExtensionsType::TwoBytes, extensions);
 
 		REQUIRE(packet->GetSize() == 32);
 		REQUIRE(packet->HasHeaderExtension() == true);
@@ -780,7 +780,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value3 // value
 		);
 
-		packet->SetExtensions(RtpPacket::ExtensionType::TwoBytesExtension, extensions);
+		packet->SetExtensions(RtpPacket::ExtensionsType::TwoBytes, extensions);
 
 		REQUIRE(packet->GetSize() == 72); // Taking into account padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
@@ -827,7 +827,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value4 // value
 		);
 
-		packet->SetExtensions(RtpPacket::ExtensionType::TwoBytesExtension, extensions);
+		packet->SetExtensions(RtpPacket::ExtensionsType::TwoBytes, extensions);
 
 		REQUIRE(packet->GetSize() == 40);
 		REQUIRE(packet->HasHeaderExtension() == true);

--- a/worker/test/src/RTC/TestRtpPacket.cpp
+++ b/worker/test/src/RTC/TestRtpPacket.cpp
@@ -544,7 +544,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		extensions.clear();
 
-		packet->SetExtensions(1, extensions);
+		packet->SetExtensions(RtpPacket::ExtensionType::OneByteExtension, extensions);
 
 		REQUIRE(packet->GetSize() == 32);
 		REQUIRE(packet->HasHeaderExtension() == true);
@@ -605,7 +605,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value3 // value
 		);
 
-		packet->SetExtensions(1, extensions);
+		packet->SetExtensions(RtpPacket::ExtensionType::OneByteExtension, extensions);
 
 		REQUIRE(packet->GetSize() == 60); // Taking into account padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
@@ -644,7 +644,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value4 // value
 		);
 
-		packet->SetExtensions(1, extensions);
+		packet->SetExtensions(RtpPacket::ExtensionType::OneByteExtension, extensions);
 
 		REQUIRE(packet->GetSize() == 40);
 		REQUIRE(packet->HasHeaderExtension() == true);
@@ -732,7 +732,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 
 		extensions.clear();
 
-		packet->SetExtensions(2, extensions);
+		packet->SetExtensions(RtpPacket::ExtensionType::TwoBytesExtension, extensions);
 
 		REQUIRE(packet->GetSize() == 32);
 		REQUIRE(packet->HasHeaderExtension() == true);
@@ -780,7 +780,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value3 // value
 		);
 
-		packet->SetExtensions(2, extensions);
+		packet->SetExtensions(RtpPacket::ExtensionType::TwoBytesExtension, extensions);
 
 		REQUIRE(packet->GetSize() == 72); // Taking into account padding in header extension.
 		REQUIRE(packet->HasHeaderExtension() == true);
@@ -827,7 +827,7 @@ SCENARIO("parse RTP packets", "[parser][rtp]")
 		  value4 // value
 		);
 
-		packet->SetExtensions(2, extensions);
+		packet->SetExtensions(RtpPacket::ExtensionType::TwoBytesExtension, extensions);
 
 		REQUIRE(packet->GetSize() == 40);
 		REQUIRE(packet->HasHeaderExtension() == true);


### PR DESCRIPTION
# Details

- Instead of dealing with numbers (1 and 2), let's have a proper C++ enum.