### PR TITLE
Update worker subprojects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### NEXT
 
 - Worker: `RtpStreamSend` duplicated packets are discarded ([PR #1683](https://github.com/versatica/mediasoup/pull/1683).
+- Worker: Update Catch2 from 3.8.1-1 to 3.12.0-1 ([PR #1686](https://github.com/versatica/mediasoup/pull/1686).
+- Worker: Update liburing from 2.5-2 to 2.12-1 ([PR #1686](https://github.com/versatica/mediasoup/pull/1686).
+- Worker: Update abseil-cpp from 20240722.0-4 to 20250814.1-1 ([PR #1686](https://github.com/versatica/mediasoup/pull/1686).
 
 ### 3.19.14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@
 - Worker: `RtpStreamSend` duplicated packets are discarded ([PR #1683](https://github.com/versatica/mediasoup/pull/1683).
 - Worker: Update Catch2 from 3.8.1-1 to 3.12.0-1 ([PR #1686](https://github.com/versatica/mediasoup/pull/1686).
 - Worker: Update liburing from 2.5-2 to 2.12-1 ([PR #1686](https://github.com/versatica/mediasoup/pull/1686).
-- Worker: Update abseil-cpp from 20240722.0-4 to 20250814.1-1 ([PR #1686](https://github.com/versatica/mediasoup/pull/1686).
 
 ### 3.19.14
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,12 +26,12 @@
 				"@types/node": "^24.10.1",
 				"eslint": "^9.39.2",
 				"eslint-config-prettier": "^10.1.8",
-				"eslint-plugin-jest": "^29.11.0",
+				"eslint-plugin-jest": "^29.12.1",
 				"eslint-plugin-prettier": "^5.5.4",
-				"globals": "^16.5.0",
+				"globals": "^17.0.0",
 				"ini": "^6.0.0",
 				"jest": "^30.2.0",
-				"knip": "^5.77.1",
+				"knip": "^5.80.2",
 				"marked": "^17.0.1",
 				"open-cli": "^8.0.0",
 				"pick-port": "^2.2.0",
@@ -39,7 +39,7 @@
 				"sctp": "^1.0.0",
 				"ts-jest": "^29.4.6",
 				"typescript": "^5.9.3",
-				"typescript-eslint": "^8.50.1"
+				"typescript-eslint": "^8.52.0"
 			},
 			"engines": {
 				"node": ">=22"
@@ -102,6 +102,7 @@
 			"integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.27.1",
@@ -636,9 +637,9 @@
 			}
 		},
 		"node_modules/@eslint-community/eslint-utils": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.8.0.tgz",
-			"integrity": "sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -655,9 +656,9 @@
 			}
 		},
 		"node_modules/@eslint-community/regexpp": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-			"integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+			"integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1446,6 +1447,7 @@
 			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@octokit/auth-token": "^6.0.0",
 				"@octokit/graphql": "^9.0.3",
@@ -2069,6 +2071,7 @@
 			"integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
@@ -2097,20 +2100,21 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.1.tgz",
-			"integrity": "sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.52.0.tgz",
+			"integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.50.1",
-				"@typescript-eslint/type-utils": "8.50.1",
-				"@typescript-eslint/utils": "8.50.1",
-				"@typescript-eslint/visitor-keys": "8.50.1",
-				"ignore": "^7.0.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@typescript-eslint/scope-manager": "8.52.0",
+				"@typescript-eslint/type-utils": "8.52.0",
+				"@typescript-eslint/utils": "8.52.0",
+				"@typescript-eslint/visitor-keys": "8.52.0",
+				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
-				"ts-api-utils": "^2.1.0"
+				"ts-api-utils": "^2.4.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2120,15 +2124,15 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.50.1",
+				"@typescript-eslint/parser": "^8.52.0",
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
-			"integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2136,17 +2140,18 @@
 			}
 		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.1.tgz",
-			"integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.52.0.tgz",
+			"integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.50.1",
-				"@typescript-eslint/types": "8.50.1",
-				"@typescript-eslint/typescript-estree": "8.50.1",
-				"@typescript-eslint/visitor-keys": "8.50.1",
-				"debug": "^4.3.4"
+				"@typescript-eslint/scope-manager": "8.52.0",
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/typescript-estree": "8.52.0",
+				"@typescript-eslint/visitor-keys": "8.52.0",
+				"debug": "^4.4.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2161,15 +2166,15 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.1.tgz",
-			"integrity": "sha512-E1ur1MCVf+YiP89+o4Les/oBAVzmSbeRB0MQLfSlYtbWU17HPxZ6Bhs5iYmKZRALvEuBoXIZMOIRRc/P++Ortg==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.52.0.tgz",
+			"integrity": "sha512-xD0MfdSdEmeFa3OmVqonHi+Cciab96ls1UhIF/qX/O/gPu5KXD0bY9lu33jj04fjzrXHcuvjBcBC+D3SNSadaw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.50.1",
-				"@typescript-eslint/types": "^8.50.1",
-				"debug": "^4.3.4"
+				"@typescript-eslint/tsconfig-utils": "^8.52.0",
+				"@typescript-eslint/types": "^8.52.0",
+				"debug": "^4.4.3"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2183,14 +2188,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.1.tgz",
-			"integrity": "sha512-mfRx06Myt3T4vuoHaKi8ZWNTPdzKPNBhiblze5N50//TSHOAQQevl/aolqA/BcqqbJ88GUnLqjjcBc8EWdBcVw==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.52.0.tgz",
+			"integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.50.1",
-				"@typescript-eslint/visitor-keys": "8.50.1"
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/visitor-keys": "8.52.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2201,9 +2206,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.1.tgz",
-			"integrity": "sha512-ooHmotT/lCWLXi55G4mvaUF60aJa012QzvLK0Y+Mp4WdSt17QhMhWOaBWeGTFVkb2gDgBe19Cxy1elPXylslDw==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.52.0.tgz",
+			"integrity": "sha512-jl+8fzr/SdzdxWJznq5nvoI7qn2tNYV/ZBAEcaFMVXf+K6jmXvAFrgo/+5rxgnL152f//pDEAYAhhBAZGrVfwg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2218,17 +2223,17 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.1.tgz",
-			"integrity": "sha512-7J3bf022QZE42tYMO6SL+6lTPKFk/WphhRPe9Tw/el+cEwzLz1Jjz2PX3GtGQVxooLDKeMVmMt7fWpYRdG5Etg==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.52.0.tgz",
+			"integrity": "sha512-JD3wKBRWglYRQkAtsyGz1AewDu3mTc7NtRjR/ceTyGoPqmdS5oCdx/oZMWD5Zuqmo6/MpsYs0wp6axNt88/2EQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.50.1",
-				"@typescript-eslint/typescript-estree": "8.50.1",
-				"@typescript-eslint/utils": "8.50.1",
-				"debug": "^4.3.4",
-				"ts-api-utils": "^2.1.0"
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/typescript-estree": "8.52.0",
+				"@typescript-eslint/utils": "8.52.0",
+				"debug": "^4.4.3",
+				"ts-api-utils": "^2.4.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2243,9 +2248,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.1.tgz",
-			"integrity": "sha512-v5lFIS2feTkNyMhd7AucE/9j/4V9v5iIbpVRncjk/K0sQ6Sb+Np9fgYS/63n6nwqahHQvbmujeBL7mp07Q9mlA==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.52.0.tgz",
+			"integrity": "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -2257,21 +2262,21 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.1.tgz",
-			"integrity": "sha512-woHPdW+0gj53aM+cxchymJCrh0cyS7BTIdcDxWUNsclr9VDkOSbqC13juHzxOmQ22dDkMZEpZB+3X1WpUvzgVQ==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.52.0.tgz",
+			"integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.50.1",
-				"@typescript-eslint/tsconfig-utils": "8.50.1",
-				"@typescript-eslint/types": "8.50.1",
-				"@typescript-eslint/visitor-keys": "8.50.1",
-				"debug": "^4.3.4",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
+				"@typescript-eslint/project-service": "8.52.0",
+				"@typescript-eslint/tsconfig-utils": "8.52.0",
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/visitor-keys": "8.52.0",
+				"debug": "^4.4.3",
+				"minimatch": "^9.0.5",
+				"semver": "^7.7.3",
 				"tinyglobby": "^0.2.15",
-				"ts-api-utils": "^2.1.0"
+				"ts-api-utils": "^2.4.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2311,16 +2316,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.1.tgz",
-			"integrity": "sha512-lCLp8H1T9T7gPbEuJSnHwnSuO9mDf8mfK/Nion5mZmiEaQD9sWf9W4dfeFqRyqRjF06/kBuTmAqcs9sewM2NbQ==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.52.0.tgz",
+			"integrity": "sha512-wYndVMWkweqHpEpwPhwqE2lnD2DxC6WVLupU/DOt/0/v+/+iQbbzO3jOHjmBMnhu0DgLULvOaU4h4pwHYi2oRQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.50.1",
-				"@typescript-eslint/types": "8.50.1",
-				"@typescript-eslint/typescript-estree": "8.50.1"
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.52.0",
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/typescript-estree": "8.52.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2335,13 +2340,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.1.tgz",
-			"integrity": "sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.52.0.tgz",
+			"integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.50.1",
+				"@typescript-eslint/types": "8.52.0",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
@@ -2660,6 +2665,7 @@
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -2926,6 +2932,7 @@
 				}
 			],
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"caniuse-lite": "^1.0.30001718",
 				"electron-to-chromium": "^1.5.160",
@@ -3436,6 +3443,7 @@
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -3496,6 +3504,7 @@
 			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"eslint-config-prettier": "bin/cli.js"
 			},
@@ -3507,9 +3516,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jest": {
-			"version": "29.11.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.11.0.tgz",
-			"integrity": "sha512-ay2MPUfHhwXyv+FbPxRWiEq3HNNsg4uMt/eBGlsfGHkM0891f0lcr0WrtID+TMyg17unAnNrnySD5LwirlA8EQ==",
+			"version": "29.12.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.12.1.tgz",
+			"integrity": "sha512-Rxo7r4jSANMBkXLICJKS0gjacgyopfNAsoS0e3R9AHnjoKuQOaaPfmsDJPi8UWwygI099OV/K/JhpYRVkxD4AA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4135,9 +4144,9 @@
 			}
 		},
 		"node_modules/globals": {
-			"version": "16.5.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-			"integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.0.0.tgz",
+			"integrity": "sha512-gv5BeD2EssA793rlFWVPMMCqefTlpusw6/2TbAVMy0FzcG8wKJn4O+NqJ4+XWmmwrayJgw5TzrmWjFgmz1XPqw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4557,6 +4566,7 @@
 			"integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"dependencies": {
 				"@jest/core": "30.2.0",
 				"@jest/types": "30.2.0",
@@ -5234,9 +5244,9 @@
 			}
 		},
 		"node_modules/knip": {
-			"version": "5.77.1",
-			"resolved": "https://registry.npmjs.org/knip/-/knip-5.77.1.tgz",
-			"integrity": "sha512-+yA/vfQUDEFUOcR0XRn/dOZmNEsS10pIMztS5JbKUhk9zvQiAFvr3Mcc3zC7Dn9gBG8LeImhaXA6/D3uhzwZvg==",
+			"version": "5.80.2",
+			"resolved": "https://registry.npmjs.org/knip/-/knip-5.80.2.tgz",
+			"integrity": "sha512-Yt7iF8Uzl7pp3mGA6yvum6PZBcbGhjasZYuqIwcIAX1jsIhGRUAK0icP0qrB6FSPBI3BpIeMHl7n9meCLO6ovg==",
 			"dev": true,
 			"funding": [
 				{
@@ -6004,6 +6014,7 @@
 			"integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"bin": {
 				"prettier": "bin/prettier.cjs"
 			},
@@ -6761,6 +6772,7 @@
 			"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
 			"dev": true,
 			"license": "MIT",
+			"peer": true,
 			"engines": {
 				"node": ">=12"
 			},
@@ -6804,9 +6816,9 @@
 			}
 		},
 		"node_modules/ts-api-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-			"integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+			"integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6918,6 +6930,7 @@
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
 			"dev": true,
 			"license": "Apache-2.0",
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"
@@ -6927,16 +6940,16 @@
 			}
 		},
 		"node_modules/typescript-eslint": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.50.1.tgz",
-			"integrity": "sha512-ytTHO+SoYSbhAH9CrYnMhiLx8To6PSSvqnvXyPUgPETCvB6eBKmTI9w6XMPS3HsBRGkwTVBX+urA8dYQx6bHfQ==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.52.0.tgz",
+			"integrity": "sha512-atlQQJ2YkO4pfTVQmQ+wvYQwexPDOIgo+RaVcD7gHgzy/IQA+XTyuxNM9M9TVXvttkF7koBHmcwisKdOAf2EcA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.50.1",
-				"@typescript-eslint/parser": "8.50.1",
-				"@typescript-eslint/typescript-estree": "8.50.1",
-				"@typescript-eslint/utils": "8.50.1"
+				"@typescript-eslint/eslint-plugin": "8.52.0",
+				"@typescript-eslint/parser": "8.52.0",
+				"@typescript-eslint/typescript-estree": "8.52.0",
+				"@typescript-eslint/utils": "8.52.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -7407,6 +7420,7 @@
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.27.4.tgz",
 			"integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.27.1",
@@ -7779,18 +7793,18 @@
 			}
 		},
 		"@eslint-community/eslint-utils": {
-			"version": "4.8.0",
-			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.8.0.tgz",
-			"integrity": "sha512-MJQFqrZgcW0UNYLGOuQpey/oTN59vyWwplvCGZztn1cKz9agZPPYpJB7h2OMmuu7VLqkvEjN8feFZJmxNF9D+Q==",
+			"version": "4.9.1",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.1.tgz",
+			"integrity": "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ==",
 			"dev": true,
 			"requires": {
 				"eslint-visitor-keys": "^3.4.3"
 			}
 		},
 		"@eslint-community/regexpp": {
-			"version": "4.12.1",
-			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
-			"integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
+			"version": "4.12.2",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.2.tgz",
+			"integrity": "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew==",
 			"dev": true
 		},
 		"@eslint/config-array": {
@@ -8351,6 +8365,7 @@
 			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
 			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@octokit/auth-token": "^6.0.0",
 				"@octokit/graphql": "^9.0.3",
@@ -8765,6 +8780,7 @@
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
 			"integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"undici-types": "~7.16.0"
 			}
@@ -8791,104 +8807,106 @@
 			"dev": true
 		},
 		"@typescript-eslint/eslint-plugin": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.50.1.tgz",
