### PR TITLE
worker tidy - round X + 1

### DIFF
--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -57,8 +57,9 @@ jobs:
             run-test-asan-address: false
             run-test-asan-undefined: false
             run-test-asan-thread: false
-            # Compile with all Meson option flags enabled once with gcc in Release mode.
-            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_disable_liburing=true -Dms_sctp_stack=true'
+            # Compile with all Meson option flags enabled once with gcc in
+            # Release mode.
+            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_disable_liburing=true -Dms_sctp_stack=true'
           - os: ubuntu-24.04
             cc: gcc
             cxx: g++
@@ -69,8 +70,9 @@ jobs:
             run-test-asan-address: false
             run-test-asan-undefined: false
             run-test-asan-thread: false
-            # Compile with all Meson option flags enabled once with gcc in Debug mode.
-            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_disable_liburing=true -Dms_sctp_stack=true'
+            # Compile with all Meson option flags enabled once with gcc in
+            # Debug mode.
+            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_disable_liburing=true -Dms_sctp_stack=true'
           - os: ubuntu-24.04
             cc: clang
             cxx: clang++
@@ -81,8 +83,9 @@ jobs:
             run-test-asan-address: true
             run-test-asan-undefined: true
             run-test-asan-thread: true
-            # Let's just compile with all Meson option flags enabled once with clang.
-            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_disable_liburing=true -Dms_sctp_stack=true'
+            # Let's just compile with all Meson option flags enabled once with
+            # clang.
+            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_disable_liburing=true -Dms_sctp_stack=true'
           - os: ubuntu-24.04-arm
             cc: gcc
             cxx: g++

--- a/worker/include/DepLibSRTP.hpp
+++ b/worker/include/DepLibSRTP.hpp
@@ -20,7 +20,7 @@ public:
 	static const std::string& GetErrorString(srtp_err_status_t code);
 
 private:
-	static std::unordered_map<srtp_err_status_t, std::string> mapErrorCodeString;
+	static const std::unordered_map<srtp_err_status_t, std::string> ErrorCode2String;
 };
 
 #endif

--- a/worker/include/RTC/ICE/StunPacket.hpp
+++ b/worker/include/RTC/ICE/StunPacket.hpp
@@ -81,7 +81,8 @@ namespace RTC
 				REQUEST          = 0,
 				INDICATION       = 1,
 				SUCCESS_RESPONSE = 2,
-				ERROR_RESPONSE   = 3
+				ERROR_RESPONSE   = 3,
+				UNSET            = 255
 			};
 
 			/**
@@ -89,7 +90,8 @@ namespace RTC
 			 */
 			enum class Method : uint16_t
 			{
-				BINDING = 1
+				BINDING = 1,
+				UNSET   = 255
 			};
 
 			/**
@@ -523,8 +525,8 @@ namespace RTC
 			void AssertNotProtected() const;
 
 		private:
-			StunPacket::Class klass;
-			StunPacket::Method method;
+			StunPacket::Class klass{ StunPacket::Class::UNSET };
+			StunPacket::Method method{ StunPacket::Method::UNSET };
 			// Map of STUN Attributes indexed by Attribute type.
 			std::unordered_map<StunPacket::AttributeType, StunPacket::Attribute> attributes;
 		};

--- a/worker/include/RTC/RTCP/FeedbackPsRemb.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsRemb.hpp
@@ -75,7 +75,7 @@ namespace RTC
 			size_t Serialize(uint8_t* buffer) override;
 			size_t GetSize() const override
 			{
-				// NOLINTNEXTLINE (bugprone-parent-virtual-call)
+				// NOLINTNEXTLINE(bugprone-parent-virtual-call)
 				return FeedbackPsPacket::GetSize() + 8 + (4u * this->ssrcs.size());
 			}
 

--- a/worker/include/RTC/RtpDictionaries.hpp
+++ b/worker/include/RTC/RtpDictionaries.hpp
@@ -20,7 +20,7 @@ namespace RTC
 		};
 	};
 
-	// NOLINTNEXTLINE (cppcoreguidelines-pro-type-member-init)
+	// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 	class RtpCodecMimeType
 	{
 	public:
@@ -31,7 +31,6 @@ namespace RTC
 		};
 
 	public:
-		// NOLINTNEXTLINE
 		enum class Subtype
 		{
 			// Audio codecs:
@@ -207,7 +206,7 @@ namespace RTC
 		bool ksvc{ false };
 	};
 
-	// NOLINTNEXTLINE (cppcoreguidelines-pro-type-member-init)
+	// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 	class RtpHeaderExtensionParameters
 	{
 	public:

--- a/worker/include/RTC/SCTP/packet/ErrorCause.hpp
+++ b/worker/include/RTC/SCTP/packet/ErrorCause.hpp
@@ -47,7 +47,7 @@ namespace RTC
 			 * Error Cause Code.
 			 * NOTE: This field MUST be 2 bytes long.
 			 */
