### PR TITLE
Worker: Improve test files for clang-tidy checks

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -60,6 +60,10 @@ Runs [clang-tidy](http://clang.llvm.org/extra/clang-tidy) and performs C++ code 
 
 See [Install clang-tidy](#install-clang-tidy) for requirements.
 
+### `npm run tidy:worker:fix`
+
+Same as `npm run tidy:worker` but it also applies fixes.
+
 ### `npm run flatc`
 
 Runs both `flatc:node` and `flatc:worker` tasks.
@@ -246,6 +250,10 @@ It may happens that `clang-tidy` doesn't know where C++ standard libraries are s
 ```bash
 PATH="/opt/homebrew/opt/llvm/bin/:$PATH" CPATH=/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/include/c++/v1 invoke tidy
 ```
+
+### `invoke tidy-fix`
+
+Same as `invoke tidy` but it also applies fixes.
 
 ### `invoke test`
 

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -193,7 +193,13 @@ async function run() {
 		}
 
 		case 'tidy:worker': {
-			tidyWorker();
+			tidyWorker({ fix: false });
+
+			break;
+		}
+
+		case 'tidy:worker:fix': {
+			tidyWorker({ true: false });
 
 			break;
 		}
@@ -313,7 +319,7 @@ function buildTypescript({ force }) {
 		return;
 	}
 
-	logInfo('buildTypescript()');
+	logInfo(`buildTypescript() [force:${force}]`);
 
 	deleteNodeLib();
 
@@ -389,12 +395,16 @@ function formatWorker() {
 	executeCmd(`"${PYTHON}" -m invoke -r worker format`);
 }
 
-function tidyWorker() {
-	logInfo('tidyWorker()');
+function tidyWorker({ fix }) {
+	logInfo(`tidyWorker() [fix:${fix}]`);
 
 	installInvoke();
 
-	executeCmd(`"${PYTHON}" -m invoke -r worker tidy`);
+	if (fix) {
+		executeCmd(`"${PYTHON}" -m invoke -r worker tidy-fix`);
+	} else {
+		executeCmd(`"${PYTHON}" -m invoke -r worker tidy`);
+	}
 }
 
 async function flatcNode() {

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -199,7 +199,7 @@ async function run() {
 		}
 
 		case 'tidy:worker:fix': {
-			tidyWorker({ true: false });
+			tidyWorker({ fix: true });
 
 			break;
 		}

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
 		"format:node": "node npm-scripts.mjs format:node",
 		"format:worker": "node npm-scripts.mjs format:worker",
 		"tidy:worker": "node npm-scripts.mjs tidy:worker",
+		"tidy:worker:fix": "node npm-scripts.mjs tidy:worker:fix",
 		"flatc": "node npm-scripts.mjs flatc:node && node npm-scripts.mjs flatc:worker",
 		"flatc:node": "node npm-scripts.mjs flatc:node",
 		"flatc:worker": "node npm-scripts.mjs flatc:worker",

--- a/worker/.clang-tidy
+++ b/worker/.clang-tidy
@@ -44,7 +44,6 @@ Checks: "*,\
   -google-build-using-namespace,\
   -google-default-arguments,\
   -google-readability-*,\
-  -google-runtime-references,\
   -google-runtime-int,\
   -google-upgrade-googletest-case,\
   -hicpp-avoid-c-arrays,\
@@ -68,7 +67,6 @@ Checks: "*,\
   -modernize-make-unique,\
   -modernize-pass-by-value,\
   -modernize-use-nodiscard, \
-  -modernize-use-static, \
   -modernize-use-trailing-return-type,\
   -performance-no-int-to-ptr,\
   -portability-template-virtual-member-function,\
@@ -76,7 +74,6 @@ Checks: "*,\
   -readability-else-after-return,\
   -readability-function-cognitive-complexity,\
   -readability-identifier-length,\
-  -readability-implicit-bool-cast,\
   -readability-implicit-bool-conversion,\
   -readability-magic-numbers,\
   -readability-redundant-access-specifiers, \
@@ -93,10 +90,6 @@ CheckOptions:
     value: '0'
   - key: cppcoreguidelines-macro-usage.AllowedRegexp
     value: ^MS_*
-  - key: misc-assert-side-effect.AssertMacros
-    value: assert
-  - key: misc-assert-side-effect.CheckFunctionCalls
-    value: '0'
   - key: misc-throw-by-value-catch-by-reference.CheckThrowTemporaries
     value: '1'
   - key: modernize-loop-convert.MaxCopySize

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -32,6 +32,7 @@ endif
 	lint \
 	format \
 	tidy \
+	tidy-fix \
 	test \
 	test-asan-address \
 	test-asan-undefined \
@@ -97,6 +98,9 @@ format: invoke
 
 tidy: invoke
 	"$(PYTHON)" -m invoke tidy
+
+tidy-fix: invoke
+	"$(PYTHON)" -m invoke tidy-fix
 
 test: invoke
 	"$(PYTHON)" -m invoke test

--- a/worker/scripts/clang-scripts.mjs
+++ b/worker/scripts/clang-scripts.mjs
@@ -44,7 +44,13 @@ async function run() {
 		}
 
 		case 'tidy': {
-			tidy();
+			tidy({ fix: false });
+
+			break;
+		}
+
+		case 'tidy:fix': {
+			tidy({ fix: true });
 
 			break;
 		}
@@ -85,8 +91,8 @@ function format() {
 	executeCmd(`"${clangFormat}" --Werror -i ${files}`);
 }
 
-function tidy() {
-	logInfo('tidy()');
+function tidy({ fix }) {
+	logInfo(`tidy() [fix:${fix}]`);
 
 	const clangTidy = getClangToolBinary({
 		clangToolName: 'clang-tidy',
@@ -114,8 +120,13 @@ function tidy() {
 
 	const files = process.env.MEDIASOUP_TIDY_FILES ?? CLANG_TIDY_PATHS.join(' ');
 
+	const fixArg = fix ? '-fix' : '';
+
+	// Check .clang-tidy config file and fail if some option is invalid/unknown.
+	executeCmd(`"${clangTidy}" --verify-config`);
+
 	executeCmd(
-		`"${PYTHON}" "${runClangTidy}" -clang-tidy-binary="${clangTidy}" -clang-apply-replacements-binary="${clangApplyReplacements}" -p="${BUILD_DIR}" -j=${NUM_CORES} -quiet -fix -format -checks=${tidyChecks} ${files}`
+		`"${PYTHON}" "${runClangTidy}" -clang-tidy-binary="${clangTidy}" -clang-apply-replacements-binary="${clangApplyReplacements}" -p="${BUILD_DIR}" -j=${NUM_CORES} -quiet ${fixArg} -format -checks=${tidyChecks} ${files}`
 	);
 }
 

--- a/worker/scripts/package.json
+++ b/worker/scripts/package.json
@@ -5,7 +5,8 @@
 	"scripts": {
 		"lint": "node clang-scripts.mjs lint",
 		"format": "node clang-scripts.mjs format",
-		"tidy": "node clang-scripts.mjs tidy"
+		"tidy": "node clang-scripts.mjs tidy",
+		"tidy:fix": "node clang-scripts.mjs tidy:fix"
 	},
 	"dependencies": {
 		"glob": "^13.0.0"

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -383,6 +383,21 @@ def tidy(ctx):
         );
 
 
+@task
+def tidy_fix(ctx):
+    """
+    Performs C++ code checks according to `worker/.clang-tidy` rules and applies
+    fixes
+    """
+    with cd_worker():
+        ctx.run(
+            f'"{NPM}" run tidy:fix --prefix scripts/',
+            echo=True,
+            pty=PTY_SUPPORTED,
+            shell=SHELL
+        );
+
+
 @task(pre=[setup, flatc])
 def test(ctx):
     """

--- a/worker/test/src/RTC/RTCP/TestBye.cpp
+++ b/worker/test/src/RTC/RTCP/TestBye.cpp
@@ -6,7 +6,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestBye
+SCENARIO("RTCP BYE parsing", "[parser][rtcp][bye]")
 {
 	// RCTP BYE packet.
 
@@ -23,11 +23,14 @@ namespace TestBye
 	};
 	// clang-format on
 
-	uint32_t ssrc1{ 0x624276e0 };
-	uint32_t ssrc2{ 0x2624670e };
-	std::string reason("Hasta la vista");
+	const uint32_t ssrc1{ 0x624276e0 };
+	const uint32_t ssrc2{ 0x2624670e };
+	const std::string reason("Hasta la vista");
 
-	void verify(ByePacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	// NOTE: If we pass const integers then clang-tidy complains with
+	// 'clang-diagnostic-unused-lambda-capture'.
+	auto verify = [&reason](ByePacket* packet)
 	{
 		REQUIRE(packet->GetReason() == reason);
 
@@ -35,16 +38,11 @@ namespace TestBye
 
 		REQUIRE(*it == ssrc1);
 
-		it++;
+		++it;
 
 		REQUIRE(*it == ssrc2);
-	}
-} // namespace TestBye
+	};
 
-using namespace TestBye;
-
-SCENARIO("RTCP BYE parsing", "[parser][rtcp][bye]")
-{
 	SECTION("parse BYE packet")
 	{
 		std::unique_ptr<ByePacket> packet{ ByePacket::Parse(buffer, sizeof(buffer)) };

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsAfb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsAfb.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackPsAfb
+SCENARIO("RTCP Feedback PS AFB parsing", "[parser][rtcp][feedback-ps][afb]")
 {
 	// RTCP AFB packet.
 
@@ -20,25 +20,18 @@ namespace TestFeedbackPsAfb
 	// clang-format on
 
 	// AFB values.
-	uint32_t senderSsrc{ 0xfa17fa17 };
-	uint32_t mediaSsrc{ 0 };
-	size_t dataSize{ 4 };
-	uint8_t dataBitmask{ 1 };
+	const uint32_t senderSsrc{ 0xfa17fa17 };
+	const uint32_t mediaSsrc{ 0 };
 
-	void verify(FeedbackPsAfbPacket* packet)
+	auto verify = [](FeedbackPsAfbPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
 		REQUIRE(packet->GetApplication() == FeedbackPsAfbPacket::Application::UNKNOWN);
-	}
-} // namespace TestFeedbackPsAfb
+	};
 
-SCENARIO("RTCP Feedback PS AFB parsing", "[parser][rtcp][feedback-ps][afb]")
-{
 	SECTION("parse FeedbackPsAfbPacket")
 	{
-		using namespace TestFeedbackPsAfb;
-
 		std::unique_ptr<FeedbackPsAfbPacket> packet{ FeedbackPsAfbPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);


### PR DESCRIPTION
# Details

- Make `tidy` task NOT fix code by default.
- Add `tidy:fix` (and `tidy-fix` in `Makefile` and `tasks.py`).
- Check unused/invalid rules/options in `.clang-tidy` and fail if so.
- Modify `worker/test/src/RTC/RTCP/TestBye.cpp` and `worker/test/src/RTC/RTCP/TestFeedbackPsAfb.cpp` so they pass `tidy` task.

## Note

Of course for this to be tested those files must be added to the `tidy` task. In `clang-scripts.mjs`:

```js
// TODO: Enable test/ and fuzzer/ source files.
const CLANG_TIDY_PATHS = await glob([
	// '../src/**/*.cpp',
	// '../test/src/**/*.cpp',
	// '../fuzzer/src/**/*.cpp',

	'../test/src/RTC/RTCP/TestBye.cpp',
]);
```