-			"integrity": "sha512-PKhLGDq3JAg0Jk/aK890knnqduuI/Qj+udH7wCf0217IGi4gt+acgCyPVe79qoT+qKUvHMDQkwJeKW9fwl8Cyw==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.52.0.tgz",
+			"integrity": "sha512-okqtOgqu2qmZJ5iN4TWlgfF171dZmx2FzdOv2K/ixL2LZWDStL8+JgQerI2sa8eAEfoydG9+0V96m7V+P8yE1Q==",
 			"dev": true,
+			"peer": true,
 			"requires": {
-				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.50.1",
-				"@typescript-eslint/type-utils": "8.50.1",
-				"@typescript-eslint/utils": "8.50.1",
-				"@typescript-eslint/visitor-keys": "8.50.1",
-				"ignore": "^7.0.0",
+				"@eslint-community/regexpp": "^4.12.2",
+				"@typescript-eslint/scope-manager": "8.52.0",
+				"@typescript-eslint/type-utils": "8.52.0",
+				"@typescript-eslint/utils": "8.52.0",
+				"@typescript-eslint/visitor-keys": "8.52.0",
+				"ignore": "^7.0.5",
 				"natural-compare": "^1.4.0",
-				"ts-api-utils": "^2.1.0"
+				"ts-api-utils": "^2.4.0"
 			},
 			"dependencies": {
 				"ignore": {
-					"version": "7.0.4",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
-					"integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+					"version": "7.0.5",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+					"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
 					"dev": true
 				}
 			}
 		},
 		"@typescript-eslint/parser": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.50.1.tgz",