-			// NOLINTNEXTLINE (performance-enum-size)
+			// NOLINTNEXTLINE(performance-enum-size)
 			enum class ErrorCauseCode : uint16_t
 			{
 				INVALID_STREAM_IDENTIFIER                    = 0x0001,

--- a/worker/include/RTC/SCTP/packet/parameters/ReconfigurationResponseParameter.hpp
+++ b/worker/include/RTC/SCTP/packet/parameters/ReconfigurationResponseParameter.hpp
@@ -41,7 +41,7 @@ namespace RTC
 			friend class Chunk;
 
 		public:
-			// NOLINTNEXTLINE (performance-enum-siz)
+			// NOLINTNEXTLINE(performance-enum-siz)
 			enum class Result : uint32_t
 			{
 				SUCCESS_NOTHING_TO_DO             = 0x00000000,

--- a/worker/include/RTC/SCTP/packet/parameters/ZeroChecksumAcceptableParameter.hpp
+++ b/worker/include/RTC/SCTP/packet/parameters/ZeroChecksumAcceptableParameter.hpp
@@ -38,7 +38,7 @@ namespace RTC
 			/**
 			 * Zero Checksum Alternate Error Detection Method.
 			 */
-			// NOLINTNEXTLINE (performance-enum-size)
+			// NOLINTNEXTLINE(performance-enum-size)
 			enum class AlternateErrorDetectionMethod : uint32_t
 			{
 				NONE           = 0x0000,

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -241,7 +241,7 @@ namespace Utils
 
 		static uint32_t GetCRC32c(const uint8_t* data, size_t size);
 
-		static const uint8_t* GetHmacSha1(const std::string& key, const uint8_t* data, size_t len);
+		static const uint8_t* GetHmacSha1(const char* key, size_t keyLen, const uint8_t* data, size_t len);
 
 		static void WriteRandomBytes(uint8_t* buffer, size_t len);
 

--- a/worker/include/lib.hpp
+++ b/worker/include/lib.hpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 
-// NOLINTNEXTLINE (readability-identifier-naming)
+// NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" int mediasoup_worker_run(
   int argc,
   char* argv[],

--- a/worker/scripts/clang-scripts.mjs
+++ b/worker/scripts/clang-scripts.mjs
@@ -115,7 +115,7 @@ function tidy() {
 	const files = process.env.MEDIASOUP_TIDY_FILES ?? CLANG_TIDY_PATHS.join(' ');
 
 	executeCmd(
-		`"${PYTHON}" "${runClangTidy}" -clang-tidy-binary="${clangTidy}" -clang-apply-replacements-binary="${clangApplyReplacements}" -p="${BUILD_DIR}" -j=${NUM_CORES} -fix -format -checks=${tidyChecks} ${files}`
+		`"${PYTHON}" "${runClangTidy}" -clang-tidy-binary="${clangTidy}" -clang-apply-replacements-binary="${clangApplyReplacements}" -p="${BUILD_DIR}" -j=${NUM_CORES} -quiet -fix -format -checks=${tidyChecks} ${files}`
 	);
 }
 

--- a/worker/src/DepLibSRTP.cpp
+++ b/worker/src/DepLibSRTP.cpp
@@ -16,7 +16,7 @@ static size_t GlobalInstances = 0;
 //   https://github.com/cisco/libsrtp/blob/main/include/srtp.h
 //
 // clang-format off
-std::unordered_map<srtp_err_status_t, std::string> DepLibSRTP::mapErrorCodeString =
+const std::unordered_map<srtp_err_status_t, std::string> DepLibSRTP::ErrorCode2String =
 {
 	{ srtp_err_status_ok,            "nothing to report" },
 	{ srtp_err_status_fail,          "unspecified failure" },
@@ -97,9 +97,9 @@ const std::string& DepLibSRTP::GetErrorString(srtp_err_status_t code)
 
 	static const std::string UnknownError("unknown libsrtp error");
 
-	auto it = DepLibSRTP::mapErrorCodeString.find(code);
+	auto it = DepLibSRTP::ErrorCode2String.find(code);
 
-	if (it == DepLibSRTP::mapErrorCodeString.end())
+	if (it == DepLibSRTP::ErrorCode2String.end())
 	{
 		return UnknownError;
 	}

--- a/worker/src/DepLibUring.cpp
+++ b/worker/src/DepLibUring.cpp
@@ -16,7 +16,7 @@ thread_local bool DepLibUring::enabled{ false };
 // liburing instance per thread.
 thread_local DepLibUring::LibUring* DepLibUring::liburing{ nullptr };
 // Completion queue entry array used to retrieve processes tasks.
-thread_local struct io_uring_cqe* cqes[DepLibUring::QueueDepth];
+thread_local struct io_uring_cqe* Cqes[DepLibUring::QueueDepth];
 
 /* Static methods for UV callbacks. */
 
@@ -25,27 +25,27 @@ inline static void onCloseFd(uv_handle_t* handle)
 	delete reinterpret_cast<uv_poll_t*>(handle);
 }
 
-inline static void onFdEvent(uv_poll_t* handle, int status, int events)
+inline static void onFdEvent(uv_poll_t* handle, int /*status*/, int /*events*/)
 {
 	auto* liburing = static_cast<DepLibUring::LibUring*>(handle->data);
-	auto count     = io_uring_peek_batch_cqe(liburing->GetRing(), cqes, DepLibUring::QueueDepth);
+	auto count     = io_uring_peek_batch_cqe(liburing->GetRing(), Cqes, DepLibUring::QueueDepth);
 
 	// libuv uses level triggering, so we need to read from the socket to reset
 	// the counter in order to avoid libuv calling this callback indefinitely.
 	eventfd_t v;
-	int err = eventfd_read(liburing->GetEventFd(), std::addressof(v));
+	const int err = eventfd_read(liburing->GetEventFd(), std::addressof(v));
 
 	if (err < 0)
 	{
 		// Get positive errno.
-		int error = -err;
+		const int error = -err;
 
 		MS_ABORT("eventfd_read() failed: %s", std::strerror(error));
 	};
 
 	for (unsigned int i{ 0 }; i < count; ++i)
 	{
-		struct io_uring_cqe* cqe = cqes[i];
+		struct io_uring_cqe* cqe = Cqes[i];
 		auto* userData           = static_cast<DepLibUring::UserData*>(io_uring_cqe_get_data(cqe));
 
 		if (liburing->IsZeroCopyEnabled())
@@ -161,11 +161,9 @@ void DepLibUring::ClassDestroy()
 
 bool DepLibUring::CheckRuntimeSupport()
 {
-	// clang-format off
 	struct utsname buffer{};
-	// clang-format on
 
-	auto err = uname(std::addressof(buffer));
+	const auto err = uname(std::addressof(buffer));
 
 	if (err != 0)
 	{
@@ -288,7 +286,7 @@ DepLibUring::LibUring::LibUring()
 	 * (or thread) will submit requests, which is used for internal optimisations.
 	 */
 
-	unsigned int flags = IORING_SETUP_SINGLE_ISSUER;
+	const unsigned int flags = IORING_SETUP_SINGLE_ISSUER;
 
 	// Initialize io_uring.
 	auto err = io_uring_queue_init(DepLibUring::QueueDepth, std::addressof(this->ring), flags);
@@ -296,7 +294,7 @@ DepLibUring::LibUring::LibUring()
 	if (err < 0)
 	{
 		// Get positive errno.
-		int error = -err;
+		const int error = -err;
 
 		MS_THROW_ERROR("io_uring_queue_init() failed: %s", std::strerror(error));
 	}
@@ -314,7 +312,7 @@ DepLibUring::LibUring::LibUring()
 	if (err < 0)
 	{
 		// Get positive errno.
-		int error = -err;
+		const int error = -err;
 
 		MS_THROW_ERROR("io_uring_register_eventfd() failed: %s", std::strerror(error));
 	}
@@ -338,7 +336,7 @@ DepLibUring::LibUring::LibUring()
 	if (err < 0)
 	{
 		// Get positive errno.
-		int error = -err;
+		const int error = -err;
 
 		if (error == ENOMEM)
 		{
@@ -381,13 +379,13 @@ DepLibUring::LibUring::~LibUring()
 	if (err != 0)
 	{
 		// Get positive errno.
-		int error = -err;
+		const int error = -err;
 
 		try
 		{
 			MS_ABORT("close() failed: %s", std::strerror(error));
 		}
-		catch (const std::exception& error)
+		catch (const std::exception& error) // NOLINT(bugprone-empty-catch)
 		{
 			// NOTE: This is to avoid a warning:
 			// warning: ‘throw’ will always call ‘terminate’ [-Wterminate]
@@ -440,7 +438,7 @@ void DepLibUring::LibUring::StopPollingCQEs()
 	this->uvHandle->data = nullptr;
 
 	// Stop polling the event file descriptor.
-	auto err = uv_poll_stop(this->uvHandle);
+	const auto err = uv_poll_stop(this->uvHandle);
 
 	if (err != 0)
 	{
@@ -508,7 +506,7 @@ bool DepLibUring::LibUring::PrepareSend(
 
 	io_uring_sqe_set_data(sqe, userData);
 
-	socklen_t addrlen = Utils::IP::GetAddressLen(addr);
+	const socklen_t addrlen = Utils::IP::GetAddressLen(addr);
 
 	if (this->zeroCopyEnabled)
 	{
@@ -603,7 +601,7 @@ void DepLibUring::LibUring::Submit()
 	// Unset active flag.
 	SetInactive();
 
-	auto err = io_uring_submit(std::addressof(this->ring));
+	const auto err = io_uring_submit(std::addressof(this->ring));
 
 	if (err >= 0)
 	{
@@ -612,7 +610,7 @@ void DepLibUring::LibUring::Submit()
 	else
 	{
 		// Get positive errno.
-		int error = -err;
+		const int error = -err;
 
 		MS_ERROR("io_uring_submit() failed: %s", std::strerror(error));
 	}

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -69,7 +69,7 @@ void DepUsrSCTP::ClassInit()
 
 	MS_DEBUG_TAG(info, "usrsctp");
 
-	const std::lock_guard<std::mutex> lock(GlobalSyncMutex);
+	std::scoped_lock lock(GlobalSyncMutex);
 
 	if (GlobalInstances == 0)
 	{
@@ -90,7 +90,8 @@ void DepUsrSCTP::ClassDestroy()
 {
 	MS_TRACE();
 
-	const std::lock_guard<std::mutex> lock(GlobalSyncMutex);
+	std::scoped_lock lock(GlobalSyncMutex);
+
 	--GlobalInstances;
 
 	if (GlobalInstances == 0)
@@ -126,7 +127,7 @@ uintptr_t DepUsrSCTP::GetNextSctpAssociationId()
 {
 	MS_TRACE();
 
-	const std::lock_guard<std::mutex> lock(GlobalSyncMutex);
+	std::scoped_lock lock(GlobalSyncMutex);
 
 	// NOTE: usrsctp_connect() fails with a value of 0.
 	if (DepUsrSCTP::nextSctpAssociationId == 0u)
@@ -154,7 +155,7 @@ void DepUsrSCTP::RegisterSctpAssociation(RTC::SctpAssociation* sctpAssociation)
 {
 	MS_TRACE();
 
-	const std::lock_guard<std::mutex> lock(GlobalSyncMutex);
+	std::scoped_lock lock(GlobalSyncMutex);
 
 	MS_ASSERT(DepUsrSCTP::checker != nullptr, "Checker not created");
 
@@ -176,7 +177,7 @@ void DepUsrSCTP::DeregisterSctpAssociation(RTC::SctpAssociation* sctpAssociation
 {
 	MS_TRACE();
 
-	const std::lock_guard<std::mutex> lock(GlobalSyncMutex);
+	std::scoped_lock lock(GlobalSyncMutex);
 
 	MS_ASSERT(DepUsrSCTP::checker != nullptr, "Checker not created");
 
@@ -195,7 +196,7 @@ RTC::SctpAssociation* DepUsrSCTP::RetrieveSctpAssociation(uintptr_t id)
 {
 	MS_TRACE();
 
-	const std::lock_guard<std::mutex> lock(GlobalSyncMutex);
+	std::scoped_lock lock(GlobalSyncMutex);
 
 	auto it = DepUsrSCTP::mapIdSctpAssociation.find(id);
 

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -470,12 +470,10 @@ namespace RTC
 
 		this->bufferedAmount = bufferedAmount;
 
-		// clang-format off
 		if (
-				(this->forceTriggerBufferedAmountLow || previousBufferedAmount > this->bufferedAmountLowThreshold) &&
-				this->bufferedAmount <= this->bufferedAmountLowThreshold
-		)
-		// clang-format on
+		  (this->forceTriggerBufferedAmountLow ||
+		   previousBufferedAmount > this->bufferedAmountLowThreshold) &&
+		  this->bufferedAmount <= this->bufferedAmountLowThreshold)
 		{
 			this->forceTriggerBufferedAmountLow = false;
 

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -13,7 +13,7 @@
 #include <cstring> // std::memcpy(), std::strcmp()
 
 // clang-format off
-// NOLINTNEXTLINE (cppcoreguidelines-macro-usage)
+// NOLINTNEXTLINE(cppcoreguidelines-macro-usage)
 #define LOG_OPENSSL_ERROR(desc) \
 	do \
 	{ \
@@ -102,7 +102,6 @@ namespace RTC
 {
 	/* Static. */
 
-	// clang-format off
 	static constexpr int DtlsMtu{ 1350 };
 	static constexpr int SslReadBufferSize{ 65536 };
 	// AES-HMAC: http://tools.ietf.org/html/rfc3711
@@ -112,11 +111,12 @@ namespace RTC
 	// AES-GCM: http://tools.ietf.org/html/rfc7714
 	static constexpr size_t SrtpAesGcm256MasterKeyLength{ 32u };
 	static constexpr size_t SrtpAesGcm256MasterSaltLength{ 12u };
-	static constexpr size_t SrtpAesGcm256MasterLength{ SrtpAesGcm256MasterKeyLength + SrtpAesGcm256MasterSaltLength };
+	static constexpr size_t SrtpAesGcm256MasterLength{ SrtpAesGcm256MasterKeyLength +
+		                                                 SrtpAesGcm256MasterSaltLength };
 	static constexpr size_t SrtpAesGcm128MasterKeyLength{ 16u };
 	static constexpr size_t SrtpAesGcm128MasterSaltLength{ 12u };
-	static constexpr size_t SrtpAesGcm128MasterLength{ SrtpAesGcm128MasterKeyLength + SrtpAesGcm128MasterSaltLength };
-	// clang-format on
+	static constexpr size_t SrtpAesGcm128MasterLength{ SrtpAesGcm128MasterKeyLength +
+		                                                 SrtpAesGcm128MasterSaltLength };
 
 	/* Class variables. */
 
@@ -359,7 +359,7 @@ namespace RTC
 		  std::string("mediasoup") + std::to_string(Utils::Crypto::GetRandomUInt(100000, 999999));
 
 		// Create key with curve.
-		// NOLINTNEXTLINE (cppcoreguidelines-pro-type-cstyle-cast)
+		// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
 		DtlsTransport::privateKey = EVP_EC_gen(SN_X9_62_prime256v1);
 
 		if (!DtlsTransport::privateKey)
@@ -1244,7 +1244,7 @@ namespace RTC
 		}
 	}
 
-	// NOLINTNEXTLINE (misc-no-recursion)
+	// NOLINTNEXTLINE(misc-no-recursion)
 	bool DtlsTransport::SetTimeout()
 	{
 		MS_TRACE();
@@ -1260,7 +1260,7 @@ namespace RTC
 		// DTLSv1_get_timeout queries the next DTLS handshake timeout. If there is
 		// a timeout in progress, it sets *out to the time remaining and returns
 		// one. Otherwise, it returns zero.
-		DTLSv1_get_timeout(this->ssl, static_cast<void*>(std::addressof(dtlsTimeout))); // NOLINT
+		DTLSv1_get_timeout(this->ssl, static_cast<void*>(std::addressof(dtlsTimeout)));
 
 		timeoutMs = (dtlsTimeout.tv_sec * static_cast<uint64_t>(1000)) + (dtlsTimeout.tv_usec / 1000);
 
@@ -1452,7 +1452,7 @@ namespace RTC
 
 		BUF_MEM* mem;
 
-		BIO_get_mem_ptr(bio, std::addressof(mem)); // NOLINT[cppcoreguidelines-pro-type-cstyle-cast]
+		BIO_get_mem_ptr(bio, std::addressof(mem));
 
 		if (!mem || !mem->data || mem->length == 0u)
 		{
@@ -1699,7 +1699,7 @@ namespace RTC
 		// callback).
 	}
 
-	// NOLINTNEXTLINE (misc-no-recursion)
+	// NOLINTNEXTLINE(misc-no-recursion)
 	void DtlsTransport::OnTimer(TimerHandle* /*timer*/)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/ICE/IceServer.cpp
+++ b/worker/src/RTC/ICE/IceServer.cpp
@@ -20,13 +20,13 @@ namespace RTC
 		/* Class variables. */
 
 		// clang-format off
-	std::unordered_map<IceServer::IceState, std::string> IceServer::iceStateToString =
-	{
-		{ IceServer::IceState::NEW,          "new"          },
-		{ IceServer::IceState::CONNECTED,    "connected"    },
-		{ IceServer::IceState::COMPLETED,    "completed"    },
-		{ IceServer::IceState::DISCONNECTED, "disconnected" },
-	};
+		std::unordered_map<IceServer::IceState, std::string> IceServer::iceStateToString =
+		{
+			{ IceServer::IceState::NEW,          "new"          },
+			{ IceServer::IceState::CONNECTED,    "connected"    },
+			{ IceServer::IceState::COMPLETED,    "completed"    },
+			{ IceServer::IceState::DISCONNECTED, "disconnected" },
+		};
 		// clang-format on
 
 		/* Class methods. */
@@ -423,15 +423,10 @@ namespace RTC
 				{
 					// We may have changed our usernameFragment and password, so check the
 					// old ones.
-					// clang-format off
-				if (
-				  !this->oldUsernameFragment.empty() &&
-				  !this->oldPassword.empty() &&
-				  request->CheckAuthentication(
-				    this->oldUsernameFragment, this->oldPassword
-				  ) == RTC::ICE::StunPacket::AuthenticationResult::OK
-				)
-					// clang-format on
+					if (
+					  !this->oldUsernameFragment.empty() && !this->oldPassword.empty() &&
+					  request->CheckAuthentication(this->oldUsernameFragment, this->oldPassword) ==
+					    RTC::ICE::StunPacket::AuthenticationResult::OK)
 					{
 						MS_DEBUG_TAG(ice, "using old ICE credentials");
 

--- a/worker/src/RTC/ICE/StunPacket.cpp
+++ b/worker/src/RTC/ICE/StunPacket.cpp
@@ -25,17 +25,14 @@ namespace RTC
 
 		bool StunPacket::IsStun(const uint8_t* buffer, size_t bufferLength)
 		{
-			// clang-format off
 			return (
-				// STUN headers are 20 bytes.
-				(bufferLength >= StunPacket::FixedHeaderLength) &&
-				// @see RFC 7983.
-				(buffer[0] < 3) &&
-				// Magic Cookie must match.
-				(buffer[4] == StunPacket::MagicCookie[0]) && (buffer[5] == StunPacket::MagicCookie[1]) &&
-				(buffer[6] == StunPacket::MagicCookie[2]) && (buffer[7] == StunPacket::MagicCookie[3])
-			);
-			// clang-format on
+			  // STUN headers are 20 bytes.
+			  (bufferLength >= StunPacket::FixedHeaderLength) &&
+			  // @see RFC 7983.
+			  (buffer[0] < 3) &&
+			  // Magic Cookie must match.
+			  (buffer[4] == StunPacket::MagicCookie[0]) && (buffer[5] == StunPacket::MagicCookie[1]) &&
+			  (buffer[6] == StunPacket::MagicCookie[2]) && (buffer[7] == StunPacket::MagicCookie[3]));
 		}
 
 		StunPacket* StunPacket::Parse(const uint8_t* buffer, size_t bufferLength)
@@ -186,6 +183,11 @@ namespace RTC
 					klass = "error response";
 					break;
 				}
+				case Class::UNSET:
+				{
+					klass = "(unset)";
+					break;
+				}
 			}
 
 			if (this->method == Method::BINDING)
@@ -202,7 +204,7 @@ namespace RTC
 				  static_cast<uint16_t>(this->method));
 			}
 
-			char transactionId[12 * 2 + 1]; // 12 bytes × 2 hex chars + null terminator.
+			char transactionId[(12 * 2) + 1]; // 12 bytes × 2 hex chars + null terminator.
 
 			for (uint8_t i{ 0 }; i < 12; ++i)
 			{
@@ -299,7 +301,7 @@ namespace RTC
 			{
 				char messageIntegrity[41];
 
-				for (uint8_t i{ 0 }; i < StunPacket::MessageIntegrityAttributeLength; ++i)
+				for (size_t i{ 0 }; i < StunPacket::MessageIntegrityAttributeLength; ++i)
 				{
 					std::snprintf(messageIntegrity + (i * 2), 3, "%.2x", GetMessageIntegrity()[i]);
 				}
@@ -463,9 +465,9 @@ namespace RTC
 				std::memcpy(std::addressof(addr), attributeValue + 4, 4);
 
 				// XOR with each byte of the Magic Cookie.
-				uint8_t* addrBytes = reinterpret_cast<uint8_t*>(&addr);
+				auto* addrBytes = reinterpret_cast<uint8_t*>(&addr);
 
-				for (uint8_t i{ 0 }; i < sizeof(StunPacket::MagicCookie); ++i)
+				for (size_t i{ 0 }; i < sizeof(StunPacket::MagicCookie); ++i)
 				{
 					addrBytes[i] ^= StunPacket::MagicCookie[i];
 				}
@@ -492,17 +494,17 @@ namespace RTC
 				addr6->sin6_family = AF_INET6;
 				addr6->sin6_port   = htons(port);
 
-				const auto transactionId = GetTransactionId();
+				const auto* transactionId = GetTransactionId();
 
 				// XOR with first 4 bytes with each byte of the Magic Cookie.
-				for (uint8_t i{ 0 }; i < sizeof(StunPacket::MagicCookie); ++i)
+				for (size_t i{ 0 }; i < sizeof(StunPacket::MagicCookie); ++i)
 				{
 					addr6->sin6_addr.s6_addr[i] =
 					  attributeValue[sizeof(StunPacket::MagicCookie) + i] ^ StunPacket::MagicCookie[i];
 				}
 
 				// XOR other bytes with each byte of the Transaction id.
-				for (uint8_t i{ 0 }; i < sizeof(StunPacket::MagicCookie) + StunPacket::TransactionIdLength;
+				for (size_t i{ 0 }; i < sizeof(StunPacket::MagicCookie) + StunPacket::TransactionIdLength;
 				     ++i)
 				{
 					addr6->sin6_addr.s6_addr[i] = attributeValue[sizeof(StunPacket::MagicCookie) + i] ^
@@ -644,7 +646,7 @@ namespace RTC
 				case StunPacket::Class::INDICATION:
 				{
 					// usernameFragment1 must not be empty.
-					if (usernameFragment1.length() == 0)
+					if (usernameFragment1.empty())
 					{
 						MS_WARN_TAG(
 						  ice, "cannot authenticate request or indication, empty usernameFragment1 given");
@@ -729,7 +731,7 @@ namespace RTC
 			// rules, this is, by checking the bytes from 0 to the beginning of the
 			// MESSAGE-INTEGRITY Attribute.
 			const uint8_t* computedMessageIntegrity = Utils::Crypto::GetHmacSha1(
-			  password.data(), fixedHeader, (messageIntegrity - 4) - fixedHeader);
+			  password.data(), password.length(), fixedHeader, (messageIntegrity - 4) - fixedHeader);
 
 			StunPacket::AuthenticationResult result;
 
@@ -789,7 +791,7 @@ namespace RTC
 				// Calculate the HMAC-SHA1 of the STUN Packet according to
 				// MESSAGE-INTEGRITY rules.
 				const uint8_t* computedMessageIntegrity =
-				  Utils::Crypto::GetHmacSha1(password.data(), GetBuffer(), currentLength);
+				  Utils::Crypto::GetHmacSha1(password.data(), password.length(), GetBuffer(), currentLength);
 
 				StoreNewAttribute(
 				  StunPacket::AttributeType::MESSAGE_INTEGRITY,
@@ -916,7 +918,7 @@ namespace RTC
 
 			const uint8_t* attributesStart = GetAttributesPointer();
 			const uint8_t* attributesEnd   = attributesStart + GetAttributesLength();
-			uint8_t* ptr                   = const_cast<uint8_t*>(attributesStart);
+			auto* ptr                      = const_cast<uint8_t*>(attributesStart);
 
 			// Ensure there are at least 4 remaining bytes (Attribute with 0 length).
 			while (ptr + 4 <= attributesEnd)
@@ -928,7 +930,7 @@ namespace RTC
 				  static_cast<StunPacket::AttributeType>(ntohs(static_cast<uint16_t>(attribute->type)));
 
 				// Get the Attribute length.
-				const auto attrLen = static_cast<uint16_t>(ntohs(attribute->len));
+				const uint16_t attrLen = ntohs(attribute->len);
 
 				// Offset of the Attribute from the start of the attributes.
 				const auto attrOffset = static_cast<size_t>((ptr - attributesStart));

--- a/worker/src/RTC/NackGenerator.cpp
+++ b/worker/src/RTC/NackGenerator.cpp
@@ -179,12 +179,8 @@ namespace RTC
 
 		if (static_cast<uint16_t>(this->nackList.size()) + numNewNacks > MaxNackPackets)
 		{
-			// clang-format off
-			while (
-				RemoveNackItemsUntilKeyFrame() &&
-				static_cast<uint16_t>(this->nackList.size()) + numNewNacks > MaxNackPackets
-			)
-			// clang-format on
+			while (RemoveNackItemsUntilKeyFrame() &&
+			       static_cast<uint16_t>(this->nackList.size()) + numNewNacks > MaxNackPackets)
 			{
 			}
 
@@ -265,16 +261,10 @@ namespace RTC
 				continue;
 			}
 
-			// clang-format off
 			if (
-				filter == NackFilter::SEQ &&
-				nackInfo.sentAtMs == 0 &&
-				(
-					nackInfo.sendAtSeq == this->lastSeq ||
-					SeqManager<uint16_t>::IsSeqHigherThan(this->lastSeq, nackInfo.sendAtSeq)
-				)
-			)
-			// clang-format on
+			  filter == NackFilter::SEQ && nackInfo.sentAtMs == 0 &&
+			  (nackInfo.sendAtSeq == this->lastSeq ||
+			   SeqManager<uint16_t>::IsSeqHigherThan(this->lastSeq, nackInfo.sendAtSeq)))
 			{
 				nackBatch.emplace_back(seq);
 				nackInfo.retries++;

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -264,7 +264,7 @@ namespace RTC
 		return 0u;
 	}
 
-	// NOLINTNEXTLINE (misc-no-recursion)
+	// NOLINTNEXTLINE(misc-no-recursion)
 	void PipeConsumer::SendRtpPacket(RTC::RTP::Packet* packet, RTC::RTP::SharedPacket& sharedPacket)
 	{
 		MS_TRACE();
@@ -490,12 +490,9 @@ namespace RTC
 
 		// Special condition for PipeConsumer since this method will be called in a
 		// loop for each stream in this PipeConsumer.
-		// clang-format off
 		if (
-			nowMs != this->lastRtcpSentTime &&
-			static_cast<float>((nowMs - this->lastRtcpSentTime) * 1.15) < this->maxRtcpInterval
-		)
-		// clang-format on
+		  nowMs != this->lastRtcpSentTime &&
+		  static_cast<float>((nowMs - this->lastRtcpSentTime) * 1.15) < this->maxRtcpInterval)
 		{
 			return true;
 		}

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -388,7 +388,7 @@ namespace RTC
 						MS_THROW_TYPE_ERROR("missing port");
 					}
 
-					// NOLINTNEXTLINE (bugprone-unchecked-optional-access)
+					// NOLINTNEXTLINE(bugprone-unchecked-optional-access)
 					port = body->port().value();
 
 					int err;

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -11,7 +11,6 @@ namespace RTC
 {
 	/* Static. */
 
-	// clang-format off
 	// AES-HMAC: http://tools.ietf.org/html/rfc3711
 	static constexpr size_t SrtpMasterKeyLength{ 16 };
 	static constexpr size_t SrtpMasterSaltLength{ 14 };
@@ -19,11 +18,12 @@ namespace RTC
 	// AES-GCM: http://tools.ietf.org/html/rfc7714
 	static constexpr size_t SrtpAesGcm256MasterKeyLength{ 32 };
 	static constexpr size_t SrtpAesGcm256MasterSaltLength{ 12 };
-	static constexpr size_t SrtpAesGcm256MasterLength{ SrtpAesGcm256MasterKeyLength + SrtpAesGcm256MasterSaltLength };
+	static constexpr size_t SrtpAesGcm256MasterLength{ SrtpAesGcm256MasterKeyLength +
+		                                                 SrtpAesGcm256MasterSaltLength };
 	static constexpr size_t SrtpAesGcm128MasterKeyLength{ 16 };
 	static constexpr size_t SrtpAesGcm128MasterSaltLength{ 12 };
-	static constexpr size_t SrtpAesGcm128MasterLength{ SrtpAesGcm128MasterKeyLength + SrtpAesGcm128MasterSaltLength };
-	// clang-format on
+	static constexpr size_t SrtpAesGcm128MasterLength{ SrtpAesGcm128MasterKeyLength +
+		                                                 SrtpAesGcm128MasterSaltLength };
 
 	/* Class variables. */
 
@@ -594,7 +594,7 @@ namespace RTC
 							MS_THROW_TYPE_ERROR("missing port");
 						}
 
-						// NOLINTNEXTLINE (bugprone-unchecked-optional-access)
+						// NOLINTNEXTLINE(bugprone-unchecked-optional-access)
 						port = body->port().value();
 
 						if (body->rtcpPort().has_value())
@@ -604,7 +604,7 @@ namespace RTC
 								MS_THROW_TYPE_ERROR("cannot set rtcpPort with rtcpMux enabled");
 							}
 
-							// NOLINTNEXTLINE (bugprone-unchecked-optional-access)
+							// NOLINTNEXTLINE(bugprone-unchecked-optional-access)
 							rtcpPort = body->rtcpPort().value();
 						}
 						else

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -86,26 +86,17 @@ namespace RTC
 
 			// rid is optional.
 			// However ssrc or rid must be present (if more than 1 encoding).
-			// clang-format off
 			if (
-				encodings->size() > 1 &&
-				!encoding->ssrc().has_value() &&
-				!flatbuffers::IsFieldPresent(encoding, FBS::RtpParameters::EncodingMapping::VT_RID)
-			)
-			// clang-format on
+			  encodings->size() > 1 && !encoding->ssrc().has_value() &&
+			  !flatbuffers::IsFieldPresent(encoding, FBS::RtpParameters::EncodingMapping::VT_RID))
 			{
 				MS_THROW_TYPE_ERROR("wrong entry in rtpMapping.encodings (missing ssrc or rid)");
 			}
 
 			// If there is no mid and a single encoding, ssrc or rid must be present.
-			// clang-format off
 			if (
-				this->rtpParameters.mid.empty() &&
-				encodings->size() == 1 &&
-				!encoding->ssrc().has_value() &&
-				!flatbuffers::IsFieldPresent(encoding, FBS::RtpParameters::EncodingMapping::VT_RID)
-			)
-			// clang-format on
+			  this->rtpParameters.mid.empty() && encodings->size() == 1 && !encoding->ssrc().has_value() &&
+			  !flatbuffers::IsFieldPresent(encoding, FBS::RtpParameters::EncodingMapping::VT_RID))
 			{
 				MS_THROW_TYPE_ERROR(
 				  "wrong entry in rtpMapping.encodings (missing ssrc or rid, or rtpParameters.mid)");
@@ -819,14 +810,9 @@ namespace RTC
 		//
 		// NOTE: We know that this may only happen before calling MangleRtpPacket()
 		// so the SSRC of the packet is still the original one and not the mapped one.
-		//
-		// clang-format off
 		if (
-			this->currentRtpPacket &&
-			this->currentRtpPacket->GetSsrc() == ssrc &&
-			this->currentRtpPacket->IsKeyFrame()
-		)
-		// clang-format on
+		  this->currentRtpPacket && this->currentRtpPacket->GetSsrc() == ssrc &&
+		  this->currentRtpPacket->IsKeyFrame())
 		{
 			return;
 		}
@@ -993,14 +979,9 @@ namespace RTC
 
 		// If not found, and there is a single encoding without ssrc and RID, this
 		// may be the media or RTX stream.
-		//
-		// clang-format off
 		if (
-			this->rtpParameters.encodings.size() == 1 &&
-			!this->rtpParameters.encodings[0].ssrc &&
-			this->rtpParameters.encodings[0].rid.empty()
-		)
-		// clang-format on
+		  this->rtpParameters.encodings.size() == 1 && !this->rtpParameters.encodings[0].ssrc &&
+		  this->rtpParameters.encodings[0].rid.empty())
 		{
 			auto& encoding           = this->rtpParameters.encodings[0];
 			const auto* mediaCodec   = this->rtpParameters.GetCodecForEncoding(encoding);
@@ -1442,14 +1423,9 @@ namespace RTC
 			{
 				// If video orientation was not yet detected or any value has changed,
 				// emit event.
-				// clang-format off
 				if (
-					!this->videoOrientationDetected ||
-					camera != this->videoOrientation.camera ||
-					flip != this->videoOrientation.flip ||
-					rotation != this->videoOrientation.rotation
-				)
-				// clang-format on
+				  !this->videoOrientationDetected || camera != this->videoOrientation.camera ||
+				  flip != this->videoOrientation.flip || rotation != this->videoOrientation.rotation)
 				{
 					this->videoOrientationDetected  = true;
 					this->videoOrientation.camera   = camera;

--- a/worker/src/RTC/RTCP/Feedback.cpp
+++ b/worker/src/RTC/RTCP/Feedback.cpp
@@ -128,7 +128,7 @@ namespace RTC
 			}
 
 			auto* commonHeader = const_cast<CommonHeader*>(reinterpret_cast<const CommonHeader*>(data));
-			FeedbackPsPacket* packet{ nullptr };
+			FeedbackPsPacket* packet{ nullptr }; // NOLINT(misc-const-correctness)
 
 			switch (FeedbackPs::MessageType(commonHeader->count))
 			{

--- a/worker/src/RTC/RTCP/FeedbackPsAfb.cpp
+++ b/worker/src/RTC/RTCP/FeedbackPsAfb.cpp
@@ -31,12 +31,9 @@ namespace RTC
 
 			constexpr size_t Offset = Packet::CommonHeaderSize + FeedbackPacket::HeaderSize;
 
-			// clang-format off
 			if (
-				len >= Packet::CommonHeaderSize + FeedbackPacket::HeaderSize + 4 &&
-				Utils::Byte::Get4Bytes(data, Offset) == FeedbackPsRembPacket::UniqueIdentifier
-			)
-			// clang-format on
+			  len >= Packet::CommonHeaderSize + FeedbackPacket::HeaderSize + 4 &&
+			  Utils::Byte::Get4Bytes(data, Offset) == FeedbackPsRembPacket::UniqueIdentifier)
 			{
 				packet.reset(FeedbackPsRembPacket::Parse(data, len));
 			}

--- a/worker/src/RTC/RTCP/FeedbackPsRemb.cpp
+++ b/worker/src/RTC/RTCP/FeedbackPsRemb.cpp
@@ -110,7 +110,7 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			// NOLINTNEXTLINE (bugprone-parent-virtual-call)
+			// NOLINTNEXTLINE(bugprone-parent-virtual-call)
 			size_t offset     = FeedbackPsPacket::Serialize(buffer);
 			uint64_t mantissa = this->bitrate;
 			uint8_t exponent{ 0u };
@@ -147,7 +147,7 @@ namespace RTC
 			MS_TRACE();
 
 			MS_DUMP_CLEAN(indentation, "<FeedbackPsRembPacket>");
-			// NOLINTNEXTLINE (bugprone-parent-virtual-call)
+			// NOLINTNEXTLINE(bugprone-parent-virtual-call)
 			FeedbackPsPacket::Dump();
 			MS_DUMP_CLEAN(indentation, "  bitrate (bps): %" PRIu64, this->bitrate);
 			for (auto ssrc : this->ssrcs)

--- a/worker/src/RTC/RTCP/FeedbackPsRpsi.cpp
+++ b/worker/src/RTC/RTCP/FeedbackPsRpsi.cpp
@@ -1,8 +1,9 @@
+#include <cstdint>
 #define MS_CLASS "RTC::RTCP::FeedbackPsRpsi"
 // #define MS_LOG_DEV_LEVEL 3
 
-#include "RTC/RTCP/FeedbackPsRpsi.hpp"
 #include "Logger.hpp"
+#include "RTC/RTCP/FeedbackPsRpsi.hpp"
 #include <cstring>
 
 namespace RTC
@@ -46,20 +47,22 @@ namespace RTC
 			  length <= FeedbackPsRpsiItem::MaxBitStringSize,
 			  "rpsi bit string length exceeds the maximum value");
 
-			this->raw    = new uint8_t[HeaderSize];
 			this->header = reinterpret_cast<Header*>(this->raw);
 
+			// TODO: We should use Utils::Byte::PadTo4Bytes().
 			// 32 bits padding.
-			const size_t padding = (-length) & 3;
+			const uint8_t padding = (-length) & 3;
 
 			this->header->paddingBits = padding * 8;
 			this->header->zero        = 0;
 			std::memcpy(this->header->bitString, bitString, length);
 
+			this->raw = new uint8_t[FeedbackPsRpsiItem::HeaderSize + padding];
+
 			// Fill padding.
-			for (size_t i{ 0 }; i < padding; ++i)
+			for (uint8_t i{ 0 }; i < padding; ++i)
 			{
-				this->raw[HeaderSize + i - 1] = 0;
+				this->raw[FeedbackPsRpsiItem::HeaderSize + i - 1] = 0;
 			}
 		}
 
@@ -67,9 +70,9 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			std::memcpy(buffer, this->header, HeaderSize);
+			std::memcpy(buffer, this->header, FeedbackPsRpsiItem::HeaderSize);
 
-			return HeaderSize;
+			return FeedbackPsRpsiItem::HeaderSize;
 		}
 
 		void FeedbackPsRpsiItem::Dump(int indentation) const

--- a/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
+++ b/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
@@ -327,12 +327,9 @@ namespace RTC
 			// NOTE: Read it as int 64 to detect long elapsed times.
 			const int64_t delta64 = (timestamp - this->latestTimestamp) * 4;
 
-			// clang-format off
 			if (
-				delta64 > FeedbackRtpTransportPacket::maxPacketDelta ||
-				delta64 < -1 * static_cast<int64_t>(FeedbackRtpTransportPacket::maxPacketDelta)
-			)
-			// clang-format on
+			  delta64 > FeedbackRtpTransportPacket::maxPacketDelta ||
+			  delta64 < -1 * static_cast<int64_t>(FeedbackRtpTransportPacket::maxPacketDelta))
 			{
 				MS_WARN_DEV(
 				  "RTP packet delta exceeded [latestTimestamp:%" PRIu64 ", timestamp:%" PRIu64 "]",
@@ -400,7 +397,7 @@ namespace RTC
 			}
 
 			size_t deltaIdx{ 0u };
-			// NOLINTNEXTLINE (bugprone-misplaced-widening-cast)
+			// NOLINTNEXTLINE(bugprone-misplaced-widening-cast)
 			auto currentReceivedAtMs = static_cast<int64_t>(this->referenceTime * 64);
 
 			for (size_t idx{ 0u }; idx < packetResults.size(); ++idx)
@@ -511,13 +508,9 @@ namespace RTC
 			}
 
 			// Create a long run chunk before processing this packet, if needed.
-			// clang-format off
 			if (
-				this->context.statuses.size() >= 7 &&
-				this->context.allSameStatus &&
-				status != this->context.currentStatus
-			)
-			// clang-format on
+			  this->context.statuses.size() >= 7 && this->context.allSameStatus &&
+			  status != this->context.currentStatus)
 			{
 				CreateRunLengthChunk(this->context.currentStatus, this->context.statuses.size());
 
@@ -530,12 +523,9 @@ namespace RTC
 
 			// Update context info.
 
-			// clang-format off
 			if (
-				this->context.currentStatus == Status::None ||
-				(this->context.allSameStatus && this->context.currentStatus == status)
-			)
-			// clang-format on
+			  this->context.currentStatus == Status::None ||
+			  (this->context.allSameStatus && this->context.currentStatus == status))
 			{
 				this->context.allSameStatus = true;
 			}

--- a/worker/src/RTC/RTCP/Packet.cpp
+++ b/worker/src/RTC/RTCP/Packet.cpp
@@ -41,7 +41,7 @@ namespace RTC
 			MS_TRACE();
 
 			// First, Currently parsing and Last RTCP packets in the compound packet.
-			Packet* first{ nullptr };
+			Packet* first{ nullptr }; // NOLINT(misc-const-correctness)
 			Packet* current{ nullptr };
 			Packet* last{ nullptr };
 

--- a/worker/src/RTC/RTP/Codecs/AV1.cpp
+++ b/worker/src/RTC/RTP/Codecs/AV1.cpp
@@ -100,7 +100,7 @@ namespace RTC
 				// the active decode targets mask.
 			}
 
-			// NOLINTNEXTLINE (readability-make-member-function-const)
+			// NOLINTNEXTLINE(readability-make-member-function-const)
 			void AV1::PayloadDescriptor::UpdateActiveDecodeTargets(uint16_t spatialLayer, uint16_t temporalLayer)
 			{
 				MS_TRACE();
@@ -138,12 +138,7 @@ namespace RTC
 
 				// If packet spatial or temporal layer is higher than maximum announced
 				// one, drop the packet.
-				// clang-format off
-			if (
-				packetSpatialLayer >= context->GetSpatialLayers() ||
-				packetTemporalLayer >= context->GetTemporalLayers()
-			)
-				// clang-format on
+				if (packetSpatialLayer >= context->GetSpatialLayers() || packetTemporalLayer >= context->GetTemporalLayers())
 				{
 					MS_WARN_TAG(
 					  rtp, "too high packet layers %" PRIu8 ":%" PRIu8, packetSpatialLayer, packetTemporalLayer);
@@ -171,12 +166,7 @@ namespace RTC
 				// Downgrade current spatial layer if needed.
 				else if (context->GetTargetSpatialLayer() < context->GetCurrentSpatialLayer())
 				{
-					// clang-format off
-				if (
-					packetSpatialLayer == context->GetTargetSpatialLayer() &&
-					this->payloadDescriptor->endOfFrame
-				)
-					// clang-format on
+					if (packetSpatialLayer == context->GetTargetSpatialLayer() && this->payloadDescriptor->endOfFrame)
 					{
 						MS_DEBUG_DEV(
 						  "downgrading tmpSpatialLayer from %" PRIu16 " to %" PRIu16 " (packet:%" PRIu8
@@ -216,12 +206,7 @@ namespace RTC
 				// Downgrade current temporal layer if needed.
 				else if (context->GetTargetTemporalLayer() < context->GetCurrentTemporalLayer())
 				{
-					// clang-format off
-				if (
-					packetTemporalLayer == context->GetTargetTemporalLayer() &&
-					this->payloadDescriptor->endOfFrame
-				)
-					// clang-format on
+					if (packetTemporalLayer == context->GetTargetTemporalLayer() && this->payloadDescriptor->endOfFrame)
 					{
 						MS_DEBUG_DEV(
 						  "downgrading tmpTemporalLayer from %" PRIu16 " to %" PRIu16 " (packet:%" PRIu8
@@ -261,12 +246,10 @@ namespace RTC
 
 				// TODO: Enable once we rewrite the Dependency Descriptor header extension.
 				// // Store the encoding data for retransmissions.
-				// // clang-format off
 				// this->payloadDescriptor->CreateEncoder({
 				//   static_cast<uint32_t>(context->GetCurrentSpatialLayer()),
 				//   static_cast<uint32_t>(context->GetCurrentTemporalLayer())
 				// });
-				// // clang-format on
 				// this->payloadDescriptor->Encode();
 
 				return true;

--- a/worker/src/RTC/RTP/Codecs/VP8.cpp
+++ b/worker/src/RTC/RTP/Codecs/VP8.cpp
@@ -114,15 +114,11 @@ namespace RTC
 					payloadDescriptor->keyIndex   = byte & 0x1F;
 				}
 
-				// clang-format off
-			if (
-				// NOLINTNEXTLINE (bugprone-inc-dec-in-conditions)
-				(len >= ++offset + 1) &&
-				payloadDescriptor->start &&
-				payloadDescriptor->partitionIndex == 0 &&
-				(!(data[offset] & 0x01)) // Inverse Keyframe bit.
-			)
-				// clang-format on
+				if (
+				  // NOLINTNEXTLINE(bugprone-inc-dec-in-conditions)
+				  (len >= ++offset + 1) && payloadDescriptor->start &&
+				  payloadDescriptor->partitionIndex == 0 && (!(data[offset] & 0x01)) // Inverse Keyframe bit.
+				)
 				{
 					payloadDescriptor->isKeyFrame = true;
 				}
@@ -259,12 +255,7 @@ namespace RTC
 			{
 				MS_TRACE();
 
-				// clang-format off
-			if (
-				this->hasPictureId &&
-				this->hasTl0PictureIndex
-			)
-				// clang-format on
+				if (this->hasPictureId && this->hasTl0PictureIndex)
 				{
 					Encode(data, this->pictureId, this->tl0PictureIndex);
 				}
@@ -300,13 +291,9 @@ namespace RTC
 				}
 
 				// Check whether pictureId and tl0PictureIndex sync is required.
-				// clang-format off
-			if (
-				context->syncRequired &&
-				this->payloadDescriptor->hasPictureId &&
-				this->payloadDescriptor->hasTl0PictureIndex
-			)
-				// clang-format on
+				if (
+				  context->syncRequired && this->payloadDescriptor->hasPictureId &&
+				  this->payloadDescriptor->hasTl0PictureIndex)
 				{
 					context->pictureIdManager.Sync(this->payloadDescriptor->pictureId - 1);
 					context->tl0PictureIndexManager.Sync(this->payloadDescriptor->tl0PictureIndex - 1);
@@ -315,27 +302,19 @@ namespace RTC
 				}
 
 				// Incremental pictureId. Check the temporal layer.
-				// clang-format off
-			if (
-				this->payloadDescriptor->hasPictureId &&
-				this->payloadDescriptor->hasTlIndex &&
-				this->payloadDescriptor->hasTl0PictureIndex &&
-				!RTC::SeqManager<uint16_t, 15>::IsSeqLowerThan(
-					this->payloadDescriptor->pictureId,
-					context->pictureIdManager.GetMaxInput())
-			)
-				// clang-format on
+				if (
+				  this->payloadDescriptor->hasPictureId && this->payloadDescriptor->hasTlIndex &&
+				  this->payloadDescriptor->hasTl0PictureIndex &&
+				  !RTC::SeqManager<uint16_t, 15>::IsSeqLowerThan(
+				    this->payloadDescriptor->pictureId, context->pictureIdManager.GetMaxInput()))
 				{
 					// Drop if:
 					// - Temporal layer is higher than target.
 					// - Temporal layer is higher than current and sync flag is not set.
-					// clang-format off
-				if (
-				  this->payloadDescriptor->tlIndex > context->GetTargetTemporalLayer() ||
-				  (this->payloadDescriptor->tlIndex > context->GetCurrentTemporalLayer() &&
-				   !this->payloadDescriptor->y)
-				)
-					// clang-format on
+					if (
+					  this->payloadDescriptor->tlIndex > context->GetTargetTemporalLayer() ||
+					  (this->payloadDescriptor->tlIndex > context->GetCurrentTemporalLayer() &&
+					   !this->payloadDescriptor->y))
 					{
 						context->pictureIdManager.Drop(this->payloadDescriptor->pictureId);
 
@@ -353,35 +332,24 @@ namespace RTC
 				uint8_t tl0PictureIndex;
 
 				// Do not send a dropped pictureId.
-				// clang-format off
-			if (
-				this->payloadDescriptor->hasPictureId &&
-				!context->pictureIdManager.Input(this->payloadDescriptor->pictureId, pictureId)
-			)
-				// clang-format on
+				if (
+				  this->payloadDescriptor->hasPictureId &&
+				  !context->pictureIdManager.Input(this->payloadDescriptor->pictureId, pictureId))
 				{
 					return false;
 				}
 
 				// Do not send a dropped tl0PictureIndex.
-				// clang-format off
-			if (
-				this->payloadDescriptor->hasTl0PictureIndex &&
-				!context->tl0PictureIndexManager.Input(
-					this->payloadDescriptor->tl0PictureIndex, tl0PictureIndex)
-			)
-				// clang-format on
+				if (
+				  this->payloadDescriptor->hasTl0PictureIndex &&
+				  !context->tl0PictureIndexManager.Input(
+				    this->payloadDescriptor->tl0PictureIndex, tl0PictureIndex))
 				{
 					return false;
 				}
 
 				// Update/fix current temporal layer.
-				// clang-format off
-			if (
-				this->payloadDescriptor->hasTlIndex &&
-				this->payloadDescriptor->tlIndex == context->GetTargetTemporalLayer()
-			)
-				// clang-format on
+				if (this->payloadDescriptor->hasTlIndex && this->payloadDescriptor->tlIndex == context->GetTargetTemporalLayer())
 				{
 					context->SetCurrentTemporalLayer(this->payloadDescriptor->tlIndex);
 				}
@@ -401,12 +369,7 @@ namespace RTC
 					return false;
 				}
 
-				// clang-format off
-			if (
-				this->payloadDescriptor->hasPictureId &&
-				this->payloadDescriptor->hasTl0PictureIndex
-			)
-				// clang-format on
+				if (this->payloadDescriptor->hasPictureId && this->payloadDescriptor->hasTl0PictureIndex)
 				{
 					// Store the encoding data for retransmissions.
 					this->payloadDescriptor->CreateEncoder({ pictureId, tl0PictureIndex });
@@ -430,12 +393,7 @@ namespace RTC
 			{
 				MS_TRACE();
 
-				// clang-format off
-			if (
-				this->payloadDescriptor->hasPictureId &&
-				this->payloadDescriptor->hasTl0PictureIndex
-			)
-				// clang-format on
+				if (this->payloadDescriptor->hasPictureId && this->payloadDescriptor->hasTl0PictureIndex)
 				{
 					this->payloadDescriptor->Restore(packet->GetPayload());
 				}

--- a/worker/src/RTC/RTP/Codecs/VP9.cpp
+++ b/worker/src/RTC/RTP/Codecs/VP9.cpp
@@ -102,13 +102,7 @@ namespace RTC
 					}
 				}
 
-				// clang-format off
-			if (
-				!payloadDescriptor->p &&
-				payloadDescriptor->b &&
-				payloadDescriptor->slIndex == 0
-			)
-				// clang-format on
+				if (!payloadDescriptor->p && payloadDescriptor->b && payloadDescriptor->slIndex == 0)
 				{
 					payloadDescriptor->isKeyFrame = true;
 				}
@@ -203,12 +197,7 @@ namespace RTC
 
 				// If packet spatial or temporal layer is higher than maximum announced
 				// one, drop the packet.
-				// clang-format off
-			if (
-				packetSpatialLayer >= context->GetSpatialLayers() ||
-				packetTemporalLayer >= context->GetTemporalLayers()
-			)
-				// clang-format on
+				if (packetSpatialLayer >= context->GetSpatialLayers() || packetTemporalLayer >= context->GetTemporalLayers())
 				{
 					MS_WARN_TAG(
 					  rtp, "too high packet layers %" PRIu8 ":%" PRIu8, packetSpatialLayer, packetTemporalLayer);
@@ -217,26 +206,17 @@ namespace RTC
 				}
 
 				// Check whether pictureId sync is required.
-				// clang-format off
-			if (
-				context->syncRequired &&
-				this->payloadDescriptor->hasPictureId
-			)
-				// clang-format on
+				if (context->syncRequired && this->payloadDescriptor->hasPictureId)
 				{
 					context->pictureIdManager.Sync(this->payloadDescriptor->pictureId - 1);
 
 					context->syncRequired = false;
 				}
 
-				// clang-format off
-			const bool isOldPacket = (
-				this->payloadDescriptor->hasPictureId &&
-				RTC::SeqManager<uint16_t, 15>::IsSeqLowerThan(
-					this->payloadDescriptor->pictureId,
-					context->pictureIdManager.GetMaxInput())
-			);
-				// clang-format on
+				const bool isOldPacket =
+				  (this->payloadDescriptor->hasPictureId &&
+				   RTC::SeqManager<uint16_t, 15>::IsSeqLowerThan(
+				     this->payloadDescriptor->pictureId, context->pictureIdManager.GetMaxInput()));
 
 				if (!isOldPacket)
 				{
@@ -264,7 +244,6 @@ namespace RTC
 						if (context->IsKSvc())
 						{
 							if (this->payloadDescriptor->isKeyFrame)
-							// clang-format on
 							{
 								MS_DEBUG_DEV(
 								  "downgrading tmpSpatialLayer from %" PRIu16 " to %" PRIu16 " (packet:%" PRIu8
@@ -281,12 +260,7 @@ namespace RTC
 						// In full SVC we do not need a keyframe.
 						else
 						{
-							// clang-format off
-						if (
-							packetSpatialLayer == context->GetTargetSpatialLayer() &&
-							this->payloadDescriptor->e
-						)
-							// clang-format on
+							if (packetSpatialLayer == context->GetTargetSpatialLayer() && this->payloadDescriptor->e)
 							{
 								MS_DEBUG_DEV(
 								  "downgrading tmpSpatialLayer from %" PRIu16 " to %" PRIu16 " (packet:%" PRIu8
@@ -311,12 +285,10 @@ namespace RTC
 				  isOldPacket ? context->GetSpatialLayerForPictureId(this->payloadDescriptor->pictureId)
 				              : tmpSpatialLayer;
 
-				// clang-format off
-			if (
-				packetSpatialLayer > spatialLayerForPictureId ||
-				(context->IsKSvc() && this->payloadDescriptor->p && packetSpatialLayer != spatialLayerForPictureId)
-			)
-				// clang-format on
+				if (
+				  packetSpatialLayer > spatialLayerForPictureId ||
+				  (context->IsKSvc() && this->payloadDescriptor->p &&
+				   packetSpatialLayer != spatialLayerForPictureId))
 				{
 					return false;
 				}
@@ -327,16 +299,10 @@ namespace RTC
 					// Upgrade current temporal layer if needed.
 					if (context->GetTargetTemporalLayer() > context->GetCurrentTemporalLayer())
 					{
-						// clang-format off
-					if (
-						packetTemporalLayer >= context->GetCurrentTemporalLayer() + 1 &&
-						(
-							context->GetCurrentTemporalLayer() == -1 ||
-							this->payloadDescriptor->switchingUpPoint
-						) &&
-						this->payloadDescriptor->b
-					)
-						// clang-format on
+						if (
+						  packetTemporalLayer >= context->GetCurrentTemporalLayer() + 1 &&
+						  (context->GetCurrentTemporalLayer() == -1 || this->payloadDescriptor->switchingUpPoint) &&
+						  this->payloadDescriptor->b)
 						{
 							MS_DEBUG_DEV(
 							  "upgrading tmpTemporalLayer from %" PRIu16 " to %" PRIu8 " (packet:%" PRIu8
@@ -352,12 +318,7 @@ namespace RTC
 					// Downgrade current temporal layer if needed.
 					else if (context->GetTargetTemporalLayer() < context->GetCurrentTemporalLayer())
 					{
-						// clang-format off
-					if (
-						packetTemporalLayer == context->GetTargetTemporalLayer() &&
-						this->payloadDescriptor->e
-					)
-						// clang-format on
+						if (packetTemporalLayer == context->GetTargetTemporalLayer() && this->payloadDescriptor->e)
 						{
 							MS_DEBUG_DEV(
 							  "downgrading tmpTemporalLayer from %" PRIu16 " to %" PRIu16 " (packet:%" PRIu8

--- a/worker/src/RTC/RTP/Packet.cpp
+++ b/worker/src/RTC/RTP/Packet.cpp
@@ -29,15 +29,12 @@ namespace RTC
 
 			const auto* header = const_cast<FixedHeader*>(reinterpret_cast<const FixedHeader*>(buffer));
 
-			// clang-format off
 			return (
-				(bufferLength >= Packet::FixedHeaderMinLength) &&
-				// @see RFC 7983.
-				(buffer[0] > 127 && buffer[0] < 192) &&
-				// RTP Version must be 2.
-				(header->version == 2)
-			);
-			// clang-format on
+			  (bufferLength >= Packet::FixedHeaderMinLength) &&
+			  // @see RFC 7983.
+			  (buffer[0] > 127 && buffer[0] < 192) &&
+			  // RTP Version must be 2.
+			  (header->version == 2));
 		}
 
 		Packet* Packet::Parse(const uint8_t* buffer, size_t packetLength, size_t bufferLength)
@@ -723,7 +720,7 @@ namespace RTC
 			}
 
 			const uint8_t* extensionsStart = GetHeaderExtensionValue();
-			uint8_t* ptr                   = const_cast<uint8_t*>(extensionsStart);
+			auto* ptr                      = const_cast<uint8_t*>(extensionsStart);
 
 			if (type == ExtensionsType::OneByte)
 			{
@@ -1204,9 +1201,9 @@ namespace RTC
 				return false;
 			}
 
-			uint32_t v = Utils::Byte::Get3Bytes(extenValue, 0);
-			minDelay   = v >> 12u;
-			maxDelay   = v & 0xFFFu;
+			const uint32_t v = Utils::Byte::Get3Bytes(extenValue, 0);
+			minDelay         = v >> 12u;
+			maxDelay         = v & 0xFFFu;
 
 			return true;
 		}
@@ -1256,7 +1253,10 @@ namespace RTC
 			// Unset padding flag.
 			GetFixedHeaderPointer()->padding = 0;
 
-			std::memmove(GetPayloadPointer(), payload, payloadLength);
+			if (payload)
+			{
+				std::memmove(GetPayloadPointer(), payload, payloadLength);
+			}
 		}
 
 		void Packet::SetPayloadLength(size_t payloadLength)
@@ -1610,7 +1610,7 @@ namespace RTC
 			{
 				const uint8_t* extensionsStart = GetHeaderExtensionValue();
 				const uint8_t* extensionsEnd   = extensionsStart + GetHeaderExtensionValueLength();
-				uint8_t* ptr                   = const_cast<uint8_t*>(extensionsStart);
+				auto* ptr                      = const_cast<uint8_t*>(extensionsStart);
 
 				// One-Byte Extensions cannot have length 0.
 				while (ptr < extensionsEnd)
@@ -1670,7 +1670,7 @@ namespace RTC
 				const uint8_t* extensionsEnd   = extensionsStart + GetHeaderExtensionValueLength();
 				// ptr points to the Extension id field (1 byte).
 				// ptr+1 points to the length field (1 byte, can have value 0).
-				uint8_t* ptr = const_cast<uint8_t*>(extensionsStart);
+				auto* ptr = const_cast<uint8_t*>(extensionsStart);
 
 				// Two-Byte Extensions can have length 0.
 				while (ptr + 1 < extensionsEnd)

--- a/worker/src/RTC/RTP/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RTP/RtpStreamRecv.cpp
@@ -121,13 +121,7 @@ namespace RTC
 
 			uint32_t rate{ 0u };
 
-			// clang-format off
-		for (
-			size_t tIdx{ 0u };
-			tIdx < this->spatialLayerCounters[spatialLayer].size();
-			++tIdx
-		)
-			// clang-format on
+			for (size_t tIdx{ 0u }; tIdx < this->spatialLayerCounters[spatialLayer].size(); ++tIdx)
 			{
 				auto& temporalLayerCounter = this->spatialLayerCounters[spatialLayer][tIdx];
 

--- a/worker/src/RTC/RTP/SharedPacket.cpp
+++ b/worker/src/RTC/RTP/SharedPacket.cpp
@@ -17,6 +17,7 @@ namespace RTC
 		// Callback to pass to every cloned RTP Packet to deallocate its buffer once
 		// the Packet releases its buffer (for example when the Packet is destroyed).
 		static thread_local Serializable::BufferReleasedListener PacketBufferReleasedListener =
+		  // NOLINTNEXTLINE(misc-unused-parameters)
 		  [](const Serializable* packet, uint8_t* buffer)
 		{
 			delete[] buffer;

--- a/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
@@ -11,6 +11,7 @@ namespace RTC
 {
 	/* Class variables. */
 
+	// clang-format off
 	const absl::flat_hash_map<RtpParameters::Type, std::string> RtpParameters::Type2String = {
 		{ RtpParameters::Type::SIMPLE, "simple" },
 		{ RtpParameters::Type::SIMULCAST, "simulcast" },

--- a/worker/src/RTC/SCTP/packet/Packet.cpp
+++ b/worker/src/RTC/SCTP/packet/Packet.cpp
@@ -70,7 +70,7 @@ namespace RTC
 					return nullptr;
 				}
 
-				Chunk* chunk{ nullptr };
+				Chunk* chunk{ nullptr }; // NOLINT(misc-const-correctness)
 
 				MS_DEBUG_DEV("parsing SCTP Chunk [ptr:%zu, type:%" PRIu8 "]", ptr - buffer, chunkType);
 

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -15,7 +15,7 @@ static const uint32_t SendBufferThreshold{ 256u };
 
 /* SCTP events to which we are subscribing. */
 
-/* clang-format off */
+// clang-format off
 const uint16_t EventTypes[] =
 {
 	SCTP_ADAPTATION_INDICATION,
@@ -27,7 +27,7 @@ const uint16_t EventTypes[] =
 	SCTP_STREAM_RESET_EVENT,
 	SCTP_STREAM_CHANGE_EVENT
 };
-/* clang-format on */
+// clang-format on
 
 /* Static methods for usrsctp callbacks. */
 

--- a/worker/src/RTC/SctpDictionaries/SctpStreamParameters.cpp
+++ b/worker/src/RTC/SctpDictionaries/SctpStreamParameters.cpp
@@ -46,13 +46,7 @@ namespace RTC
 			MS_THROW_TYPE_ERROR("cannot provide both maxPacketLifeTime and maxRetransmits");
 		}
 
-		// clang-format off
-		if (
-			orderedGiven &&
-			this->ordered &&
-			(this->maxPacketLifeTime || this->maxRetransmits)
-		)
-		// clang-format on
+		if (orderedGiven && this->ordered && (this->maxPacketLifeTime || this->maxRetransmits))
 		{
 			MS_THROW_TYPE_ERROR("cannot be ordered with maxPacketLifeTime or maxRetransmits");
 		}

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -312,7 +312,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	// NOLINTNEXTLINE (misc-no-recursion)
+	// NOLINTNEXTLINE(misc-no-recursion)
 	void SimpleConsumer::SendRtpPacket(RTC::RTP::Packet* packet, RTC::RTP::SharedPacket& sharedPacket)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -355,12 +355,7 @@ namespace RTC
 				UpdateTargetLayers(-1, -1);
 			}
 			// Just check target layers if the stream has died or reborned.
-			// clang-format off
-			else if (
-				!this->externallyManagedBitrate ||
-				(score == 0u || previousScore == 0u)
-			)
-			// clang-format on
+			else if (!this->externallyManagedBitrate || (score == 0u || previousScore == 0u))
 			{
 				MayChangeLayers();
 			}
@@ -504,13 +499,10 @@ namespace RTC
 
 			// If the stream has not been active time enough and we have an active one
 			// already, move to the next spatial layer.
-			// clang-format off
 			if (
-				spatialLayer != this->provisionalTargetLayers.spatial &&
-				this->provisionalTargetLayers.spatial != -1 &&
-				producerRtpStream->GetActiveMs() < StreamMinActiveMs
-			)
-			// clang-format on
+			  spatialLayer != this->provisionalTargetLayers.spatial &&
+			  this->provisionalTargetLayers.spatial != -1 &&
+			  producerRtpStream->GetActiveMs() < StreamMinActiveMs)
 			{
 				const auto* provisionalProducerRtpStream =
 				  this->producerRtpStreams.at(this->provisionalTargetLayers.spatial);
@@ -536,12 +528,9 @@ namespace RTC
 			{
 				// Ignore temporal layers lower than the one we already have (taking
 				// into account the spatial layer too).
-				// clang-format off
 				if (
-					spatialLayer == this->provisionalTargetLayers.spatial &&
-					temporalLayer <= this->provisionalTargetLayers.temporal
-				)
-				// clang-format on
+				  spatialLayer == this->provisionalTargetLayers.spatial &&
+				  temporalLayer <= this->provisionalTargetLayers.temporal)
 				{
 					continue;
 				}
@@ -551,15 +540,9 @@ namespace RTC
 				// This is simulcast so we must substract the bitrate of the current
 				// temporal spatial layer if this is the temporal layer 0 of a higher
 				// spatial layer.
-				//
-				// clang-format off
 				if (
-					requiredBitrate &&
-					temporalLayer == 0 &&
-					this->provisionalTargetLayers.spatial > -1 &&
-					spatialLayer > this->provisionalTargetLayers.spatial
-				)
-				// clang-format on
+				  requiredBitrate && temporalLayer == 0 && this->provisionalTargetLayers.spatial > -1 &&
+				  spatialLayer > this->provisionalTargetLayers.spatial)
 				{
 					auto* provisionalProducerRtpStream =
 					  this->producerRtpStreams.at(this->provisionalTargetLayers.spatial);
@@ -659,14 +642,12 @@ namespace RTC
 		{
 			UpdateTargetLayers(provisionalTargetLayers.spatial, provisionalTargetLayers.temporal);
 
-			// If this looks like a spatial layer downgrade due to BWE limitations, set member.
-			// clang-format off
+			// If this looks like a spatial layer downgrade due to BWE limitations, set
+			// member.
 			if (
-				this->rtpStream->GetActiveMs() > BweDowngradeMinActiveMs &&
-				this->targetLayers.spatial < this->currentSpatialLayer &&
-				this->currentSpatialLayer <= this->preferredLayers.spatial
-			)
-			// clang-format on
+			  this->rtpStream->GetActiveMs() > BweDowngradeMinActiveMs &&
+			  this->targetLayers.spatial < this->currentSpatialLayer &&
+			  this->currentSpatialLayer <= this->preferredLayers.spatial)
 			{
 				MS_DEBUG_DEV(
 				  "possible target spatial layer downgrade (from %" PRIi16 " to %" PRIi16
@@ -721,7 +702,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	// NOLINTNEXTLINE (misc-no-recursion)
+	// NOLINTNEXTLINE(misc-no-recursion)
 	void SimulcastConsumer::SendRtpPacket(RTC::RTP::Packet* packet, RTC::RTP::SharedPacket& sharedPacket)
 	{
 		MS_TRACE();
@@ -790,12 +771,9 @@ namespace RTC
 
 		// Check whether this is the packet we are waiting for in order to update
 		// the current spatial layer.
-		// clang-format off
 		if (
 		  this->currentSpatialLayer != this->targetLayers.spatial &&
-		  spatialLayer == this->targetLayers.spatial
-		)
-		// clang-format on
+		  spatialLayer == this->targetLayers.spatial)
 		{
 			// Ignore if not a key frame.
 			if (!packet->IsKeyFrame())
@@ -937,15 +915,9 @@ namespace RTC
 
 			// When switching to a new stream it may happen that the timestamp of this
 			// key frame is lower than the highest timestamp sent to the remote endpoint.
-			// If so, apply an extra offset to "fix" it for the whole live of this selected
-			// Producer stream.
-			//
-			// clang-format off
-			if (
-				shouldSwitchCurrentSpatialLayer &&
-				(packet->GetTimestamp() - tsOffset <= this->rtpStream->GetMaxPacketTs())
-			)
-			// clang-format on
+			// If so, apply an extra offset to "fix" it for the whole live of this
+			// selected Producer stream.
+			if (shouldSwitchCurrentSpatialLayer && (packet->GetTimestamp() - tsOffset <= this->rtpStream->GetMaxPacketTs()))
 			{
 				// Max delay in ms we allow for the stream when switching.
 				// https://en.wikipedia.org/wiki/Audio-to-video_synchronization#Recommendations
@@ -1639,13 +1611,7 @@ namespace RTC
 			// If the stream has not been active time enough and we have an active one
 			// already, move to the next spatial layer.
 			// NOTE: Require bitrate externally managed for this.
-			// clang-format off
-			if (
-				this->externallyManagedBitrate &&
-				newTargetLayers.spatial != -1 &&
-				producerRtpStream->GetActiveMs() < StreamMinActiveMs
-			)
-			// clang-format on
+			if (this->externallyManagedBitrate && newTargetLayers.spatial != -1 && producerRtpStream->GetActiveMs() < StreamMinActiveMs)
 			{
 				continue;
 			}
@@ -1766,14 +1732,9 @@ namespace RTC
 		// - the given spatial layer matches the TS reference spatial layer, or
 		// - both , the RTP streams of our TS reference spatial layer and the given
 		//   spatial layer, have Sender Report.
-		//
-		// clang-format off
 		return (
-			this->tsReferenceSpatialLayer == -1 ||
-			spatialLayer == this->tsReferenceSpatialLayer ||
-			this->producerRtpStreams.at(spatialLayer)->GetSenderReportNtpMs()
-		);
-		// clang-format on
+		  this->tsReferenceSpatialLayer == -1 || spatialLayer == this->tsReferenceSpatialLayer ||
+		  this->producerRtpStreams.at(spatialLayer)->GetSenderReportNtpMs());
 	}
 
 	void SimulcastConsumer::StorePacketInTargetLayerRetransmissionBuffer(

--- a/worker/src/RTC/SrtpSession.cpp
+++ b/worker/src/RTC/SrtpSession.cpp
@@ -226,8 +226,7 @@ namespace RTC
 				{
 					MS_ABORT("srtp_dealloc() failed: %s", DepLibSRTP::GetErrorString(err).c_str());
 				}
-				// NOLINTNEXTLINE
-				catch (const std::exception& error)
+				catch (const std::exception& error) // NOLINT(bugprone-empty-catch)
 				{
 					// NOTE: This is to avoid a warning:
 					// '~SrtpSession' has a non-throwing exception specification but can

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -314,12 +314,7 @@ namespace RTC
 		if (RTC::Consumer::IsActive())
 		{
 			// Just check target layers if the stream has died or reborned.
-			// clang-format off
-			if (
-				!this->externallyManagedBitrate ||
-				(score == 0u || previousScore == 0u)
-			)
-			// clang-format on
+			if (!this->externallyManagedBitrate || (score == 0u || previousScore == 0u))
 			{
 				MayChangeLayers();
 			}
@@ -424,12 +419,9 @@ namespace RTC
 			{
 				// Ignore temporal layers lower than the one we already have (taking into account
 				// the spatial layer too).
-				// clang-format off
 				if (
-					spatialLayer == this->provisionalTargetLayers.spatial &&
-					temporalLayer <= this->provisionalTargetLayers.temporal
-				)
-				// clang-format on
+				  spatialLayer == this->provisionalTargetLayers.spatial &&
+				  temporalLayer <= this->provisionalTargetLayers.temporal)
 				{
 					continue;
 				}
@@ -440,15 +432,10 @@ namespace RTC
 				// When using K-SVC we must subtract the bitrate of the current used layer
 				// if the new layer is the temporal layer 0 of an higher spatial layer.
 				//
-				// clang-format off
 				if (
-					this->encodingContext->IsKSvc() &&
-					requiredBitrate &&
-					temporalLayer == 0 &&
-					this->provisionalTargetLayers.spatial > -1 &&
-					spatialLayer > this->provisionalTargetLayers.spatial
-				)
-				// clang-format on
+				  this->encodingContext->IsKSvc() && requiredBitrate && temporalLayer == 0 &&
+				  this->provisionalTargetLayers.spatial > -1 &&
+				  spatialLayer > this->provisionalTargetLayers.spatial)
 				{
 					auto provisionalRequiredBitrate = this->producerRtpStream->GetSpatialLayerBitrate(
 					  nowMs, this->provisionalTargetLayers.spatial);
@@ -546,13 +533,11 @@ namespace RTC
 			UpdateTargetLayers(provisionalTargetLayers.spatial, provisionalTargetLayers.temporal);
 
 			// If this looks like a spatial layer downgrade due to BWE limitations, set member.
-			// clang-format off
 			if (
-				this->rtpStream->GetActiveMs() > BweDowngradeMinActiveMs &&
-				this->encodingContext->GetTargetSpatialLayer() < this->encodingContext->GetCurrentSpatialLayer() &&
-				this->encodingContext->GetCurrentSpatialLayer() <= this->preferredLayers.spatial
-			)
-			// clang-format on
+			  this->rtpStream->GetActiveMs() > BweDowngradeMinActiveMs &&
+			  this->encodingContext->GetTargetSpatialLayer() <
+			    this->encodingContext->GetCurrentSpatialLayer() &&
+			  this->encodingContext->GetCurrentSpatialLayer() <= this->preferredLayers.spatial)
 			{
 				MS_DEBUG_DEV(
 				  "possible target spatial layer downgrade (from %" PRIi16 " to %" PRIi16
@@ -610,7 +595,7 @@ namespace RTC
 		return desiredBitrate;
 	}
 
-	// NOLINTNEXTLINE (misc-no-recursion)
+	// NOLINTNEXTLINE(misc-no-recursion)
 	void SvcConsumer::SendRtpPacket(RTC::RTP::Packet* packet, RTC::RTP::SharedPacket& sharedPacket)
 	{
 		MS_TRACE();
@@ -630,12 +615,7 @@ namespace RTC
 			return;
 		}
 
-		// clang-format off
-		if (
-			this->encodingContext->GetTargetSpatialLayer() == -1 ||
-			this->encodingContext->GetTargetTemporalLayer() == -1
-		)
-		// clang-format on
+		if (this->encodingContext->GetTargetSpatialLayer() == -1 || this->encodingContext->GetTargetTemporalLayer() == -1)
 		{
 #ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Discarded(RTC::RtcLogger::RtpPacket::DiscardReason::INVALID_TARGET_LAYER);

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -725,20 +725,18 @@ namespace RTC
 					// - there is transport-wide-cc-01 RTP header extension, and
 					// - there is "transport-cc" in codecs RTCP feedback.
 					//
-					// clang-format off
 					if (
-						rtpHeaderExtensionIds.transportWideCc01 != 0u &&
-						std::any_of(
-							codecs.begin(), codecs.end(), [](const RTC::RtpCodecParameters& codec)
-							{
-								return std::any_of(
-									codec.rtcpFeedback.begin(), codec.rtcpFeedback.end(), [](const RTC::RtcpFeedback& fb)
-									{
-										return fb.type == "transport-cc";
-									});
-							})
-					)
-					// clang-format on
+					  rtpHeaderExtensionIds.transportWideCc01 != 0u &&
+					  std::any_of(
+					    codecs.begin(),
+					    codecs.end(),
+					    [](const RTC::RtpCodecParameters& codec)
+					    {
+						    return std::any_of(
+						      codec.rtcpFeedback.begin(),
+						      codec.rtcpFeedback.end(),
+						      [](const RTC::RtcpFeedback& fb) { return fb.type == "transport-cc"; });
+					    }))
 					{
 						MS_DEBUG_TAG(bwe, "enabling TransportCongestionControlServer with transport-cc");
 
@@ -749,20 +747,18 @@ namespace RTC
 					// - there is abs-send-time RTP header extension, and
 					// - there is "remb" in codecs RTCP feedback.
 					//
-					// clang-format off
 					else if (
-						rtpHeaderExtensionIds.absSendTime != 0u &&
-						std::any_of(
-							codecs.begin(), codecs.end(), [](const RTC::RtpCodecParameters& codec)
-							{
-								return std::any_of(
-									codec.rtcpFeedback.begin(), codec.rtcpFeedback.end(), [](const RTC::RtcpFeedback& fb)
-									{
-										return fb.type == "goog-remb";
-									});
-							})
-					)
-					// clang-format on
+					  rtpHeaderExtensionIds.absSendTime != 0u && std::any_of(
+					                                               codecs.begin(),
+					                                               codecs.end(),
+					                                               [](const RTC::RtpCodecParameters& codec)
+					                                               {
+						                                               return std::any_of(
+						                                                 codec.rtcpFeedback.begin(),
+						                                                 codec.rtcpFeedback.end(),
+						                                                 [](const RTC::RtcpFeedback& fb)
+						                                                 { return fb.type == "goog-remb"; });
+					                                               }))
 					{
 						MS_DEBUG_TAG(bwe, "enabling TransportCongestionControlServer with REMB");
 
@@ -904,21 +900,19 @@ namespace RTC
 					// - there is transport-wide-cc-01 RTP header extension, and
 					// - there is "transport-cc" in codecs RTCP feedback.
 					//
-					// clang-format off
-						if (
-								consumer->GetKind() == RTC::Media::Kind::VIDEO &&
-								rtpHeaderExtensionIds.transportWideCc01 != 0u &&
-								std::any_of(
-									codecs.begin(), codecs.end(), [](const RTC::RtpCodecParameters& codec)
-									{
-									return std::any_of(
-											codec.rtcpFeedback.begin(), codec.rtcpFeedback.end(), [](const RTC::RtcpFeedback& fb)
-											{
-											return fb.type == "transport-cc";
-											});
-									})
-							 )
-					// clang-format on
+					if (
+					  consumer->GetKind() == RTC::Media::Kind::VIDEO &&
+					  rtpHeaderExtensionIds.transportWideCc01 != 0u &&
+					  std::any_of(
+					    codecs.begin(),
+					    codecs.end(),
+					    [](const RTC::RtpCodecParameters& codec)
+					    {
+						    return std::any_of(
+						      codec.rtcpFeedback.begin(),
+						      codec.rtcpFeedback.end(),
+						      [](const RTC::RtcpFeedback& fb) { return fb.type == "transport-cc"; });
+					    }))
 					{
 						MS_DEBUG_TAG(bwe, "enabling TransportCongestionControlClient with transport-cc");
 
@@ -930,21 +924,19 @@ namespace RTC
 					// - there is abs-send-time RTP header extension, and
 					// - there is "remb" in codecs RTCP feedback.
 					//
-					// clang-format off
-						else if (
-								consumer->GetKind() == RTC::Media::Kind::VIDEO &&
-								rtpHeaderExtensionIds.absSendTime != 0u &&
-								std::any_of(
-									codecs.begin(), codecs.end(), [](const RTC::RtpCodecParameters& codec)
-									{
-									return std::any_of(
-											codec.rtcpFeedback.begin(), codec.rtcpFeedback.end(), [](const RTC::RtcpFeedback& fb)
-											{
-											return fb.type == "goog-remb";
-											});
-									})
-								)
-					// clang-format on
+					else if (
+					  consumer->GetKind() == RTC::Media::Kind::VIDEO &&
+					  rtpHeaderExtensionIds.absSendTime != 0u &&
+					  std::any_of(
+					    codecs.begin(),
+					    codecs.end(),
+					    [](const RTC::RtpCodecParameters& codec)
+					    {
+						    return std::any_of(
+						      codec.rtcpFeedback.begin(),
+						      codec.rtcpFeedback.end(),
+						      [](const RTC::RtcpFeedback& fb) { return fb.type == "goog-remb"; });
+					    }))
 					{
 						MS_DEBUG_TAG(bwe, "enabling TransportCongestionControlClient with REMB");
 
@@ -990,22 +982,19 @@ namespace RTC
 				// - there is transport-wide-cc-01 RTP header extension, and
 				// - there is "transport-cc" in codecs RTCP feedback.
 				//
-				// clang-format off
-					if (
-							!this->senderBwe &&
-							consumer->GetKind() == RTC::Media::Kind::VIDEO &&
-							rtpHeaderExtensionIds.transportWideCc01 != 0u &&
-							std::any_of(
-								codecs.begin(), codecs.end(), [](const RTC::RtpCodecParameters& codec)
-								{
-								return std::any_of(
-										codec.rtcpFeedback.begin(), codec.rtcpFeedback.end(), [](const RTC::RtcpFeedback& fb)
-										{
-										return fb.type == "transport-cc";
-										});
-								})
-						 )
-				// clang-format on
+				if (
+				  !this->senderBwe && consumer->GetKind() == RTC::Media::Kind::VIDEO &&
+				  rtpHeaderExtensionIds.transportWideCc01 != 0u &&
+				  std::any_of(
+				    codecs.begin(),
+				    codecs.end(),
+				    [](const RTC::RtpCodecParameters& codec)
+				    {
+					    return std::any_of(
+					      codec.rtcpFeedback.begin(),
+					      codec.rtcpFeedback.end(),
+					      [](const RTC::RtcpFeedback& fb) { return fb.type == "transport-cc"; });
+				    }))
 				{
 					MS_DEBUG_TAG(bwe, "enabling SenderBandwidthEstimator");
 
@@ -1925,12 +1914,7 @@ namespace RTC
 							auto* remb = static_cast<RTC::RTCP::FeedbackPsRembPacket*>(afb);
 
 							// Pass it to the TCC client.
-							// clang-format off
-							if (
-								this->tccClient &&
-								this->tccClient->GetBweType() == RTC::BweType::REMB
-							)
-							// clang-format on
+							if (this->tccClient && this->tccClient->GetBweType() == RTC::BweType::REMB)
 							{
 								this->tccClient->ReceiveEstimatedBitrate(remb->GetBitrate());
 							}
@@ -1973,17 +1957,10 @@ namespace RTC
 
 				// If no Consumer is found and this is not a Transport Feedback for the
 				// probation SSRC or any Consumer RTX SSRC, ignore it.
-				//
-				// clang-format off
 				if (
-					!consumer &&
-					feedback->GetMessageType() != RTC::RTCP::FeedbackRtp::MessageType::TCC &&
-					(
-						feedback->GetMediaSsrc() != RTC::RTP::ProbationGenerator::Ssrc ||
-						!GetConsumerByRtxSsrc(feedback->GetMediaSsrc())
-					)
-				)
-				// clang-format on
+				  !consumer && feedback->GetMessageType() != RTC::RTCP::FeedbackRtp::MessageType::TCC &&
+				  (feedback->GetMediaSsrc() != RTC::RTP::ProbationGenerator::Ssrc ||
+				   !GetConsumerByRtxSsrc(feedback->GetMediaSsrc())))
 				{
 					MS_DEBUG_TAG(
 					  rtcp,
@@ -2481,13 +2458,9 @@ namespace RTC
 		packet->UpdateAbsSendTime(DepLibUV::GetTimeMs());
 
 		// Update transport wide sequence number if present.
-		// clang-format off
 		if (
-			this->tccClient &&
-			this->tccClient->GetBweType() == RTC::BweType::TRANSPORT_CC &&
-			packet->UpdateTransportWideCc01(this->transportWideCcSeq + 1)
-		)
-		// clang-format on
+		  this->tccClient && this->tccClient->GetBweType() == RTC::BweType::TRANSPORT_CC &&
+		  packet->UpdateTransportWideCc01(this->transportWideCcSeq + 1))
 		{
 			this->transportWideCcSeq++;
 
@@ -2575,13 +2548,9 @@ namespace RTC
 		packet->UpdateAbsSendTime(DepLibUV::GetTimeMs());
 
 		// Update transport wide sequence number if present.
-		// clang-format off
 		if (
-			this->tccClient &&
-			this->tccClient->GetBweType() == RTC::BweType::TRANSPORT_CC &&
-			packet->UpdateTransportWideCc01(this->transportWideCcSeq + 1)
-		)
-		// clang-format on
+		  this->tccClient && this->tccClient->GetBweType() == RTC::BweType::TRANSPORT_CC &&
+		  packet->UpdateTransportWideCc01(this->transportWideCcSeq + 1))
 		{
 			this->transportWideCcSeq++;
 
@@ -2976,12 +2945,9 @@ namespace RTC
 		packet->UpdateAbsSendTime(DepLibUV::GetTimeMs());
 
 		// Update transport wide sequence number if present.
-		// clang-format off
 		if (
-			this->tccClient->GetBweType() == RTC::BweType::TRANSPORT_CC &&
-			packet->UpdateTransportWideCc01(this->transportWideCcSeq + 1)
-		)
-		// clang-format on
+		  this->tccClient->GetBweType() == RTC::BweType::TRANSPORT_CC &&
+		  packet->UpdateTransportWideCc01(this->transportWideCcSeq + 1))
 		{
 			this->transportWideCcSeq++;
 

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -75,14 +75,12 @@ namespace RTC
 
 		this->processTimer = new TimerHandle(this);
 
-		// clang-format off
-		this->processTimer->Start(std::min(
-			// Depends on probation being done and WebRTC-Pacer-MinPacketLimitMs field trial.
-			this->rtpTransportControllerSend->packet_sender()->TimeUntilNextProcess(),
-			// Fixed value (25ms), libwebrtc/api/transport/goog_cc_factory.cc.
-			this->controllerFactory->GetProcessInterval().ms()
-		));
-		// clang-format on
+		this->processTimer->Start(
+		  std::min(
+		    // Depends on probation being done and WebRTC-Pacer-MinPacketLimitMs field trial.
+		    this->rtpTransportControllerSend->packet_sender()->TimeUntilNextProcess(),
+		    // Fixed value (25ms), libwebrtc/api/transport/goog_cc_factory.cc.
+		    this->controllerFactory->GetProcessInterval().ms()));
 	}
 
 	void TransportCongestionControlClient::DestroyController()
@@ -508,15 +506,10 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// NOTE: The same value as 'this->initialAvailableBitrate' is received periodically
-		// regardless of the real available bitrate. Skip such value except for the first time
-		// this event is called.
-		// clang-format off
-		if (
-			this->availableBitrateEventCalled &&
-			targetTransferRate.target_rate.bps() == this->initialAvailableBitrate
-		)
-		// clang-format on
+		// NOTE: The same value as 'this->initialAvailableBitrate' is received
+		// periodically regardless of the real available bitrate. Skip such value
+		// except for the first time this event is called.
+		if (this->availableBitrateEventCalled && targetTransferRate.target_rate.bps() == this->initialAvailableBitrate)
 		{
 			return;
 		}
@@ -569,14 +562,12 @@ namespace RTC
 			// Time to call PacedSender::Process().
 			this->rtpTransportControllerSend->packet_sender()->Process();
 
-			/* clang-format off */
-			this->processTimer->Start(std::min<uint64_t>(
-				// Depends on probation being done and WebRTC-Pacer-MinPacketLimitMs field trial.
-				this->rtpTransportControllerSend->packet_sender()->TimeUntilNextProcess(),
-				// Fixed value (25ms), libwebrtc/api/transport/goog_cc_factory.cc.
-				this->controllerFactory->GetProcessInterval().ms()
-			));
-			/* clang-format on */
+			this->processTimer->Start(
+			  std::min<uint64_t>(
+			    // Depends on probation being done and WebRTC-Pacer-MinPacketLimitMs field trial.
+			    this->rtpTransportControllerSend->packet_sender()->TimeUntilNextProcess(),
+			    // Fixed value (25ms), libwebrtc/api/transport/goog_cc_factory.cc.
+			    this->controllerFactory->GetProcessInterval().ms()));
 
 			MayEmitAvailableBitrateEvent(this->bitrates.availableBitrate);
 		}

--- a/worker/src/RTC/TransportCongestionControlServer.cpp
+++ b/worker/src/RTC/TransportCongestionControlServer.cpp
@@ -366,18 +366,11 @@ namespace RTC
 		}
 
 		// In case this is the first unlimited REMB packet, send it fast.
-		// clang-format off
 		if (
-			(
-				(this->bweType != RTC::BweType::REMB && this->maxIncomingBitrate != 0u) ||
-				this->unlimitedRembCounter > 0u
-			) &&
-			(
-				nowMs - this->limitationRembSentAtMs > LimitationRembInterval ||
-				this->unlimitedRembCounter == UnlimitedRembNumPackets
-			)
-		)
-		// clang-format on
+		  ((this->bweType != RTC::BweType::REMB && this->maxIncomingBitrate != 0u) ||
+		   this->unlimitedRembCounter > 0u) &&
+		  (nowMs - this->limitationRembSentAtMs > LimitationRembInterval ||
+		   this->unlimitedRembCounter == UnlimitedRembNumPackets))
 		{
 			MS_DEBUG_DEV(
 			  "sending limitation RTCP REMB packet [bitrate:%" PRIu32 "]", this->maxIncomingBitrate);

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -657,15 +657,10 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// clang-format off
 		return (
-			(
-				this->iceServer->GetState() == RTC::ICE::IceServer::IceState::CONNECTED ||
-				this->iceServer->GetState() == RTC::ICE::IceServer::IceState::COMPLETED
-			) &&
-			this->dtlsTransport->GetState() == RTC::DtlsTransport::DtlsState::CONNECTED
-		);
-		// clang-format on
+		  (this->iceServer->GetState() == RTC::ICE::IceServer::IceState::CONNECTED ||
+		   this->iceServer->GetState() == RTC::ICE::IceServer::IceState::COMPLETED) &&
+		  this->dtlsTransport->GetState() == RTC::DtlsTransport::DtlsState::CONNECTED);
 	}
 
 	void WebRtcTransport::MayRunDtlsTransport()
@@ -686,12 +681,9 @@ namespace RTC
 			// 'completed'.
 			case RTC::DtlsTransport::Role::AUTO:
 			{
-				// clang-format off
 				if (
-					this->iceServer->GetState() == RTC::ICE::IceServer::IceState::CONNECTED ||
-					this->iceServer->GetState() == RTC::ICE::IceServer::IceState::COMPLETED
-				)
-				// clang-format on
+				  this->iceServer->GetState() == RTC::ICE::IceServer::IceState::CONNECTED ||
+				  this->iceServer->GetState() == RTC::ICE::IceServer::IceState::COMPLETED)
 				{
 					MS_DEBUG_TAG(
 					  dtls, "transition from DTLS local role 'auto' to 'server' and running DTLS transport");
@@ -712,12 +704,9 @@ namespace RTC
 			//   https://bugs.chromium.org/p/webrtc/issues/detail?id=3661
 			case RTC::DtlsTransport::Role::CLIENT:
 			{
-				// clang-format off
 				if (
-					this->iceServer->GetState() == RTC::ICE::IceServer::IceState::CONNECTED ||
-					this->iceServer->GetState() == RTC::ICE::IceServer::IceState::COMPLETED
-				)
-				// clang-format on
+				  this->iceServer->GetState() == RTC::ICE::IceServer::IceState::CONNECTED ||
+				  this->iceServer->GetState() == RTC::ICE::IceServer::IceState::COMPLETED)
 				{
 					MS_DEBUG_TAG(dtls, "running DTLS transport in local role 'client'");
 
@@ -731,12 +720,9 @@ namespace RTC
 			// USE-CANDIDATE) or 'completed'.
 			case RTC::DtlsTransport::Role::SERVER:
 			{
-				// clang-format off
 				if (
-					this->iceServer->GetState() == RTC::ICE::IceServer::IceState::CONNECTED ||
-					this->iceServer->GetState() == RTC::ICE::IceServer::IceState::COMPLETED
-				)
-				// clang-format on
+				  this->iceServer->GetState() == RTC::ICE::IceServer::IceState::CONNECTED ||
+				  this->iceServer->GetState() == RTC::ICE::IceServer::IceState::COMPLETED)
 				{
 					MS_DEBUG_TAG(dtls, "running DTLS transport in local role 'server'");
 
@@ -874,7 +860,6 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// clang-format on
 		if (!IsConnected())
 		{
 			MS_WARN_TAG(sctp, "DTLS not connected, cannot send SCTP data");

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -69,7 +69,7 @@ void Settings::SetConfiguration(int argc, char* argv[])
 	/* Parse command line options. */
 
 	// getopt_long_only() is not thread-safe
-	const std::lock_guard<std::mutex> lock(GlobalSyncMutex);
+	std::scoped_lock lock(GlobalSyncMutex);
 
 	optind = 1; // Set explicitly, otherwise subsequent runs will fail.
 	opterr = 0; // Don't allow getopt to print error messages.

--- a/worker/src/Utils/BitStream.cpp
+++ b/worker/src/Utils/BitStream.cpp
@@ -6,7 +6,7 @@
 
 namespace Utils
 {
-	//NOLINTNEXTLINE (cppcoreguidelines-pro-type-member-init)
+	// NOLINTNEXTLINE(cppcoreguidelines-pro-type-member-init)
 	BitStream::BitStream(uint8_t* data, size_t len) : len(len)
 	{
 		MS_TRACE();

--- a/worker/src/Utils/Crypto.cpp
+++ b/worker/src/Utils/Crypto.cpp
@@ -200,7 +200,7 @@ namespace Utils
 		return crc32;
 	}
 
-	const uint8_t* Crypto::GetHmacSha1(const std::string& key, const uint8_t* data, size_t len)
+	const uint8_t* Crypto::GetHmacSha1(const char* key, size_t keyLen, const uint8_t* data, size_t len)
 	{
 		MS_TRACE();
 
@@ -208,25 +208,22 @@ namespace Utils
 
 		OSSL_PARAM sha1[] = { { "digest", OSSL_PARAM_UTF8_STRING, (void*)"sha1", 4, 0 }, OSSL_PARAM_END };
 
-		ret = EVP_MAC_init(
-		  Crypto::hmacSha1Ctx, reinterpret_cast<const unsigned char*>(key.c_str()), key.length(), sha1);
+		ret =
+		  EVP_MAC_init(Crypto::hmacSha1Ctx, reinterpret_cast<const unsigned char*>(key), keyLen, sha1);
 
-		MS_ASSERT(ret == 1, "OpenSSL EVP_MAC_init() failed with key '%s'", key.c_str());
+		MS_ASSERT(ret == 1, "OpenSSL EVP_MAC_init() failed with key '%s'", key);
 
 		ret = EVP_MAC_update(Crypto::hmacSha1Ctx, data, len);
 
 		MS_ASSERT(
-		  ret == 1,
-		  "OpenSSL EVP_MAC_update() failed with key '%s' and data length %zu bytes",
-		  key.c_str(),
-		  len);
+		  ret == 1, "OpenSSL EVP_MAC_update() failed with key '%s' and data length %zu bytes", key, len);
 
 		size_t resultLen;
 
 		ret = EVP_MAC_final(Crypto::hmacSha1Ctx, Crypto::hmacSha1Buffer, &resultLen, SHA_DIGEST_LENGTH);
 
 		MS_ASSERT(
-		  ret == 1, "OpenSSL HMAC_Final() failed with key '%s' and data length %zu bytes", key.c_str(), len);
+		  ret == 1, "OpenSSL HMAC_Final() failed with key '%s' and data length %zu bytes", key, len);
 		MS_ASSERT(
 		  resultLen == SHA_DIGEST_LENGTH, "OpenSSL HMAC_Final() resultLen is %zu instead of 20", resultLen);
 

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -356,7 +356,7 @@ void Worker::HandleRequest(Channel::ChannelRequest* request)
 
 		case Channel::ChannelRequest::Method::WORKER_WEBRTCSERVER_CLOSE:
 		{
-			RTC::WebRtcServer* webRtcServer{ nullptr };
+			const RTC::WebRtcServer* webRtcServer{ nullptr };
 
 			const auto* body = request->data->body_as<FBS::Worker::CloseWebRtcServerRequest>();
 
@@ -411,7 +411,7 @@ void Worker::HandleRequest(Channel::ChannelRequest* request)
 
 		case Channel::ChannelRequest::Method::WORKER_CLOSE_ROUTER:
 		{
-			RTC::Router* router{ nullptr };
+			const RTC::Router* router{ nullptr };
 
 			const auto* body = request->data->body_as<FBS::Worker::CloseRouterRequest>();
 
@@ -547,9 +547,9 @@ RTC::WebRtcServer* Worker::OnRouterNeedWebRtcServer(RTC::Router* /*router*/, std
 {
 	MS_TRACE();
 
-	RTC::WebRtcServer* webRtcServer{ nullptr };
+	RTC::WebRtcServer* webRtcServer{ nullptr }; // NOLINT(misc-const-correctness)
 
-	auto it = this->mapWebRtcServers.find(webRtcServerId);
+	const auto it = this->mapWebRtcServers.find(webRtcServerId);
 
 	if (it != this->mapWebRtcServers.end())
 	{

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -35,7 +35,7 @@ static void ignoreSignals();
  * - 134 when any other uncaught C++ exception happens (only in non executable
  *   mode).
  */
-// NOLINTNEXTLINE
+// NOLINTNEXTLINE(readability-identifier-naming)
 extern "C" int mediasoup_worker_run(
   int argc,
   char* argv[],
@@ -121,7 +121,7 @@ extern "C" int mediasoup_worker_run(
 
 	MS_DEBUG_TAG(info, "starting mediasoup-worker process [version:%s]", version);
 
-#if defined(MS_LITTLE_ENDIAN)
+#ifdef MS_LITTLE_ENDIAN
 	MS_DEBUG_TAG(info, "little-endian CPU detected");
 #elif defined(MS_BIG_ENDIAN)
 	MS_DEBUG_TAG(info, "big-endian CPU detected");

--- a/worker/src/main.cpp
+++ b/worker/src/main.cpp
@@ -11,8 +11,10 @@ static constexpr int ProducerChannelFd{ 4 };
 
 int main(int argc, char* argv[])
 {
+	const char* envVersion = std::getenv("MEDIASOUP_VERSION");
+
 	// Ensure we are called by our Node library.
-	if (!std::getenv("MEDIASOUP_VERSION"))
+	if (!envVersion)
 	{
 		MS_ERROR_STD("you don't seem to be my real father!");
 
@@ -20,7 +22,7 @@ int main(int argc, char* argv[])
 		std::_Exit(41);
 	}
 
-	const std::string version = std::getenv("MEDIASOUP_VERSION");
+	const std::string version{ envVersion };
 
 	const auto statusCode = mediasoup_worker_run(
 	  /*argc*/ argc,


### PR DESCRIPTION
# Details

- Fixes #1709

## Bonus tracks

- Remove all `// clang-format off/on` lines. Only keep those that wrap definitions of maps. Motivation is that there where those lines everywhere within methods and code and they were producing terrible indentation (for example when a new `namespace` is added in a C++ class).
- CI worker: Enable all meson options in some hosts.