### PR TITLE
Enable clang-tidy for RTCP tests

### DIFF
--- a/.github/workflows/mediasoup-worker-clang-tidy.yaml
+++ b/.github/workflows/mediasoup-worker-clang-tidy.yaml
@@ -3,8 +3,12 @@ name: mediasoup-worker-clang-tidy
 on:
   pull_request:
     paths:
-      - 'worker/include/**/*.hpp'
       - 'worker/src/**/*.cpp'
+      - 'worker/include/**/*.hpp'
+      - 'worker/test/src/**/*.cpp'
+      - 'worker/test/include/**/*.hpp'
+      - 'worker/fuzzer/src/**/*.cpp'
+      - 'worker/fuzzer/include/**/*.hpp'
       - 'worker/.clang-tidy'
       - '.github/workflows/mediasoup-worker-clang-tidy.yaml'
 
@@ -38,7 +42,7 @@ jobs:
           clang_tidy_version: '21'
           # TMP until this bug is fixes https://github.com/ZedThree/clang-tidy-review/issues/157#issuecomment-3552341821.
           extra_arguments: '--allow-no-checks --quiet'
-          include: 'worker/include/**/*.hpp,worker/src/**/*.cpp'
+          include: 'worker/src/**/*.cpp,worker/test/src/**/*.cpp,worker/fuzzer/src/**/*.cpp'
 
       # Uploads an artifact containing clang_fixes.json.
       - uses: ZedThree/clang-tidy-review/upload@v0.22.1

--- a/worker/.clang-tidy
+++ b/worker/.clang-tidy
@@ -37,6 +37,7 @@ Checks: "*,\
   -cppcoreguidelines-special-member-functions,\
   -hicpp-exception-baseclass,\
   -hicpp-no-malloc,\
+  -hicpp-function-size,\
   -fuchsia-default-arguments-calls,\
   -fuchsia-default-arguments-declarations,\
   -fuchsia-overloaded-operator,\
@@ -109,7 +110,7 @@ CheckOptions:
   - key: readability-function-size.LineThreshold
     value: '4294967295'
   - key: readability-function-size.StatementThreshold
-    value: '800'
+    value: '1500'
   - key: readability-identifier-naming.AbstractClassCase
     value: CamelCase
   - key: readability-identifier-naming.AbstractClassPrefix

--- a/worker/scripts/clang-scripts.mjs
+++ b/worker/scripts/clang-scripts.mjs
@@ -18,9 +18,11 @@ const CLANG_FORMAT_PATHS = [
 	'../fuzzer/include/**/*.hpp',
 ];
 
