### PR TITLE
Worker: Consumer, remove unneeded unique pointer

### DIFF
--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -81,8 +81,7 @@ namespace RTC
 		absl::flat_hash_map<uint32_t, RTC::RtpStreamSend*> mapSsrcRtpStream;
 		bool keyFrameSupported{ false };
 		absl::flat_hash_map<RTC::RtpStreamSend*, bool> mapRtpStreamSyncRequired;
-		absl::flat_hash_map<RTC::RtpStreamSend*, std::unique_ptr<RTC::SeqManager<uint16_t>>>
-		  mapRtpStreamRtpSeqManager;
+		absl::flat_hash_map<RTC::RtpStreamSend*, RTC::SeqManager<uint16_t>> mapRtpStreamRtpSeqManager;
 		// Buffers to store packets that arrive earlier than the first packet of the
 		// video key frame.
 		absl::flat_hash_map<

--- a/worker/include/RTC/SimpleConsumer.hpp
+++ b/worker/include/RTC/SimpleConsumer.hpp
@@ -90,7 +90,7 @@ namespace RTC
 		RTC::RtpStreamRecv* producerRtpStream{ nullptr };
 		bool keyFrameSupported{ false };
 		bool syncRequired{ false };
-		std::unique_ptr<RTC::SeqManager<uint16_t>> rtpSeqManager;
+		RTC::SeqManager<uint16_t> rtpSeqManager;
 		bool managingBitrate{ false };
 		std::unique_ptr<RTC::Codecs::EncodingContext> encodingContext;
 		// Buffer to store packets that arrive earlier than the first packet of the

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -118,7 +118,7 @@ namespace RTC
 		bool syncRequired{ false };
 		int16_t spatialLayerToSync{ -1 };
 		bool lastSentPacketHasMarker{ false };
-		std::unique_ptr<RTC::SeqManager<uint16_t>> rtpSeqManager;
+		RTC::SeqManager<uint16_t> rtpSeqManager;
 		VideoLayers preferredLayers;
 		VideoLayers provisionalTargetLayers;
 		VideoLayers targetLayers;

--- a/worker/include/RTC/SvcConsumer.hpp
+++ b/worker/include/RTC/SvcConsumer.hpp
@@ -102,7 +102,7 @@ namespace RTC
 		std::vector<RTC::RtpStreamSend*> rtpStreams;
 		RTC::RtpStreamRecv* producerRtpStream{ nullptr };
 		bool syncRequired{ false };
-		std::unique_ptr<RTC::SeqManager<uint16_t>> rtpSeqManager;
+		RTC::SeqManager<uint16_t> rtpSeqManager;
 		VideoLayers preferredLayers;
 		VideoLayers provisionalTargetLayers;
 		std::unique_ptr<RTC::Codecs::EncodingContext> encodingContext;

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -286,7 +286,7 @@ namespace RTC
 			packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::CONSUMER_INACTIVE);
 #endif
 
-			rtpSeqManager->Drop(packet->GetSequenceNumber());
+			rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -323,7 +323,7 @@ namespace RTC
 			packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::UNSUPPORTED_PAYLOAD_TYPE);
 #endif
 
-			rtpSeqManager->Drop(packet->GetSequenceNumber());
+			rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -335,7 +335,7 @@ namespace RTC
 			packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::EMPTY_PAYLOAD);
 #endif
 
-			rtpSeqManager->Drop(packet->GetSequenceNumber());
+			rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -362,7 +362,7 @@ namespace RTC
 				sendPacketsInTargetLayerRetransmissionBuffer = true;
 			}
 
-			rtpSeqManager->Sync(packet->GetSequenceNumber() - 1);
+			rtpSeqManager.Sync(packet->GetSequenceNumber() - 1);
 
 			syncRequired = false;
 		}
@@ -370,7 +370,7 @@ namespace RTC
 		// Update RTP seq number and timestamp.
 		uint16_t seq;
 