-			"integrity": "sha512-hM5faZwg7aVNa819m/5r7D0h0c9yC4DUlWAOvHAtISdFTc8xB86VmX5Xqabrama3wIPJ/q9RbGS1worb6JfnMg==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.52.0.tgz",
+			"integrity": "sha512-iIACsx8pxRnguSYhHiMn2PvhvfpopO9FXHyn1mG5txZIsAaB6F0KwbFnUQN3KCiG3Jcuad/Cao2FAs1Wp7vAyg==",
 			"dev": true,
+			"peer": true,
 			"requires": {
-				"@typescript-eslint/scope-manager": "8.50.1",
-				"@typescript-eslint/types": "8.50.1",
-				"@typescript-eslint/typescript-estree": "8.50.1",
-				"@typescript-eslint/visitor-keys": "8.50.1",
-				"debug": "^4.3.4"
+				"@typescript-eslint/scope-manager": "8.52.0",
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/typescript-estree": "8.52.0",
+				"@typescript-eslint/visitor-keys": "8.52.0",
+				"debug": "^4.4.3"
 			}
 		},
 		"@typescript-eslint/project-service": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.50.1.tgz",
-			"integrity": "sha512-E1ur1MCVf+YiP89+o4Les/oBAVzmSbeRB0MQLfSlYtbWU17HPxZ6Bhs5iYmKZRALvEuBoXIZMOIRRc/P++Ortg==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.52.0.tgz",
+			"integrity": "sha512-xD0MfdSdEmeFa3OmVqonHi+Cciab96ls1UhIF/qX/O/gPu5KXD0bY9lu33jj04fjzrXHcuvjBcBC+D3SNSadaw==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/tsconfig-utils": "^8.50.1",
-				"@typescript-eslint/types": "^8.50.1",
-				"debug": "^4.3.4"
+				"@typescript-eslint/tsconfig-utils": "^8.52.0",
+				"@typescript-eslint/types": "^8.52.0",
+				"debug": "^4.4.3"
 			}
 		},
 		"@typescript-eslint/scope-manager": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.50.1.tgz",