-// TODO: Enable test/ and fuzzer/ source files.
 const CLANG_TIDY_PATHS = [
 	'../src/**/*.cpp',
+	// TODO: Temporal until all tests are included.
+	'../test/src/RTC/RTCP/*.cpp',
+	// TODO: Enable test/ and fuzzer/ source files.
 	// '../test/src/**/*.cpp',
 	// '../fuzzer/src/**/*.cpp',
 ];

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsFir.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsFir.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackPsFir
+SCENARIO("RTCP Feedback PS FIR parsing", "[parser][rtcp][feedback-ps][fir]")
 {
 	// RTCP FIR packet.
 
@@ -21,26 +21,22 @@ namespace TestFeedbackPsFir
 	// clang-format on
 
 	// FIR values.
-	uint32_t senderSsrc{ 0xfa17fa17 };
-	uint32_t mediaSsrc{ 0 };
-	uint32_t ssrc{ 0x02d03702 };
-	uint8_t seq{ 4 };
+	const uint32_t senderSsrc{ 0xfa17fa17 };
+	const uint32_t mediaSsrc{ 0 };
+	const uint32_t ssrc{ 0x02d03702 };
+	const uint8_t seq{ 4 };
 
-	void verify(FeedbackPsFirPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](FeedbackPsFirPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
 
-		FeedbackPsFirItem* item = *(packet->Begin());
+		const FeedbackPsFirItem* item = *(packet->Begin());
 
 		REQUIRE(item->GetSsrc() == ssrc);
 		REQUIRE(item->GetSequenceNumber() == seq);
-	}
-} // namespace TestFeedbackPsFir
-
-SCENARIO("RTCP Feedback PS FIR parsing", "[parser][rtcp][feedback-ps][fir]")
-{
-	using namespace TestFeedbackPsFir;
+	};
 
 	SECTION("parse FeedbackPsFirPacket")
 	{

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsLei.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsLei.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackPsLei
+SCENARIO("RTCP Feedback PS LEI parsing", "[parser][rtcp][feedback-ps][lei]")
 {
 	// RTCP LEI packet.
 
@@ -20,24 +20,20 @@ namespace TestFeedbackPsLei
 	// clang-format on
 
 	// LEI values.
-	uint32_t senderSsrc{ 0xfa17fa17 };
-	uint32_t mediaSsrc{ 0 };
-	uint32_t ssrc{ 0x02d03702 };
+	const uint32_t senderSsrc{ 0xfa17fa17 };
+	const uint32_t mediaSsrc{ 0 };
+	const uint32_t ssrc{ 0x02d03702 };
 
-	void verify(FeedbackPsLeiPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](FeedbackPsLeiPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
 
-		FeedbackPsLeiItem* item = *(packet->Begin());
+		const FeedbackPsLeiItem* item = *(packet->Begin());
 
 		REQUIRE(item->GetSsrc() == ssrc);
-	}
-} // namespace TestFeedbackPsLei
-
-SCENARIO("RTCP Feedback PS LEI parsing", "[parser][rtcp][feedback-ps][lei]")
-{
-	using namespace TestFeedbackPsLei;
+	};
 
 	SECTION("parse FeedbackPsLeiPacket")
 	{

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsPli.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsPli.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackPsPli
+SCENARIO("RTCP Feeback RTP PLI parsing", "[parser][rtcp][feedback-ps][pli]")
 {
 	// RTCP PLI packet.
 
@@ -19,19 +19,15 @@ namespace TestFeedbackPsPli
 	// clang-format on
 
 	// PLI values.
-	uint32_t senderSsrc{ 0x00000001 };
-	uint32_t mediaSsrc{ 0x0330bdee };
+	const uint32_t senderSsrc{ 0x00000001 };
+	const uint32_t mediaSsrc{ 0x0330bdee };
 
-	void verify(FeedbackPsPliPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](FeedbackPsPliPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
-	}
-} // namespace TestFeedbackPsPli
-
-SCENARIO("RTCP Feeback RTP PLI parsing", "[parser][rtcp][feedback-ps][pli]")
-{
-	using namespace TestFeedbackPsPli;
+	};
 
 	SECTION("parse FeedbackPsPliPacket")
 	{

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsRemb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsRemb.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackPsRemb
+SCENARIO("RTCP Feedback PS parsing", "[parser][rtcp][feedback-ps][remb]")
 {
 	// RTCP REMB packet.
 
@@ -23,23 +23,19 @@ namespace TestFeedbackPsRemb
 	// clang-format on
 
 	// REMB values.
-	uint32_t senderSsrc{ 0xfa17fa17 };
-	uint32_t mediaSsrc{ 0u };
-	uint64_t bitrate{ 122754u };
-	std::vector<uint32_t> ssrcs{ 0x02d03702, 0x04a76747 };
+	const uint32_t senderSsrc{ 0xfa17fa17 };
+	const uint32_t mediaSsrc{ 0u };
+	const uint64_t bitrate{ 122754u };
+	const std::vector<uint32_t> ssrcs{ 0x02d03702, 0x04a76747 };
 
-	void verify(FeedbackPsRembPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [&ssrcs](FeedbackPsRembPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
 		REQUIRE(packet->GetBitrate() == bitrate);
 		REQUIRE(packet->GetSsrcs() == ssrcs);
-	}
-} // namespace TestFeedbackPsRemb
-
-SCENARIO("RTCP Feedback PS parsing", "[parser][rtcp][feedback-ps][remb]")
-{
-	using namespace TestFeedbackPsRemb;
+	};
 
 	SECTION("parse FeedbackPsRembPacket")
 	{

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackPsRpsi
+SCENARIO("RTCP Feedback PS RPSI parsing", "[parser][rtcp][feedback-ps][rpsi]")
 {
 	// RTCP RPSI packet.
 
@@ -23,29 +23,25 @@ namespace TestFeedbackPsRpsi
 	// clang-format on
 
 	// RPSI values.
-	uint32_t senderSsrc{ 0xfa17fa17 };
-	uint32_t mediaSsrc{ 0 };
-	uint8_t payloadType{ 2 };
-	uint8_t payloadMask{ 1 };
-	size_t length{ 5 };
+	const uint32_t senderSsrc{ 0xfa17fa17 };
+	const uint32_t mediaSsrc{ 0 };
+	const uint8_t payloadType{ 2 };
+	const uint8_t payloadMask{ 1 };
+	const size_t length{ 5 };
 
-	void verify(FeedbackPsRpsiPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](FeedbackPsRpsiPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
 
-		FeedbackPsRpsiItem* item = *(packet->Begin());
+		const FeedbackPsRpsiItem* item = *(packet->Begin());
 
 		REQUIRE(item);
 		REQUIRE(item->GetPayloadType() == payloadType);
 		REQUIRE(item->GetLength() == length);
 		REQUIRE((item->GetBitString()[item->GetLength() - 1] & 1) == payloadMask);
-	}
-} // namespace TestFeedbackPsRpsi
-
-SCENARIO("RTCP Feedback PS RPSI parsing", "[parser][rtcp][feedback-ps][rpsi]")
-{
-	using namespace TestFeedbackPsRpsi;
+	};
 
 	SECTION("parse FeedbackPsRpsiPacket")
 	{

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsSli.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsSli.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackPsSli
+SCENARIO("RTCP Feedback PS SLI parsing", "[parser][rtcp][feedback-ps][sli]")
 {
 	// RTCP SLI packet.
 
@@ -20,29 +20,25 @@ namespace TestFeedbackPsSli
 	// clang-format on
 
 	// SLI values.
-	uint32_t senderSsrc{ 0xfa17fa17 };
-	uint32_t mediaSsrc{ 0 };
-	uint16_t first{ 1 };
-	uint16_t number{ 4 };
-	uint8_t pictureId{ 1 };
+	const uint32_t senderSsrc{ 0xfa17fa17 };
+	const uint32_t mediaSsrc{ 0 };
+	const uint16_t first{ 1 };
+	const uint16_t number{ 4 };
+	const uint8_t pictureId{ 1 };
 
-	void verify(FeedbackPsSliPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](FeedbackPsSliPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
 
-		FeedbackPsSliItem* item = *(packet->Begin());
+		const FeedbackPsSliItem* item = *(packet->Begin());
 
 		REQUIRE(item);
 		REQUIRE(item->GetFirst() == first);
 		REQUIRE(item->GetNumber() == number);
 		REQUIRE(item->GetPictureId() == pictureId);
-	}
-} // namespace TestFeedbackPsSli
-
-SCENARIO("RTCP Feedback PS SLI parsing", "[parser][rtcp][feedback-ps][sli]")
-{
-	using namespace TestFeedbackPsSli;
+	};
 
 	SECTION("parse FeedbackPsSliPacket")
 	{

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsTst.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsTst.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackPsTstn
+SCENARIO("RTCP Feedback PS TSTN parsing", "[parser][rtcp][feedback-ps][tstn]")
 {
 	// RTCP TSTN packet.
 
@@ -21,27 +21,24 @@ namespace TestFeedbackPsTstn
 	// clang-format on
 
 	// TSTN values.
-	uint32_t senderSsrc{ 0xfa17fa17 };
-	uint32_t mediaSsrc{ 0 };
-	uint32_t ssrc{ 0x02d03702 };
-	uint8_t seq{ 8 };
-	uint8_t index{ 1 };
+	const uint32_t senderSsrc{ 0xfa17fa17 };
+	const uint32_t mediaSsrc{ 0 };
+	const uint32_t ssrc{ 0x02d03702 };
+	const uint8_t seq{ 8 };
+	const uint8_t index{ 1 };
 
-	void verify(FeedbackPsTstnPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](FeedbackPsTstnPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
 
-		FeedbackPsTstnItem* item = *(packet->Begin());
+		const FeedbackPsTstnItem* item = *(packet->Begin());
 
+		REQUIRE(item);
 		REQUIRE(item->GetSsrc() == ssrc);
 		REQUIRE(item->GetSequenceNumber() == seq);
-	}
-} // namespace TestFeedbackPsTstn
-
-SCENARIO("RTCP Feedback PS TSTN parsing", "[parser][rtcp][feedback-ps][tstn]")
-{
-	using namespace TestFeedbackPsTstn;
+	};
 
 	SECTION("parse FeedbackPsTstPacket")
 	{
@@ -68,7 +65,7 @@ SCENARIO("RTCP Feedback PS TSTN parsing", "[parser][rtcp][feedback-ps][tstn]")
 	{
 		FeedbackPsTstnPacket packet(senderSsrc, mediaSsrc);
 
-		auto* item = new FeedbackPsTstnItem(ssrc, seq, TestFeedbackPsTstn::index);
+		auto* item = new FeedbackPsTstnItem(ssrc, seq, index);
 
 		packet.AddItem(item);
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackPsVbcm
+SCENARIO("RTCP Feedback PS VBCM parsing", "[parser][rtcp][feedback-ps][vbcm]")
 {
 	// RTCP VBCM packet.
 
@@ -25,20 +25,21 @@ namespace TestFeedbackPsVbcm
 	// clang-format on
 
 	// VBCM values.
-	uint32_t senderSsrc{ 0xfa17fa17 };
-	uint32_t mediaSsrc{ 0 };
-	uint32_t ssrc{ 0x02d03702 };
-	uint8_t seq{ 8 };
-	uint8_t payloadType{ 2 };
-	uint16_t length{ 1 };
-	uint8_t valueMask{ 1 };
+	const uint32_t senderSsrc{ 0xfa17fa17 };
+	const uint32_t mediaSsrc{ 0 };
+	const uint32_t ssrc{ 0x02d03702 };
+	const uint8_t seq{ 8 };
+	const uint8_t payloadType{ 2 };
+	const uint16_t length{ 1 };
+	const uint8_t valueMask{ 1 };
 
-	void verify(FeedbackPsVbcmPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](FeedbackPsVbcmPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
 
-		FeedbackPsVbcmItem* item = *(packet->Begin());
+		const FeedbackPsVbcmItem* item = *(packet->Begin());
 
 		REQUIRE(item);
 		REQUIRE(item->GetSsrc() == ssrc);
@@ -46,12 +47,7 @@ namespace TestFeedbackPsVbcm
 		REQUIRE(item->GetPayloadType() == payloadType);
 		REQUIRE(item->GetLength() == length);
 		REQUIRE((item->GetValue()[item->GetLength() - 1] & 1) == valueMask);
-	}
-} // namespace TestFeedbackPsVbcm
-
-SCENARIO("RTCP Feedback PS VBCM parsing", "[parser][rtcp][feedback-ps][vbcm]")
-{
-	using namespace TestFeedbackPsVbcm;
+	};
 
 	SECTION("parse FeedbackPsVbcmPacket")
 	{

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp
@@ -5,10 +5,8 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackRtpEcn
+SCENARIO("RTCP Feeback RTP ECN parsing", "[parser][rtcp][feedback-rtp][ecn]")
 {
-	// RTCP ECN packet.
-
 	// clang-format off
 	uint8_t buffer[] =
 	{
@@ -26,23 +24,24 @@ namespace TestFeedbackRtpEcn
 	// clang-format on
 
 	// ECN values.
-	uint32_t senderSsrc{ 0x00000001 };
-	uint32_t mediaSsrc{ 0x0330bdee };
-	uint32_t sequenceNumber{ 1 };
-	uint32_t ect0Counter{ 1 };
-	uint32_t ect1Counter{ 1 };
-	uint16_t ecnCeCounter{ 1 };
-	uint16_t notEctCounter{ 1 };
-	uint16_t lostPackets{ 1 };
-	uint16_t duplicatedPackets{ 1 };
+	const uint32_t senderSsrc{ 0x00000001 };
+	const uint32_t mediaSsrc{ 0x0330bdee };
+	const uint32_t sequenceNumber{ 1 };
+	const uint32_t ect0Counter{ 1 };
+	const uint32_t ect1Counter{ 1 };
+	const uint16_t ecnCeCounter{ 1 };
+	const uint16_t notEctCounter{ 1 };
+	const uint16_t lostPackets{ 1 };
+	const uint16_t duplicatedPackets{ 1 };
 
-	void verify(FeedbackRtpEcnPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](FeedbackRtpEcnPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
 
-		auto it   = packet->Begin();
-		auto item = *it;
+		auto it          = packet->Begin();
+		const auto* item = *it;
 
 		REQUIRE(item);
 		REQUIRE(item->GetSequenceNumber() == sequenceNumber);
@@ -52,15 +51,10 @@ namespace TestFeedbackRtpEcn
 		REQUIRE(item->GetNotEctCounter() == notEctCounter);
 		REQUIRE(item->GetLostPackets() == lostPackets);
 		REQUIRE(item->GetDuplicatedPackets() == duplicatedPackets);
-	}
-} // namespace TestFeedbackRtpEcn
+	};
 
-SCENARIO("RTCP Feeback RTP ECN parsing", "[parser][rtcp][feedback-rtp][ecn]")
-{
 	SECTION("parse FeedbackRtpEcnPacket")
 	{
-		using namespace TestFeedbackRtpEcn;
-
 		std::unique_ptr<FeedbackRtpEcnPacket> packet{ FeedbackRtpEcnPacket::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpNack.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpNack.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackRtpNack
+SCENARIO("RTCP Feeback RTP NACK parsing", "[parser][rtcp][feedback-rtp][nack]")
 {
 	// RTCP NACK packet.
 
@@ -20,28 +20,24 @@ namespace TestFeedbackRtpNack
 	// clang-format on
 
 	// NACK values.
-	uint32_t senderSsrc{ 0x00000001 };
-	uint32_t mediaSsrc{ 0x0330bdee };
-	uint16_t pid{ 2959 };
-	uint16_t lostPacketBitmask{ 0x0003 };
+	const uint32_t senderSsrc{ 0x00000001 };
+	const uint32_t mediaSsrc{ 0x0330bdee };
+	const uint16_t pid{ 2959 };
+	const uint16_t lostPacketBitmask{ 0x0003 };
 
-	void verify(FeedbackRtpNackPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](FeedbackRtpNackPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
 
-		auto it   = packet->Begin();
-		auto item = *it;
+		auto it          = packet->Begin();
+		const auto* item = *it;
 
 		REQUIRE(item->GetPacketId() == pid);
 		REQUIRE(item->GetLostPacketBitmask() == lostPacketBitmask);
 		REQUIRE(item->CountRequestedPackets() == 3);
-	}
-} // namespace TestFeedbackRtpNack
-
-SCENARIO("RTCP Feeback RTP NACK parsing", "[parser][rtcp][feedback-rtp][nack]")
-{
-	using namespace TestFeedbackRtpNack;
+	};
 
 	SECTION("parse FeedbackRtpNackItem")
 	{

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpSrReq.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpSrReq.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackRtpSrReq
+SCENARIO("RTCP Feeback RTP SR-REQ parsing", "[parser][rtcp][feedback-rtp][sr-req]")
 {
 	// RTCP SR-REQ packet.
 
@@ -19,19 +19,15 @@ namespace TestFeedbackRtpSrReq
 	// clang-format on
 
 	// SR-REQ values.
-	uint32_t senderSsrc{ 0x00000001 };
-	uint32_t mediaSsrc{ 0x0330bdee };
+	const uint32_t senderSsrc{ 0x00000001 };
+	const uint32_t mediaSsrc{ 0x0330bdee };
 
-	void verify(FeedbackRtpSrReqPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](FeedbackRtpSrReqPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
-	}
-} // namespace TestFeedbackRtpSrReq
-
-SCENARIO("RTCP Feeback RTP SR-REQ parsing", "[parser][rtcp][feedback-rtp][sr-req]")
-{
-	using namespace TestFeedbackRtpSrReq;
+	};
 
 	SECTION("parse FeedbackRtpSrReqPacket")
 	{

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackRtpTllei
+SCENARIO("RTCP Feeback RTP TLLEI parsing", "[parser][rtcp][feedback-rtp][tllei]")
 {
 	// RTCP TLLEI packet.
 
@@ -20,31 +20,27 @@ namespace TestFeedbackRtpTllei
 	// clang-format on
 
 	// TLLEI values.
-	uint32_t senderSsrc{ 0x00000001 };
-	uint32_t mediaSsrc{ 0x0330bdee };
-	uint16_t packetId{ 1 };
-	uint16_t lostPacketBitmask{ 0b1010101001010101 };
+	const uint32_t senderSsrc{ 0x00000001 };
+	const uint32_t mediaSsrc{ 0x0330bdee };
+	const uint16_t packetId{ 1 };
+	const uint16_t lostPacketBitmask{ 0b1010101001010101 };
 
-	void verify(FeedbackRtpTlleiPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](FeedbackRtpTlleiPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
 
-		auto it   = packet->Begin();
-		auto item = *it;
+		auto it          = packet->Begin();
+		const auto* item = *it;
 
 		REQUIRE(item);
 		REQUIRE(item->GetPacketId() == packetId);
 		REQUIRE(item->GetLostPacketBitmask() == lostPacketBitmask);
-	}
-} // namespace TestFeedbackRtpTllei
+	};
 
-SCENARIO("RTCP Feeback RTP TLLEI parsing", "[parser][rtcp][feedback-rtp][tllei]")
-{
 	SECTION("parse FeedbackRtpTlleiPacket")
 	{
-		using namespace TestFeedbackRtpTllei;
-
 		std::unique_ptr<FeedbackRtpTlleiPacket> packet{ FeedbackRtpTlleiPacket::Parse(
 			buffer, sizeof(buffer)) };
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestFeedbackRtpTmmbr
+SCENARIO("RTCP Feeback RTP TMMBR parsing", "[parser][rtcp][feedback-rtp][tmmb]")
 {
 	// RTCP TMMBR packet.
 
@@ -21,30 +21,26 @@ namespace TestFeedbackRtpTmmbr
 	// clang-format on
 
 	// TMMBR values.
-	uint32_t senderSsrc{ 0x00000001 };
-	uint32_t mediaSsrc{ 0x0330bdee };
-	uint32_t ssrc{ 0x02d03702 };
-	uint64_t bitrate{ 365504 };
-	uint16_t overhead{ 0 };
+	const uint32_t senderSsrc{ 0x00000001 };
+	const uint32_t mediaSsrc{ 0x0330bdee };
+	const uint32_t ssrc{ 0x02d03702 };
+	const uint64_t bitrate{ 365504 };
+	const uint16_t overhead{ 0 };
 
-	void verify(FeedbackRtpTmmbrPacket* packet)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](FeedbackRtpTmmbrPacket* packet)
 	{
 		REQUIRE(packet->GetSenderSsrc() == senderSsrc);
 		REQUIRE(packet->GetMediaSsrc() == mediaSsrc);
 
-		auto it   = packet->Begin();
-		auto item = *it;
+		auto it          = packet->Begin();
+		const auto* item = *it;
 
 		REQUIRE(item);
 		REQUIRE(item->GetSsrc() == ssrc);
 		REQUIRE(item->GetBitrate() == bitrate);
 		REQUIRE(item->GetOverhead() == overhead);
-	}
-} // namespace TestFeedbackRtpTmmbr
-
-SCENARIO("RTCP Feeback RTP TMMBR parsing", "[parser][rtcp][feedback-rtp][tmmb]")
-{
-	using namespace TestFeedbackRtpTmmbr;
+	};
 
 	SECTION("parse FeedbackRtpTmmbrPacket")
 	{
@@ -65,7 +61,7 @@ SCENARIO("RTCP Feeback RTP TMMBR parsing", "[parser][rtcp][feedback-rtp][tmmb]")
 			// represent the same content.
 			SECTION("create a packet out of the serialized buffer")
 			{
-				std::unique_ptr<FeedbackRtpTmmbrPacket> packet{ FeedbackRtpTmmbrPacket::Parse(
+				const std::unique_ptr<FeedbackRtpTmmbrPacket> packet{ FeedbackRtpTmmbrPacket::Parse(
 					buffer, sizeof(buffer)) };
 
 				verify(packet.get());

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
@@ -6,65 +6,68 @@
 
 using namespace RTC::RTCP;
 
-struct TestFeedbackRtpTransportInput
+namespace
 {
-	TestFeedbackRtpTransportInput(uint16_t sequenceNumber, uint64_t timestamp, size_t maxPacketSize)
-	  : sequenceNumber(sequenceNumber), timestamp(timestamp), maxPacketSize(maxPacketSize)
+	struct TestFeedbackRtpTransportInput
 	{
-	}
-
-	uint16_t sequenceNumber{ 0u };
-	uint64_t timestamp{ 0u };
-	size_t maxPacketSize{ 0u };
-};
-
-void validate(
-  const std::vector<struct TestFeedbackRtpTransportInput>& inputs,
-  std::vector<struct FeedbackRtpTransportPacket::PacketResult> packetResults)
-{
-	auto inputsIterator        = inputs.begin();
-	auto packetResultsIterator = packetResults.begin();
-	auto lastInput             = *inputsIterator;
-
-	for (++inputsIterator; inputsIterator != inputs.end(); ++inputsIterator, ++packetResultsIterator)
-	{
-		auto& input             = *inputsIterator;
-		auto& packetResult      = *packetResultsIterator;
-		uint16_t missingPackets = input.sequenceNumber - lastInput.sequenceNumber - 1;
-
-		if (missingPackets > 0)
+		TestFeedbackRtpTransportInput(uint16_t sequenceNumber, uint64_t timestamp, size_t maxPacketSize)
+		  : sequenceNumber(sequenceNumber), timestamp(timestamp), maxPacketSize(maxPacketSize)
 		{
-			// All missing packets must be represented in packetResults.
-			for (uint16_t i{ 0u }; i < missingPackets; ++i)
-			{
-				packetResult = *packetResultsIterator;
-
-				REQUIRE(packetResult.sequenceNumber == lastInput.sequenceNumber + i + 1);
-				REQUIRE(packetResult.received == false);
-
-				packetResultsIterator++;
-			}
-		}
-		else
-		{
-			REQUIRE(packetResult.sequenceNumber == lastInput.sequenceNumber + 1);
-			REQUIRE(packetResult.sequenceNumber == input.sequenceNumber);
-			REQUIRE(packetResult.received == true);
-			REQUIRE(
-			  static_cast<int32_t>(packetResult.receivedAtMs & 0x1FFFFFC0) / 64 ==
-			  static_cast<int32_t>(input.timestamp & 0x1FFFFFC0) / 64);
 		}
 
-		lastInput = input;
-	}
-}
+		uint16_t sequenceNumber{ 0u };
+		uint64_t timestamp{ 0u };
+		size_t maxPacketSize{ 0u };
+	};
+} // namespace
 
 SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]")
 {
 	static constexpr size_t RtcpMtu{ 1200u };
 
-	uint32_t senderSsrc{ 1111u };
-	uint32_t mediaSsrc{ 2222u };
+	const uint32_t senderSsrc{ 1111u };
+	const uint32_t mediaSsrc{ 2222u };
+
+	auto verify = [](
+	                const std::vector<struct TestFeedbackRtpTransportInput>& inputs,
+	                std::vector<struct FeedbackRtpTransportPacket::PacketResult> packetResults)
+	{
+		auto inputsIterator        = inputs.begin();
+		auto packetResultsIterator = packetResults.begin();
+		auto lastInput             = *inputsIterator;
+
+		for (++inputsIterator; inputsIterator != inputs.end(); ++inputsIterator, ++packetResultsIterator)
+		{
+			const auto& input             = *inputsIterator;
+			auto& packetResult            = *packetResultsIterator;
+			const uint16_t missingPackets = input.sequenceNumber - lastInput.sequenceNumber - 1;
+
+			if (missingPackets > 0)
+			{
+				// All missing packets must be represented in packetResults.
+				for (uint16_t i{ 0u }; i < missingPackets; ++i)
+				{
+					packetResult = *packetResultsIterator;
+
+					REQUIRE(packetResult.sequenceNumber == lastInput.sequenceNumber + i + 1);
+					REQUIRE(packetResult.received == false);
+
+					packetResultsIterator++;
+				}
+			}
+			else
+			{
+				REQUIRE(packetResult.sequenceNumber == lastInput.sequenceNumber + 1);
+				REQUIRE(packetResult.sequenceNumber == input.sequenceNumber);
+				REQUIRE(packetResult.received == true);
+				REQUIRE(
+				  static_cast<int32_t>(packetResult.receivedAtMs & 0x1FFFFFC0) / 64 ==
+				  static_cast<int32_t>(input.timestamp & 0x1FFFFFC0) / 64);
+			}
+
+			lastInput = input;
+		}
+	};
 
 	SECTION(
 	  "create FeedbackRtpTransportPacket, small delta run length chunk and single large delta status packet")
@@ -125,7 +128,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		REQUIRE(packet->GetLatestTimestamp() == 1000000015);
 
 		packet->Finish();
-		validate(inputs, packet->GetPacketResults());
+		verify(inputs, packet->GetPacketResults());
 
 		REQUIRE(packet->GetBaseSequenceNumber() == 1000);
 		REQUIRE(packet->GetPacketStatusCount() == 16);
@@ -188,7 +191,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		}
 
 		packet->Finish();
-		validate(inputs, packet->GetPacketResults());
+		verify(inputs, packet->GetPacketResults());
 
 		REQUIRE(packet->GetBaseSequenceNumber() == 1000);
 		REQUIRE(packet->GetPacketStatusCount() == 51);
@@ -257,7 +260,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		}
 
 		packet->Finish();
-		validate(inputs, packet->GetPacketResults());
+		verify(inputs, packet->GetPacketResults());
 
 		REQUIRE(packet->GetBaseSequenceNumber() == 1000);
 		REQUIRE(packet->GetPacketStatusCount() == 18);
@@ -319,7 +322,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		}
 
 		packet->Finish();
-		validate(inputs, packet->GetPacketResults());
+		verify(inputs, packet->GetPacketResults());
 
 		REQUIRE(packet->GetBaseSequenceNumber() == 1000);
 		REQUIRE(packet->GetPacketStatusCount() == 2);
@@ -390,7 +393,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		}
 
 		packet->Finish();
-		validate(inputs, packet->GetPacketResults());
+		verify(inputs, packet->GetPacketResults());
 
 		REQUIRE(packet->GetBaseSequenceNumber() == 1000);
 		REQUIRE(packet->GetPacketStatusCount() == 8);
@@ -457,7 +460,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		}
 
 		packet2->Finish();
-		validate(inputs2, packet2->GetPacketResults());
+		verify(inputs2, packet2->GetPacketResults());
 
 		REQUIRE(packet2->GetBaseSequenceNumber() == 1008);
 		REQUIRE(packet2->GetPacketStatusCount() == 7);
@@ -517,7 +520,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		REQUIRE(
 		  packet->GetReferenceTimestamp() ==
 		  FeedbackRtpTransportPacket::TimeWrapPeriod +
-		    static_cast<int64_t>(6275825) * FeedbackRtpTransportPacket::BaseTimeTick);
+		    (static_cast<int64_t>(6275825) * FeedbackRtpTransportPacket::BaseTimeTick));
 		REQUIRE(packet->GetFeedbackPacketCount() == 3);
 
 		SECTION("serialize packet")
@@ -554,7 +557,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		REQUIRE(
 		  packet->GetReferenceTimestamp() ==
 		  FeedbackRtpTransportPacket::TimeWrapPeriod +
-		    static_cast<int64_t>(-2) * FeedbackRtpTransportPacket::BaseTimeTick);
+		    (static_cast<int64_t>(-2) * FeedbackRtpTransportPacket::BaseTimeTick));
 		REQUIRE(packet->GetFeedbackPacketCount() == 1);
 
 		SECTION("serialize packet")
@@ -592,7 +595,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		REQUIRE(
 		  packet->GetReferenceTimestamp() ==
 		  FeedbackRtpTransportPacket::TimeWrapPeriod +
-		    static_cast<int64_t>(-4368470) * FeedbackRtpTransportPacket::BaseTimeTick);
+		    (static_cast<int64_t>(-4368470) * FeedbackRtpTransportPacket::BaseTimeTick));
 
 		REQUIRE(packet->GetFeedbackPacketCount() == 0);
 
@@ -620,7 +623,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 
 		// Metadata collected by parsing buffers with libwebrtc, buffers itself.
 		// were generated by chrome in direction of mediasoup.
-		std::vector<FeedbackPacketsMeta> feedbackPacketsMeta = {
+		const std::vector<FeedbackPacketsMeta> feedbackPacketsMeta = {
 			{ .baseTimeRaw       = 35504,
 			  .baseTimeMs        = 1076014080,
 			  .baseSequence      = 13,
@@ -770,8 +773,9 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 
 	SECTION("Check GetBaseDelta Wraparound")
 	{
-		auto MaxBaseTime =
+		static const auto MaxBaseTime =
 		  FeedbackRtpTransportPacket::TimeWrapPeriod - FeedbackRtpTransportPacket::BaseTimeTick;
+
 		auto packet1 = std::make_unique<FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
 		auto packet2 = std::make_unique<FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
 		auto packet3 = std::make_unique<FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);

--- a/worker/test/src/RTC/RTCP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTCP/TestPacket.cpp
@@ -18,7 +18,7 @@ SCENARIO("RTCP parsing", "[parser][rtcp][packet]")
 
 	SECTION("a RTCP packet may only contain the RTCP common header")
 	{
-		std::unique_ptr<Packet> packet{ Packet::Parse(buffer, sizeof(buffer)) };
+		const std::unique_ptr<Packet> packet{ Packet::Parse(buffer, sizeof(buffer)) };
 
 		REQUIRE(packet);
 	}
@@ -26,11 +26,11 @@ SCENARIO("RTCP parsing", "[parser][rtcp][packet]")
 	SECTION("a too small RTCP packet should fail")
 	{
 		// Provide a wrong packet length.
-		size_t length = sizeof(buffer) - 1;
+		const size_t length = sizeof(buffer) - 1;
 
-		std::unique_ptr<Packet> packet{ Packet::Parse(buffer, length) };
+		const std::unique_ptr<Packet> packet{ Packet::Parse(buffer, length) };
 
-		REQUIRE_FALSE(packet);
+		REQUIRE(!packet);
 	}
 
 	SECTION("a RTCP packet with incorrect version should fail")
@@ -38,9 +38,9 @@ SCENARIO("RTCP parsing", "[parser][rtcp][packet]")
 		// Set an incorrect version value (0).
 		buffer[0] &= 0b00111111;
 
-		std::unique_ptr<Packet> packet{ Packet::Parse(buffer, sizeof(buffer)) };
+		const std::unique_ptr<Packet> packet{ Packet::Parse(buffer, sizeof(buffer)) };
 
-		REQUIRE_FALSE(packet);
+		REQUIRE(!packet);
 	}
 
 	SECTION("a RTCP packet with incorrect length should fail")
@@ -48,9 +48,9 @@ SCENARIO("RTCP parsing", "[parser][rtcp][packet]")
 		// Set the packet length to zero.
 		buffer[3] = 1;
 
-		std::unique_ptr<Packet> packet{ Packet::Parse(buffer, sizeof(buffer)) };
+		const std::unique_ptr<Packet> packet{ Packet::Parse(buffer, sizeof(buffer)) };
 
-		REQUIRE_FALSE(packet);
+		REQUIRE(!packet);
 	}
 
 	SECTION("a RTCP packet with unknown type should fail")
@@ -58,8 +58,8 @@ SCENARIO("RTCP parsing", "[parser][rtcp][packet]")
 		// Set and unknown packet type (0).
 		buffer[1] = 0;
 
-		std::unique_ptr<Packet> packet{ Packet::Parse(buffer, sizeof(buffer)) };
+		const std::unique_ptr<Packet> packet{ Packet::Parse(buffer, sizeof(buffer)) };
 
-		REQUIRE_FALSE(packet);
+		REQUIRE(!packet);
 	}
 }

--- a/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestReceiverReport
+SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
 {
 	// RTCP Receiver Report Packet.
 
@@ -25,17 +25,18 @@ namespace TestReceiverReport
 	// clang-format on
 
 	// Receiver Report buffer start point.
-	uint8_t* rrBuffer = buffer + Packet::CommonHeaderSize + sizeof(uint32_t) /*Sender SSRC*/;
+	const uint8_t* rrBuffer = buffer + Packet::CommonHeaderSize + sizeof(uint32_t); // Sender SSRC.
 
-	uint32_t ssrc{ 0x01932db4 };
-	uint8_t fractionLost{ 0 };
-	int32_t totalLost{ -1 };
-	uint32_t lastSeq{ 0 };
-	uint32_t jitter{ 0 };
-	uint32_t lastSenderReport{ 0 };
-	uint32_t delaySinceLastSenderReport{ 5 };
+	const uint32_t ssrc{ 0x01932db4 };
+	const uint8_t fractionLost{ 0 };
+	const int32_t totalLost{ -1 };
+	const uint32_t lastSeq{ 0 };
+	const uint32_t jitter{ 0 };
+	const uint32_t lastSenderReport{ 0 };
+	const uint32_t delaySinceLastSenderReport{ 5 };
 
-	void verify(ReceiverReport* report)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](ReceiverReport* report)
 	{
 		REQUIRE(report->GetSsrc() == ssrc);
 		REQUIRE(report->GetFractionLost() == fractionLost);
@@ -44,13 +45,8 @@ namespace TestReceiverReport
 		REQUIRE(report->GetJitter() == jitter);
 		REQUIRE(report->GetLastSenderReport() == lastSenderReport);
 		REQUIRE(report->GetDelaySinceLastSenderReport() == delaySinceLastSenderReport);
-	}
-} // namespace TestReceiverReport
+	};
 
-using namespace TestReceiverReport;
-
-SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
-{
 	SECTION("parse RR packet with a single report")
 	{
 		std::unique_ptr<ReceiverReportPacket> packet{ ReceiverReportPacket::Parse(buffer, sizeof(buffer)) };
@@ -108,7 +104,7 @@ SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
 		for (size_t i = 1; i <= count; i++)
 		{
 			// Create report and add to packet.
-			ReceiverReport* report = new ReceiverReport();
+			auto* report = new ReceiverReport();
 
 			report->SetSsrc(i);
 			report->SetFractionLost(i);
@@ -149,7 +145,7 @@ SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
 			REQUIRE(report->GetDelaySinceLastSenderReport() == i);
 		}
 
-		ReceiverReportPacket* packet3 = static_cast<ReceiverReportPacket*>(packet2->GetNext());
+		auto* packet3 = static_cast<ReceiverReportPacket*>(packet2->GetNext());
 
 		REQUIRE(packet3 != nullptr);
 		REQUIRE(packet3->GetCount() == 2);

--- a/worker/test/src/RTC/RTCP/TestSdes.cpp
+++ b/worker/test/src/RTC/RTCP/TestSdes.cpp
@@ -7,7 +7,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestSdes
+SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 {
 	// RTCP Sdes Packet.
 
@@ -26,11 +26,11 @@ namespace TestSdes
 	// clang-format on
 
 	// First chunk (chunk 1).
-	uint32_t ssrc1{ 0x9f65e742 };
+	const uint32_t ssrc1{ 0x9f65e742 };
 	// First item (item 1).
-	SdesItem::Type item1Type{ SdesItem::Type::CNAME };
-	std::string item1Value{ "t7mkYnCm46OcINy/" };
-	size_t item1Length{ 16u };
+	const SdesItem::Type item1Type{ SdesItem::Type::CNAME };
+	const std::string item1Value{ "t7mkYnCm46OcINy/" };
+	const size_t item1Length{ 16u };
 
 	// clang-format off
 	uint8_t buffer2[] =
@@ -55,22 +55,22 @@ namespace TestSdes
 	// clang-format on
 
 	// First chunk (chunk 2).
-	uint32_t ssrc2{ 1234 };
+	const uint32_t ssrc2{ 1234 };
 	// First item (item 2).
-	SdesItem::Type item2Type{ SdesItem::Type::CNAME };
-	std::string item2Value{ "qwerty" };
-	size_t item2Length{ 6u };
+	const SdesItem::Type item2Type{ SdesItem::Type::CNAME };
+	const std::string item2Value{ "qwerty" };
+	const size_t item2Length{ 6u };
 	// First item (item 3).
-	SdesItem::Type item3Type{ SdesItem::Type::TOOL };
-	std::string item3Value{ "iñaki" };
-	size_t item3Length{ 6u };
+	const SdesItem::Type item3Type{ SdesItem::Type::TOOL };
+	const std::string item3Value{ "iñaki" };
+	const size_t item3Length{ 6u };
 
 	// Second chunk (chunk 3).
-	uint32_t ssrc3{ 5678 };
+	const uint32_t ssrc3{ 5678 };
 	// First item (item 4).
-	SdesItem::Type item4Type{ SdesItem::Type::LOC };
-	std::string item4Value{ "somewhere œæ€" };
-	size_t item4Length{ 17u };
+	const SdesItem::Type item4Type{ SdesItem::Type::LOC };
+	const std::string item4Value{ "somewhere œæ€" };
+	const size_t item4Length{ 17u };
 
 	// clang-format off
 	uint8_t buffer3[] =
@@ -84,17 +84,12 @@ namespace TestSdes
 	// clang-format on
 
 	// First chunk (chunk 4).
-	uint32_t ssrc4{ 0x11223344 };
+	const uint32_t ssrc4{ 0x11223344 };
 	// First item (item 5).
-	SdesItem::Type item5Type{ SdesItem::Type::LOC };
-	std::string item5Value{ "ab" };
-	size_t item5Length{ 2u };
-} // namespace TestSdes
+	const SdesItem::Type item5Type{ SdesItem::Type::LOC };
+	const std::string item5Value{ "ab" };
+	const size_t item5Length{ 2u };
 
-using namespace TestSdes;
-
-SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
-{
 	SECTION("parse packet 1")
 	{
 		std::unique_ptr<SdesPacket> packet{ SdesPacket::Parse(buffer1, sizeof(buffer1)) };
@@ -111,6 +106,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 		{
 			auto* chunk = *it;
 
+			// NOLINTNEXTLINE(hicpp-multiway-paths-covered)
 			switch (chunkIdx)
 			{
 				/* First chunk (chunk 1). */
@@ -126,6 +122,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 					{
 						auto* item = *it2;
 
+						// NOLINTNEXTLINE(hicpp-multiway-paths-covered)
 						switch (itemIdx)
 						{
 							/* First item (item 1). */
@@ -137,6 +134,8 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 								break;
 							}
+
+							default:;
 						}
 					}
 
@@ -145,6 +144,8 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 					break;
 				}
+
+				default:;
 			}
 		}
 
@@ -153,9 +154,9 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 		SECTION("serialize SdesChunk instance")
 		{
-			auto it               = packet->Begin();
-			auto* chunk1          = *it;
-			uint8_t* chunk1Buffer = buffer1 + Packet::CommonHeaderSize;
+			auto it                     = packet->Begin();
+			auto* chunk1                = *it;
+			const uint8_t* chunk1Buffer = buffer1 + Packet::CommonHeaderSize;
 
 			// NOTE: Length of first chunk (including null octets) is 24.
 			uint8_t serialized1[24] = { 0 };
@@ -220,6 +221,8 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 								break;
 							}
+
+							default:;
 						}
 					}
 
@@ -242,6 +245,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 					{
 						auto* item = *it2;
 
+						// NOLINTNEXTLINE(hicpp-multiway-paths-covered)
 						switch (itemIdx)
 						{
 							/* First item (item 4). */
@@ -253,6 +257,8 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 								break;
 							}
+
+							default:;
 						}
 					}
 
@@ -261,6 +267,8 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 					break;
 				}
+
+				default:;
 			}
 		}
 
@@ -269,9 +277,9 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 		SECTION("serialize SdesChunk instances")
 		{
-			auto it               = packet->Begin();
-			auto* chunk1          = *it;
-			uint8_t* chunk1Buffer = buffer2 + Packet::CommonHeaderSize;
+			auto it                     = packet->Begin();
+			auto* chunk1                = *it;
+			const uint8_t* chunk1Buffer = buffer2 + Packet::CommonHeaderSize;
 
 			// NOTE: Length of first chunk (including null octets) is 24.
 			uint8_t serialized1[24] = { 0 };
@@ -280,8 +288,8 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 			REQUIRE(std::memcmp(chunk1Buffer, serialized1, 24) == 0);
 
-			auto* chunk2          = *(++it);
-			uint8_t* chunk2Buffer = buffer2 + Packet::CommonHeaderSize + 24;
+			auto* chunk2                = *(++it);
+			const uint8_t* chunk2Buffer = buffer2 + Packet::CommonHeaderSize + 24;
 
 			// NOTE: Length of second chunk (including null octets) is 24.
 			uint8_t serialized2[24] = { 0 };
@@ -308,6 +316,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 		{
 			auto* chunk = *it;
 
+			// NOLINTNEXTLINE(hicpp-multiway-paths-covered)
 			switch (chunkIdx)
 			{
 				/* First chunk (chunk 4). */
@@ -322,6 +331,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 					{
 						auto* item = *it2;
 
+						// NOLINTNEXTLINE(hicpp-multiway-paths-covered)
 						switch (itemIdx)
 						{
 							/* First item (item 5). */
@@ -333,6 +343,8 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 								break;
 							}
+
+							default:;
 						}
 					}
 
@@ -341,6 +353,8 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 					break;
 				}
+
+				default:;
 			}
 		}
 
@@ -349,9 +363,9 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 		SECTION("serialize SdesChunk instance")
 		{
-			auto it               = packet->Begin();
-			auto* chunk1          = *it;
-			uint8_t* chunk1Buffer = buffer3 + Packet::CommonHeaderSize;
+			auto it                     = packet->Begin();
+			auto* chunk1                = *it;
+			const uint8_t* chunk1Buffer = buffer3 + Packet::CommonHeaderSize;
 
 			// NOTE: Length of first chunk (including null octets) is 12.
 			uint8_t serialized1[12] = { 0 };
@@ -373,7 +387,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 			0x08, 0x02, 0x61, 0x62  // Item Type: 8 (PRIV), Length: 2, Text: "ab"
 		};
 
-		SdesPacket* packet = SdesPacket::Parse(buffer, sizeof(buffer));
+		const auto* packet = SdesPacket::Parse(buffer, sizeof(buffer));
 
 		REQUIRE(!packet);
 	}
