### PR TITLE
Enhance GH workflows

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'node/**'
       - 'worker/**'
+      - '.github/workflows/mediasoup-node.yaml'
   pull_request:
     paths:
       - 'node/**'
       - 'worker/**'
+      - '.github/workflows/mediasoup-node.yaml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -3,7 +3,13 @@ name: mediasoup-node
 on:
   push:
     branches: [v3]
+    paths:
+      - 'node/**'
+      - 'worker/**'
   pull_request:
+    paths:
+      - 'node/**'
+      - 'worker/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -6,10 +6,12 @@ on:
     paths:
       - 'rust/**'
       - 'worker/**'
+      - '.github/workflows/mediasoup-rust.yaml'
   pull_request:
     paths:
       - 'rust/**'
       - 'worker/**'
+      - '.github/workflows/mediasoup-rust.yaml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -3,7 +3,13 @@ name: mediasoup-rust
 on:
   push:
     branches: [v3]
+    paths:
+      - 'rust/**'
+      - 'worker/**'
   pull_request:
+    paths:
+      - 'rust/**'
+      - 'worker/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -5,9 +5,11 @@ on:
     branches: [v3]
     paths:
       - 'worker/**'
+      - '.github/workflows/mediasoup-worker-fuzzer.yaml'
   pull_request:
     paths:
       - 'worker/**'
+      - '.github/workflows/mediasoup-worker-fuzzer.yaml'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -3,7 +3,11 @@ name: mediasoup-worker-fuzzer
 on:
   push:
     branches: [v3]
+    paths:
+      - 'worker/**'
   pull_request:
+    paths:
+      - 'worker/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -3,7 +3,11 @@ name: mediasoup-worker
 on:
   push:
     branches: [v3]
+    paths:
+      - 'worker/**'
   pull_request:
+    paths:
+      - 'worker/**'
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -5,9 +5,11 @@ on:
     branches: [v3]
     paths:
       - 'worker/**'
+      - '.github/workflows/mediasoup-worker.yaml'
   pull_request:
     paths:
       - 'worker/**'
+      - '.github/workflows/mediasoup-worker.yaml'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Trigger workflows only when the affecting folder is changed.

I'm tired of seeing all workflows triggered for unrelated changes. I know we could go more granular, but that would require also maintenance. I think this is a good balance.