### PR TITLE
clang-tidy for RTP tests

### DIFF
--- a/worker/.clang-tidy
+++ b/worker/.clang-tidy
@@ -58,6 +58,7 @@ Checks: "*,\
   -llvm-include-order,\
   -llvm-header-guard,\
   -llvm-else-after-return,\
+  -llvm-prefer-static-over-anonymous-namespace,\
   -llvmlibc-*,\
   -misc-confusable-identifiers,\
   -misc-include-cleaner,\

--- a/worker/scripts/clang-scripts.mjs
+++ b/worker/scripts/clang-scripts.mjs
@@ -21,7 +21,8 @@ const CLANG_FORMAT_PATHS = [
 const CLANG_TIDY_PATHS = [
 	'../src/**/*.cpp',
 	// TODO: Temporal until all tests are included.
-	'../test/src/RTC/RTCP/*.cpp',
+	'../test/src/RTC/RTP/**/*.cpp',
+	'../test/src/RTC/RTCP/**/*.cpp',
 	// TODO: Enable test/ and fuzzer/ source files.
 	// '../test/src/**/*.cpp',
 	// '../fuzzer/src/**/*.cpp',

--- a/worker/test/include/RTC/RTP/rtpCommon.hpp
+++ b/worker/test/include/RTC/RTP/rtpCommon.hpp
@@ -11,22 +11,19 @@
 
 using namespace RTC::RTP;
 
-namespace RTC
+namespace RTP_COMMON
 {
-	namespace RTP
-	{
-		// NOTE: We need to declare them here with `extern` and then define them in
-		// rtpCommon.cpp.
-		// NOTE: Random size buffers because anyway we use sizeof(XxxxBuffer).
-		extern thread_local uint8_t FactoryBuffer[66661];
-		extern thread_local uint8_t SerializeBuffer[66662];
-		extern thread_local uint8_t CloneBuffer[66663];
-		extern thread_local uint8_t DataBuffer[66664];
-		extern thread_local uint8_t ThrowBuffer[66665];
+	// NOTE: We need to declare them here with `extern` and then define them in
+	// rtpCommon.cpp.
+	// NOTE: Random size buffers because anyway we use sizeof(XxxxBuffer).
+	extern thread_local uint8_t FactoryBuffer[66661];
+	extern thread_local uint8_t SerializeBuffer[66662];
+	extern thread_local uint8_t CloneBuffer[66663];
+	extern thread_local uint8_t DataBuffer[66664];
+	extern thread_local uint8_t ThrowBuffer[66665];
 
-		void ResetBuffers();
-	} // namespace RTP
-} // namespace RTC
+	void ResetBuffers();
+} // namespace RTP_COMMON
 
 // NOLINTNEXTLINE (cppcoreguidelines-macro-usage)
 #define CHECK_RTP_PACKET(/*const Packet**/ packet,                                                   \

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
@@ -6,7 +6,7 @@
 
 using namespace RTC::RTCP;
 
-namespace
+SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]")
 {
 	struct TestFeedbackRtpTransportInput
 	{
@@ -19,10 +19,7 @@ namespace
 		uint64_t timestamp{ 0u };
 		size_t maxPacketSize{ 0u };
 	};
-} // namespace
 
-SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]")
-{
 	static constexpr size_t RtcpMtu{ 1200u };
 
 	const uint32_t senderSsrc{ 1111u };
@@ -771,7 +768,7 @@ SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]"
 		}
 	}
 