@@ -395,7 +409,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 		for (size_t i{ 1 }; i <= count; ++i)
 		{
 			// Create chunk and add to packet.
-			SdesChunk* chunk = new SdesChunk(i /*ssrc*/);
+			auto* chunk = new SdesChunk(i /*ssrc*/);
 
 			auto* item1 =
 			  new RTC::RTCP::SdesItem(SdesItem::Type::CNAME, item1Value.size(), item1Value.c_str());
@@ -458,7 +472,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 		for (size_t i{ 1 }; i <= count; ++i)
 		{
 			// Create chunk and add to packet.
-			SdesChunk* chunk = new SdesChunk(i /*ssrc*/);
+			auto* chunk = new SdesChunk(i /*ssrc*/);
 
 			auto* item1 =
 			  new RTC::RTCP::SdesItem(SdesItem::Type::CNAME, item1Value.size(), item1Value.c_str());
@@ -497,7 +511,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 			REQUIRE(std::string(item->GetValue()) == item1Value);
 		}
 
-		SdesPacket* packet3 = static_cast<SdesPacket*>(packet2->GetNext());
+		auto* packet3 = static_cast<SdesPacket*>(packet2->GetNext());
 
 		REQUIRE(packet3 != nullptr);
 		REQUIRE(packet3->GetCount() == count - 31);
@@ -532,7 +546,7 @@ SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
 
 		REQUIRE(chunk.GetSsrc() == ssrc1);
 
-		SdesItem* item1 = *(chunk.Begin());
+		const SdesItem* item1 = *(chunk.Begin());
 
 		REQUIRE(item1->GetType() == item1Type);
 		REQUIRE(item1->GetLength() == item1Length);

--- a/worker/test/src/RTC/RTCP/TestSenderReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestSenderReport.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-namespace TestSenderReport
+SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 {
 	// RTCP Packet. Sender Report and Receiver Report.
 
@@ -23,17 +23,18 @@ namespace TestSenderReport
 	// clang-format on
 
 	// Sender Report buffer start point.
-	uint8_t* srBuffer = buffer + Packet::CommonHeaderSize;
+	const uint8_t* srBuffer = buffer + Packet::CommonHeaderSize;
 
 	// SR values.
-	uint32_t ssrc{ 0x5d931534 };
-	uint32_t ntpSec{ 3711615412 };
-	uint32_t ntpFrac{ 1985245553 };
-	uint32_t rtpTs{ 577280 };
-	uint32_t packetCount{ 3608 };
-	uint32_t octetCount{ 577280 };
+	const uint32_t ssrc{ 0x5d931534 };
+	const uint32_t ntpSec{ 3711615412 };
+	const uint32_t ntpFrac{ 1985245553 };
+	const uint32_t rtpTs{ 577280 };
+	const uint32_t packetCount{ 3608 };
+	const uint32_t octetCount{ 577280 };
 
-	void verify(SenderReport* report)
+	// NOTE: No need to pass const integers to the lambda.
+	auto verify = [](SenderReport* report)
 	{
 		REQUIRE(report->GetSsrc() == ssrc);
 		REQUIRE(report->GetNtpSec() == ntpSec);
@@ -41,13 +42,8 @@ namespace TestSenderReport
 		REQUIRE(report->GetRtpTs() == rtpTs);
 		REQUIRE(report->GetPacketCount() == packetCount);
 		REQUIRE(report->GetOctetCount() == octetCount);
-	}
-} // namespace TestSenderReport
+	};
 