-			"integrity": "sha512-mfRx06Myt3T4vuoHaKi8ZWNTPdzKPNBhiblze5N50//TSHOAQQevl/aolqA/BcqqbJ88GUnLqjjcBc8EWdBcVw==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.52.0.tgz",
+			"integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.50.1",
-				"@typescript-eslint/visitor-keys": "8.50.1"
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/visitor-keys": "8.52.0"
 			}
 		},
 		"@typescript-eslint/tsconfig-utils": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.50.1.tgz",
-			"integrity": "sha512-ooHmotT/lCWLXi55G4mvaUF60aJa012QzvLK0Y+Mp4WdSt17QhMhWOaBWeGTFVkb2gDgBe19Cxy1elPXylslDw==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.52.0.tgz",
+			"integrity": "sha512-jl+8fzr/SdzdxWJznq5nvoI7qn2tNYV/ZBAEcaFMVXf+K6jmXvAFrgo/+5rxgnL152f//pDEAYAhhBAZGrVfwg==",
 			"dev": true,
 			"requires": {}
 		},
 		"@typescript-eslint/type-utils": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.50.1.tgz",
-			"integrity": "sha512-7J3bf022QZE42tYMO6SL+6lTPKFk/WphhRPe9Tw/el+cEwzLz1Jjz2PX3GtGQVxooLDKeMVmMt7fWpYRdG5Etg==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.52.0.tgz",
+			"integrity": "sha512-JD3wKBRWglYRQkAtsyGz1AewDu3mTc7NtRjR/ceTyGoPqmdS5oCdx/oZMWD5Zuqmo6/MpsYs0wp6axNt88/2EQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.50.1",
-				"@typescript-eslint/typescript-estree": "8.50.1",
-				"@typescript-eslint/utils": "8.50.1",
-				"debug": "^4.3.4",
-				"ts-api-utils": "^2.1.0"
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/typescript-estree": "8.52.0",
+				"@typescript-eslint/utils": "8.52.0",
+				"debug": "^4.4.3",
+				"ts-api-utils": "^2.4.0"
 			}
 		},
 		"@typescript-eslint/types": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.50.1.tgz",