-		rtpSeqManager->Input(packet->GetSequenceNumber(), seq);
+		rtpSeqManager.Input(packet->GetSequenceNumber(), seq);
 
 		// Save original packet fields.
 		auto origSsrc = packet->GetSsrc();
@@ -832,8 +832,7 @@ namespace RTC
 			const uint16_t initialOutputSeq =
 			  Utils::Crypto::GetRandomUInt(1000u, std::numeric_limits<uint16_t>::max() / 2);
 
-			this->mapRtpStreamRtpSeqManager[rtpStream].reset(
-			  new RTC::SeqManager<uint16_t>(initialOutputSeq));
+			this->mapRtpStreamRtpSeqManager[rtpStream] = RTC::SeqManager<uint16_t>(initialOutputSeq);
 
 			this->mapRtpStreamTargetLayerRetransmissionBuffer[rtpStream];
 		}

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -51,7 +51,7 @@ namespace RTC
 		const uint16_t initialOutputSeq =
 		  Utils::Crypto::GetRandomUInt(1000u, std::numeric_limits<uint16_t>::max() / 2);
 
-		this->rtpSeqManager.reset(new RTC::SeqManager<uint16_t>(initialOutputSeq));
+		this->rtpSeqManager = RTC::SeqManager<uint16_t>(initialOutputSeq);
 
 		// Create the encoding context for Opus.
 		if (
@@ -327,7 +327,7 @@ namespace RTC
 			packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::CONSUMER_INACTIVE);
 #endif
 
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -363,7 +363,7 @@ namespace RTC
 			packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::UNSUPPORTED_PAYLOAD_TYPE);
 #endif
 
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -375,7 +375,7 @@ namespace RTC
 			packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::EMPTY_PAYLOAD);
 #endif
 
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -395,7 +395,7 @@ namespace RTC
 			packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::DROPPED_BY_CODEC);
 #endif
 
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -422,7 +422,7 @@ namespace RTC
 				sendPacketsInTargetLayerRetransmissionBuffer = true;
 			}
 
-			this->rtpSeqManager->Sync(packet->GetSequenceNumber() - 1);
+			this->rtpSeqManager.Sync(packet->GetSequenceNumber() - 1);
 
 			this->syncRequired = false;
 		}
@@ -430,7 +430,7 @@ namespace RTC
 		// Update RTP seq number and timestamp.
 		uint16_t seq;
 
-		this->rtpSeqManager->Input(packet->GetSequenceNumber(), seq);
+		this->rtpSeqManager.Input(packet->GetSequenceNumber(), seq);
 
 		// Save original packet fields.
 		auto origSsrc = packet->GetSsrc();

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -111,7 +111,7 @@ namespace RTC
 		const uint16_t initialOutputSeq =
 		  Utils::Crypto::GetRandomUInt(1000u, std::numeric_limits<uint16_t>::max() / 2);
 
-		this->rtpSeqManager.reset(new RTC::SeqManager<uint16_t>(initialOutputSeq));
+		this->rtpSeqManager = RTC::SeqManager<uint16_t>(initialOutputSeq);
 
 		RTC::Codecs::EncodingContext::Params params;
 
@@ -741,7 +741,7 @@ namespace RTC
 				packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::CONSUMER_INACTIVE);
 #endif
 
-				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+				this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 			}
 
 			return;
@@ -757,7 +757,7 @@ namespace RTC
 				packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::INVALID_TARGET_LAYER);
 #endif
 
-				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+				this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 			}
 
 			return;
@@ -779,7 +779,7 @@ namespace RTC
 				packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::UNSUPPORTED_PAYLOAD_TYPE);
 #endif
 
-				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+				this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 			}
 
 			return;
@@ -860,7 +860,7 @@ namespace RTC
 				packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::EMPTY_PAYLOAD);
 #endif
 
-				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+				this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 			}
 
 			return;
@@ -1022,7 +1022,7 @@ namespace RTC
 			// 'packet->GetSequenceNumber() -2' may increase SeqManager::base and
 			// increase the output sequence number.
 			// https://github.com/versatica/mediasoup/issues/408