-using namespace TestSenderReport;
-
-SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
-{
 	SECTION("parse SR packet")
 	{
 		std::unique_ptr<SenderReportPacket> packet{ SenderReportPacket::Parse(buffer, sizeof(buffer)) };
@@ -99,7 +95,7 @@ SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 		for (size_t i = 1; i <= count; ++i)
 		{
 			// Create report and add to packet.
-			SenderReport* report = new SenderReport();
+			auto* report = new SenderReport();
 
 			report->SetSsrc(i);
 			report->SetNtpSec(i);
@@ -116,7 +112,10 @@ SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 		// Serialization must contain 3 SR packets.
 		packet.Serialize(buffer);
 
-		SenderReport* reports[count]{ nullptr };
+		// NOTE: clang-tidy says that this could be `const SenderReport* const reports`
+		// but that's absolutely wrong!
+		// NOLINTNEXTLINE(misc-const-correctness)
+		const SenderReport* reports[count]{ nullptr };
 
 		std::unique_ptr<SenderReportPacket> packet2{ static_cast<SenderReportPacket*>(
 			Packet::Parse(buffer, sizeof(buffer))) };
@@ -139,10 +138,9 @@ SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
 
 		for (size_t i = 1; i <= count; ++i)
 		{
-			auto* report = reports[i - 1];
+			const auto* report = reports[i - 1];
 
 			REQUIRE(report != nullptr);
-
 			REQUIRE(report->GetSsrc() == i);
 			REQUIRE(report->GetNtpSec() == i);
 			REQUIRE(report->GetNtpFrac() == i);

--- a/worker/test/src/RTC/RTCP/TestXr.cpp
+++ b/worker/test/src/RTC/RTCP/TestXr.cpp
@@ -44,6 +44,7 @@ SCENARIO("RTCP XR parsing", "[parser][rtcp][xr]")
 		{
 			auto* block = *it;
 
+			// NOLINTNEXTLINE(hicpp-multiway-paths-covered)
 			switch (blockIdx)
 			{
 				case 0:
@@ -76,6 +77,8 @@ SCENARIO("RTCP XR parsing", "[parser][rtcp][xr]")
 
 								break;
 							}
+
+							default:;
 						}
 					}
 
@@ -84,6 +87,8 @@ SCENARIO("RTCP XR parsing", "[parser][rtcp][xr]")
 
 					break;
 				}
+
+				default:;
 			}
 		}
 