-			"integrity": "sha512-v5lFIS2feTkNyMhd7AucE/9j/4V9v5iIbpVRncjk/K0sQ6Sb+Np9fgYS/63n6nwqahHQvbmujeBL7mp07Q9mlA==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.52.0.tgz",
+			"integrity": "sha512-LWQV1V4q9V4cT4H5JCIx3481iIFxH1UkVk+ZkGGAV1ZGcjGI9IoFOfg3O6ywz8QqCDEp7Inlg6kovMofsNRaGg==",
 			"dev": true
 		},
 		"@typescript-eslint/typescript-estree": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.50.1.tgz",
-			"integrity": "sha512-woHPdW+0gj53aM+cxchymJCrh0cyS7BTIdcDxWUNsclr9VDkOSbqC13juHzxOmQ22dDkMZEpZB+3X1WpUvzgVQ==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.52.0.tgz",
+			"integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/project-service": "8.50.1",
-				"@typescript-eslint/tsconfig-utils": "8.50.1",
-				"@typescript-eslint/types": "8.50.1",
-				"@typescript-eslint/visitor-keys": "8.50.1",
-				"debug": "^4.3.4",
-				"minimatch": "^9.0.4",
-				"semver": "^7.6.0",
+				"@typescript-eslint/project-service": "8.52.0",
+				"@typescript-eslint/tsconfig-utils": "8.52.0",
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/visitor-keys": "8.52.0",
+				"debug": "^4.4.3",
+				"minimatch": "^9.0.5",
+				"semver": "^7.7.3",
 				"tinyglobby": "^0.2.15",
-				"ts-api-utils": "^2.1.0"
+				"ts-api-utils": "^2.4.0"
 			},
 			"dependencies": {
 				"brace-expansion": {
@@ -8912,24 +8930,24 @@
 			}
 		},
 		"@typescript-eslint/utils": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.50.1.tgz",
-			"integrity": "sha512-lCLp8H1T9T7gPbEuJSnHwnSuO9mDf8mfK/Nion5mZmiEaQD9sWf9W4dfeFqRyqRjF06/kBuTmAqcs9sewM2NbQ==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.52.0.tgz",
+			"integrity": "sha512-wYndVMWkweqHpEpwPhwqE2lnD2DxC6WVLupU/DOt/0/v+/+iQbbzO3jOHjmBMnhu0DgLULvOaU4h4pwHYi2oRQ==",
 			"dev": true,
 			"requires": {
-				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.50.1",
-				"@typescript-eslint/types": "8.50.1",
-				"@typescript-eslint/typescript-estree": "8.50.1"
+				"@eslint-community/eslint-utils": "^4.9.1",
+				"@typescript-eslint/scope-manager": "8.52.0",
+				"@typescript-eslint/types": "8.52.0",
+				"@typescript-eslint/typescript-estree": "8.52.0"
 			}
 		},
 		"@typescript-eslint/visitor-keys": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.50.1.tgz",