-			this->rtpSeqManager->Sync(packet->GetSequenceNumber() - (this->lastSentPacketHasMarker ? 1 : 2));
+			this->rtpSeqManager.Sync(packet->GetSequenceNumber() - (this->lastSentPacketHasMarker ? 1 : 2));
 
 			this->encodingContext->SyncRequired();
 
@@ -1045,7 +1045,7 @@ namespace RTC
 				  RtcLogger::RtpPacket::DiscardReason::PACKET_PREVIOUS_TO_SPATIAL_LAYER_SWITCH);
 #endif
 
-				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+				this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 				return;
 			}
@@ -1095,7 +1095,7 @@ namespace RTC
 				packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::DROPPED_BY_CODEC);
 #endif
 
-				this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+				this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 				return;
 			}
@@ -1110,7 +1110,7 @@ namespace RTC
 		uint16_t seq;
 		const uint32_t timestamp = packet->GetTimestamp() - this->tsOffset;
 
-		this->rtpSeqManager->Input(packet->GetSequenceNumber(), seq);
+		this->rtpSeqManager.Input(packet->GetSequenceNumber(), seq);
 
 		// Save original packet fields.
 		auto origSsrc      = packet->GetSsrc();
@@ -1146,7 +1146,7 @@ namespace RTC
 
 		if (result != RTC::RtpStreamSend::ReceivePacketResult::DISCARDED)
 		{
-			if (this->rtpSeqManager->GetMaxOutput() == packet->GetSequenceNumber())
+			if (this->rtpSeqManager.GetMaxOutput() == packet->GetSequenceNumber())
 			{
 				this->lastSentPacketHasMarker = packet->HasMarker();
 			}

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -91,7 +91,7 @@ namespace RTC
 		const uint16_t initialOutputSeq =
 		  Utils::Crypto::GetRandomUInt(1000u, std::numeric_limits<uint16_t>::max() / 2);
 
-		this->rtpSeqManager.reset(new RTC::SeqManager<uint16_t>(initialOutputSeq));
+		this->rtpSeqManager = RTC::SeqManager<uint16_t>(initialOutputSeq);
 
 		RTC::Codecs::EncodingContext::Params params;
 
@@ -624,7 +624,7 @@ namespace RTC
 			packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::CONSUMER_INACTIVE);
 #endif
 
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -640,7 +640,7 @@ namespace RTC
 			packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::INVALID_TARGET_LAYER);
 #endif
 
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -675,7 +675,7 @@ namespace RTC
 			packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::UNSUPPORTED_PAYLOAD_TYPE);
 #endif
 
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -687,7 +687,7 @@ namespace RTC
 			packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::EMPTY_PAYLOAD);
 #endif
 
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -714,7 +714,7 @@ namespace RTC
 				sendPacketsInTargetLayerRetransmissionBuffer = true;
 			}
 
-			this->rtpSeqManager->Sync(packet->GetSequenceNumber() - 1);
+			this->rtpSeqManager.Sync(packet->GetSequenceNumber() - 1);
 			this->encodingContext->SyncRequired();
 
 			this->syncRequired = false;
@@ -731,7 +731,7 @@ namespace RTC
 			packet->logger.Discarded(RtcLogger::RtpPacket::DiscardReason::DROPPED_BY_CODEC);
 #endif
 
-			this->rtpSeqManager->Drop(packet->GetSequenceNumber());
+			this->rtpSeqManager.Drop(packet->GetSequenceNumber());
 
 			return;
 		}
@@ -745,7 +745,7 @@ namespace RTC
 		// Update RTP seq number and timestamp based on NTP offset.
 		uint16_t seq;
 
-		this->rtpSeqManager->Input(packet->GetSequenceNumber(), seq);
+		this->rtpSeqManager.Input(packet->GetSequenceNumber(), seq);
 
 		// Save original packet fields.
 		auto origSsrc = packet->GetSsrc();


### PR DESCRIPTION
SeqManager in [XYZ]Consumer does not need to be a unique pointer.

Use a simple instance and remove a level of indirection.