-	SECTION("Check GetBaseDelta Wraparound")
+	SECTION("check GetBaseDelta() wraparound")
 	{
 		static const auto MaxBaseTime =
 		  FeedbackRtpTransportPacket::TimeWrapPeriod - FeedbackRtpTransportPacket::BaseTimeTick;

--- a/worker/test/src/RTC/RTP/Codecs/TestDependencyDescriptor.cpp
+++ b/worker/test/src/RTC/RTP/Codecs/TestDependencyDescriptor.cpp
@@ -4,16 +4,16 @@
 
 using namespace RTC;
 
-class Listener : public ::RTC::RTP::Codecs::DependencyDescriptor::Listener
-{
-public:
-	void OnDependencyDescriptorUpdated(const uint8_t* data, size_t len) override
-	{
-	}
-};
-
 SCENARIO("parse Dependency Descriptor", "[rtp][codecs][DD]")
 {
+	class Listener : public ::RTC::RTP::Codecs::DependencyDescriptor::Listener
+	{
+	public:
+		void OnDependencyDescriptorUpdated(const uint8_t* data, size_t len) override
+		{
+		}
+	};
+
 	SECTION("parse Dependency Descriptor")
 	{
 		/**

--- a/worker/test/src/RTC/RTP/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/RTP/Codecs/TestVP8.cpp
@@ -6,8 +6,69 @@
 #include <cstring> // std::memcmp(), std::memcpy()
 
 using namespace RTC;
+using namespace RTP_COMMON;
 
-constexpr uint16_t MaxPictureId = (1 << 15) - 1;
+namespace
+{
+	RTP::Codecs::VP8::PayloadDescriptor* createVP8PayloadDescriptor(
+	  uint8_t* buffer,
+	  size_t bufferLen,
+	  uint16_t pictureId,
+	  uint8_t tl0PictureIndex,
+	  uint8_t tlIndex,
+	  bool layerSync = true)
+	{
+		uint16_t netPictureId = htons(pictureId);
+		std::memcpy(buffer + 2, &netPictureId, 2);
+		buffer[2] |= 0x80;
+		buffer[4] = tl0PictureIndex;
+		buffer[5] = tlIndex << 6;
+
+		if (layerSync)
+		{
+			buffer[5] |= 0x20; // y bit
+		}
+
+		auto* payloadDescriptor = RTP::Codecs::VP8::Parse(buffer, bufferLen);
+
+		REQUIRE(payloadDescriptor);
+
+		return payloadDescriptor;
+	}
+
+	std::unique_ptr<RTP::Codecs::VP8::PayloadDescriptor> processVP8Packet(
+	  RTP::Codecs::VP8::EncodingContext& context,
+	  uint16_t pictureId,
+	  uint8_t tl0PictureIndex,
+	  uint8_t tlIndex,
+	  bool layerSync = true)
+	{
+		// clang-format off
+		uint8_t payload[] =
+		{
+			0x90, 0xe0, 0x80, 0x00, 0x00, 0x00
+		};
+		// clang-format on
+
+		std::unique_ptr<RTP::Packet> packet{ RTP::Packet::Factory(FactoryBuffer, sizeof(FactoryBuffer)) };
+
+		packet->SetPayload(payload, sizeof(payload));
+
+		bool marker;
+		auto* payloadDescriptor = createVP8PayloadDescriptor(
+		  packet->GetPayload(), packet->GetPayloadLength(), pictureId, tl0PictureIndex, tlIndex, layerSync);
+		std::unique_ptr<RTP::Codecs::VP8::PayloadDescriptorHandler> payloadDescriptorHandler(
+		  new RTP::Codecs::VP8::PayloadDescriptorHandler(payloadDescriptor));
+
+		if (payloadDescriptorHandler->Process(&context, packet.get(), marker))
+		{
+			return std::unique_ptr<RTP::Codecs::VP8::PayloadDescriptor>(
+			  RTP::Codecs::VP8::Parse(packet->GetPayload(), packet->GetPayloadLength()));
+		}
+
+		return nullptr;
+	}
+} // namespace
 
 SCENARIO("parse VP8 payload descriptor", "[rtp][codecs][vp8]")
 {
@@ -244,9 +305,9 @@ SCENARIO("parse VP8 payload descriptor", "[rtp][codecs][vp8]")
 		};
 		// clang-format on
 
-		auto payloadDescriptor = RTP::Codecs::VP8::Parse(buffer, sizeof(buffer));
+		const auto* payloadDescriptor = RTP::Codecs::VP8::Parse(buffer, sizeof(buffer));
 
-		REQUIRE_FALSE(payloadDescriptor);
+		REQUIRE(!payloadDescriptor);
 	}
 
 	SECTION("parse payload descriptor. X flag is not set, no keyframe")
@@ -356,67 +417,10 @@ SCENARIO("parse VP8 payload descriptor", "[rtp][codecs][vp8]")
 	}
 }
 
-RTP::Codecs::VP8::PayloadDescriptor* CreateVP8PayloadDescriptor(
-  uint8_t* buffer,
-  size_t bufferLen,
-  uint16_t pictureId,
-  uint8_t tl0PictureIndex,
-  uint8_t tlIndex,
-  bool layerSync = true)
-{
-	uint16_t netPictureId = htons(pictureId);
-	std::memcpy(buffer + 2, &netPictureId, 2);
-	buffer[2] |= 0x80;
-	buffer[4] = tl0PictureIndex;
-	buffer[5] = tlIndex << 6;
-
-	if (layerSync)
-	{
-		buffer[5] |= 0x20; // y bit
-	}
-
-	auto* payloadDescriptor = RTP::Codecs::VP8::Parse(buffer, bufferLen);
-
-	REQUIRE(payloadDescriptor);
-
-	return payloadDescriptor;
-}
-
-std::unique_ptr<RTP::Codecs::VP8::PayloadDescriptor> ProcessVP8Packet(
-  RTP::Codecs::VP8::EncodingContext& context,
-  uint16_t pictureId,
-  uint8_t tl0PictureIndex,
-  uint8_t tlIndex,
-  bool layerSync = true)
-{
-	// clang-format off
-	uint8_t payload[] =
-	{
-		0x90, 0xe0, 0x80, 0x00, 0x00, 0x00
-	};
-	// clang-format on
-
-	std::unique_ptr<RTP::Packet> packet{ RTP::Packet::Factory(FactoryBuffer, sizeof(FactoryBuffer)) };
-
-	packet->SetPayload(payload, sizeof(payload));
-
-	bool marker;
-	auto* payloadDescriptor = CreateVP8PayloadDescriptor(
-	  packet->GetPayload(), packet->GetPayloadLength(), pictureId, tl0PictureIndex, tlIndex, layerSync);
-	std::unique_ptr<RTP::Codecs::VP8::PayloadDescriptorHandler> payloadDescriptorHandler(
-	  new RTP::Codecs::VP8::PayloadDescriptorHandler(payloadDescriptor));
-
-	if (payloadDescriptorHandler->Process(&context, packet.get(), marker))
-	{
-		return std::unique_ptr<RTP::Codecs::VP8::PayloadDescriptor>(
-		  RTP::Codecs::VP8::Parse(packet->GetPayload(), packet->GetPayloadLength()));
-	}
-
-	return nullptr;
-}
-
 SCENARIO("process VP8 payload descriptor", "[rtp][codecs][vp8]")
 {
+	constexpr uint16_t MaxPictureId = (1 << 15) - 1;
+
 	SECTION("do not drop TL0PICIDX from temporal layers higher than 0")
 	{
 		RTP::Codecs::EncodingContext::Params params;
@@ -428,7 +432,7 @@ SCENARIO("process VP8 payload descriptor", "[rtp][codecs][vp8]")
 		context.SetTargetTemporalLayer(0);
 
 		// Frame 1.
-		auto forwarded = ProcessVP8Packet(context, 0, 0, 0);
+		auto forwarded = processVP8Packet(context, 0, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 0);
 		REQUIRE(forwarded->tl0PictureIndex == 0);
@@ -436,11 +440,11 @@ SCENARIO("process VP8 payload descriptor", "[rtp][codecs][vp8]")
 		// Frame 2 gets lost.
 
 		// Frame 3.
-		forwarded = ProcessVP8Packet(context, 2, 1, 1);
-		REQUIRE_FALSE(forwarded);
+		forwarded = processVP8Packet(context, 2, 1, 1);
+		REQUIRE(!forwarded);
 
 		// Frame 2 retransmitted.
-		forwarded = ProcessVP8Packet(context, 1, 1, 0);
+		forwarded = processVP8Packet(context, 1, 1, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 1);
 		REQUIRE(forwarded->tl0PictureIndex == 1);
@@ -458,20 +462,20 @@ SCENARIO("process VP8 payload descriptor", "[rtp][codecs][vp8]")
 		context.SetTargetTemporalLayer(0);
 
 		// Frame 1.
-		auto forwarded = ProcessVP8Packet(context, MaxPictureId, 0, 0);
+		auto forwarded = processVP8Packet(context, MaxPictureId, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 1);
 		REQUIRE(forwarded->tl0PictureIndex == 1);
 
 		// Frame 2.
-		forwarded = ProcessVP8Packet(context, 0, 0, 0);
+		forwarded = processVP8Packet(context, 0, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 2);
 		REQUIRE(forwarded->tl0PictureIndex == 1);
 
 		// Frame 3.
-		forwarded = ProcessVP8Packet(context, 1, 0, 1);
-		REQUIRE_FALSE(forwarded);
+		forwarded = processVP8Packet(context, 1, 0, 1);
+		REQUIRE(!forwarded);
 	}
 
 	SECTION("old packets with higher temporal layer than current are dropped")
@@ -486,22 +490,22 @@ SCENARIO("process VP8 payload descriptor", "[rtp][codecs][vp8]")
 		context.SetTargetTemporalLayer(0);
 
 		// Frame 1.
-		auto forwarded = ProcessVP8Packet(context, 1, 0, 0);
+		auto forwarded = processVP8Packet(context, 1, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 1);
 		REQUIRE(forwarded->tlIndex == 0);
 		REQUIRE(forwarded->tl0PictureIndex == 1);
 
 		// Frame 2.
-		forwarded = ProcessVP8Packet(context, 2, 0, 0);
+		forwarded = processVP8Packet(context, 2, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 2);
 		REQUIRE(forwarded->tlIndex == 0);
 		REQUIRE(forwarded->tl0PictureIndex == 1);
 
 		// Frame 3. Old packet with higher temporal layer than current.
-		forwarded = ProcessVP8Packet(context, 0, 0, 1);
-		REQUIRE_FALSE(forwarded);
+		forwarded = processVP8Packet(context, 0, 0, 1);
+		REQUIRE(!forwarded);
 		REQUIRE(context.GetCurrentTemporalLayer() == 0);
 	}
 
@@ -517,14 +521,14 @@ SCENARIO("process VP8 payload descriptor", "[rtp][codecs][vp8]")
 		context.SetTargetTemporalLayer(0);
 
 		// Frame 1.
-		auto forwarded = ProcessVP8Packet(context, 1, 0, 0);
+		auto forwarded = processVP8Packet(context, 1, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 1);
 		REQUIRE(forwarded->tlIndex == 0);
 		REQUIRE(forwarded->tl0PictureIndex == 1);
 
 		// Frame 2.
-		forwarded = ProcessVP8Packet(context, 2, 0, 0);
+		forwarded = processVP8Packet(context, 2, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 2);
 		REQUIRE(forwarded->tlIndex == 0);
@@ -533,8 +537,8 @@ SCENARIO("process VP8 payload descriptor", "[rtp][codecs][vp8]")
 		context.SetTargetTemporalLayer(2);
 
 		// Frame 3. Old packet with higher temporal layer than current.
-		forwarded = ProcessVP8Packet(context, 3, 0, 1);
-		REQUIRE_FALSE(forwarded);
+		forwarded = processVP8Packet(context, 3, 0, 1);
+		REQUIRE(!forwarded);
 		REQUIRE(context.GetCurrentTemporalLayer() == 0);
 	}
 }

--- a/worker/test/src/RTC/RTP/Codecs/TestVP9.cpp
+++ b/worker/test/src/RTC/RTP/Codecs/TestVP9.cpp
@@ -6,54 +6,59 @@
 #include <cstring> // std::memcmp()
 
 using namespace RTC;
+using namespace RTP_COMMON;
 
-constexpr uint16_t MaxPictureId = (1 << 15) - 1;
-
-RTP::Codecs::VP9::PayloadDescriptor* CreateVP9PayloadDescriptor(
-  uint8_t* buffer, size_t bufferLen, uint16_t pictureId, uint8_t tlIndex)
+namespace
 {
-	buffer[0]             = 0xAD; // I, L, B, E bits
-	uint16_t netPictureId = htons(pictureId);
-	std::memcpy(buffer + 1, &netPictureId, 2);
-	buffer[1] |= 0x80;
-	buffer[3] = (tlIndex << 5) | (1 << 4); // tlIndex, switchingUpPoint
-
-	auto* payloadDescriptor = RTP::Codecs::VP9::Parse(buffer, bufferLen);
-
-	REQUIRE(payloadDescriptor);
-
-	return payloadDescriptor;
-}
-
-std::unique_ptr<RTP::Codecs::VP9::PayloadDescriptor> ProcessVP9Packet(
-  RTP::Codecs::VP9::EncodingContext& context, uint16_t pictureId, uint8_t tlIndex)
-{
-	// clang-format off
-	uint8_t payload[] =
+	RTP::Codecs::VP9::PayloadDescriptor* createVP9PayloadDescriptor(
+	  uint8_t* buffer, size_t bufferLen, uint16_t pictureId, uint8_t tlIndex)
 	{
-		0xAD, 0x80, 0x00, 0x00, 0x00, 0x00
-	};
-	// clang-format on
-	bool marker;
-	auto* payloadDescriptor = CreateVP9PayloadDescriptor(payload, sizeof(payload), pictureId, tlIndex);
-	std::unique_ptr<RTP::Codecs::VP9::PayloadDescriptorHandler> payloadDescriptorHandler(
-	  new RTP::Codecs::VP9::PayloadDescriptorHandler(payloadDescriptor));
+		buffer[0]             = 0xAD; // I, L, B, E bits
+		uint16_t netPictureId = htons(pictureId);
+		std::memcpy(buffer + 1, &netPictureId, 2);
+		buffer[1] |= 0x80;
+		buffer[3] = (tlIndex << 5) | (1 << 4); // tlIndex, switchingUpPoint
 
-	std::unique_ptr<RTP::Packet> packet{ RTP::Packet::Factory(FactoryBuffer, sizeof(FactoryBuffer)) };
+		auto* payloadDescriptor = RTP::Codecs::VP9::Parse(buffer, bufferLen);
 
-	packet->SetPayload(payload, sizeof(payload));
+		REQUIRE(payloadDescriptor);
 
-	if (payloadDescriptorHandler->Process(&context, packet.get(), marker))
-	{
-		return std::unique_ptr<RTP::Codecs::VP9::PayloadDescriptor>(
-		  RTP::Codecs::VP9::Parse(payload, sizeof(payload)));
+		return payloadDescriptor;
 	}
 
-	return nullptr;
-}
+	std::unique_ptr<RTP::Codecs::VP9::PayloadDescriptor> processVP9Packet(
+	  RTP::Codecs::VP9::EncodingContext& context, uint16_t pictureId, uint8_t tlIndex)
+	{
+		// clang-format off
+		uint8_t payload[] =
+		{
+			0xAD, 0x80, 0x00, 0x00, 0x00, 0x00
+		};
+		// clang-format on
+		bool marker;
+		auto* payloadDescriptor =
+		  createVP9PayloadDescriptor(payload, sizeof(payload), pictureId, tlIndex);
+		std::unique_ptr<RTP::Codecs::VP9::PayloadDescriptorHandler> payloadDescriptorHandler(
+		  new RTP::Codecs::VP9::PayloadDescriptorHandler(payloadDescriptor));
+
+		std::unique_ptr<RTP::Packet> packet{ RTP::Packet::Factory(FactoryBuffer, sizeof(FactoryBuffer)) };
+
+		packet->SetPayload(payload, sizeof(payload));
+
+		if (payloadDescriptorHandler->Process(&context, packet.get(), marker))
+		{
+			return std::unique_ptr<RTP::Codecs::VP9::PayloadDescriptor>(
+			  RTP::Codecs::VP9::Parse(payload, sizeof(payload)));
+		}
+
+		return nullptr;
+	}
+} // namespace
 
 SCENARIO("process VP9 payload descriptor", "[rtp][codecs][vp9]")
 {
+	constexpr uint16_t MaxPictureId = (1 << 15) - 1;
+
 	SECTION("drop packets that belong to other temporal layers after rolling over pictureID")
 	{
 		RTP::Codecs::EncodingContext::Params params;
@@ -69,18 +74,18 @@ SCENARIO("process VP9 payload descriptor", "[rtp][codecs][vp9]")
 		context.SetTargetSpatialLayer(0);
 
 		// Frame 1.
-		auto forwarded = ProcessVP9Packet(context, MaxPictureId, 0);
+		auto forwarded = processVP9Packet(context, MaxPictureId, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == MaxPictureId);
 
 		// Frame 2.
-		forwarded = ProcessVP9Packet(context, 0, 0);
+		forwarded = processVP9Packet(context, 0, 0);
 		REQUIRE(forwarded);
 		REQUIRE(forwarded->pictureId == 0);
 
 		// Frame 3.
-		forwarded = ProcessVP9Packet(context, 1, 1);
-		REQUIRE_FALSE(forwarded);
+		forwarded = processVP9Packet(context, 1, 1);
+		REQUIRE(!forwarded);
 	}
 
 	SECTION("test PayloadDescriptorHandler")
@@ -91,7 +96,7 @@ SCENARIO("process VP9 payload descriptor", "[rtp][codecs][vp9]")
 
 		RTP::Codecs::VP9::EncodingContext context(params);
 
-		uint16_t start = MaxPictureId - 2000;
+		const uint16_t start = MaxPictureId - 2000;
 
 		context.SetCurrentTemporalLayer(0, start + 0);
 		context.SetCurrentTemporalLayer(1, start + 1);
@@ -128,8 +133,8 @@ SCENARIO("process VP9 payload descriptor", "[rtp][codecs][vp9]")
 		context.SetCurrentSpatialLayer(0, 0);
 		context.SetTargetSpatialLayer(0);
 
-		uint16_t start                                                     = MaxPictureId - 20;
-		std::vector<std::tuple<uint16_t, uint16_t, int16_t, bool>> packets = {
+		const uint16_t start                                                     = MaxPictureId - 20;
+		const std::vector<std::tuple<uint16_t, uint16_t, int16_t, bool>> packets = {
 			// targetTemporalLayer=0
 			{ start, 0, 0, true },
 			{ start, 1, -1, false },
@@ -175,7 +180,7 @@ SCENARIO("process VP9 payload descriptor", "[rtp][codecs][vp9]")
 				context.SetTargetTemporalLayer(targetTemporalLayer);
 			}
 
-			auto forwarded = ProcessVP9Packet(context, pictureId, tlIndex);
+			auto forwarded = processVP9Packet(context, pictureId, tlIndex);
 
 			if (shouldForward)
 			{
@@ -184,7 +189,7 @@ SCENARIO("process VP9 payload descriptor", "[rtp][codecs][vp9]")
 			}
 			else
 			{
-				REQUIRE_FALSE(forwarded);
+				REQUIRE(!forwarded);
 			}
 		}
 	}

--- a/worker/test/src/RTC/RTP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTP/TestPacket.cpp
@@ -10,6 +10,7 @@
 #include <string>
 
 using namespace RTC;
+using namespace RTP_COMMON;
 
 // NOLINTNEXTLINE (clang-tidy readability-function-size)
 SCENARIO("RTP Packet", "[serializable][rtp][packet]")

--- a/worker/test/src/RTC/RTP/TestProbationGenerator.cpp
+++ b/worker/test/src/RTC/RTP/TestProbationGenerator.cpp
@@ -10,8 +10,8 @@ SCENARIO("RTP ProbationGenerator", "[rtp][probationgenerator]")
 	{
 		RTP::ProbationGenerator probationGenerator;
 
-		auto* packet = probationGenerator.GetNextPacket(1000);
-		auto seq     = packet->GetSequenceNumber();
+		const auto* packet = probationGenerator.GetNextPacket(1000);
+		const auto seq     = packet->GetSequenceNumber();
 
 		REQUIRE(packet->GetSsrc() == RTP::ProbationGenerator::Ssrc);
 		REQUIRE(packet->GetPayloadType() == RTP::ProbationGenerator::PayloadType);

--- a/worker/test/src/RTC/RTP/TestRetransmissionBuffer.cpp
+++ b/worker/test/src/RTC/RTP/TestRetransmissionBuffer.cpp
@@ -7,73 +7,76 @@
 
 using namespace RTC;
 
-// Class inheriting from RtpRetransmissionBuffer so we can access its protected
-// buffer member.
-class RtpMyRetransmissionBuffer : public RTP::RetransmissionBuffer
+namespace
 {
-public:
-	struct VerificationItem
+	// Class inheriting from RtpRetransmissionBuffer so we can access its protected
+	// buffer member.
+	class RtpMyRetransmissionBuffer : public RTP::RetransmissionBuffer
 	{
-		bool isPresent;
-		uint16_t sequenceNumber;
-		uint32_t timestamp;
-	};
+	public:
+		struct VerificationItem
+		{
+			bool isPresent;
+			uint16_t sequenceNumber;
+			uint32_t timestamp;
+		};
 
-public:
-	RtpMyRetransmissionBuffer(uint16_t maxItems, uint32_t maxRetransmissionDelayMs, uint32_t clockRate)
-	  : RTP::RetransmissionBuffer(maxItems, maxRetransmissionDelayMs, clockRate)
-	{
-	}
+	public:
+		RtpMyRetransmissionBuffer(uint16_t maxItems, uint32_t maxRetransmissionDelayMs, uint32_t clockRate)
+		  : RTP::RetransmissionBuffer(maxItems, maxRetransmissionDelayMs, clockRate)
+		{
+		}
 
-public:
-	void Insert(uint16_t seq, uint32_t timestamp)
-	{
-		// clang-format off
+	public:
+		void Insert(uint16_t seq, uint32_t timestamp)
+		{
+			// clang-format off
 		uint8_t rtpBuffer[] =
 		{
 			0b10000000, 0b01111011, 0b01010010, 0b00001110,
 			0b01011011, 0b01101011, 0b11001010, 0b10110101,
 			0, 0, 0, 2
 		};
-		// clang-format on
+			// clang-format on
 
-		std::unique_ptr<RTP::Packet> packet{ RTP::Packet::Parse(rtpBuffer, sizeof(rtpBuffer)) };
+			std::unique_ptr<RTP::Packet> packet{ RTP::Packet::Parse(rtpBuffer, sizeof(rtpBuffer)) };
 
-		packet->SetSequenceNumber(seq);
-		packet->SetTimestamp(timestamp);
+			packet->SetSequenceNumber(seq);
+			packet->SetTimestamp(timestamp);
 
-		RTP::SharedPacket sharedPacket;
+			const RTP::SharedPacket sharedPacket;
 
-		RTP::RetransmissionBuffer::Insert(packet.get(), sharedPacket);
-	}
+			RTP::RetransmissionBuffer::Insert(packet.get(), sharedPacket);
+		}
 
-	void AssertBuffer(std::vector<VerificationItem> verificationBuffer)
-	{
-		REQUIRE(verificationBuffer.size() == this->buffer.size());
-
-		for (size_t idx{ 0u }; idx < verificationBuffer.size(); ++idx)
+		void AssertBuffer(std::vector<VerificationItem> verificationBuffer)
 		{
-			auto& verificationItem = verificationBuffer.at(idx);
-			auto* item             = this->buffer.at(idx);
+			REQUIRE(verificationBuffer.size() == this->buffer.size());
 
-			REQUIRE(verificationItem.isPresent == !!item);
-
-			if (item)
+			for (size_t idx{ 0u }; idx < verificationBuffer.size(); ++idx)
 			{
-				REQUIRE(verificationItem.sequenceNumber == item->sequenceNumber);
-				REQUIRE(verificationItem.timestamp == item->timestamp);
+				auto& verificationItem = verificationBuffer.at(idx);
+				auto* item             = this->buffer.at(idx);
+
+				REQUIRE(verificationItem.isPresent == !!item);
+
+				if (item)
+				{
+					REQUIRE(verificationItem.sequenceNumber == item->sequenceNumber);
+					REQUIRE(verificationItem.timestamp == item->timestamp);
+				}
 			}
 		}
-	}
-};
+	};
+} // namespace
 
 SCENARIO("RTP RetransmissionBuffer", "[rtp][rtx]")
 {
 	SECTION("proper packets received in order")
 	{
-		uint16_t maxItems{ 4 };
-		uint32_t maxRetransmissionDelayMs{ 2000u };
-		uint32_t clockRate{ 90000 };
+		const uint16_t maxItems{ 4 };
+		const uint32_t maxRetransmissionDelayMs{ 2000u };
+		const uint32_t clockRate{ 90000 };
 
 		RtpMyRetransmissionBuffer myRetransmissionBuffer(maxItems, maxRetransmissionDelayMs, clockRate);
 
@@ -96,9 +99,9 @@ SCENARIO("RTP RetransmissionBuffer", "[rtp][rtx]")
 
 	SECTION("proper packets received out of order")
 	{
-		uint16_t maxItems{ 4 };
-		uint32_t maxRetransmissionDelayMs{ 2000u };
-		uint32_t clockRate{ 90000 };
+		const uint16_t maxItems{ 4 };
+		const uint32_t maxRetransmissionDelayMs{ 2000u };
+		const uint32_t clockRate{ 90000 };
 
 		RtpMyRetransmissionBuffer myRetransmissionBuffer(maxItems, maxRetransmissionDelayMs, clockRate);
 
@@ -121,9 +124,9 @@ SCENARIO("RTP RetransmissionBuffer", "[rtp][rtx]")
 
 	SECTION("packet with too new sequence number produces buffer emptying")
 	{
-		uint16_t maxItems{ 4 };
-		uint32_t maxRetransmissionDelayMs{ 2000u };
-		uint32_t clockRate{ 90000 };
+		const uint16_t maxItems{ 4 };
+		const uint32_t maxRetransmissionDelayMs{ 2000u };
+		const uint32_t clockRate{ 90000 };
 
 		RtpMyRetransmissionBuffer myRetransmissionBuffer(maxItems, maxRetransmissionDelayMs, clockRate);
 
@@ -143,9 +146,9 @@ SCENARIO("RTP RetransmissionBuffer", "[rtp][rtx]")
 
 	SECTION("blank slots are properly created")
 	{
-		uint16_t maxItems{ 10 };
-		uint32_t maxRetransmissionDelayMs{ 2000u };
-		uint32_t clockRate{ 90000 };
+		const uint16_t maxItems{ 10 };
+		const uint32_t maxRetransmissionDelayMs{ 2000u };
+		const uint32_t clockRate{ 90000 };
 
 		RtpMyRetransmissionBuffer myRetransmissionBuffer(maxItems, maxRetransmissionDelayMs, clockRate);
 
@@ -181,9 +184,9 @@ SCENARIO("RTP RetransmissionBuffer", "[rtp][rtx]")
 
 	SECTION("packet with too old sequence number is discarded")
 	{
-		uint16_t maxItems{ 4 };
-		uint32_t maxRetransmissionDelayMs{ 2000u };
-		uint32_t clockRate{ 90000 };
+		const uint16_t maxItems{ 4 };
+		const uint32_t maxRetransmissionDelayMs{ 2000u };
+		const uint32_t clockRate{ 90000 };
 
 		RtpMyRetransmissionBuffer myRetransmissionBuffer(maxItems, maxRetransmissionDelayMs, clockRate);
 
@@ -206,9 +209,9 @@ SCENARIO("RTP RetransmissionBuffer", "[rtp][rtx]")
 
 	SECTION("packet with too old timestamp is discarded")
 	{
-		uint16_t maxItems{ 4 };
-		uint32_t maxRetransmissionDelayMs{ 2000u };
-		uint32_t clockRate{ 90000 };
+		const uint16_t maxItems{ 4 };
+		const uint32_t maxRetransmissionDelayMs{ 2000u };
+		const uint32_t clockRate{ 90000 };
 
 		RtpMyRetransmissionBuffer myRetransmissionBuffer(maxItems, maxRetransmissionDelayMs, clockRate);
 
@@ -233,9 +236,9 @@ SCENARIO("RTP RetransmissionBuffer", "[rtp][rtx]")
 
 	SECTION("packet with very newest timestamp is inserted as newest item despite its seq is old")
 	{
-		uint16_t maxItems{ 4 };
-		uint32_t maxRetransmissionDelayMs{ 2000u };
-		uint32_t clockRate{ 90000 };
+		const uint16_t maxItems{ 4 };
+		const uint32_t maxRetransmissionDelayMs{ 2000u };
+		const uint32_t clockRate{ 90000 };
 
 		RtpMyRetransmissionBuffer myRetransmissionBuffer(maxItems, maxRetransmissionDelayMs, clockRate);
 
@@ -257,9 +260,9 @@ SCENARIO("RTP RetransmissionBuffer", "[rtp][rtx]")
 	SECTION(
 	  "packet with lower seq than newest packet in the buffer and higher timestamp forces buffer emptying")
 	{
-		uint16_t maxItems{ 4 };
-		uint32_t maxRetransmissionDelayMs{ 2000u };
-		uint32_t clockRate{ 90000 };
+		const uint16_t maxItems{ 4 };
+		const uint32_t maxRetransmissionDelayMs{ 2000u };
+		const uint32_t clockRate{ 90000 };
 
 		RtpMyRetransmissionBuffer myRetransmissionBuffer(maxItems, maxRetransmissionDelayMs, clockRate);
 
@@ -278,9 +281,9 @@ SCENARIO("RTP RetransmissionBuffer", "[rtp][rtx]")
 
 	SECTION("fuzzer generated packets")
 	{
-		uint16_t maxItems{ 2500u };
-		uint32_t maxRetransmissionDelayMs{ 2000u };
-		uint32_t clockRate{ 90000 };
+		const uint16_t maxItems{ 2500u };
+		const uint32_t maxRetransmissionDelayMs{ 2000u };
+		const uint32_t clockRate{ 90000 };
 
 		RtpMyRetransmissionBuffer myRetransmissionBuffer(maxItems, maxRetransmissionDelayMs, clockRate);
 

--- a/worker/test/src/RTC/RTP/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/RTP/TestRtpStreamRecv.cpp
@@ -76,10 +76,10 @@ SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream][rtpstreamrecv
 
 							for (auto it = nackPacket->Begin(); it != nackPacket->End(); ++it)
 							{
-								RTCP::FeedbackRtpNackItem* item = *it;
+								const RTCP::FeedbackRtpNackItem* item = *it;
 
-								uint16_t firstSeq = item->GetPacketId();
-								uint16_t bitmask  = item->GetLostPacketBitmask();
+								const uint16_t firstSeq = item->GetPacketId();
+								uint16_t bitmask        = item->GetLostPacketBitmask();
 
 								this->nackedSeqNumbers.push_back(firstSeq);
 

--- a/worker/test/src/RTC/RTP/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/RTP/TestRtpStreamSend.cpp
@@ -16,67 +16,76 @@
 
 using namespace RTC;
 
-static std::unique_ptr<RTP::Packet> CreateRtpPacket(
-  uint8_t* buffer, size_t len, uint16_t seq, uint32_t timestamp)
+namespace
 {
-	auto* packet = RTP::Packet::Parse(buffer, len);
-
-	REQUIRE(packet);
-
-	packet->SetPayloadType(123);
-	packet->SetSequenceNumber(seq);
-	packet->SetTimestamp(timestamp);
-
-	return std::unique_ptr<RTP::Packet>(packet);
-}
-
-static void SendRtpPacket(
-  std::vector<std::pair<RTP::RtpStreamSend*, uint32_t>> streams, RTP::Packet* packet)
-{
-	RTP::SharedPacket sharedPacket;
-
-	for (auto& kv : streams)
+	std::unique_ptr<RTP::Packet> createRtpPacket(
+	  uint8_t* buffer, size_t len, uint16_t seq, uint32_t timestamp)
 	{
-		auto stream   = kv.first;
-		auto ssrc     = kv.second;
-		auto origSsrc = packet->GetSsrc();
+		auto* packet = RTP::Packet::Parse(buffer, len);
 
-		packet->SetSsrc(ssrc);
+		REQUIRE(packet);
 
-		auto result = stream->ReceivePacket(packet, sharedPacket);
+		packet->SetPayloadType(123);
+		packet->SetSequenceNumber(seq);
+		packet->SetTimestamp(timestamp);
 
-		packet->SetSsrc(origSsrc);
+		return std::unique_ptr<RTP::Packet>(packet);
+	}
 
-		// NOTE: Here we must replicate the behaviour of Consumer::SendRtpPacket()
-		// in which, if the shared packet has been stored and it didn't contain the
-		// packet yet, we fill it with a cloned packet.
-		if (result == RTP::RtpStreamSend::ReceivePacketResult::ACCEPTED_AND_STORED && !sharedPacket.HasPacket())
+	void sendRtpPacket(
+	  // NOTE: clang-tidy suggests passing `streams` by reference but that's wrong
+	  // because we create `streams` in place when calling this function.
+	  // NOLINTNEXTLINE(performance-unnecessary-value-param)
+	  std::vector<std::pair<RTP::RtpStreamSend*, uint32_t>> streams,
+	  RTP::Packet* packet)
+	{
+		RTP::SharedPacket sharedPacket;
+
+		for (auto& kv : streams)
 		{
-			sharedPacket.Assign(packet);
+			auto* stream  = kv.first;
+			auto ssrc     = kv.second;
+			auto origSsrc = packet->GetSsrc();
+
+			packet->SetSsrc(ssrc);
+
+			auto result = stream->ReceivePacket(packet, sharedPacket);
+
+			packet->SetSsrc(origSsrc);
+
+			// NOTE: Here we must replicate the behaviour of Consumer::sendRtpPacket()
+			// in which, if the shared packet has been stored and it didn't contain the
+			// packet yet, we fill it with a cloned packet.
+			if (result == RTP::RtpStreamSend::ReceivePacketResult::ACCEPTED_AND_STORED && !sharedPacket.HasPacket())
+			{
+				sharedPacket.Assign(packet);
+			}
 		}
 	}
-}
 
-static void CheckRtxPacket(RTP::Packet* rtxPacket, RTP::Packet* origPacket)
-{
-	REQUIRE(rtxPacket);
-	REQUIRE(rtxPacket->GetSequenceNumber() == origPacket->GetSequenceNumber());
-	REQUIRE(rtxPacket->GetTimestamp() == origPacket->GetTimestamp());
-	REQUIRE(rtxPacket->HasMarker() == origPacket->HasMarker());
-}
+	void checkRtxPacket(RTP::Packet* rtxPacket, RTP::Packet* origPacket)
+	{
+		REQUIRE(rtxPacket);
+		REQUIRE(rtxPacket->GetSequenceNumber() == origPacket->GetSequenceNumber());
+		REQUIRE(rtxPacket->GetTimestamp() == origPacket->GetTimestamp());
+		REQUIRE(rtxPacket->HasMarker() == origPacket->HasMarker());
+	}
 
-static void ParseAV1RtpPacket(
-  RTP::Packet* packet,
-  std::unique_ptr<RTP::Codecs::DependencyDescriptor::TemplateDependencyStructure>& templateDependencyStructure)
-{
-	std::unique_ptr<RTP::Codecs::DependencyDescriptor> dependencyDescriptor;
-	packet->ReadDependencyDescriptor(dependencyDescriptor, templateDependencyStructure);
-	REQUIRE(dependencyDescriptor);
+	void parseAV1RtpPacket(
+	  RTP::Packet* packet,
+	  std::unique_ptr<RTP::Codecs::DependencyDescriptor::TemplateDependencyStructure>&
+	    templateDependencyStructure)
+	{
+		std::unique_ptr<RTP::Codecs::DependencyDescriptor> dependencyDescriptor;
+		packet->ReadDependencyDescriptor(dependencyDescriptor, templateDependencyStructure);
+		REQUIRE(dependencyDescriptor);
 
-	auto* payloadDescriptor = RTP::Codecs::AV1::Parse(dependencyDescriptor);
-	auto* payloadDescriptorHandler = new RTP::Codecs::AV1::PayloadDescriptorHandler(payloadDescriptor);
-	packet->SetPayloadDescriptorHandler(payloadDescriptorHandler);
-}
+		auto* payloadDescriptor = RTP::Codecs::AV1::Parse(dependencyDescriptor);
+		auto* payloadDescriptorHandler =
+		  new RTP::Codecs::AV1::PayloadDescriptorHandler(payloadDescriptor);
+		packet->SetPayloadDescriptorHandler(payloadDescriptorHandler);
+	}
+} // namespace
 
 SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rtpstreamsend]")
 {
@@ -118,16 +127,16 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 	SECTION("receive NACK and get retransmitted packets")
 	{
 		// packet1 [seq:21006, timestamp:1533790901]
-		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
+		auto packet1(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
 		// packet2 [seq:21007, timestamp:1533790901]
-		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
+		auto packet2(createRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
 		packet2->SetMarker(true);
 		// packet3 [seq:21008, timestamp:1533793871]
-		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871));
+		auto packet3(createRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871));
 		// packet4 [seq:21009, timestamp:1533793871]
-		auto packet4(CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871));
+		auto packet4(createRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871));
 		// packet5 [seq:21010, timestamp:1533796931]
-		auto packet5(CreateRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931));
+		auto packet5(createRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931));
 		packet5->SetMarker(true);
 
 		// Create a RtpStreamSend instance.
@@ -144,13 +153,13 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		auto stream = std::make_unique<RTP::RtpStreamSend>(&testRtpStreamListener, params, mid);
 
 		// Receive all the packets (some of them not in order and/or duplicated).
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet1.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet3.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet2.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet3.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet4.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet5.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet5.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet1.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet3.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet2.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet3.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet4.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet5.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet5.get());
 
 		// Create a NACK item that request for all the packets.
 		RTCP::FeedbackRtpNackPacket nackPacket(0, params.ssrc);
@@ -173,25 +182,25 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 
 		testRtpStreamListener.retransmittedPackets.clear();
 
-		CheckRtxPacket(rtxPacket1, packet1.get());
-		CheckRtxPacket(rtxPacket2, packet2.get());
-		CheckRtxPacket(rtxPacket3, packet3.get());
-		CheckRtxPacket(rtxPacket4, packet4.get());
-		CheckRtxPacket(rtxPacket5, packet5.get());
+		checkRtxPacket(rtxPacket1, packet1.get());
+		checkRtxPacket(rtxPacket2, packet2.get());
+		checkRtxPacket(rtxPacket3, packet3.get());
+		checkRtxPacket(rtxPacket4, packet4.get());
+		checkRtxPacket(rtxPacket5, packet5.get());
 	}
 
 	SECTION("receive NACK and get zero retransmitted packets if useNack is not set")
 	{
 		// packet1 [seq:21006, timestamp:1533790901]
-		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
+		auto packet1(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
 		// packet2 [seq:21007, timestamp:1533790901]
-		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
+		auto packet2(createRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
 		// packet3 [seq:21008, timestamp:1533793871]
-		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871));
+		auto packet3(createRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871));
 		// packet4 [seq:21009, timestamp:1533793871]
-		auto packet4(CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871));
+		auto packet4(createRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871));
 		// packet5 [seq:21010, timestamp:1533796931]
-		auto packet5(CreateRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931));
+		auto packet5(createRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931));
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -207,13 +216,13 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		auto stream = std::make_unique<RTP::RtpStreamSend>(&testRtpStreamListener, params, mid);
 
 		// Receive all the packets (some of them not in order and/or duplicated).
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet1.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet3.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet2.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet3.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet4.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet5.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet5.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet1.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet3.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet2.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet3.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet4.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet5.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet5.get());
 
 		// Create a NACK item that request for all the packets.
 		RTCP::FeedbackRtpNackPacket nackPacket(0, params.ssrc);
@@ -234,15 +243,15 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 	SECTION("receive NACK and get zero retransmitted packets for audio")
 	{
 		// packet1 [seq:21006, timestamp:1533790901]
-		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
+		auto packet1(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
 		// packet2 [seq:21007, timestamp:1533790901]
-		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
+		auto packet2(createRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
 		// packet3 [seq:21008, timestamp:1533793871]
-		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871));
+		auto packet3(createRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, 1533793871));
 		// packet4 [seq:21009, timestamp:1533793871]
-		auto packet4(CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871));
+		auto packet4(createRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 21009, 1533793871));
 		// packet5 [seq:21010, timestamp:1533796931]
-		auto packet5(CreateRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931));
+		auto packet5(createRtpPacket(rtpBuffer5, sizeof(rtpBuffer5), 21010, 1533796931));
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -258,13 +267,13 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		auto stream = std::make_unique<RTP::RtpStreamSend>(&testRtpStreamListener, params, mid);
 
 		// Receive all the packets (some of them not in order and/or duplicated).
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet1.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet3.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet2.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet3.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet4.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet5.get());
-		SendRtpPacket({ { stream.get(), params.ssrc } }, packet5.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet1.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet3.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet2.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet3.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet4.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet5.get());
+		sendRtpPacket({ { stream.get(), params.ssrc } }, packet5.get());
 
 		// Create a NACK item that request for all the packets.
 		RTCP::FeedbackRtpNackPacket nackPacket(0, params.ssrc);
@@ -285,9 +294,9 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 	SECTION("receive NACK in different RtpStreamSend instances and get retransmitted packets")
 	{
 		// packet1 [seq:21006, timestamp:1533790901]
-		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
+		auto packet1(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, 1533790901));
 		// packet2 [seq:21007, timestamp:1533790901]
-		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
+		auto packet2(createRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, 1533790901));
 
 		// Create two RtpStreamSend instances.
 		TestRtpStreamListener testRtpStreamListener1;
@@ -315,8 +324,8 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		  new RTP::RtpStreamSend(&testRtpStreamListener2, params2, mid));
 
 		// Receive all the packets in both streams.
-		SendRtpPacket({ { stream1.get(), params1.ssrc }, { stream2.get(), params2.ssrc } }, packet1.get());
-		SendRtpPacket({ { stream1.get(), params1.ssrc }, { stream2.get(), params2.ssrc } }, packet2.get());
+		sendRtpPacket({ { stream1.get(), params1.ssrc }, { stream2.get(), params2.ssrc } }, packet1.get());
+		sendRtpPacket({ { stream1.get(), params1.ssrc }, { stream2.get(), params2.ssrc } }, packet2.get());
 
 		// Create a NACK item that request for all the packets.
 		RTCP::FeedbackRtpNackPacket nackPacket(0, params1.ssrc);
@@ -337,8 +346,8 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 
 		testRtpStreamListener1.retransmittedPackets.clear();
 
-		CheckRtxPacket(rtxPacket1, packet1.get());
-		CheckRtxPacket(rtxPacket2, packet2.get());
+		checkRtxPacket(rtxPacket1, packet1.get());
+		checkRtxPacket(rtxPacket2, packet2.get());
 
 		// Process the NACK packet on stream2.
 		stream2->ReceiveNack(&nackPacket);
@@ -350,8 +359,8 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 
 		testRtpStreamListener2.retransmittedPackets.clear();
 
-		CheckRtxPacket(rtxPacket1, packet1.get());
-		CheckRtxPacket(rtxPacket2, packet2.get());
+		checkRtxPacket(rtxPacket1, packet1.get());
+		checkRtxPacket(rtxPacket2, packet2.get());
 	}
 
 	SECTION("retransmitted packets are correctly encoded [VP8]")
@@ -384,11 +393,11 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		// clang-format on
 
 		// packet1 [seq:1, timestamp:1]
-		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 1, 1));
+		auto packet1(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 1, 1));
 		// packet2 [seq:2, timestamp:1]
-		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 2, 1));
+		auto packet2(createRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 2, 1));
 		// packet3 [seq:3, timestamp:1]
-		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 3, 1));
+		auto packet3(createRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 3, 1));
 
 		// Create two RtpStreamSend instances.
 		TestRtpStreamListener testRtpStreamListener1;
@@ -476,7 +485,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		REQUIRE(forwarded);
 
 		// Receive the third packet in the first stream.
-		SendRtpPacket({ { stream1.get(), params1.ssrc } }, packet3.get());
+		sendRtpPacket({ { stream1.get(), params1.ssrc } }, packet3.get());
 
 		// Update current/target temporal layers for context2.
 		context2.SetCurrentTemporalLayer(3);
@@ -486,7 +495,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		REQUIRE(forwarded);
 
 		// Receive the third packet in the second stream.
-		SendRtpPacket({ { stream2.get(), params2.ssrc } }, packet3.get());
+		sendRtpPacket({ { stream2.get(), params2.ssrc } }, packet3.get());
 
 		// Create a NACK item that requests the third packet.
 		RTCP::FeedbackRtpNackPacket nackPacket(0, params1.ssrc);
@@ -643,15 +652,15 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		headerExtensionIds.dependencyDescriptor = 12;
 
 		// packet1 [seq:1, timestamp:1]
-		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 1, 1));
+		auto packet1(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 1, 1));
 		packet1->AssignExtensionIds(headerExtensionIds);
 
 		// packet2 [seq:2, timestamp:1]
-		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 2, 1));
+		auto packet2(createRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 2, 1));
 		packet2->AssignExtensionIds(headerExtensionIds);
 
 		// packet3 [seq:3, timestamp:1]
-		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 3, 1));
+		auto packet3(createRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 3, 1));
 		packet3->AssignExtensionIds(headerExtensionIds);
 
 		// Create two RtpStreamSend instances.
@@ -699,9 +708,9 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		std::unique_ptr<RTP::Codecs::DependencyDescriptor::TemplateDependencyStructure> templateDependencyStructure;
 
 		// Parse the first packet for the shake of having the template dependency structure.
-		ParseAV1RtpPacket(packet1.get(), templateDependencyStructure);
+		parseAV1RtpPacket(packet1.get(), templateDependencyStructure);
 		// Parse the second packet.
-		ParseAV1RtpPacket(packet2.get(), templateDependencyStructure);
+		parseAV1RtpPacket(packet2.get(), templateDependencyStructure);
 
 		bool marker    = false;
 		bool forwarded = false;
@@ -717,7 +726,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		REQUIRE(context2.GetCurrentTemporalLayer() == 1);
 
 		// Parse the third packet
-		ParseAV1RtpPacket(packet3.get(), templateDependencyStructure);
+		parseAV1RtpPacket(packet3.get(), templateDependencyStructure);
 
 		// Process the third packet with context1 and verify current spatial layers.
 		forwarded = packet3->ProcessPayload(&context1, marker);
@@ -789,13 +798,13 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 
 	SECTION("packets get retransmitted as long as they don't exceed MaxRetransmissionDelayForVideoMs")
 	{
-		uint32_t clockRate = 90000;
-		uint32_t firstTs   = 1533790901;
-		uint32_t diffTs    = RTP::RtpStreamSend::MaxRetransmissionDelayForVideoMs * clockRate / 1000;
-		uint32_t secondTs  = firstTs + diffTs;
+		const uint32_t clockRate = 90000;
+		const uint32_t firstTs   = 1533790901;
+		const uint32_t diffTs = RTP::RtpStreamSend::MaxRetransmissionDelayForVideoMs * clockRate / 1000;
+		const uint32_t secondTs = firstTs + diffTs;
 
-		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, firstTs));
-		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, secondTs - 1));
+		auto packet1(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, firstTs));
+		auto packet2(createRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, secondTs - 1));
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -811,8 +820,8 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		auto stream = std::make_unique<RTP::RtpStreamSend>(&testRtpStreamListener, params1, mid);
 
 		// Receive all the packets.
-		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet1.get());
-		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet2.get());
+		sendRtpPacket({ { stream.get(), params1.ssrc } }, packet1.get());
+		sendRtpPacket({ { stream.get(), params1.ssrc } }, packet2.get());
 
 		// Create a NACK item that request for all the packets.
 		RTCP::FeedbackRtpNackPacket nackPacket(0, params1.ssrc);
@@ -833,23 +842,23 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 
 		testRtpStreamListener.retransmittedPackets.clear();
 
-		CheckRtxPacket(rtxPacket1, packet1.get());
-		CheckRtxPacket(rtxPacket2, packet2.get());
+		checkRtxPacket(rtxPacket1, packet1.get());
+		checkRtxPacket(rtxPacket2, packet2.get());
 	}
 
 	SECTION("packets don't get retransmitted if MaxRetransmissionDelayForVideoMs is exceeded")
 	{
-		uint32_t clockRate = 90000;
-		uint32_t firstTs   = 1533790901;
-		uint32_t diffTs    = RTP::RtpStreamSend::MaxRetransmissionDelayForVideoMs * clockRate / 1000;
+		const uint32_t clockRate = 90000;
+		const uint32_t firstTs   = 1533790901;
+		const uint32_t diffTs = RTP::RtpStreamSend::MaxRetransmissionDelayForVideoMs * clockRate / 1000;
 		// Make second packet arrive more than MaxRetransmissionDelayForVideoMs later.
-		uint32_t secondTs = firstTs + diffTs + 100;
+		const uint32_t secondTs = firstTs + diffTs + 100;
 		// Send a third packet so it will clean old packets from the buffer.
-		uint32_t thirdTs = firstTs + (2 * diffTs);
+		const uint32_t thirdTs = firstTs + (2 * diffTs);
 
-		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, firstTs));
-		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, secondTs));
-		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, thirdTs));
+		auto packet1(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, firstTs));
+		auto packet2(createRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 21007, secondTs));
+		auto packet3(createRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 21008, thirdTs));
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -865,9 +874,9 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		auto stream = std::make_unique<RTP::RtpStreamSend>(&testRtpStreamListener, params1, mid);
 
 		// Receive all the packets.
-		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet1.get());
-		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet2.get());
-		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet3.get());
+		sendRtpPacket({ { stream.get(), params1.ssrc } }, packet1.get());
+		sendRtpPacket({ { stream.get(), params1.ssrc } }, packet2.get());
+		sendRtpPacket({ { stream.get(), params1.ssrc } }, packet3.get());
 
 		// Create a NACK item that requests for all packets.
 		RTCP::FeedbackRtpNackPacket nackPacket(0, params1.ssrc);
@@ -887,21 +896,21 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 
 		testRtpStreamListener.retransmittedPackets.clear();
 
-		CheckRtxPacket(rtxPacket2, packet2.get());
+		checkRtxPacket(rtxPacket2, packet2.get());
 	}
 
 	SECTION("packets get removed from the retransmission buffer if seq number of the stream is reset")
 	{
 		// This scenario reproduce the "too bad sequence number" and "bad sequence
 		// number" scenarios in RtpStream::UpdateSeq().
-		auto packet1(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 50001, 1000001));
-		auto packet2(CreateRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 50002, 1000002));
+		auto packet1(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 50001, 1000001));
+		auto packet2(createRtpPacket(rtpBuffer2, sizeof(rtpBuffer2), 50002, 1000002));
 		// Third packet has bad sequence number (its seq is more than MaxDropout=3000
 		// older than current max seq) and will be dropped.
-		auto packet3(CreateRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 40003, 1000003));
+		auto packet3(createRtpPacket(rtpBuffer3, sizeof(rtpBuffer3), 40003, 1000003));
 		// Forth packet has seq=badSeq+1 so will be accepted and will trigger a
 		// stream reset.
-		auto packet4(CreateRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 40004, 1000004));
+		auto packet4(createRtpPacket(rtpBuffer4, sizeof(rtpBuffer4), 40004, 1000004));
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -916,10 +925,10 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		std::string mid;
 		auto stream = std::make_unique<RTP::RtpStreamSend>(&testRtpStreamListener, params1, mid);
 
-		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet1.get());
-		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet2.get());
-		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet3.get());
-		SendRtpPacket({ { stream.get(), params1.ssrc } }, packet4.get());
+		sendRtpPacket({ { stream.get(), params1.ssrc } }, packet1.get());
+		sendRtpPacket({ { stream.get(), params1.ssrc } }, packet2.get());
+		sendRtpPacket({ { stream.get(), params1.ssrc } }, packet3.get());
+		sendRtpPacket({ { stream.get(), params1.ssrc } }, packet4.get());
 
 		// Create a NACK item that requests for packets 1 and 2.
 		RTCP::FeedbackRtpNackPacket nackPacket2(0, params1.ssrc);
@@ -935,7 +944,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 
 	SECTION("duplicated packets are discarded")
 	{
-		auto packet(CreateRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 50001, 1000001));
+		auto packet(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 50001, 1000001));
 
 		// Create a RtpStreamSend instance.
 		TestRtpStreamListener testRtpStreamListener;
@@ -950,7 +959,7 @@ SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rt
 		std::string mid;
 		auto stream = std::make_unique<RTP::RtpStreamSend>(&testRtpStreamListener, params, mid);
 
-		RTP::SharedPacket sharedPacket;
+		const RTP::SharedPacket sharedPacket;
 
 		auto result = stream->ReceivePacket(packet.get(), sharedPacket);
 

--- a/worker/test/src/RTC/RTP/TestSharedPacket.cpp
+++ b/worker/test/src/RTC/RTP/TestSharedPacket.cpp
@@ -5,17 +5,18 @@
 #include <catch2/catch_test_macros.hpp>
 
 using namespace RTC;
-
-static void CompareRtpPackets(const RTP::Packet* packet1, const RTP::Packet* packet2)
-{
-	REQUIRE(packet1->GetSsrc() == packet2->GetSsrc());
-	REQUIRE(packet1->GetSequenceNumber() == packet2->GetSequenceNumber());
-	REQUIRE(packet1->GetTimestamp() == packet2->GetTimestamp());
-	REQUIRE(packet1->GetLength() == packet2->GetLength());
-}
+using namespace RTP_COMMON;
 
 SCENARIO("RTP SharedPacket", "[rtp][sharedpacket]")
 {
+	auto compareRtpPackets = [](const RTP::Packet* packet1, const RTP::Packet* packet2)
+	{
+		REQUIRE(packet1->GetSsrc() == packet2->GetSsrc());
+		REQUIRE(packet1->GetSequenceNumber() == packet2->GetSequenceNumber());
+		REQUIRE(packet1->GetTimestamp() == packet2->GetTimestamp());
+		REQUIRE(packet1->GetLength() == packet2->GetLength());
+	};
+
 	auto* packetA = RTP::Packet::Factory(FactoryBuffer, 2000);
 
 	packetA->SetSequenceNumber(1111);
@@ -38,7 +39,7 @@ SCENARIO("RTP SharedPacket", "[rtp][sharedpacket]")
 		sharedPacket.Assign(packetA);
 
 		REQUIRE(sharedPacket.HasPacket());
-		CompareRtpPackets(sharedPacket.GetPacket(), packetA);
+		compareRtpPackets(sharedPacket.GetPacket(), packetA);
 
 		sharedPacket.Reset();
 
@@ -55,20 +56,20 @@ SCENARIO("RTP SharedPacket", "[rtp][sharedpacket]")
 		RTP::SharedPacket sharedPacket1(packetA);
 
 		REQUIRE(sharedPacket1.HasPacket());
-		CompareRtpPackets(sharedPacket1.GetPacket(), packetA);
+		compareRtpPackets(sharedPacket1.GetPacket(), packetA);
 
 		// Create sharedPacket2 using copy constructor.
 		RTP::SharedPacket sharedPacket2(sharedPacket1);
 
 		REQUIRE(sharedPacket2.HasPacket());
-		CompareRtpPackets(sharedPacket2.GetPacket(), packetA);
+		compareRtpPackets(sharedPacket2.GetPacket(), packetA);
 
 		sharedPacket2.Assign(packetB);
 
 		REQUIRE(sharedPacket1.HasPacket());
-		CompareRtpPackets(sharedPacket1.GetPacket(), packetB);
+		compareRtpPackets(sharedPacket1.GetPacket(), packetB);
 		REQUIRE(sharedPacket2.HasPacket());
-		CompareRtpPackets(sharedPacket2.GetPacket(), packetB);
+		compareRtpPackets(sharedPacket2.GetPacket(), packetB);
 		REQUIRE(sharedPacket1.GetPacket() == sharedPacket2.GetPacket());
 
 		sharedPacket1.AssertSamePacket(sharedPacket1.GetPacket());
@@ -92,7 +93,7 @@ SCENARIO("RTP SharedPacket", "[rtp][sharedpacket]")
 		RTP::SharedPacket sharedPacket1(packetA);
 
 		REQUIRE(sharedPacket1.HasPacket());
-		CompareRtpPackets(sharedPacket1.GetPacket(), packetA);
+		compareRtpPackets(sharedPacket1.GetPacket(), packetA);
 
 		RTP::SharedPacket sharedPacket2;
 
@@ -100,14 +101,14 @@ SCENARIO("RTP SharedPacket", "[rtp][sharedpacket]")
 		sharedPacket2 = sharedPacket1;
 
 		REQUIRE(sharedPacket2.HasPacket());
-		CompareRtpPackets(sharedPacket2.GetPacket(), packetA);
+		compareRtpPackets(sharedPacket2.GetPacket(), packetA);
 
 		sharedPacket2.Assign(packetB);
 
 		REQUIRE(sharedPacket1.HasPacket());
-		CompareRtpPackets(sharedPacket1.GetPacket(), packetB);
+		compareRtpPackets(sharedPacket1.GetPacket(), packetB);
 		REQUIRE(sharedPacket2.HasPacket());
-		CompareRtpPackets(sharedPacket2.GetPacket(), packetB);
+		compareRtpPackets(sharedPacket2.GetPacket(), packetB);
 		REQUIRE(sharedPacket1.GetPacket() == sharedPacket2.GetPacket());
 
 		sharedPacket1.AssertSamePacket(sharedPacket1.GetPacket());
@@ -131,7 +132,7 @@ SCENARIO("RTP SharedPacket", "[rtp][sharedpacket]")
 		RTP::SharedPacket sharedPacket(packetA);
 
 		REQUIRE(sharedPacket.HasPacket());
-		CompareRtpPackets(sharedPacket.GetPacket(), packetA);
+		compareRtpPackets(sharedPacket.GetPacket(), packetA);
 
 		sharedPacket.Assign(nullptr);
 

--- a/worker/test/src/RTC/RTP/rtpCommon.cpp
+++ b/worker/test/src/RTC/RTP/rtpCommon.cpp
@@ -1,28 +1,25 @@
 #include "RTC/RTP/rtpCommon.hpp" // in worker/test/include/
 #include <cstring>               // std::memset
 
-namespace RTC
+namespace RTP_COMMON
 {
-	namespace RTP
+	thread_local uint8_t FactoryBuffer[];
+	thread_local uint8_t SerializeBuffer[];
+	thread_local uint8_t CloneBuffer[];
+	thread_local uint8_t DataBuffer[];
+	thread_local uint8_t ThrowBuffer[];
+
+	void ResetBuffers()
 	{
-		thread_local uint8_t FactoryBuffer[];
-		thread_local uint8_t SerializeBuffer[];
-		thread_local uint8_t CloneBuffer[];
-		thread_local uint8_t DataBuffer[];
-		thread_local uint8_t ThrowBuffer[];
+		std::memset(FactoryBuffer, 0xAA, sizeof(FactoryBuffer));
+		std::memset(SerializeBuffer, 0xBB, sizeof(SerializeBuffer));
+		std::memset(CloneBuffer, 0xCC, sizeof(CloneBuffer));
+		std::memset(DataBuffer, 0xDD, sizeof(DataBuffer));
+		std::memset(ThrowBuffer, 0xEE, sizeof(ThrowBuffer));
 
-		void ResetBuffers()
+		for (size_t i = 0; i < 256; ++i)
 		{
-			std::memset(FactoryBuffer, 0xAA, sizeof(FactoryBuffer));
-			std::memset(SerializeBuffer, 0xBB, sizeof(SerializeBuffer));
-			std::memset(CloneBuffer, 0xCC, sizeof(CloneBuffer));
-			std::memset(DataBuffer, 0xDD, sizeof(DataBuffer));
-			std::memset(ThrowBuffer, 0xEE, sizeof(ThrowBuffer));
-
-			for (size_t i = 0; i < 256; ++i)
-			{
-				DataBuffer[i] = static_cast<uint8_t>(i);
-			}
+			DataBuffer[i] = static_cast<uint8_t>(i);
 		}
-	} // namespace RTP
-} // namespace RTC
+	}
+} // namespace RTP_COMMON

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -9,136 +9,137 @@
 #include <vector>
 
 using namespace RTC;
-
-static constexpr unsigned int SendNackDelay{ 0u }; // In ms.
-
-struct TestNackGeneratorInput
-{
-	TestNackGeneratorInput() = default;
-	TestNackGeneratorInput(
-	  uint16_t seq,
-	  bool isKeyFrame,
-	  uint16_t firstNacked,
-	  size_t numNacked,
-	  bool keyFrameRequired = false,
-	  size_t nackListSize   = 0)
-	  : seq(seq), isKeyFrame(isKeyFrame), firstNacked(firstNacked), numNacked(numNacked),
-	    keyFrameRequired(keyFrameRequired), nackListSize(nackListSize)
-	{
-	}
-
-	uint16_t seq{ 0 };
-	bool isKeyFrame{ false };
-	uint16_t firstNacked{ 0 };
-	size_t numNacked{ 0 };
-	bool keyFrameRequired{ false };
-	size_t nackListSize{ 0 };
-};
-
-class TestPayloadDescriptorHandler : public RTP::Codecs::PayloadDescriptorHandler
-{
-public:
-	explicit TestPayloadDescriptorHandler(bool isKeyFrame) : isKeyFrame(isKeyFrame) {};
-	~TestPayloadDescriptorHandler() override = default;
-	void Dump(int indentation = 0) const override
-	{
-	}
-	bool Process(RTP::Codecs::EncodingContext* /*context*/, RTP::Packet* /*packet*/, bool& /*marker*/) override
-	{
-		return true;
-	}
-	void RtpPacketChanged(RTC::RTP::Packet* packet) override
-	{
-	}
-	std::unique_ptr<RTP::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
-	{
-		return nullptr;
-	}
-	void Encode(RTP::Packet* /*packet*/, RTP::Codecs::PayloadDescriptor::Encoder* /*encoder*/) override
-	{
-	}
-	void Restore(RTP::Packet* /*packet*/) override
-	{
-	}
-	uint8_t GetSpatialLayer() const override
-	{
-		return 0;
-	}
-	uint8_t GetTemporalLayer() const override
-	{
-		return 0;
-	}
-	bool IsKeyFrame() const override
-	{
-		return this->isKeyFrame;
-	}
-
-private:
-	bool isKeyFrame{ false };
-};
-
-class TestNackGeneratorListener : public NackGenerator::Listener
-{
-	void OnNackGeneratorNackRequired(const std::vector<uint16_t>& seqNumbers) override
-	{
-		this->nackRequiredTriggered = true;
-
-		auto it          = seqNumbers.begin();
-		auto firstNacked = *it;
-		auto numNacked   = seqNumbers.size();
-
-		REQUIRE(this->currentInput.firstNacked == firstNacked);
-		REQUIRE(this->currentInput.numNacked == numNacked);
-	};
-
-	void OnNackGeneratorKeyFrameRequired() override
-	{
-		this->keyFrameRequiredTriggered = true;
-
-		REQUIRE(this->currentInput.keyFrameRequired);
-	}
-
-public:
-	void Reset(TestNackGeneratorInput& input)
-	{
-		this->currentInput              = input;
-		this->nackRequiredTriggered     = false;
-		this->keyFrameRequiredTriggered = false;
-	}
-
-	void Check(NackGenerator& nackGenerator)
-	{
-		REQUIRE(this->nackRequiredTriggered == static_cast<bool>(this->currentInput.numNacked));
-		REQUIRE(this->keyFrameRequiredTriggered == this->currentInput.keyFrameRequired);
-	}
-
-private:
-	TestNackGeneratorInput currentInput{};
-	bool nackRequiredTriggered{ false };
-	bool keyFrameRequiredTriggered{ false };
-};
-
-void validate(std::unique_ptr<RTP::Packet>& packet, std::vector<TestNackGeneratorInput>& inputs)
-{
-	TestNackGeneratorListener listener;
-	NackGenerator nackGenerator = NackGenerator(&listener, SendNackDelay);
-
-	for (auto input : inputs)
-	{
-		listener.Reset(input);
-
-		auto* tpdh = new TestPayloadDescriptorHandler(input.isKeyFrame);
-
-		packet->SetPayloadDescriptorHandler(tpdh);
-		packet->SetSequenceNumber(input.seq);
-		nackGenerator.ReceivePacket(packet.get(), /*isRecovered*/ false);
-
-		listener.Check(nackGenerator);
-	}
-};
+using namespace RTP_COMMON;
 
 SCENARIO("NACK generator", "[rtp][rtcp]")
 {
+	constexpr unsigned int SendNackDelay{ 0u }; // In ms.
+
+	struct TestNackGeneratorInput
+	{
+		TestNackGeneratorInput() = default;
+		TestNackGeneratorInput(
+		  uint16_t seq,
+		  bool isKeyFrame,
+		  uint16_t firstNacked,
+		  size_t numNacked,
+		  bool keyFrameRequired = false,
+		  size_t nackListSize   = 0)
+		  : seq(seq), isKeyFrame(isKeyFrame), firstNacked(firstNacked), numNacked(numNacked),
+		    keyFrameRequired(keyFrameRequired), nackListSize(nackListSize)
+		{
+		}
+
+		uint16_t seq{ 0 };
+		bool isKeyFrame{ false };
+		uint16_t firstNacked{ 0 };
+		size_t numNacked{ 0 };
+		bool keyFrameRequired{ false };
+		size_t nackListSize{ 0 };
+	};
+
+	class TestPayloadDescriptorHandler : public RTP::Codecs::PayloadDescriptorHandler
+	{
+	public:
+		explicit TestPayloadDescriptorHandler(bool isKeyFrame) : isKeyFrame(isKeyFrame) {};
+		~TestPayloadDescriptorHandler() override = default;
+		void Dump(int indentation = 0) const override
+		{
+		}
+		bool Process(RTP::Codecs::EncodingContext* /*context*/, RTP::Packet* /*packet*/, bool& /*marker*/) override
+		{
+			return true;
+		}
+		void RtpPacketChanged(RTC::RTP::Packet* packet) override
+		{
+		}
+		std::unique_ptr<RTP::Codecs::PayloadDescriptor::Encoder> GetEncoder() const override
+		{
+			return nullptr;
+		}
+		void Encode(RTP::Packet* /*packet*/, RTP::Codecs::PayloadDescriptor::Encoder* /*encoder*/) override
+		{
+		}
+		void Restore(RTP::Packet* /*packet*/) override
+		{
+		}
+		uint8_t GetSpatialLayer() const override
+		{
+			return 0;
+		}
+		uint8_t GetTemporalLayer() const override
+		{
+			return 0;
+		}
+		bool IsKeyFrame() const override
+		{
+			return this->isKeyFrame;
+		}
+
+	private:
+		bool isKeyFrame{ false };
+	};
+
+	class TestNackGeneratorListener : public NackGenerator::Listener
+	{
+		void OnNackGeneratorNackRequired(const std::vector<uint16_t>& seqNumbers) override
+		{
+			this->nackRequiredTriggered = true;
+
+			auto it          = seqNumbers.begin();
+			auto firstNacked = *it;
+			auto numNacked   = seqNumbers.size();
+
+			REQUIRE(this->currentInput.firstNacked == firstNacked);
+			REQUIRE(this->currentInput.numNacked == numNacked);
+		};
+
+		void OnNackGeneratorKeyFrameRequired() override
+		{
+			this->keyFrameRequiredTriggered = true;
+
+			REQUIRE(this->currentInput.keyFrameRequired);
+		}
+
+	public:
+		void Reset(TestNackGeneratorInput& input)
+		{
+			this->currentInput              = input;
+			this->nackRequiredTriggered     = false;
+			this->keyFrameRequiredTriggered = false;
+		}
+
+		void Check(NackGenerator& nackGenerator)
+		{
+			REQUIRE(this->nackRequiredTriggered == static_cast<bool>(this->currentInput.numNacked));
+			REQUIRE(this->keyFrameRequiredTriggered == this->currentInput.keyFrameRequired);
+		}
+
+	private:
+		TestNackGeneratorInput currentInput{};
+		bool nackRequiredTriggered{ false };
+		bool keyFrameRequiredTriggered{ false };
+	};
+
+	auto validate = [](std::unique_ptr<RTP::Packet>& packet, std::vector<TestNackGeneratorInput>& inputs)
+	{
+		TestNackGeneratorListener listener;
+		NackGenerator nackGenerator = NackGenerator(&listener, SendNackDelay);
+
+		for (auto input : inputs)
+		{
+			listener.Reset(input);
+
+			auto* tpdh = new TestPayloadDescriptorHandler(input.isKeyFrame);
+
+			packet->SetPayloadDescriptorHandler(tpdh);
+			packet->SetSequenceNumber(input.seq);
+			nackGenerator.ReceivePacket(packet.get(), /*isRecovered*/ false);
+
+			listener.Check(nackGenerator);
+		}
+	};
+
 	// clang-format off
 	uint8_t rtpBuffer[] =
 	{


### PR DESCRIPTION
# Details

- Enable RTP tests in clang-tidy task.
- This PR follows same guidelines as previous one (RTCP tests):
  - If there is a single `SCENARIO` in a test file, declare variables, structs and classes in the `SCENARIO` block and also use lambda functions there (such as `validate()`).
  - If there are N `SCENARIOs` in a test file and they need access to same variables/classes/structs/functions, then declare those within an anonymous C++ namespace.