-			"integrity": "sha512-IrDKrw7pCRUR94zeuCSUWQ+w8JEf5ZX5jl/e6AHGSLi1/zIr0lgutfn/7JpfCey+urpgQEdrZVYzCaVVKiTwhQ==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.52.0.tgz",
+			"integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/types": "8.50.1",
+				"@typescript-eslint/types": "8.52.0",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"dependencies": {
@@ -9101,7 +9119,8 @@
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"acorn-jsx": {
 			"version": "5.3.2",
@@ -9276,6 +9295,7 @@
 			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.25.0.tgz",
 			"integrity": "sha512-PJ8gYKeS5e/whHBh8xrwYK+dAvEj7JXtz6uTucnMRB8OiGTsKccFekoRrjajPBHV8oOY+2tI4uxeceSimKwMFA==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"caniuse-lite": "^1.0.30001718",
 				"electron-to-chromium": "^1.5.160",
@@ -9611,6 +9631,7 @@
 			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.2.tgz",
 			"integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@eslint-community/eslint-utils": "^4.8.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -9661,12 +9682,13 @@
 			"resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-10.1.8.tgz",
 			"integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
 			"dev": true,
+			"peer": true,
 			"requires": {}
 		},
 		"eslint-plugin-jest": {
-			"version": "29.11.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.11.0.tgz",
-			"integrity": "sha512-ay2MPUfHhwXyv+FbPxRWiEq3HNNsg4uMt/eBGlsfGHkM0891f0lcr0WrtID+TMyg17unAnNrnySD5LwirlA8EQ==",
+			"version": "29.12.1",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.12.1.tgz",
+			"integrity": "sha512-Rxo7r4jSANMBkXLICJKS0gjacgyopfNAsoS0e3R9AHnjoKuQOaaPfmsDJPi8UWwygI099OV/K/JhpYRVkxD4AA==",
 			"dev": true,
 			"requires": {
 				"@typescript-eslint/utils": "^8.0.0"
@@ -10062,9 +10084,9 @@
 			}
 		},
 		"globals": {
-			"version": "16.5.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-16.5.0.tgz",
-			"integrity": "sha512-c/c15i26VrJ4IRt5Z89DnIzCGDn9EcebibhAOjw5ibqEHsE1wLUgkPn9RDmNcUKyU87GeaL633nyJ+pplFR2ZQ==",
+			"version": "17.0.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-17.0.0.tgz",
+			"integrity": "sha512-gv5BeD2EssA793rlFWVPMMCqefTlpusw6/2TbAVMy0FzcG8wKJn4O+NqJ4+XWmmwrayJgw5TzrmWjFgmz1XPqw==",
 			"dev": true
 		},
 		"graceful-fs": {
@@ -10330,6 +10352,7 @@
 			"resolved": "https://registry.npmjs.org/jest/-/jest-30.2.0.tgz",
 			"integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
 			"dev": true,
+			"peer": true,
 			"requires": {
 				"@jest/core": "30.2.0",
 				"@jest/types": "30.2.0",
@@ -10823,9 +10846,9 @@
 			}
 		},
 		"knip": {
-			"version": "5.77.1",
-			"resolved": "https://registry.npmjs.org/knip/-/knip-5.77.1.tgz",
-			"integrity": "sha512-+yA/vfQUDEFUOcR0XRn/dOZmNEsS10pIMztS5JbKUhk9zvQiAFvr3Mcc3zC7Dn9gBG8LeImhaXA6/D3uhzwZvg==",
+			"version": "5.80.2",
+			"resolved": "https://registry.npmjs.org/knip/-/knip-5.80.2.tgz",
+			"integrity": "sha512-Yt7iF8Uzl7pp3mGA6yvum6PZBcbGhjasZYuqIwcIAX1jsIhGRUAK0icP0qrB6FSPBI3BpIeMHl7n9meCLO6ovg==",
 			"dev": true,
 			"requires": {
 				"@nodelib/fs.walk": "^1.2.3",
@@ -11334,7 +11357,8 @@
 			"version": "3.7.4",
 			"resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
 			"integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",
@@ -11801,7 +11825,8 @@
 					"version": "4.0.3",
 					"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
 					"integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
-					"dev": true
+					"dev": true,
+					"peer": true
 				}
 			}
 		},
@@ -11831,9 +11856,9 @@
 			}
 		},
 		"ts-api-utils": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
-			"integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.4.0.tgz",
+			"integrity": "sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==",
 			"dev": true,
 			"requires": {}
 		},
@@ -11886,18 +11911,19 @@
 			"version": "5.9.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
 			"integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-			"dev": true
+			"dev": true,
+			"peer": true
 		},
 		"typescript-eslint": {
-			"version": "8.50.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.50.1.tgz",
-			"integrity": "sha512-ytTHO+SoYSbhAH9CrYnMhiLx8To6PSSvqnvXyPUgPETCvB6eBKmTI9w6XMPS3HsBRGkwTVBX+urA8dYQx6bHfQ==",
+			"version": "8.52.0",
+			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.52.0.tgz",
+			"integrity": "sha512-atlQQJ2YkO4pfTVQmQ+wvYQwexPDOIgo+RaVcD7gHgzy/IQA+XTyuxNM9M9TVXvttkF7koBHmcwisKdOAf2EcA==",
 			"dev": true,
 			"requires": {
-				"@typescript-eslint/eslint-plugin": "8.50.1",
-				"@typescript-eslint/parser": "8.50.1",
-				"@typescript-eslint/typescript-estree": "8.50.1",
-				"@typescript-eslint/utils": "8.50.1"
+				"@typescript-eslint/eslint-plugin": "8.52.0",
+				"@typescript-eslint/parser": "8.52.0",
+				"@typescript-eslint/typescript-estree": "8.52.0",
+				"@typescript-eslint/utils": "8.52.0"
 			}
 		},
 		"uglify-js": {

--- a/package.json
+++ b/package.json
@@ -107,12 +107,12 @@
 		"@types/node": "^24.10.1",
 		"eslint": "^9.39.2",
 		"eslint-config-prettier": "^10.1.8",
-		"eslint-plugin-jest": "^29.11.0",
+		"eslint-plugin-jest": "^29.12.1",
 		"eslint-plugin-prettier": "^5.5.4",
-		"globals": "^16.5.0",
+		"globals": "^17.0.0",
 		"ini": "^6.0.0",
 		"jest": "^30.2.0",
-		"knip": "^5.77.1",
+		"knip": "^5.80.2",
 		"marked": "^17.0.1",
 		"open-cli": "^8.0.0",
 		"pick-port": "^2.2.0",
@@ -120,6 +120,6 @@
 		"sctp": "^1.0.0",
 		"ts-jest": "^29.4.6",
 		"typescript": "^5.9.3",
-		"typescript-eslint": "^8.50.1"
+		"typescript-eslint": "^8.52.0"
 	}
 }

