### PR TITLE
clang-tidy: only output diagnose from our code

### DIFF
--- a/worker/.clang-tidy
+++ b/worker/.clang-tidy
@@ -1,5 +1,4 @@
 ---
-HeaderFilterRegex: '.*/worker/(include|src)/.*'
 Checks: "*,\
   -altera*,\
   -android*,\
@@ -84,6 +83,7 @@ Checks: "*,\
   -readability-simplify-boolean-expr,\
   -readability-uppercase-literal-suffix,\
   "
+HeaderFilterRegex: '.*/worker/(include|src|test|fuzzer)/.*'
 FormatStyle: 'file'
 User: mediasoup
 CheckOptions:

--- a/worker/.clang-tidy
+++ b/worker/.clang-tidy
@@ -1,4 +1,5 @@
 ---
+HeaderFilterRegex: '.*/worker/(include|src)/.*'
 Checks: "*,\
   -altera*,\
   -android*,\

--- a/worker/.clang-tidy
+++ b/worker/.clang-tidy
@@ -83,7 +83,8 @@ Checks: "*,\
   -readability-simplify-boolean-expr,\
   -readability-uppercase-literal-suffix,\
   "
-HeaderFilterRegex: '.*/worker/(include|src|test|fuzzer)/.*'
+HeaderFilterRegex: '.*/worker/(include|test/include|fuzzer/include)/.*
+
 FormatStyle: 'file'
 User: mediasoup
 CheckOptions:


### PR DESCRIPTION
Ignore external libaries.