### PR TITLE
Worker: RtpStreamSend, do not send duplicated RTP packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### NEXT
 
+- Worker: `RtpStreamSend` duplicated packets are discarded ([PR #1675](https://github.com/versatica/mediasoup/pull/1675).
+- Worker: `RtpStreamSend` packets larger than MTU size are discarded ([PR #1675](https://github.com/versatica/mediasoup/pull/1675).
+
 ### 3.19.14
 
 - Worker: Fix missing system header include, which fails in GCC 15 ([PR #1679](https://github.com/versatica/mediasoup/pull/1679), credits to @upisfree).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ### NEXT
 
-- Worker: `RtpStreamSend` duplicated packets are discarded ([PR #1675](https://github.com/versatica/mediasoup/pull/1675).
-- Worker: `RtpStreamSend` packets larger than MTU size are discarded ([PR #1675](https://github.com/versatica/mediasoup/pull/1675).
+- Worker: `RtpStreamSend` duplicated packets are discarded ([PR #1683](https://github.com/versatica/mediasoup/pull/1683).
+- Worker: `RtpStreamSend` packets larger than MTU size are discarded ([PR #1683](https://github.com/versatica/mediasoup/pull/1683).
 
 ### 3.19.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ### NEXT
 
 - Worker: `RtpStreamSend` duplicated packets are discarded ([PR #1683](https://github.com/versatica/mediasoup/pull/1683).
-- Worker: `RtpStreamSend` packets larger than MTU size are discarded ([PR #1683](https://github.com/versatica/mediasoup/pull/1683).
 
 ### 3.19.14
 

--- a/worker/include/RTC/RtpStreamSend.hpp
+++ b/worker/include/RTC/RtpStreamSend.hpp
@@ -59,7 +59,6 @@ namespace RTC
 		uint32_t GetLayerBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer) override;
 
 	private:
-		bool StorePacket(RTC::RtpPacket* packet, const RTC::SharedRtpPacket& sharedPacket);
 		void FillRetransmissionContainer(uint16_t seq, uint16_t bitmask);
 		void UpdateScore(RTC::RTCP::ReceiverReport* report);
 

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -121,8 +121,6 @@ namespace RTC
 			  packet->GetSsrc(),
 			  packet->GetSequenceNumber(),
 			  packet->GetSize());
-
-			return ReceivePacketResult::DISCARDED;
 		}
 
 		bool stored{ false };

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -112,15 +112,40 @@ namespace RTC
 			return ReceivePacketResult::DISCARDED;
 		}
 
+		// Check the packet size.
+		if (packet->GetSize() > RTC::Consts::MtuSize)
+		{
+			MS_WARN_TAG(
+			  rtp,
+			  "packet too big [ssrc:%" PRIu32 ", seq:%" PRIu16 ", size:%zu]",
+			  packet->GetSsrc(),
+			  packet->GetSequenceNumber(),
+			  packet->GetSize());
+
+			return ReceivePacketResult::DISCARDED;
+		}
+
 		bool stored{ false };
 
 		// If NACK is enabled, store the packet into the buffer.
 		if (this->retransmissionBuffer)
 		{
-			if (StorePacket(packet, sharedPacket))
+			// Check if the packet is already stored.
+			if (this->retransmissionBuffer->Get(packet->GetSequenceNumber()))
 			{
-				stored = true;
+				// Packet already stored, do not resend it since the receiver will
+				// fail decrypting it and this packet will be considered not received
+				// in the RTCP transport feedback affecting the bandwidth estimation.
+
+				MS_DEBUG_DEV(
+				  "packet already stored in retransmission buffer [ssrc:%" PRIu32 ", seq:%" PRIu16 "]",
+				  packet->GetSsrc(),
+				  packet->GetSequenceNumber());
+
+				return ReceivePacketResult::DISCARDED;
 			}
+
+			stored = this->retransmissionBuffer->Insert(packet, sharedPacket);
 		}
 
 		// Increase transmission counter.
@@ -437,25 +462,6 @@ namespace RTC
 		MS_TRACE();
 
 		MS_ABORT("invalid method call");
-	}
-
-	bool RtpStreamSend::StorePacket(RTC::RtpPacket* packet, const RTC::SharedRtpPacket& sharedPacket)
-	{
-		MS_TRACE();
-
-		if (packet->GetSize() > RTC::Consts::MtuSize)
-		{
-			MS_WARN_TAG(
-			  rtp,
-			  "packet too big [ssrc:%" PRIu32 ", seq:%" PRIu16 ", size:%zu]",
-			  packet->GetSsrc(),
-			  packet->GetSequenceNumber(),
-			  packet->GetSize());
-
-			return false;
-		}
-
-		return this->retransmissionBuffer->Insert(packet, sharedPacket);
 	}
 
 	// This method looks for the requested RTP packets and inserts them into the

--- a/worker/src/RTC/RtpStreamSend.cpp
+++ b/worker/src/RTC/RtpStreamSend.cpp
@@ -112,17 +112,6 @@ namespace RTC
 			return ReceivePacketResult::DISCARDED;
 		}
 
-		// Check the packet size.
-		if (packet->GetSize() > RTC::Consts::MtuSize)
-		{
-			MS_WARN_TAG(
-			  rtp,
-			  "packet too big [ssrc:%" PRIu32 ", seq:%" PRIu16 ", size:%zu]",
-			  packet->GetSsrc(),
-			  packet->GetSequenceNumber(),
-			  packet->GetSize());
-		}
-
 		bool stored{ false };
 
 		// If NACK is enabled, store the packet into the buffer.

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -2,7 +2,6 @@
 #include "RTC/Codecs/AV1.hpp"
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
 #include "RTC/Codecs/VP8.hpp"
-#include "RTC/Consts.hpp"
 #include "RTC/RTCP/FeedbackRtpNack.hpp"
 #include "RTC/RtpPacket.hpp"
 #include "RTC/RtpStream.hpp"

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -931,30 +931,6 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstreamsend
 		REQUIRE(result == RTC::RtpStreamSend::ReceivePacketResult::DISCARDED);
 	}
 
-	SECTION("packets larger than MTU size are discarded")
-	{
-		auto packet(CreateRtpPacket(rtpBuffer1, RTC::Consts::MtuSize + 1, 50001, 1000001));
-
-		// Create a RtpStreamSend instance.
-		TestRtpStreamListener testRtpStreamListener;
-
-		RtpStream::Params params;
-
-		params.ssrc          = packet->GetSsrc();
-		params.clockRate     = 90000;
-		params.useNack       = true;
-		params.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
-
-		std::string mid;
-		auto stream = std::make_unique<RtpStreamSend>(&testRtpStreamListener, params, mid);
-
-		RTC::SharedRtpPacket sharedPacket;
-
-		auto result = stream->ReceivePacket(packet.get(), sharedPacket);
-
-		REQUIRE(result == RTC::RtpStreamSend::ReceivePacketResult::DISCARDED);
-	}
-
 #ifdef PERFORMANCE_TEST
 	SECTION("Performance")
 	{

--- a/worker/test/src/RTC/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/TestRtpStreamSend.cpp
@@ -2,6 +2,7 @@
 #include "RTC/Codecs/AV1.hpp"
 #include "RTC/Codecs/PayloadDescriptorHandler.hpp"
 #include "RTC/Codecs/VP8.hpp"
+#include "RTC/Consts.hpp"
 #include "RTC/RTCP/FeedbackRtpNack.hpp"
 #include "RTC/RtpPacket.hpp"
 #include "RTC/RtpStream.hpp"
@@ -900,6 +901,58 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstreamsend
 		stream->ReceiveNack(&nackPacket2);
 
 		REQUIRE(testRtpStreamListener.retransmittedPackets.empty());
+	}
+
+	SECTION("duplicated packets are discarded")
+	{
+		auto packet(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 50001, 1000001));
+
+		// Create a RtpStreamSend instance.
+		TestRtpStreamListener testRtpStreamListener;
+
+		RtpStream::Params params;
+
+		params.ssrc          = packet->GetSsrc();
+		params.clockRate     = 90000;
+		params.useNack       = true;
+		params.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
+
+		std::string mid;
+		auto stream = std::make_unique<RtpStreamSend>(&testRtpStreamListener, params, mid);
+
+		RTC::SharedRtpPacket sharedPacket;
+
+		auto result = stream->ReceivePacket(packet.get(), sharedPacket);
+
+		REQUIRE(result == RTC::RtpStreamSend::ReceivePacketResult::ACCEPTED_AND_STORED);
+
+		result = stream->ReceivePacket(packet.get(), sharedPacket);
+
+		REQUIRE(result == RTC::RtpStreamSend::ReceivePacketResult::DISCARDED);
+	}
+
+	SECTION("packets larger than MTU size are discarded")
+	{
+		auto packet(CreateRtpPacket(rtpBuffer1, RTC::Consts::MtuSize + 1, 50001, 1000001));
+
+		// Create a RtpStreamSend instance.
+		TestRtpStreamListener testRtpStreamListener;
+
+		RtpStream::Params params;
+
+		params.ssrc          = packet->GetSsrc();
+		params.clockRate     = 90000;
+		params.useNack       = true;
+		params.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
+
+		std::string mid;
+		auto stream = std::make_unique<RtpStreamSend>(&testRtpStreamListener, params, mid);
+
+		RTC::SharedRtpPacket sharedPacket;
+
+		auto result = stream->ReceivePacket(packet.get(), sharedPacket);
+
+		REQUIRE(result == RTC::RtpStreamSend::ReceivePacketResult::DISCARDED);
 	}
 
 #ifdef PERFORMANCE_TEST


### PR DESCRIPTION
Fixes #1675

If the packet is already present in the retransmission buffer then discard it.