--- a/worker/subprojects/abseil-cpp.wrap
+++ b/worker/subprojects/abseil-cpp.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = abseil-cpp-20250127.1
-source_url = https://github.com/abseil/abseil-cpp/releases/download/20250127.1/abseil-cpp-20250127.1.tar.gz
-source_filename = abseil-cpp-20250127.1.tar.gz
-source_hash = b396401fd29e2e679cace77867481d388c807671dc2acc602a0259eeb79b7811
-patch_filename = abseil-cpp_20250127.1-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20250127.1-2/get_patch
-patch_hash = 086fd801fb3bd3771876946adc89c684f2adefe32fbd463fb2e593e4d76682bc
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20250127.1-2/abseil-cpp-20250127.1.tar.gz
-wrapdb_version = 20250127.1-2
+directory = abseil-cpp-20250814.1
+source_url = https://github.com/abseil/abseil-cpp/releases/download/20250814.1/abseil-cpp-20250814.1.tar.gz
+source_filename = abseil-cpp-20250814.1.tar.gz
+source_hash = 1692f77d1739bacf3f94337188b78583cf09bab7e420d2dc6c5605a4f86785a1
+patch_filename = abseil-cpp_20250814.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20250814.1-1/get_patch
+patch_hash = f44ad4d72ff2919a6a48cf0887f69aef34c338bfdd8931153596e3766d75f654
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20250814.1-1/abseil-cpp-20250814.1.tar.gz
+wrapdb_version = 20250814.1-1
 
 [provide]
 absl_base = absl_base_dep

--- a/worker/subprojects/abseil-cpp.wrap
+++ b/worker/subprojects/abseil-cpp.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = abseil-cpp-20250814.1
-source_url = https://github.com/abseil/abseil-cpp/releases/download/20250814.1/abseil-cpp-20250814.1.tar.gz
-source_filename = abseil-cpp-20250814.1.tar.gz
-source_hash = 1692f77d1739bacf3f94337188b78583cf09bab7e420d2dc6c5605a4f86785a1
-patch_filename = abseil-cpp_20250814.1-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20250814.1-1/get_patch
-patch_hash = f44ad4d72ff2919a6a48cf0887f69aef34c338bfdd8931153596e3766d75f654
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20250814.1-1/abseil-cpp-20250814.1.tar.gz
-wrapdb_version = 20250814.1-1
+directory = abseil-cpp-20240722.0
+source_url = https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz
+source_filename = abseil-cpp-20240722.0.tar.gz
+source_hash = f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3
+patch_filename = abseil-cpp_20240722.0-4_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20240722.0-4/get_patch
+patch_hash = e39d535c4707f6e342e84e3e616449e1cc98cb7fadda92a09820b0ae67c6d0d6
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20240722.0-4/abseil-cpp-20240722.0.tar.gz
+wrapdb_version = 20240722.0-4
 
 [provide]
 absl_base = absl_base_dep

--- a/worker/subprojects/abseil-cpp.wrap
+++ b/worker/subprojects/abseil-cpp.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = abseil-cpp-20240722.0
-source_url = https://github.com/abseil/abseil-cpp/releases/download/20240722.0/abseil-cpp-20240722.0.tar.gz
-source_filename = abseil-cpp-20240722.0.tar.gz
-source_hash = f50e5ac311a81382da7fa75b97310e4b9006474f9560ac46f54a9967f07d4ae3
-patch_filename = abseil-cpp_20240722.0-4_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20240722.0-4/get_patch
-patch_hash = e39d535c4707f6e342e84e3e616449e1cc98cb7fadda92a09820b0ae67c6d0d6
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20240722.0-4/abseil-cpp-20240722.0.tar.gz
-wrapdb_version = 20240722.0-4
+directory = abseil-cpp-20250814.1
+source_url = https://github.com/abseil/abseil-cpp/releases/download/20250814.1/abseil-cpp-20250814.1.tar.gz
+source_filename = abseil-cpp-20250814.1.tar.gz
+source_hash = 1692f77d1739bacf3f94337188b78583cf09bab7e420d2dc6c5605a4f86785a1
+patch_filename = abseil-cpp_20250814.1-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20250814.1-1/get_patch
+patch_hash = f44ad4d72ff2919a6a48cf0887f69aef34c338bfdd8931153596e3766d75f654
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20250814.1-1/abseil-cpp-20250814.1.tar.gz
+wrapdb_version = 20250814.1-1
 
 [provide]
 absl_base = absl_base_dep