@@ -149,7 +154,8 @@ SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
 		// Create a new report out of the external buffer.
 		// NOTE: We cannot use unique_ptr here since the instance lifecycle will be
 		// managed by the packet.
-		auto report2 = ReceiverReferenceTime::Parse(bufferReport1, report1->GetSize());
+		// NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
+		auto* report2 = ReceiverReferenceTime::Parse(bufferReport1, report1->GetSize());
 
 		REQUIRE(report1->GetType() == report2->GetType());
 		REQUIRE(report1->GetNtpSec() == report2->GetNtpSec());
@@ -222,7 +228,8 @@ SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
 		// Create a new report out of the external buffer.
 		// NOTE: We cannot use unique_ptr here since the instance lifecycle will be
 		// managed by the packet.
-		auto report2 = DelaySinceLastRr::Parse(bufferReport1, report1->GetSize());
+		// NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
+		auto* report2 = DelaySinceLastRr::Parse(bufferReport1, report1->GetSize());
 
 		REQUIRE(report1->GetType() == report2->GetType());
 


### PR DESCRIPTION
# Details

- Redo all `worker/test/src/RTC/RTCP/*.cpp` tests by removing those custom `namespaces`. Move local variables to `SCENARIO`, etc.
- So basically `MEDIASOUP_TIDY_FILES="test/src/RTC/RTCP/*.cpp" make tidy` produces zero errors/warnings.
- Also update `mediasoup-worker-clang-tidy.yaml` to include test and fuzzer. And remove .hpp from `include` since header files must not be given to clang-tidy command.