--- a/worker/subprojects/abseil-cpp.wrap
+++ b/worker/subprojects/abseil-cpp.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = abseil-cpp-20250814.1
-source_url = https://github.com/abseil/abseil-cpp/releases/download/20250814.1/abseil-cpp-20250814.1.tar.gz
-source_filename = abseil-cpp-20250814.1.tar.gz
-source_hash = 1692f77d1739bacf3f94337188b78583cf09bab7e420d2dc6c5605a4f86785a1
-patch_filename = abseil-cpp_20250814.1-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20250814.1-1/get_patch
-patch_hash = f44ad4d72ff2919a6a48cf0887f69aef34c338bfdd8931153596e3766d75f654
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20250814.1-1/abseil-cpp-20250814.1.tar.gz
-wrapdb_version = 20250814.1-1
+directory = abseil-cpp-20250127.1
+source_url = https://github.com/abseil/abseil-cpp/releases/download/20250127.1/abseil-cpp-20250127.1.tar.gz
+source_filename = abseil-cpp-20250127.1.tar.gz
+source_hash = b396401fd29e2e679cace77867481d388c807671dc2acc602a0259eeb79b7811
+patch_filename = abseil-cpp_20250127.1-2_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/abseil-cpp_20250127.1-2/get_patch
+patch_hash = 086fd801fb3bd3771876946adc89c684f2adefe32fbd463fb2e593e4d76682bc
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/abseil-cpp_20250127.1-2/abseil-cpp-20250127.1.tar.gz
+wrapdb_version = 20250127.1-2
 
 [provide]
 absl_base = absl_base_dep

--- a/worker/subprojects/catch2.wrap
+++ b/worker/subprojects/catch2.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = Catch2-3.8.1
-source_url = https://github.com/catchorg/Catch2/archive/v3.8.1.tar.gz
-source_filename = Catch2-3.8.1.tar.gz
-source_hash = 18b3f70ac80fccc340d8c6ff0f339b2ae64944782f8d2fca2bd705cf47cadb79
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/catch2_3.8.1-1/Catch2-3.8.1.tar.gz
-wrapdb_version = 3.8.1-1
+directory = Catch2-3.12.0
+source_url = https://github.com/catchorg/Catch2/archive/v3.12.0.tar.gz
+source_filename = Catch2-3.12.0.tar.gz
+source_hash = e077079f214afc99fee940d91c14cf1a8c1d378212226bb9f50efff75fe07b23
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/catch2_3.12.0-1/get_source/Catch2-3.12.0.tar.gz
+wrapdb_version = 3.12.0-1
 
 [provide]
 catch2 = catch2_dep

--- a/worker/subprojects/liburing.wrap
+++ b/worker/subprojects/liburing.wrap
@@ -1,13 +1,13 @@
 [wrap-file]
-directory = liburing-liburing-2.5
-source_url = https://github.com/axboe/liburing/archive/refs/tags/liburing-2.5.tar.gz
-source_filename = liburing-2.5.tar.gz
-source_hash = 456f5f882165630f0dc7b75e8fd53bd01a955d5d4720729b4323097e6e9f2a98
-patch_filename = liburing_2.5-2_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/liburing_2.5-2/get_patch
-patch_hash = b502734fe6c1ce8318fe22b549883a1a0fee47ac13ae22cbc239191fe8baf4d0
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/liburing_2.5-2/liburing-2.5.tar.gz
-wrapdb_version = 2.5-2
+directory = liburing-liburing-2.12
+source_url = https://github.com/axboe/liburing/archive/refs/tags/liburing-2.12.tar.gz
+source_filename = liburing-2.12.tar.gz
+source_hash = f1d10cb058c97c953b4c0c446b11e9177e8c8b32a5a88b309f23fdd389e26370
+patch_filename = liburing_2.12-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/liburing_2.12-1/get_patch
+patch_hash = b21f90196008cde9ed242571a71d8302c703272a2f8b91edd589bd8d6abea47a
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/liburing_2.12-1/liburing-2.12.tar.gz
+wrapdb_version = 2.12-1
 
 [provide]
 dependency_names = liburing

--- a/worker/subprojects/usrsctp.wrap
+++ b/worker/subprojects/usrsctp.wrap
@@ -1,8 +1,8 @@
 [wrap-file]
-directory = usrsctp-d45b53f5dfa79533f5c5e7aefa5d7570405afb39
-source_url = https://github.com/sctplab/usrsctp/archive/d45b53f5dfa79533f5c5e7aefa5d7570405afb39.zip
-source_filename = d45b53f5dfa79533f5c5e7aefa5d7570405afb39.zip
-source_hash = da5f9adafc48fb5451f8355fee06508db52a3fca11138852c73ecb844f3b8647
+directory = usrsctp-fd070e05a7474f38c7fecdf4d4b6005d2547ee00
+source_url = https://github.com/sctplab/usrsctp/archive/fd070e05a7474f38c7fecdf4d4b6005d2547ee00.zip
+source_filename = fd070e05a7474f38c7fecdf4d4b6005d2547ee00.zip
+source_hash = a0f9255a88fef2e375b590f2823ddbc70ab38142b9931cd3f1c7c0b700bf7043
 
 [provide]
 usrsctp = usrsctp_dep


### PR DESCRIPTION
# Details

- Update Catch2 from 3.8.1-1 to 3.12.0-1.
- Update liburing from 2.5-2 to 2.12-1.
- Bonus track: Update NPM dev deps.

## Note

I haven't updated abseil-cpp because newer versions fail in Windows + Rust. See comments below.