### PR TITLE
clang-tidy for all worker tests

### DIFF
--- a/worker/.clang-tidy
+++ b/worker/.clang-tidy
@@ -75,6 +75,7 @@ Checks: "*,\
   -readability-convert-member-functions-to-static,\
   -readability-else-after-return,\
   -readability-function-cognitive-complexity,\
+  -readability-function-size,\
   -readability-identifier-length,\
   -readability-implicit-bool-conversion,\
   -readability-magic-numbers,\
@@ -106,12 +107,6 @@ CheckOptions:
     value: 'NULL'
   - key: readability-braces-around-statements.ShortStatementLines
     value: '3'
-  - key: readability-function-size.BranchThreshold
-    value: '4294967295'
-  - key: readability-function-size.LineThreshold
-    value: '4294967295'
-  - key: readability-function-size.StatementThreshold
-    value: '1500'
   - key: readability-identifier-naming.AbstractClassCase
     value: CamelCase
   - key: readability-identifier-naming.AbstractClassPrefix

--- a/worker/scripts/clang-scripts.mjs
+++ b/worker/scripts/clang-scripts.mjs
@@ -20,11 +20,8 @@ const CLANG_FORMAT_PATHS = [
 
 const CLANG_TIDY_PATHS = [
 	'../src/**/*.cpp',
-	// TODO: Temporal until all tests are included.
-	'../test/src/RTC/RTP/**/*.cpp',
-	'../test/src/RTC/RTCP/**/*.cpp',
-	// TODO: Enable test/ and fuzzer/ source files.
-	// '../test/src/**/*.cpp',
+	'../test/src/**/*.cpp',
+	// TODO
 	// '../fuzzer/src/**/*.cpp',
 ];
 

--- a/worker/test/include/RTC/ICE/iceCommon.hpp
+++ b/worker/test/include/RTC/ICE/iceCommon.hpp
@@ -2,34 +2,31 @@
 #define MS_TEST_RTC_ICE_COMMON_HPP
 
 #include "common.hpp"
-#include "MediaSoupErrors.hpp"
-#include "Utils.hpp"
-#include "testHelpers.hpp"
-#include "RTC/ICE/StunPacket.hpp"
-#include <catch2/catch_test_macros.hpp>
-#include <cstdlib> // std::malloc(), std::free()
-#include <cstring> // std::memcpy()
+#include "MediaSoupErrors.hpp"          // IWYU pragma: export
+#include "Utils.hpp"                    // IWYU pragma: export
+#include "testHelpers.hpp"              // IWYU pragma: export
+#include "RTC/ICE/StunPacket.hpp"       // IWYU pragma: export
+#include <catch2/catch_test_macros.hpp> // IWYU pragma: export
+#include <cstdlib>                      // std::malloc(), std::free()
+#include <cstring>                      // std::memcpy()
 #include <string_view>
 
 using namespace RTC::ICE;
 
-namespace RTC
+namespace ICE_COMMON
 {
-	namespace ICE
-	{
-		// NOTE: We need to declare them here with `extern` and then define them in
-		// iceCommon.cpp.
-		// NOTE: Random size buffers because anyway we use sizeof(XxxxBuffer).
-		extern thread_local uint8_t FactoryBuffer[66661];
-		extern thread_local uint8_t ResponseFactoryBuffer[66661];
-		extern thread_local uint8_t SerializeBuffer[66662];
-		extern thread_local uint8_t CloneBuffer[66663];
-		extern thread_local uint8_t DataBuffer[66664];
-		extern thread_local uint8_t ThrowBuffer[66665];
+	// NOTE: We need to declare them here with `extern` and then define them in
+	// iceCommon.cpp.
+	// NOTE: Random size buffers because anyway we use sizeof(XxxxBuffer).
+	extern thread_local uint8_t FactoryBuffer[66661];
+	extern thread_local uint8_t ResponseFactoryBuffer[66661];
+	extern thread_local uint8_t SerializeBuffer[66662];
+	extern thread_local uint8_t CloneBuffer[66663];
+	extern thread_local uint8_t DataBuffer[66664];
+	extern thread_local uint8_t ThrowBuffer[66665];
 
-		void ResetBuffers();
-	} // namespace ICE
-} // namespace RTC
+	void ResetBuffers();
+} // namespace ICE_COMMON
 
 // NOLINTNEXTLINE (cppcoreguidelines-macro-usage)
 #define CHECK_STUN_PACKET(/*const StunPacket**/ packet,                                             \
@@ -116,7 +113,7 @@ namespace RTC
 			REQUIRE_THROWS_AS(packet->Protect("isoiulkajdlkja"), MediaSoupError);                         \
 			REQUIRE_THROWS_AS(packet->Protect(), MediaSoupError);                                         \
 		}                                                                                               \
-		REQUIRE(helpers::AreBuffersEqual(buffer, bufferLength, originalBuffer, bufferLength) == true);  \
+		REQUIRE(helpers::areBuffersEqual(buffer, bufferLength, originalBuffer, bufferLength) == true);  \
 		REQUIRE_THROWS_AS(                                                                              \
 		  const_cast<StunPacket*>(packet)->Serialize(ThrowBuffer, length - 1), MediaSoupError);         \
 		REQUIRE_THROWS_AS(packet->Clone(ThrowBuffer, length - 1), MediaSoupError);                      \

--- a/worker/test/include/RTC/RTP/rtpCommon.hpp
+++ b/worker/test/include/RTC/RTP/rtpCommon.hpp
@@ -3,7 +3,7 @@
 
 #include "common.hpp"
 #include "MediaSoupErrors.hpp"          // IWYU pragma: export
-#include "testHelpers.hpp"              // IWYU pragma: export in worker/test/include/
+#include "testHelpers.hpp"              // IWYU pragma: export
 #include "RTC/RTP/Packet.hpp"           // IWYU pragma: export
 #include <catch2/catch_test_macros.hpp> // IWYU pragma: export
 #include <cstdlib>                      // std::malloc(), std::free()
@@ -107,9 +107,9 @@ namespace RTP_COMMON
 		if (!hasPadding)                                                                                 \
 		{                                                                                                \
 			REQUIRE_NOTHROW(packet->SetPayload(packet->GetPayload(), packet->GetPayloadLength()));         \
-			REQUIRE(helpers::AreBuffersEqual(buffer, bufferLength, originalBuffer, bufferLength) == true); \
+			REQUIRE(helpers::areBuffersEqual(buffer, bufferLength, originalBuffer, bufferLength) == true); \
 			REQUIRE_NOTHROW(packet->SetPayloadLength(packet->GetPayloadLength()));                         \
-			REQUIRE(helpers::AreBuffersEqual(buffer, bufferLength, originalBuffer, bufferLength) == true); \
+			REQUIRE(helpers::areBuffersEqual(buffer, bufferLength, originalBuffer, bufferLength) == true); \
 		}                                                                                                \
 		REQUIRE_THROWS_AS(packet->SetPayload(DataBuffer, packet->GetBufferLength()), MediaSoupError);    \
 		REQUIRE_THROWS_AS(packet->SetPayloadLength(packet->GetBufferLength()), MediaSoupError);          \
@@ -117,9 +117,9 @@ namespace RTP_COMMON
 		if (packet->IsPaddedTo4Bytes() && packet->GetPaddingLength() < 4)                                \
 		{                                                                                                \
 			REQUIRE_NOTHROW(packet->PadTo4Bytes());                                                        \
-			REQUIRE(helpers::AreBuffersEqual(buffer, bufferLength, originalBuffer, bufferLength) == true); \
+			REQUIRE(helpers::areBuffersEqual(buffer, bufferLength, originalBuffer, bufferLength) == true); \
 		}                                                                                                \
-		REQUIRE(helpers::AreBuffersEqual(buffer, bufferLength, originalBuffer, bufferLength) == true);   \
+		REQUIRE(helpers::areBuffersEqual(buffer, bufferLength, originalBuffer, bufferLength) == true);   \
 		REQUIRE_THROWS_AS(                                                                               \
 		  const_cast<Packet*>(packet)->Serialize(ThrowBuffer, length - 1), MediaSoupError);              \
 		REQUIRE_THROWS_AS(packet->Clone(ThrowBuffer, length - 1), MediaSoupError);                       \

--- a/worker/test/include/RTC/SCTP/sctpCommon.hpp
+++ b/worker/test/include/RTC/SCTP/sctpCommon.hpp
@@ -2,34 +2,32 @@
 #define MS_TEST_RTC_SCTP_COMMON_HPP
 
 #include "common.hpp"
-#include "MediaSoupErrors.hpp"            // IWYU pragma: export
-#include "Utils.hpp"                      // IWYU pragma: export
-#include "testHelpers.hpp"                // IWYU pragma: export in worker/test/include/
-#include "RTC/SCTP/packet/Chunk.hpp"      // IWYU pragma: export
-#include "RTC/SCTP/packet/ErrorCause.hpp" // IWYU pragma: export
-#include "RTC/SCTP/packet/Packet.hpp"     // IWYU pragma: export
-#include "RTC/SCTP/packet/Parameter.hpp"  // IWYU pragma: export
+#include "MediaSoupErrors.hpp"                                               // IWYU pragma: export
+#include "Utils.hpp"                                                         // IWYU pragma: export
+#include "testHelpers.hpp"                                                   // IWYU pragma: export
+#include "RTC/SCTP/packet/Chunk.hpp"                                         // IWYU pragma: export
+#include "RTC/SCTP/packet/ErrorCause.hpp"                                    // IWYU pragma: export
+#include "RTC/SCTP/packet/Packet.hpp"                                        // IWYU pragma: export
+#include "RTC/SCTP/packet/Parameter.hpp"                                     // IWYU pragma: export
 #include "RTC/SCTP/packet/errorCauses/InvalidStreamIdentifierErrorCause.hpp" // IWYU pragma: export
 #include "RTC/SCTP/packet/parameters/HeartbeatInfoParameter.hpp"             // IWYU pragma: export
 #include <catch2/catch_test_macros.hpp>                                      // IWYU pragma: export
 
 using namespace RTC::SCTP;
 
-namespace RTC
+namespace SCTP_COMMON
 {
-	namespace SCTP
-	{
-		// NOTE: We need to declare them here with `extern` and then define them in
-		// common.cpp.
-		extern thread_local uint8_t FactoryBuffer[66661];
-		extern thread_local uint8_t SerializeBuffer[66662];
-		extern thread_local uint8_t CloneBuffer[66663];
-		extern thread_local uint8_t DataBuffer[66664];
-		extern thread_local uint8_t ThrowBuffer[66665];
+	// NOTE: We need to declare them here with `extern` and then define them in
+	// common.cpp.
+	// NOTE: Random size buffers because anyway we use sizeof(XxxxBuffer).
+	extern thread_local uint8_t FactoryBuffer[66661];
+	extern thread_local uint8_t SerializeBuffer[66662];
+	extern thread_local uint8_t CloneBuffer[66663];
+	extern thread_local uint8_t DataBuffer[66664];
+	extern thread_local uint8_t ThrowBuffer[66665];
 
-		void ResetBuffers();
-	} // namespace SCTP
-} // namespace RTC
+	void ResetBuffers();
+} // namespace SCTP_COMMON
 
 // NOLINTNEXTLINE (cppcoreguidelines-macro-usage)
 #define CHECK_SCTP_PACKET(/*const Packet**/ packet,                                                \
@@ -61,7 +59,7 @@ namespace RTC
 		REQUIRE(packet->HasChunks() == (chunksCount > 0));                                             \
 		REQUIRE(packet->GetChunkAt(chunksCount) == nullptr);                                           \
 		REQUIRE(                                                                                       \
-		  helpers::AreBuffersEqual(packet->GetBuffer(), packet->GetLength(), buffer, length) == true); \
+		  helpers::areBuffersEqual(packet->GetBuffer(), packet->GetLength(), buffer, length) == true); \
 		REQUIRE_THROWS_AS(                                                                             \
 		  const_cast<Packet*>(packet)->Serialize(ThrowBuffer, length - 1), MediaSoupError);            \
 		REQUIRE_THROWS_AS(packet->Clone(ThrowBuffer, length - 1), MediaSoupError);                     \
@@ -122,7 +120,7 @@ namespace RTC
 		if (buffer)                                                                                      \
 		{                                                                                                \
 			REQUIRE(                                                                                       \
-			  helpers::AreBuffersEqual(chunk->GetBuffer(), chunk->GetLength(), buffer, length) == true);   \
+			  helpers::areBuffersEqual(chunk->GetBuffer(), chunk->GetLength(), buffer, length) == true);   \
 		}                                                                                                \
 		REQUIRE_THROWS_AS(                                                                               \
 		  const_cast<Chunk*>(reinterpret_cast<const Chunk*>(chunk))->Serialize(ThrowBuffer, length - 1), \
@@ -158,7 +156,7 @@ namespace RTC
 		if (buffer)                                                                                     \
 		{                                                                                               \
 			REQUIRE(                                                                                      \
-			  helpers::AreBuffersEqual(parameter->GetBuffer(), parameter->GetLength(), buffer, length) == \
+			  helpers::areBuffersEqual(parameter->GetBuffer(), parameter->GetLength(), buffer, length) == \
 			  true);                                                                                      \
 		}                                                                                               \
 		REQUIRE_THROWS_AS(                                                                              \
@@ -193,7 +191,7 @@ namespace RTC
 		if (buffer)                                                                                    \
 		{                                                                                              \
 			REQUIRE(                                                                                     \
-			  helpers::AreBuffersEqual(                                                                  \
+			  helpers::areBuffersEqual(                                                                  \
 			    errorCause->GetBuffer(), errorCause->GetLength(), buffer, length) == true);              \
 		}                                                                                              \
 		REQUIRE_THROWS_AS(                                                                             \

--- a/worker/test/include/testHelpers.hpp
+++ b/worker/test/include/testHelpers.hpp
@@ -5,13 +5,9 @@
 
 namespace helpers
 {
-	bool ReadBinaryFile(const char* file, uint8_t* buffer, size_t* len);
+	bool readBinaryFile(const char* file, uint8_t* buffer, size_t* len);
 
-	bool AddToBuffer(uint8_t* buf, size_t* size, const uint8_t* data, size_t len);
-
-	bool ReadPayloadData(const char* file, int pos, int bytes, uint8_t* payload);
-
-	bool AreBuffersEqual(const uint8_t* data1, size_t size1, const uint8_t* data2, size_t size2);
+	bool areBuffersEqual(const uint8_t* data1, size_t size1, const uint8_t* data2, size_t size2);
 } // namespace helpers
 
 #endif

--- a/worker/test/src/RTC/ICE/TestStunPacket.cpp
+++ b/worker/test/src/RTC/ICE/TestStunPacket.cpp
@@ -9,6 +9,7 @@
 #include <string>
 
 using namespace RTC::ICE;
+using namespace ICE_COMMON;
 
 SCENARIO("ICE StunPacket", "[serializable][ice][stunpacket]")
 {
@@ -562,7 +563,7 @@ SCENARIO("ICE StunPacket", "[serializable][ice][stunpacket]")
 		                  /*hasFingerprint*/ false);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(
+		  helpers::areBuffersEqual(
 		    request->GetTransactionId(),
 		    StunPacket::TransactionIdLength,
 		    transactionId,
@@ -599,7 +600,7 @@ SCENARIO("ICE StunPacket", "[serializable][ice][stunpacket]")
 		                  /*hasFingerprint*/ false);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(
+		  helpers::areBuffersEqual(
 		    request->GetTransactionId(),
 		    StunPacket::TransactionIdLength,
 		    transactionId,
@@ -638,7 +639,7 @@ SCENARIO("ICE StunPacket", "[serializable][ice][stunpacket]")
 		                  /*hasFingerprint*/ false);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(
+		  helpers::areBuffersEqual(
 		    request->GetTransactionId(),
 		    StunPacket::TransactionIdLength,
 		    transactionId,
@@ -1103,7 +1104,7 @@ SCENARIO("ICE StunPacket", "[serializable][ice][stunpacket]")
 		                  /*hasFingerprint*/ false);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(
+		  helpers::areBuffersEqual(
 		    successResponse->GetTransactionId(),
 		    StunPacket::TransactionIdLength,
 		    request->GetTransactionId(),
@@ -1184,7 +1185,7 @@ SCENARIO("ICE StunPacket", "[serializable][ice][stunpacket]")
 		                  /*hasFingerprint*/ false);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(
+		  helpers::areBuffersEqual(
 		    errorResponse->GetTransactionId(),
 		    StunPacket::TransactionIdLength,
 		    request->GetTransactionId(),

--- a/worker/test/src/RTC/ICE/iceCommon.cpp
+++ b/worker/test/src/RTC/ICE/iceCommon.cpp
@@ -1,30 +1,27 @@
 #include "RTC/ICE/iceCommon.hpp" // in worker/test/include/
 #include <cstring>               // std::memset
 
-namespace RTC
+namespace ICE_COMMON
 {
-	namespace ICE
+	thread_local uint8_t FactoryBuffer[];
+	thread_local uint8_t ResponseFactoryBuffer[];
+	thread_local uint8_t SerializeBuffer[];
+	thread_local uint8_t CloneBuffer[];
+	thread_local uint8_t DataBuffer[];
+	thread_local uint8_t ThrowBuffer[];
+
+	void ResetBuffers()
 	{
-		thread_local uint8_t FactoryBuffer[];
-		thread_local uint8_t ResponseFactoryBuffer[];
-		thread_local uint8_t SerializeBuffer[];
-		thread_local uint8_t CloneBuffer[];
-		thread_local uint8_t DataBuffer[];
-		thread_local uint8_t ThrowBuffer[];
+		std::memset(FactoryBuffer, 0xAA, sizeof(FactoryBuffer));
+		std::memset(ResponseFactoryBuffer, 0xAA, sizeof(ResponseFactoryBuffer));
+		std::memset(SerializeBuffer, 0xBB, sizeof(SerializeBuffer));
+		std::memset(CloneBuffer, 0xCC, sizeof(CloneBuffer));
+		std::memset(DataBuffer, 0xDD, sizeof(DataBuffer));
+		std::memset(ThrowBuffer, 0xEE, sizeof(ThrowBuffer));
 
-		void ResetBuffers()
+		for (size_t i = 0; i < 256; ++i)
 		{
-			std::memset(FactoryBuffer, 0xAA, sizeof(FactoryBuffer));
-			std::memset(ResponseFactoryBuffer, 0xAA, sizeof(ResponseFactoryBuffer));
-			std::memset(SerializeBuffer, 0xBB, sizeof(SerializeBuffer));
-			std::memset(CloneBuffer, 0xCC, sizeof(CloneBuffer));
-			std::memset(DataBuffer, 0xDD, sizeof(DataBuffer));
-			std::memset(ThrowBuffer, 0xEE, sizeof(ThrowBuffer));
-
-			for (size_t i = 0; i < 256; ++i)
-			{
-				DataBuffer[i] = static_cast<uint8_t>(i);
-			}
+			DataBuffer[i] = static_cast<uint8_t>(i);
 		}
-	} // namespace ICE
-} // namespace RTC
+	}
+} // namespace ICE_COMMON

--- a/worker/test/src/RTC/RTCP/TestBye.cpp
+++ b/worker/test/src/RTC/RTCP/TestBye.cpp
@@ -6,7 +6,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP BYE parsing", "[parser][rtcp][bye]")
+SCENARIO("RTCP BYE", "[rtcp][bye]")
 {
 	// RCTP BYE packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsAfb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsAfb.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feedback PS AFB parsing", "[parser][rtcp][feedback-ps][afb]")
+SCENARIO("RTCP Feedback PS AFB", "[rtcp][feedback-ps][afb]")
 {
 	// RTCP AFB packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsFir.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsFir.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feedback PS FIR parsing", "[parser][rtcp][feedback-ps][fir]")
+SCENARIO("RTCP Feedback PS FIR", "[rtcp][feedback-ps][fir]")
 {
 	// RTCP FIR packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsLei.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsLei.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feedback PS LEI parsing", "[parser][rtcp][feedback-ps][lei]")
+SCENARIO("RTCP Feedback PS LEI", "[rtcp][feedback-ps][lei]")
 {
 	// RTCP LEI packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsPli.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsPli.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feeback RTP PLI parsing", "[parser][rtcp][feedback-ps][pli]")
+SCENARIO("RTCP Feedback RTP PLI", "[rtcp][feedback-ps][pli]")
 {
 	// RTCP PLI packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsRemb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsRemb.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feedback PS parsing", "[parser][rtcp][feedback-ps][remb]")
+SCENARIO("RTCP Feedback PS REMB", "[rtcp][feedback-ps][remb]")
 {
 	// RTCP REMB packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feedback PS RPSI parsing", "[parser][rtcp][feedback-ps][rpsi]")
+SCENARIO("RTCP Feedback PS RPSI", "[rtcp][feedback-ps][rpsi]")
 {
 	// RTCP RPSI packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsSli.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsSli.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feedback PS SLI parsing", "[parser][rtcp][feedback-ps][sli]")
+SCENARIO("RTCP Feedback PS SLI", "[rtcp][feedback-ps][sli]")
 {
 	// RTCP SLI packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsTst.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsTst.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feedback PS TSTN parsing", "[parser][rtcp][feedback-ps][tstn]")
+SCENARIO("RTCP Feedback PS TSTN", "[rtcp][feedback-ps][tstn]")
 {
 	// RTCP TSTN packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feedback PS VBCM parsing", "[parser][rtcp][feedback-ps][vbcm]")
+SCENARIO("RTCP Feedback PS VBCM", "[rtcp][feedback-ps][vbcm]")
 {
 	// RTCP VBCM packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feeback RTP ECN parsing", "[parser][rtcp][feedback-rtp][ecn]")
+SCENARIO("RTCP Feedback RTP ECN", "[rtcp][feedback-rtp][ecn]")
 {
 	// clang-format off
 	uint8_t buffer[] =

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpNack.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpNack.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feeback RTP NACK parsing", "[parser][rtcp][feedback-rtp][nack]")
+SCENARIO("RTCP Feedback RTP NACK", "[rtcp][feedback-rtp][nack]")
 {
 	// RTCP NACK packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpSrReq.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpSrReq.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feeback RTP SR-REQ parsing", "[parser][rtcp][feedback-rtp][sr-req]")
+SCENARIO("RTCP Feedback RTP SR-REQ", "[rtcp][feedback-rtp][sr-req]")
 {
 	// RTCP SR-REQ packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feeback RTP TLLEI parsing", "[parser][rtcp][feedback-rtp][tllei]")
+SCENARIO("RTCP Feedback RTP TLLEI", "[rtcp][feedback-rtp][tllei]")
 {
 	// RTCP TLLEI packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feeback RTP TMMBR parsing", "[parser][rtcp][feedback-rtp][tmmb]")
+SCENARIO("RTCP Feedback RTP TMMBR", "[rtcp][feedback-rtp][tmmb]")
 {
 	// RTCP TMMBR packet.
 

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
@@ -6,7 +6,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP Feeback RTP transport", "[parser][rtcp][feedback-rtp][transport]")
+SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 {
 	struct TestFeedbackRtpTransportInput
 	{

--- a/worker/test/src/RTC/RTCP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTCP/TestPacket.cpp
@@ -4,7 +4,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP parsing", "[parser][rtcp][packet]")
+SCENARIO("RTCP Packet", "[rtcp][packet]")
 {
 	// RTCP common header
 	// Version:2, Padding:false, Count:0, Type:200(SR), Lengh:0

--- a/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP RR parsing", "[parser][rtcp][rr]")
+SCENARIO("RTCP ReceiverReport", "[rtcp][receiver-report]")
 {
 	// RTCP Receiver Report Packet.
 

--- a/worker/test/src/RTC/RTCP/TestSdes.cpp
+++ b/worker/test/src/RTC/RTCP/TestSdes.cpp
@@ -7,7 +7,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP SDES parsing", "[parser][rtcp][sdes]")
+SCENARIO("RTCP SDES", "[rtcp][sdes]")
 {
 	// RTCP Sdes Packet.
 

--- a/worker/test/src/RTC/RTCP/TestSenderReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestSenderReport.cpp
@@ -5,7 +5,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP SR parsing", "[parser][rtcp][sr]")
+SCENARIO("RTCP SenderReport", "[rtcp][sender-report]")
 {
 	// RTCP Packet. Sender Report and Receiver Report.
 

--- a/worker/test/src/RTC/RTCP/TestXr.cpp
+++ b/worker/test/src/RTC/RTCP/TestXr.cpp
@@ -7,7 +7,7 @@
 
 using namespace RTC::RTCP;
 
-SCENARIO("RTCP XR parsing", "[parser][rtcp][xr]")
+SCENARIO("RTCP XR", "[rtcp][xr]")
 {
 	// clang-format off
 	uint8_t buffer[] =
@@ -130,7 +130,7 @@ SCENARIO("RTCP XR parsing", "[parser][rtcp][xr]")
 	}
 }
 
-SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
+SCENARIO("RTCP XrDelaySinceLastRt", "[rtcp][xr]")
 {
 	SECTION("create RRT")
 	{
@@ -154,7 +154,6 @@ SCENARIO("RTCP XrDelaySinceLastRt parsing", "[parser][rtcp][xr-dlrr]")
 		// Create a new report out of the external buffer.
 		// NOTE: We cannot use unique_ptr here since the instance lifecycle will be
 		// managed by the packet.
-		// NOLINTNEXTLINE(llvm-qualified-auto,readability-qualified-auto)
 		auto* report2 = ReceiverReferenceTime::Parse(bufferReport1, report1->GetSize());
 
 		REQUIRE(report1->GetType() == report2->GetType());

--- a/worker/test/src/RTC/RTP/Codecs/TestDependencyDescriptor.cpp
+++ b/worker/test/src/RTC/RTP/Codecs/TestDependencyDescriptor.cpp
@@ -4,7 +4,7 @@
 
 using namespace RTC;
 
-SCENARIO("parse Dependency Descriptor", "[rtp][codecs][DD]")
+SCENARIO("Dependency Descriptor", "[rtp][codecs][dependency-descriptor]")
 {
 	class Listener : public ::RTC::RTP::Codecs::DependencyDescriptor::Listener
 	{
@@ -14,7 +14,7 @@ SCENARIO("parse Dependency Descriptor", "[rtp][codecs][DD]")
 		}
 	};
 
-	SECTION("parse Dependency Descriptor")
+	SECTION("parse")
 	{
 		/**
 		 * Taken from https://issues.webrtc.org/issues/42225660.

--- a/worker/test/src/RTC/RTP/Codecs/TestH264.cpp
+++ b/worker/test/src/RTC/RTP/Codecs/TestH264.cpp
@@ -4,7 +4,7 @@
 
 using namespace RTC;
 
-SCENARIO("parse H264 payload descriptor", "[rtp][codecs][h264]")
+SCENARIO("H264 payload descriptor", "[rtp][codecs][h264]")
 {
 	SECTION("parse payload descriptor")
 	{

--- a/worker/test/src/RTC/RTP/Codecs/TestVP8.cpp
+++ b/worker/test/src/RTC/RTP/Codecs/TestVP8.cpp
@@ -70,7 +70,7 @@ namespace
 	}
 } // namespace
 
-SCENARIO("parse VP8 payload descriptor", "[rtp][codecs][vp8]")
+SCENARIO("VP8 payload descriptor", "[rtp][codecs][vp8]")
 {
 	SECTION("parse payload descriptor")
 	{
@@ -137,7 +137,7 @@ SCENARIO("parse VP8 payload descriptor", "[rtp][codecs][vp8]")
 			payloadDescriptor->Encode(
 			  buffer, payloadDescriptor->pictureId, payloadDescriptor->tl0PictureIndex);
 
-			SECTION("compare encoded payloadDescriptor with original buffer")
+			SECTION("compare encoded payload descriptor with original buffer")
 			{
 				REQUIRE(std::memcmp(buffer, originalBuffer, sizeof(buffer)) == 0);
 			}
@@ -281,7 +281,7 @@ SCENARIO("parse VP8 payload descriptor", "[rtp][codecs][vp8]")
 		}
 	}
 
-	SECTION("parse payload descriptor. I flag set but no space for pictureId")
+	SECTION("parse payload descriptor, I flag set but no space for pictureId")
 	{
 		/**
 		 * VP8 Payload Descriptor
@@ -310,7 +310,7 @@ SCENARIO("parse VP8 payload descriptor", "[rtp][codecs][vp8]")
 		REQUIRE(!payloadDescriptor);
 	}
 
-	SECTION("parse payload descriptor. X flag is not set, no keyframe")
+	SECTION("parse payload descriptor, X flag is not set, no keyframe")
 	{
 		/**
 		 * VP8 Payload Descriptor
@@ -363,7 +363,7 @@ SCENARIO("parse VP8 payload descriptor", "[rtp][codecs][vp8]")
 		delete payloadDescriptor;
 	}
 
-	SECTION("parse payload descriptor. X flag is not set, keyframe")
+	SECTION("parse payload descriptor, X flag is not set, keyframe")
 	{
 		/**
 		 * VP8 Payload Descriptor

--- a/worker/test/src/RTC/RTP/Codecs/TestVP9.cpp
+++ b/worker/test/src/RTC/RTP/Codecs/TestVP9.cpp
@@ -88,7 +88,7 @@ SCENARIO("process VP9 payload descriptor", "[rtp][codecs][vp9]")
 		REQUIRE(!forwarded);
 	}
 
-	SECTION("test PayloadDescriptorHandler")
+	SECTION("PayloadDescriptorHandler")
 	{
 		RTP::Codecs::EncodingContext::Params params;
 		params.spatialLayers  = 1;

--- a/worker/test/src/RTC/RTP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTP/TestPacket.cpp
@@ -1,6 +1,6 @@
 #include "common.hpp"
 #include "Utils.hpp"
-#include "testHelpers.hpp" // IWYU pragma: export in worker/test/include/
+#include "testHelpers.hpp"
 #include "RTC/RTP/HeaderExtensionIds.hpp"
 #include "RTC/RTP/Packet.hpp"
 #include "RTC/RTP/rtpCommon.hpp"
@@ -22,7 +22,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		uint8_t buffer[65536];
 		size_t bufferLength;
 
-		if (!helpers::ReadBinaryFile("data/packet1.raw", buffer, std::addressof(bufferLength)))
+		if (!helpers::readBinaryFile("data/packet1.raw", buffer, std::addressof(bufferLength)))
 		{
 			FAIL("cannot open file");
 		}
@@ -126,7 +126,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		  /*paddingLength*/ 0);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 16) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 16) ==
 		  true);
 	}
 
@@ -135,7 +135,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		uint8_t buffer[65536];
 		size_t bufferLength;
 
-		if (!helpers::ReadBinaryFile("data/packet2.raw", buffer, std::addressof(bufferLength)))
+		if (!helpers::readBinaryFile("data/packet2.raw", buffer, std::addressof(bufferLength)))
 		{
 			FAIL("cannot open file");
 		}
@@ -239,7 +239,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		  /*paddingLength*/ 0);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 16) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 16) ==
 		  true);
 	}
 
@@ -248,7 +248,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		uint8_t buffer[65536];
 		size_t bufferLength;
 
-		if (!helpers::ReadBinaryFile("data/packet3.raw", buffer, std::addressof(bufferLength)))
+		if (!helpers::readBinaryFile("data/packet3.raw", buffer, std::addressof(bufferLength)))
 		{
 			FAIL("cannot open file");
 		}
@@ -352,7 +352,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		  /*paddingLength*/ 0);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 16) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 16) ==
 		  true);
 	}
 
@@ -472,7 +472,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		  /*paddingLength*/ 0);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 16) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 16) ==
 		  true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == true);
 	}
@@ -521,17 +521,17 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(packet->HasExtension(1) == true);
 		extensionValue = packet->GetExtensionValue(1, extensionLen);
 		REQUIRE(extensionLen == 1);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 1, buffer + 17, 1) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 1, buffer + 17, 1) == true);
 
 		REQUIRE(packet->HasExtension(2) == true);
 		extensionValue = packet->GetExtensionValue(2, extensionLen);
 		REQUIRE(extensionLen == 2);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 2, buffer + 19, 2) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 2, buffer + 19, 2) == true);
 
 		REQUIRE(packet->HasExtension(3) == true);
 		extensionValue = packet->GetExtensionValue(3, extensionLen);
 		REQUIRE(extensionLen == 4);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 4, buffer + 24, 4) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 4, buffer + 24, 4) == true);
 
 		REQUIRE(packet->HasExtension(4) == false);
 		REQUIRE(packet->GetExtensionValue(4, extensionLen) == nullptr);
@@ -567,17 +567,17 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(packet->HasExtension(1) == true);
 		extensionValue = packet->GetExtensionValue(1, extensionLen);
 		REQUIRE(extensionLen == 1);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 1, SerializeBuffer + 17, 1) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 1, SerializeBuffer + 17, 1) == true);
 
 		REQUIRE(packet->HasExtension(2) == true);
 		extensionValue = packet->GetExtensionValue(2, extensionLen);
 		REQUIRE(extensionLen == 2);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 2, SerializeBuffer + 19, 2) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 2, SerializeBuffer + 19, 2) == true);
 
 		REQUIRE(packet->HasExtension(3) == true);
 		extensionValue = packet->GetExtensionValue(3, extensionLen);
 		REQUIRE(extensionLen == 4);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 4, SerializeBuffer + 24, 4) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 4, SerializeBuffer + 24, 4) == true);
 
 		REQUIRE(packet->HasExtension(4) == false);
 		REQUIRE(packet->GetExtensionValue(4, extensionLen) == nullptr);
@@ -613,17 +613,17 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(packet->HasExtension(1) == true);
 		extensionValue = packet->GetExtensionValue(1, extensionLen);
 		REQUIRE(extensionLen == 1);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 1, CloneBuffer + 17, 1) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 1, CloneBuffer + 17, 1) == true);
 
 		REQUIRE(packet->HasExtension(2) == true);
 		extensionValue = packet->GetExtensionValue(2, extensionLen);
 		REQUIRE(extensionLen == 2);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 2, CloneBuffer + 19, 2) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 2, CloneBuffer + 19, 2) == true);
 
 		REQUIRE(packet->HasExtension(3) == true);
 		extensionValue = packet->GetExtensionValue(3, extensionLen);
 		REQUIRE(extensionLen == 4);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 4, CloneBuffer + 24, 4) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 4, CloneBuffer + 24, 4) == true);
 
 		REQUIRE(packet->HasExtension(4) == false);
 		REQUIRE(packet->GetExtensionValue(4, extensionLen) == nullptr);
@@ -655,7 +655,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		  /*paddingLength*/ 0);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 16) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 16) ==
 		  true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == true);
 	}
@@ -708,12 +708,12 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(packet->HasExtension(2) == true);
 		extensionValue = packet->GetExtensionValue(2, extensionLen);
 		REQUIRE(extensionLen == 1);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 1, buffer + 22, 1) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 1, buffer + 22, 1) == true);
 
 		REQUIRE(packet->HasExtension(3) == true);
 		extensionValue = packet->GetExtensionValue(3, extensionLen);
 		REQUIRE(extensionLen == 2);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 2, buffer + 26, 2) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 2, buffer + 26, 2) == true);
 
 		REQUIRE(packet->HasExtension(4) == true);
 		extensionValue = packet->GetExtensionValue(4, extensionLen);
@@ -757,12 +757,12 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(packet->HasExtension(2) == true);
 		extensionValue = packet->GetExtensionValue(2, extensionLen);
 		REQUIRE(extensionLen == 1);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 1, SerializeBuffer + 22, 1) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 1, SerializeBuffer + 22, 1) == true);
 
 		REQUIRE(packet->HasExtension(3) == true);
 		extensionValue = packet->GetExtensionValue(3, extensionLen);
 		REQUIRE(extensionLen == 2);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 2, SerializeBuffer + 26, 2) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 2, SerializeBuffer + 26, 2) == true);
 
 		REQUIRE(packet->HasExtension(4) == true);
 		extensionValue = packet->GetExtensionValue(4, extensionLen);
@@ -806,12 +806,12 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(packet->HasExtension(2) == true);
 		extensionValue = packet->GetExtensionValue(2, extensionLen);
 		REQUIRE(extensionLen == 1);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 1, CloneBuffer + 22, 1) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 1, CloneBuffer + 22, 1) == true);
 
 		REQUIRE(packet->HasExtension(3) == true);
 		extensionValue = packet->GetExtensionValue(3, extensionLen);
 		REQUIRE(extensionLen == 2);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, 2, CloneBuffer + 26, 2) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, 2, CloneBuffer + 26, 2) == true);
 
 		REQUIRE(packet->HasExtension(4) == true);
 		extensionValue = packet->GetExtensionValue(4, extensionLen);
@@ -847,7 +847,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		  /*paddingLength*/ 0);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 15) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 15) ==
 		  true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == false);
 	}
@@ -970,7 +970,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		  /*paddingLength*/ 0);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 1) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 1) ==
 		  true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == false);
 
@@ -999,7 +999,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		  /*paddingLength*/ 3);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 1) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 1) ==
 		  true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == true);
 	}
@@ -1291,7 +1291,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(extensionLen == 3);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 1) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 1) ==
 		  true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == false);
 
@@ -1340,7 +1340,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(extensionLen == 3);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 1) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 1) ==
 		  true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == true);
 
@@ -1374,7 +1374,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(packet->HasExtension(14) == false);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 1) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 1) ==
 		  true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == true);
 
@@ -1422,7 +1422,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(extensionLen == 3);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 1) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 1) ==
 		  true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == true);
 	}
@@ -1679,7 +1679,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(packet->HasExtension(101) == false);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 10) ==
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), DataBuffer, 10) ==
 		  true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == true);
 	}
@@ -1846,21 +1846,21 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 
 		REQUIRE(packet->HasExtension(1) == true);
 		extensionValue = packet->GetExtensionValue(1, extensionLen);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, extensionLen, extension1, 1) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, extensionLen, extension1, 1) == true);
 		REQUIRE(extensionLen == 1);
 
 		REQUIRE(packet->HasExtension(2) == true);
 		extensionValue = packet->GetExtensionValue(2, extensionLen);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, extensionLen, extension2, 2) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, extensionLen, extension2, 2) == true);
 		REQUIRE(extensionLen == 2);
 
 		REQUIRE(packet->HasExtension(3) == true);
 		extensionValue = packet->GetExtensionValue(3, extensionLen);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, extensionLen, extension3, 3) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, extensionLen, extension3, 3) == true);
 		REQUIRE(extensionLen == 3);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), payload, 10) == true);
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), payload, 10) == true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == true);
 
 		/* Shift payload. */
@@ -1904,21 +1904,21 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 
 		REQUIRE(packet->HasExtension(1) == true);
 		extensionValue = packet->GetExtensionValue(1, extensionLen);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, extensionLen, extension1, 1) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, extensionLen, extension1, 1) == true);
 		REQUIRE(extensionLen == 1);
 
 		REQUIRE(packet->HasExtension(2) == true);
 		extensionValue = packet->GetExtensionValue(2, extensionLen);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, extensionLen, extension2, 2) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, extensionLen, extension2, 2) == true);
 		REQUIRE(extensionLen == 2);
 
 		REQUIRE(packet->HasExtension(3) == true);
 		extensionValue = packet->GetExtensionValue(3, extensionLen);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, extensionLen, extension3, 3) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, extensionLen, extension3, 3) == true);
 		REQUIRE(extensionLen == 3);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(
+		  helpers::areBuffersEqual(
 		    packet->GetPayload(), packet->GetPayloadLength(), shiftedPayload, 11) == true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == false);
 
@@ -1963,21 +1963,21 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 
 		REQUIRE(packet->HasExtension(1) == true);
 		extensionValue = packet->GetExtensionValue(1, extensionLen);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, extensionLen, extension1, 1) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, extensionLen, extension1, 1) == true);
 		REQUIRE(extensionLen == 1);
 
 		REQUIRE(packet->HasExtension(2) == true);
 		extensionValue = packet->GetExtensionValue(2, extensionLen);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, extensionLen, extension2, 2) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, extensionLen, extension2, 2) == true);
 		REQUIRE(extensionLen == 2);
 
 		REQUIRE(packet->HasExtension(3) == true);
 		extensionValue = packet->GetExtensionValue(3, extensionLen);
-		REQUIRE(helpers::AreBuffersEqual(extensionValue, extensionLen, extension3, 3) == true);
+		REQUIRE(helpers::areBuffersEqual(extensionValue, extensionLen, extension3, 3) == true);
 		REQUIRE(extensionLen == 3);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(
+		  helpers::areBuffersEqual(
 		    packet->GetPayload(), packet->GetPayloadLength(), unshiftedPayload, 8) == true);
 		REQUIRE(packet->IsPaddedTo4Bytes() == true);
 
@@ -1991,7 +1991,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		packet->ShiftPayload(/*payloadOffset*/ 3, /*delta*/ -5);
 
 		REQUIRE(
-		  helpers::AreBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), payload, 10) == true);
+		  helpers::areBuffersEqual(packet->GetPayload(), packet->GetPayloadLength(), payload, 10) == true);
 	}
 
 	SECTION("Packet::ShiftPayload() fails if wrong values are given")

--- a/worker/test/src/RTC/RTP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTP/TestPacket.cpp
@@ -12,7 +12,6 @@
 using namespace RTC;
 using namespace RTP_COMMON;
 
-// NOLINTNEXTLINE (clang-tidy readability-function-size)
 SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 {
 	ResetBuffers();

--- a/worker/test/src/RTC/RTP/TestProbationGenerator.cpp
+++ b/worker/test/src/RTC/RTP/TestProbationGenerator.cpp
@@ -4,7 +4,7 @@
 
 using namespace RTC;
 
-SCENARIO("RTP ProbationGenerator", "[rtp][probationgenerator]")
+SCENARIO("RTP ProbationGenerator", "[rtp][probation-generator]")
 {
 	SECTION("ProbationGenerator generates RTP Packets of the requested length")
 	{

--- a/worker/test/src/RTC/RTP/TestRetransmissionBuffer.cpp
+++ b/worker/test/src/RTC/RTP/TestRetransmissionBuffer.cpp
@@ -7,7 +7,7 @@
 
 using namespace RTC;
 
-namespace
+SCENARIO("RTP RetransmissionBuffer", "[rtp][rtx]")
 {
 	// Class inheriting from RtpRetransmissionBuffer so we can access its protected
 	// buffer member.
@@ -68,10 +68,7 @@ namespace
 			}
 		}
 	};
-} // namespace
 
-SCENARIO("RTP RetransmissionBuffer", "[rtp][rtx]")
-{
 	SECTION("proper packets received in order")
 	{
 		const uint16_t maxItems{ 4 };

--- a/worker/test/src/RTC/RTP/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/RTP/TestRtpStreamRecv.cpp
@@ -13,7 +13,7 @@ static constexpr size_t MaxRequestedPackets{ 17 };
 static constexpr unsigned int SendNackDelay{ 0u }; // In ms.
 static const bool UseRtpInactivityCheck{ false };
 
-SCENARIO("receive RTP packets and trigger NACK", "[rtp][rtpstream][rtpstreamrecv]")
+SCENARIO("RtpStreamRecv", "[rtp][rtpstream][rtpstreamrecv]")
 {
 	class RtpStreamRecvListener : public RTP::RtpStreamRecv::Listener
 	{

--- a/worker/test/src/RTC/RTP/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/RTP/TestRtpStreamSend.cpp
@@ -16,10 +16,25 @@
 
 using namespace RTC;
 
-namespace
+SCENARIO("RtpStreamSend", "[rtp][rtcp][nack][rtpstream][rtpstreamsend]")
 {
-	std::unique_ptr<RTP::Packet> createRtpPacket(
-	  uint8_t* buffer, size_t len, uint16_t seq, uint32_t timestamp)
+	class TestRtpStreamListener : public RTP::RtpStreamSend::Listener
+	{
+	public:
+		void OnRtpStreamScore(RTP::RtpStream* /*rtpStream*/, uint8_t /*score*/, uint8_t /*previousScore*/) override
+		{
+		}
+
+		void OnRtpStreamRetransmitRtpPacket(RTP::RtpStreamSend* /*rtpStream*/, RTP::Packet* packet) override
+		{
+			this->retransmittedPackets.push_back(packet);
+		}
+
+	public:
+		std::vector<RTP::Packet*> retransmittedPackets;
+	};
+
+	auto createRtpPacket = [](uint8_t* buffer, size_t len, uint16_t seq, uint32_t timestamp)
 	{
 		auto* packet = RTP::Packet::Parse(buffer, len);
 
@@ -30,14 +45,14 @@ namespace
 		packet->SetTimestamp(timestamp);
 
 		return std::unique_ptr<RTP::Packet>(packet);
-	}
+	};
 
-	void sendRtpPacket(
-	  // NOTE: clang-tidy suggests passing `streams` by reference but that's wrong
-	  // because we create `streams` in place when calling this function.
-	  // NOLINTNEXTLINE(performance-unnecessary-value-param)
-	  std::vector<std::pair<RTP::RtpStreamSend*, uint32_t>> streams,
-	  RTP::Packet* packet)
+	auto sendRtpPacket = [](
+	                       // NOTE: clang-tidy suggests passing `streams` by reference but that's
+	                       // wrong because we create `streams` in place when calling this function.
+	                       // NOLINTNEXTLINE(performance-unnecessary-value-param)
+	                       std::vector<std::pair<RTP::RtpStreamSend*, uint32_t>> streams,
+	                       RTP::Packet* packet)
 	{
 		RTP::SharedPacket sharedPacket;
 
@@ -61,20 +76,21 @@ namespace
 				sharedPacket.Assign(packet);
 			}
 		}
-	}
+	};
 
-	void checkRtxPacket(RTP::Packet* rtxPacket, RTP::Packet* origPacket)
+	auto checkRtxPacket = [](RTP::Packet* rtxPacket, RTP::Packet* origPacket)
 	{
 		REQUIRE(rtxPacket);
 		REQUIRE(rtxPacket->GetSequenceNumber() == origPacket->GetSequenceNumber());
 		REQUIRE(rtxPacket->GetTimestamp() == origPacket->GetTimestamp());
 		REQUIRE(rtxPacket->HasMarker() == origPacket->HasMarker());
-	}
+	};
 
-	void parseAV1RtpPacket(
-	  RTP::Packet* packet,
-	  std::unique_ptr<RTP::Codecs::DependencyDescriptor::TemplateDependencyStructure>&
-	    templateDependencyStructure)
+	auto parseAV1RtpPacket =
+	  [](
+	    RTP::Packet* packet,
+	    std::unique_ptr<RTP::Codecs::DependencyDescriptor::TemplateDependencyStructure>&
+	      templateDependencyStructure)
 	{
 		std::unique_ptr<RTP::Codecs::DependencyDescriptor> dependencyDescriptor;
 		packet->ReadDependencyDescriptor(dependencyDescriptor, templateDependencyStructure);
@@ -84,25 +100,6 @@ namespace
 		auto* payloadDescriptorHandler =
 		  new RTP::Codecs::AV1::PayloadDescriptorHandler(payloadDescriptor);
 		packet->SetPayloadDescriptorHandler(payloadDescriptorHandler);
-	}
-} // namespace
-
-SCENARIO("NACK and RTP packets retransmission", "[rtp][rtcp][nack][rtpstream][rtpstreamsend]")
-{
-	class TestRtpStreamListener : public RTP::RtpStreamSend::Listener
-	{
-	public:
-		void OnRtpStreamScore(RTP::RtpStream* /*rtpStream*/, uint8_t /*score*/, uint8_t /*previousScore*/) override
-		{
-		}
-
-		void OnRtpStreamRetransmitRtpPacket(RTP::RtpStreamSend* /*rtpStream*/, RTP::Packet* packet) override
-		{
-			this->retransmittedPackets.push_back(packet);
-		}
-
-	public:
-		std::vector<RTP::Packet*> retransmittedPackets;
 	};
 
 	// clang-format off

--- a/worker/test/src/RTC/SCTP/association/TestStateCookie.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestStateCookie.cpp
@@ -1,10 +1,11 @@
 #include "common.hpp"
 #include "RTC/SCTP/association/StateCookie.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("SCTP State Cookie", "[sctp][statecookie]")
 {

--- a/worker/test/src/RTC/SCTP/packet/TestPacket.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestPacket.cpp
@@ -12,11 +12,12 @@
 #include "RTC/SCTP/packet/parameters/CookiePreservativeParameter.hpp"
 #include "RTC/SCTP/packet/parameters/HeartbeatInfoParameter.hpp"
 #include "RTC/SCTP/packet/parameters/IPv4AddressParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 // NOLINTNEXTLINE (readability-function-size)
 SCENARIO("SCTP Packet", "[sctp][serializable]")

--- a/worker/test/src/RTC/SCTP/packet/TestPacket.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestPacket.cpp
@@ -19,7 +19,6 @@
 using namespace RTC::SCTP;
 using namespace SCTP_COMMON;
 
-// NOLINTNEXTLINE (readability-function-size)
 SCENARIO("SCTP Packet", "[sctp][serializable]")
 {
 	ResetBuffers();

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestAbortAssociationChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestAbortAssociationChunk.cpp
@@ -4,9 +4,12 @@
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/chunks/AbortAssociationChunk.hpp"
 #include "RTC/SCTP/packet/errorCauses/StaleCookieErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("SCTP Abort Association Chunk (6)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestCookieAckChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestCookieAckChunk.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Chunk.hpp"
 #include "RTC/SCTP/packet/chunks/CookieAckChunk.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("SCTP Cookie Acknowledgement Chunk (11)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestCookieEchoChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestCookieEchoChunk.cpp
@@ -9,7 +9,6 @@
 using namespace RTC::SCTP;
 using namespace SCTP_COMMON;
 
-// NOLINTNEXTLINE (readability-function-size)
 SCENARIO("SCTP Cookie Echo Chunk (10)", "[sctp][serializable]")
 {
 	ResetBuffers();

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestCookieEchoChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestCookieEchoChunk.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Chunk.hpp"
 #include "RTC/SCTP/packet/chunks/CookieEchoChunk.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 // NOLINTNEXTLINE (readability-function-size)
 SCENARIO("SCTP Cookie Echo Chunk (10)", "[sctp][serializable]")

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestDataChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestDataChunk.cpp
@@ -11,7 +11,6 @@
 using namespace RTC::SCTP;
 using namespace SCTP_COMMON;
 
-// NOLINTNEXTLINE (readability-function-size)
 SCENARIO("SCTP Payload Data Chunk (0)", "[sctp][serializable]")
 {
 	ResetBuffers();

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestDataChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestDataChunk.cpp
@@ -4,11 +4,12 @@
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/chunks/DataChunk.hpp"
 #include "RTC/SCTP/packet/parameters/IPv4AddressParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 // NOLINTNEXTLINE (readability-function-size)
 SCENARIO("SCTP Payload Data Chunk (0)", "[sctp][serializable]")

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestForwardTsnChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestForwardTsnChunk.cpp
@@ -2,9 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Chunk.hpp"
 #include "RTC/SCTP/packet/chunks/ForwardTsnChunk.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Forward Cumulative TSN Chunk (192)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestHeartbeatAckChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestHeartbeatAckChunk.cpp
@@ -5,11 +5,12 @@
 #include "RTC/SCTP/packet/chunks/HeartbeatAckChunk.hpp"
 #include "RTC/SCTP/packet/parameters/HeartbeatInfoParameter.hpp"
 #include "RTC/SCTP/packet/parameters/UnknownParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("SCTP Hearbeat Acknowledgement Chunk (5)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestHeartbeatRequestChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestHeartbeatRequestChunk.cpp
@@ -5,10 +5,13 @@
 #include "RTC/SCTP/packet/chunks/HeartbeatRequestChunk.hpp"
 #include "RTC/SCTP/packet/parameters/HeartbeatInfoParameter.hpp"
 #include "RTC/SCTP/packet/parameters/UnknownParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
-// NOLINTNEXTLINE (readability-function-size)
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
+
 SCENARIO("SCTP Hearbeat Request Chunk (4)", "[sctp][serializable]")
 {
 	ResetBuffers();

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestIDataChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestIDataChunk.cpp
@@ -4,11 +4,12 @@
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/chunks/IDataChunk.hpp"
 #include "RTC/SCTP/packet/parameters/IPv4AddressParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("SCTP I-Data Chunk (64)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestIForwardTsnChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestIForwardTsnChunk.cpp
@@ -2,9 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Chunk.hpp"
 #include "RTC/SCTP/packet/chunks/IForwardTsnChunk.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("I-Forward Cumulative TSN Chunk (194)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestInitAckChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestInitAckChunk.cpp
@@ -4,9 +4,12 @@
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/chunks/InitAckChunk.hpp"
 #include "RTC/SCTP/packet/parameters/IPv4AddressParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 // NOTE: Simplified since it's similar to InitChunk.
 SCENARIO("SCTP Init Acknowledgement (2)", "[sctp][serializable]")

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestInitChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestInitChunk.cpp
@@ -7,9 +7,12 @@
 #include "RTC/SCTP/packet/parameters/IPv4AddressParameter.hpp"
 #include "RTC/SCTP/packet/parameters/IPv6AddressParameter.hpp"
 #include "RTC/SCTP/packet/parameters/SupportedAddressTypesParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("SCTP Init Chunk (1)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestOperationErrorChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestOperationErrorChunk.cpp
@@ -7,11 +7,13 @@
 #include "RTC/SCTP/packet/errorCauses/OutOfResourceErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/UnknownErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/UnrecognizedChunkTypeErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
-// NOLINTNEXTLINE (readability-function-size)
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
+
 SCENARIO("SCTP Operation Error Chunk (9)", "[sctp][serializable]")
 {
 	ResetBuffers();

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestReConfigChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestReConfigChunk.cpp
@@ -6,9 +6,12 @@
 #include "RTC/SCTP/packet/parameters/IncomingSsnResetRequestParameter.hpp"
 #include "RTC/SCTP/packet/parameters/OutgoingSsnResetRequestParameter.hpp"
 #include "RTC/SCTP/packet/parameters/ReconfigurationResponseParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("SCTP Re-Config Chunk (130)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestSackChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestSackChunk.cpp
@@ -2,11 +2,13 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Chunk.hpp"
 #include "RTC/SCTP/packet/chunks/SackChunk.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
-// NOLINTNEXTLINE (readability-function-size)
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
+
 SCENARIO("Selective Acknowledgement Chunk (3)", "[sctp][serializable]")
 {
 	ResetBuffers();

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestShutdownAckChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestShutdownAckChunk.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Chunk.hpp"
 #include "RTC/SCTP/packet/chunks/ShutdownAckChunk.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("SCTP Shutdown Ack Chunk (8)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestShutdownChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestShutdownChunk.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Chunk.hpp"
 #include "RTC/SCTP/packet/chunks/ShutdownChunk.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("SCTP Shutdown Association Chunk (7)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestShutdownCompleteChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestShutdownCompleteChunk.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Chunk.hpp"
 #include "RTC/SCTP/packet/chunks/ShutdownCompleteChunk.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("SCTP Shutdown Complete Chunk (14)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestUnknownChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestUnknownChunk.cpp
@@ -1,11 +1,12 @@
 #include "common.hpp"
 #include "RTC/SCTP/packet/Chunk.hpp"
 #include "RTC/SCTP/packet/chunks/UnknownChunk.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("SCTP Unknown Chunk", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestCookieReceivedWhileShuttingDownErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestCookieReceivedWhileShuttingDownErrorCause.cpp
@@ -1,9 +1,12 @@
 #include "common.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/CookieReceivedWhileShuttingDownErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Cookie Received While Shutting Down Error Cause (10)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestInvalidMandatoryParameterErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestInvalidMandatoryParameterErrorCause.cpp
@@ -1,9 +1,12 @@
 #include "common.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/InvalidMandatoryParameterErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Invalid Mandatory Parameter Error Cause (7)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestInvalidStreamIdentifierErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestInvalidStreamIdentifierErrorCause.cpp
@@ -2,9 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/InvalidStreamIdentifierErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Invalid Stream Identifier Error Cause (1)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestMissingMandatoryParameterErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestMissingMandatoryParameterErrorCause.cpp
@@ -3,9 +3,12 @@
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/errorCauses/MissingMandatoryParameterErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Invalid Stream Identifier Error Cause (2)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestNoUserDataErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestNoUserDataErrorCause.cpp
@@ -2,9 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/NoUserDataErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("No User Data Error Cause (9)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestOutOfResourceErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestOutOfResourceErrorCause.cpp
@@ -1,9 +1,12 @@
 #include "common.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/OutOfResourceErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Out of Resource Error Cause (4)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestProtocolViolationErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestProtocolViolationErrorCause.cpp
@@ -2,9 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/ProtocolViolationErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 // NOLINTNEXTLINE (readability-function-size)
 SCENARIO("Protocol Violation Error Cause (13)", "[sctp][serializable]")

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestProtocolViolationErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestProtocolViolationErrorCause.cpp
@@ -9,7 +9,6 @@
 using namespace RTC::SCTP;
 using namespace SCTP_COMMON;
 
-// NOLINTNEXTLINE (readability-function-size)
 SCENARIO("Protocol Violation Error Cause (13)", "[sctp][serializable]")
 {
 	ResetBuffers();

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestRestartOfAnAssociationWithNewAddressesErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestRestartOfAnAssociationWithNewAddressesErrorCause.cpp
@@ -2,9 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/RestartOfAnAssociationWithNewAddressesErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Restart of an Association with New Addresses Error Cause (11)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestStaleCookieErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestStaleCookieErrorCause.cpp
@@ -2,9 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/StaleCookieErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Stale Cookie Error Cause (3)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestUnknownErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestUnknownErrorCause.cpp
@@ -1,9 +1,12 @@
 #include "common.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/UnknownErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Unknown Error Cause", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestUnrecognizedChunkTypeErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestUnrecognizedChunkTypeErrorCause.cpp
@@ -2,9 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/UnrecognizedChunkTypeErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Unrecognized Chunk Type Error Cause (6)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestUnrecognizedParametersErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestUnrecognizedParametersErrorCause.cpp
@@ -2,9 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/UnrecognizedParametersErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Unrecognized Parameters Error Cause (8)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestUnresolvableAddressErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestUnresolvableAddressErrorCause.cpp
@@ -2,9 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/UnresolvableAddressErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Unresolvable Address Error Cause (5)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestUserInitiatedAbortErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestUserInitiatedAbortErrorCause.cpp
@@ -2,9 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/errorCauses/UserInitiatedAbortErrorCause.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
+
+using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("User-Initiated Abort Error Cause (12)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestAddIncomingStreamsRequestParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestAddIncomingStreamsRequestParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/AddIncomingStreamsRequestParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Add Incoming Streams Request Parameter (18)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestAddOutgoingStreamsRequestParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestAddOutgoingStreamsRequestParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/AddOutgoingStreamsRequestParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Add Outgoing Streams Request Parameter (17)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestCookiePreservativeParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestCookiePreservativeParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/CookiePreservativeParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Cookie Preservative Parameter (9)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestForwardTsnSupportedParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestForwardTsnSupportedParameter.cpp
@@ -1,11 +1,12 @@
 #include "common.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/ForwardTsnSupportedParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Forward-TSN-Supported Parameter (32769)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestHeartbeatInfoParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestHeartbeatInfoParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/HeartbeatInfoParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Heartbeat Info Parameter (1)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestIPv4AddressParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestIPv4AddressParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/IPv4AddressParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("IPv4 Adress Parameter (5)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestIPv6AddressParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestIPv6AddressParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/IPv6AddressParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("IPv6 Adress Parameter (6)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestIncomingSsnResetRequestParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestIncomingSsnResetRequestParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/IncomingSsnResetRequestParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Incoming SSN Reset Request Parameter (14)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestOutgoingSsnResetRequestParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestOutgoingSsnResetRequestParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/OutgoingSsnResetRequestParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Outgoing SSN Reset Request Parameter (13)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestReconfigurationResponseParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestReconfigurationResponseParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/ReconfigurationResponseParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Re-configuration Response Parameter (16)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestSsnTsnResetRequestParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestSsnTsnResetRequestParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/SsnTsnResetRequestParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("SSN/TSN Reset Request Parameter (15)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestStateCookieParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestStateCookieParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/StateCookieParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("State Cookie Parameter (7)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestSupportedAddressTypesParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestSupportedAddressTypesParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/SupportedAddressTypesParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Supported Address Types Parameter (12)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestSupportedExtensionsParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestSupportedExtensionsParameter.cpp
@@ -3,11 +3,12 @@
 #include "RTC/SCTP/packet/Chunk.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/SupportedExtensionsParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Supported Extensions Parameter (32776)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestUnknownParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestUnknownParameter.cpp
@@ -1,11 +1,12 @@
 #include "common.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/UnknownParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Unknown Parameter", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestUnrecognizedParameterParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestUnrecognizedParameterParameter.cpp
@@ -2,13 +2,13 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/UnrecognizedParameterParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
-// NOLINTNEXTLINE (readability-function-size)
 SCENARIO("Unrecognized Parameter Parameter (7)", "[sctp][serializable]")
 {
 	ResetBuffers();

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestZeroChecksumAcceptableParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestZeroChecksumAcceptableParameter.cpp
@@ -2,11 +2,12 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/ZeroChecksumAcceptableParameter.hpp"
-#include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
+#include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
 
 using namespace RTC::SCTP;
+using namespace SCTP_COMMON;
 
 SCENARIO("Zero Checksum Acceptable Parameter (32769)", "[sctp][serializable]")
 {

--- a/worker/test/src/RTC/SCTP/sctpCommon.cpp
+++ b/worker/test/src/RTC/SCTP/sctpCommon.cpp
@@ -1,28 +1,25 @@
 #include "RTC/SCTP/sctpCommon.hpp" // in worker/test/include/
 #include <cstring>                 // std::memset
 
-namespace RTC
+namespace SCTP_COMMON
 {
-	namespace SCTP
+	thread_local uint8_t FactoryBuffer[];
+	thread_local uint8_t SerializeBuffer[];
+	thread_local uint8_t CloneBuffer[];
+	thread_local uint8_t DataBuffer[];
+	thread_local uint8_t ThrowBuffer[];
+
+	void ResetBuffers()
 	{
-		thread_local uint8_t FactoryBuffer[];
-		thread_local uint8_t SerializeBuffer[];
-		thread_local uint8_t CloneBuffer[];
-		thread_local uint8_t DataBuffer[];
-		thread_local uint8_t ThrowBuffer[];
+		std::memset(FactoryBuffer, 0xAA, sizeof(FactoryBuffer));
+		std::memset(SerializeBuffer, 0xBB, sizeof(SerializeBuffer));
+		std::memset(CloneBuffer, 0xCC, sizeof(CloneBuffer));
+		std::memset(DataBuffer, 0xDD, sizeof(DataBuffer));
+		std::memset(ThrowBuffer, 0xEE, sizeof(ThrowBuffer));
 
-		void ResetBuffers()
+		for (size_t i = 0; i < 256; ++i)
 		{
-			std::memset(FactoryBuffer, 0xAA, sizeof(FactoryBuffer));
-			std::memset(SerializeBuffer, 0xBB, sizeof(SerializeBuffer));
-			std::memset(CloneBuffer, 0xCC, sizeof(CloneBuffer));
-			std::memset(DataBuffer, 0xDD, sizeof(DataBuffer));
-			std::memset(ThrowBuffer, 0xEE, sizeof(ThrowBuffer));
-
-			for (size_t i = 0; i < 256; ++i)
-			{
-				DataBuffer[i] = static_cast<uint8_t>(i);
-			}
+			DataBuffer[i] = static_cast<uint8_t>(i);
 		}
-	} // namespace SCTP
-} // namespace RTC
+	}
+} // namespace SCTP_COMMON

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -11,7 +11,7 @@
 using namespace RTC;
 using namespace RTP_COMMON;
 
-SCENARIO("NACK generator", "[rtp][rtcp]")
+SCENARIO("NACK generator", "[rtp][rtcp][nack]")
 {
 	constexpr unsigned int SendNackDelay{ 0u }; // In ms.
 

--- a/worker/test/src/RTC/TestRateCalculator.cpp
+++ b/worker/test/src/RTC/TestRateCalculator.cpp
@@ -7,46 +7,47 @@
 
 using namespace RTC;
 
-struct TestRateCalculatorData
+SCENARIO("RateCalculator", "[rate-calculator]")
 {
-	int64_t offset;
-	uint32_t size;
-	uint32_t rate;
-};
-
-void validate(RateCalculator& rate, uint64_t timeBase, std::vector<TestRateCalculatorData>& input)
-{
-	for (auto& item : input)
+	struct TestRateCalculatorData
 	{
-		rate.Update(item.size, timeBase + item.offset);
+		int64_t offset;
+		uint32_t size;
+		uint32_t rate;
+	};
 
-		REQUIRE(rate.GetRate(timeBase + item.offset) == item.rate);
-	}
-
-	// Repeat forcing nowMs to be 0.
-	rate.Reset();
-
-	for (auto& item : input)
+	auto validate =
+	  [](RateCalculator& rate, uint64_t timeBase, std::vector<TestRateCalculatorData>& input)
 	{
-		rate.Update(item.size, timeBase + item.offset);
+		for (auto& item : input)
+		{
+			rate.Update(item.size, timeBase + item.offset);
 
-		REQUIRE(rate.GetRate(0 + item.offset) == item.rate);
-	}
+			REQUIRE(rate.GetRate(timeBase + item.offset) == item.rate);
+		}
 
-	// Repeat forcing nowMs to be std::numeric_limits<uint64_t>::max() - 100.
-	rate.Reset();
+		// Repeat forcing nowMs to be 0.
+		rate.Reset();
 
-	for (auto& item : input)
-	{
-		rate.Update(item.size, timeBase + item.offset);
+		for (auto& item : input)
+		{
+			rate.Update(item.size, timeBase + item.offset);
 
-		REQUIRE(rate.GetRate(std::numeric_limits<uint64_t>::max() - 100 + item.offset) == item.rate);
-	}
-}
+			REQUIRE(rate.GetRate(0 + item.offset) == item.rate);
+		}
 
-SCENARIO("Rate calculator", "[rtp][RateCalculator]")
-{
-	uint64_t nowMs = DepLibUV::GetTimeMs();
+		// Repeat forcing nowMs to be std::numeric_limits<uint64_t>::max() - 100.
+		rate.Reset();
+
+		for (auto& item : input)
+		{
+			rate.Update(item.size, timeBase + item.offset);
+
+			REQUIRE(rate.GetRate(std::numeric_limits<uint64_t>::max() - 100 + item.offset) == item.rate);
+		}
+	};
+
+	const auto nowMs = DepLibUV::GetTimeMs();
 
 	SECTION("receive single item per 1000 ms")
 	{

--- a/worker/test/src/RTC/TestRtpEncodingParameters.cpp
+++ b/worker/test/src/RTC/TestRtpEncodingParameters.cpp
@@ -1,42 +1,43 @@
 #include "common.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <regex>
+#include <string>
 
-static const std::regex ScalabilityModeRegex(
-  "^[LS]([1-9]\\d{0,1})T([1-9]\\d{0,1})(_KEY)?.*", std::regex_constants::ECMAScript);
-
-struct scalabilityMode
+SCENARIO("parseScalabilityMode()", "[rtc]")
 {
-	uint8_t spatialLayers  = 1;
-	uint8_t temporalLayers = 1;
-	bool ksvc              = false;
-};
+	static const std::regex ScalabilityModeRegex(
+	  "^[LS]([1-9]\\d{0,1})T([1-9]\\d{0,1})(_KEY)?.*", std::regex_constants::ECMAScript);
 
-static struct scalabilityMode parseScalabilityMode(const std::string& scalabilityMode)
-{
-	struct scalabilityMode result;
-	std::smatch match;
-
-	std::regex_match(scalabilityMode, match, ScalabilityModeRegex);
-
-	if (!match.empty())
+	struct ScalabilityMode
 	{
-		try
-		{
-			result.spatialLayers  = std::stoul(match[1].str());
-			result.temporalLayers = std::stoul(match[2].str());
-			result.ksvc           = match.size() >= 4 && match[3].str() == "_KEY";
-		}
-		catch (std::exception& e)
-		{
-		}
-	}
+		uint8_t spatialLayers  = 1;
+		uint8_t temporalLayers = 1;
+		bool ksvc              = false;
+	};
 
-	return result;
-}
+	auto parseScalabilityMode = [](const std::string& scalabilityMode)
+	{
+		struct ScalabilityMode result;
+		std::smatch match;
 
-SCENARIO("parseScalabilityMode", "[rtc]")
-{
+		std::regex_match(scalabilityMode, match, ScalabilityModeRegex);
+
+		if (!match.empty())
+		{
+			try
+			{
+				result.spatialLayers  = std::stoul(match[1].str());
+				result.temporalLayers = std::stoul(match[2].str());
+				result.ksvc           = match.size() >= 4 && match[3].str() == "_KEY";
+			}
+			catch (std::exception& error) // NOLINT(bugprone-empty-catch)
+			{
+			}
+		}
+
+		return result;
+	};
+
 	SECTION("parse L1T3")
 	{
 		const auto scalabilityMode = parseScalabilityMode("L1T3");

--- a/worker/test/src/RTC/TestSeqManager.cpp
+++ b/worker/test/src/RTC/TestSeqManager.cpp
@@ -7,64 +7,67 @@
 
 using namespace RTC;
 
-constexpr uint16_t MaxNumberFor15Bits = (1 << 15) - 1;
-
-template<typename T>
-struct TestSeqManagerInput
+namespace
 {
-	TestSeqManagerInput(T input, T output, bool sync = false, bool drop = false, int64_t maxInput = -1)
-	  : input(input), output(output), sync(sync), drop(drop), maxInput(maxInput)
+	template<typename T>
+	struct TestSeqManagerInput
 	{
-	}
-
-	T input{ 0 };
-	T output{ 0 };
-	bool sync{ false };
-	bool drop{ false };
-	int64_t maxInput{ -1 };
-};
-
-template<typename T, uint8_t N>
-std::pair<T, T> validate(SeqManager<T, N> seqManager, std::vector<TestSeqManagerInput<T>>& inputs)
-{
-	for (auto& element : inputs)
-	{
-		if (element.sync)
+		TestSeqManagerInput(T input, T output, bool sync = false, bool drop = false, int64_t maxInput = -1)
+		  : input(input), output(output), sync(sync), drop(drop), maxInput(maxInput)
 		{
-			seqManager.Sync(element.input - 1);
 		}
 
-		if (element.drop)
-		{
-			seqManager.Drop(element.input);
-		}
-		else
-		{
-			T output;
+		T input{ 0 };
+		T output{ 0 };
+		bool sync{ false };
+		bool drop{ false };
+		int64_t maxInput{ -1 };
+	};
 
-			seqManager.Input(element.input, output);
-
-			if (output != element.output)
+	template<typename T, uint8_t N>
+	std::pair<T, T> validate(SeqManager<T, N> seqManager, std::vector<TestSeqManagerInput<T>>& inputs)
+	{
+		for (auto& element : inputs)
+		{
+			if (element.sync)
 			{
-				return std::make_pair(output, element.output);
+				seqManager.Sync(element.input - 1);
 			}
 
-			if (element.maxInput != -1)
+			if (element.drop)
 			{
-				if (element.maxInput != seqManager.GetMaxInput())
+				seqManager.Drop(element.input);
+			}
+			else
+			{
+				T output;
+
+				seqManager.Input(element.input, output);
+
+				if (output != element.output)
 				{
-					return std::make_pair(element.maxInput, seqManager.GetMaxInput());
+					return std::make_pair(output, element.output);
+				}
+
+				if (element.maxInput != -1)
+				{
+					if (element.maxInput != seqManager.GetMaxInput())
+					{
+						return std::make_pair(element.maxInput, seqManager.GetMaxInput());
+					}
 				}
 			}
 		}
+
+		// Success, return a pair of zeros for successful comparison.
+		return std::make_pair(0, 0);
 	}
+} // namespace
 
-	// Success, return a pair of zeros for successful comparison.
-	return std::make_pair(0, 0);
-}
-
-SCENARIO("SeqManager", "[rtc][SeqManager]")
+SCENARIO("SeqManager", "[rtc][seqmanager]")
 {
+	constexpr uint16_t MaxNumberFor15Bits = (1 << 15) - 1;
+
 	SECTION("0 is greater than 65000")
 	{
 		REQUIRE(SeqManager<uint16_t>::IsSeqHigherThan(0, 65000) == true);

--- a/worker/test/src/RTC/TestSimpleConsumer.cpp
+++ b/worker/test/src/RTC/TestSimpleConsumer.cpp
@@ -14,166 +14,169 @@
 
 using namespace RTC;
 
-const uint8_t PayloadType       = 111;
-auto* channelMessageRegistrator = new ChannelMessageRegistrator();
-auto* channelSocket             = new Channel::ChannelSocket();
-auto* channelNotifier           = new Channel::ChannelNotifier(channelSocket);
-auto shared                     = Shared(channelMessageRegistrator, channelNotifier);
-
-class RtpStreamRecvListener : public RTP::RtpStreamRecv::Listener
+namespace
 {
-public:
-	void OnRtpStreamScore(RTP::RtpStream* /*rtpStream*/, uint8_t /*score*/, uint8_t /*previousScore*/) override
-	{
-	}
+	const uint8_t payloadType       = 111;
+	auto* channelMessageRegistrator = new ChannelMessageRegistrator();
+	auto* channelSocket             = new Channel::ChannelSocket();
+	auto* channelNotifier           = new Channel::ChannelNotifier(channelSocket);
+	auto shared                     = Shared(channelMessageRegistrator, channelNotifier);
 
-	void OnRtpStreamSendRtcpPacket(RTP::RtpStreamRecv* rtpStream, RTCP::Packet* packet) override
+	class RtpStreamRecvListener : public RTP::RtpStreamRecv::Listener
 	{
-	}
+	public:
+		void OnRtpStreamScore(RTP::RtpStream* /*rtpStream*/, uint8_t /*score*/, uint8_t /*previousScore*/) override
+		{
+		}
 
-	void OnRtpStreamNeedWorstRemoteFractionLost(
-	  RTP::RtpStreamRecv* /*rtpStream*/, uint8_t& /*worstRemoteFractionLost*/) override
-	{
-	}
-};
+		void OnRtpStreamSendRtcpPacket(RTP::RtpStreamRecv* rtpStream, RTCP::Packet* packet) override
+		{
+		}
 
-class ConsumerListener : public Consumer::Listener
-{
-	void OnConsumerSendRtpPacket(RTC::Consumer* /*consumer*/, RTC::RTP::Packet* packet) final
-	{
-		this->sent.push_back(packet->GetSequenceNumber());
+		void OnRtpStreamNeedWorstRemoteFractionLost(
+		  RTP::RtpStreamRecv* /*rtpStream*/, uint8_t& /*worstRemoteFractionLost*/) override
+		{
+		}
 	};
-	void OnConsumerRetransmitRtpPacket(RTC::Consumer* consumer, RTC::RTP::Packet* packet) final
-	{
-	}
-	void OnConsumerKeyFrameRequested(RTC::Consumer* consumer, uint32_t mappedSsrc) final {};
-	void OnConsumerNeedBitrateChange(RTC::Consumer* consumer) final {};
-	void OnConsumerNeedZeroBitrate(RTC::Consumer* consumer) final {};
-	void OnConsumerProducerClosed(RTC::Consumer* consumer) final {};
 
-public:
-	// Verifies that the given number of packets have been sent,
-	// and that the sequence numbers are consecutive.
-	void Verify(size_t size)
+	class ConsumerListener : public Consumer::Listener
 	{
-		REQUIRE(this->sent.size() == size);
-
-		if (this->sent.size() <= 1)
+		void OnConsumerSendRtpPacket(RTC::Consumer* /*consumer*/, RTC::RTP::Packet* packet) final
 		{
-			return;
+			this->sent.push_back(packet->GetSequenceNumber());
+		};
+		void OnConsumerRetransmitRtpPacket(RTC::Consumer* consumer, RTC::RTP::Packet* packet) final
+		{
+		}
+		void OnConsumerKeyFrameRequested(RTC::Consumer* consumer, uint32_t mappedSsrc) final {};
+		void OnConsumerNeedBitrateChange(RTC::Consumer* consumer) final {};
+		void OnConsumerNeedZeroBitrate(RTC::Consumer* consumer) final {};
+		void OnConsumerProducerClosed(RTC::Consumer* consumer) final {};
+
+	public:
+		// Verifies that the given number of packets have been sent,
+		// and that the sequence numbers are consecutive.
+		void Verify(size_t size)
+		{
+			REQUIRE(this->sent.size() == size);
+
+			if (this->sent.size() <= 1)
+			{
+				return;
+			}
+
+			auto currentSeq = this->sent[0];
+
+			for (auto it = std::next(this->sent.begin()); it != this->sent.end(); ++it)
+			{
+				REQUIRE(*it == currentSeq + 1);
+				currentSeq = *it;
+			}
 		}
 
-		auto currentSeq = this->sent[0];
+	private:
+		std::vector<uint16_t> sent;
+	};
 
-		for (auto it = std::next(this->sent.begin()); it != this->sent.end(); ++it)
-		{
-			REQUIRE(*it == currentSeq + 1);
-			currentSeq = *it;
-		}
-	}
-
-private:
-	std::vector<uint16_t> sent;
-};
-
-flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<FBS::RtpParameters::RtpEncodingParameters>>> CreateRtpEncodingParameters(
-  flatbuffers::FlatBufferBuilder& builder)
-{
-	std::vector<flatbuffers::Offset<FBS::RtpParameters::RtpEncodingParameters>> encodings;
-
-	auto encoding = RTC::RtpEncodingParameters();
-
-	encoding.ssrc = 1234567890;
-
-	encodings.emplace_back(encoding.FillBuffer(builder));
-
-	return builder.CreateVector(encodings);
-};
-
-flatbuffers::Offset<FBS::RtpParameters::RtpParameters> CreateRtpParameters(
-  flatbuffers::FlatBufferBuilder& builder)
-{
-	auto rtpParameters = RTC::RtpParameters();
-	auto codec         = RTC::RtpCodecParameters();
-	auto encoding      = RTC::RtpEncodingParameters();
-
-	codec.mimeType.SetMimeType("audio/opus");
-	codec.payloadType = PayloadType;
-
-	encoding.ssrc = 1234567890;
-
-	rtpParameters.mid = "mid";
-	rtpParameters.codecs.emplace_back(codec);
-	rtpParameters.encodings.emplace_back(encoding);
-	rtpParameters.headerExtensions = std::vector<RtpHeaderExtensionParameters>();
-
-	return rtpParameters.FillBuffer(builder);
-};
-
-static std::unique_ptr<RTC::SimpleConsumer> createConsumer(ConsumerListener* listener)
-{
-	flatbuffers::FlatBufferBuilder bufferBuilder;
-
-	auto consumerId          = bufferBuilder.CreateString("consumerId");
-	auto producerId          = bufferBuilder.CreateString("producerId");
-	auto rtpParameters       = CreateRtpParameters(bufferBuilder);
-	auto consumableEncodings = CreateRtpEncodingParameters(bufferBuilder);
-
-	auto consumeRequestBuilder = FBS::Transport::ConsumeRequestBuilder(bufferBuilder);
-
-	consumeRequestBuilder.add_consumerId(consumerId);
-	consumeRequestBuilder.add_producerId(producerId);
-	consumeRequestBuilder.add_kind(FBS::RtpParameters::MediaKind::AUDIO);
-	consumeRequestBuilder.add_rtpParameters(rtpParameters);
-	consumeRequestBuilder.add_type(FBS::RtpParameters::Type::SIMPLE);
-	consumeRequestBuilder.add_consumableRtpEncodings(consumableEncodings);
-	consumeRequestBuilder.add_paused(false);
-	consumeRequestBuilder.add_preferredLayers(0);
-	consumeRequestBuilder.add_ignoreDtx(false);
-
-	auto offset = consumeRequestBuilder.Finish();
-	bufferBuilder.Finish(offset);
-
-	auto* buf = bufferBuilder.GetBufferPointer();
-
-	const auto* consumeRequest = flatbuffers::GetRoot<FBS::Transport::ConsumeRequest>(buf);
-
-	return std::make_unique<SimpleConsumer>(
-	  &shared,
-	  consumeRequest->consumerId()->str(),
-	  consumeRequest->producerId()->str(),
-	  listener,
-	  consumeRequest);
-}
-
-static std::unique_ptr<RTP::RtpStreamRecv> createRtpStreamRecv()
-{
-	RtpStreamRecvListener streamRecvListener;
-	RTP::RtpStream::Params params;
-
-	return std::make_unique<RTP::RtpStreamRecv>(&streamRecvListener, params, 0u, false);
-}
-
-/**
- * Centralize common setup and helper methods.
- */
-class Fixture
-{
-public:
-	Fixture()
-	  : listener(std::make_unique<ConsumerListener>()), consumer(createConsumer(listener.get())),
-	    rtpStream(createRtpStreamRecv())
+	flatbuffers::Offset<::flatbuffers::Vector<::flatbuffers::Offset<FBS::RtpParameters::RtpEncodingParameters>>> createRtpEncodingParameters(
+	  flatbuffers::FlatBufferBuilder& builder)
 	{
-		// Set producer scores and producer stream.
-		std::vector<uint8_t> scores{ 10 };
-		consumer->ProducerRtpStreamScores(&scores);
-		consumer->ProducerNewRtpStream(rtpStream.get(), 1234);
+		std::vector<flatbuffers::Offset<FBS::RtpParameters::RtpEncodingParameters>> encodings;
+
+		auto encoding = RTC::RtpEncodingParameters();
+
+		encoding.ssrc = 1234567890;
+
+		encodings.emplace_back(encoding.FillBuffer(builder));
+
+		return builder.CreateVector(encodings);
+	};
+
+	flatbuffers::Offset<FBS::RtpParameters::RtpParameters> createRtpParameters(
+	  flatbuffers::FlatBufferBuilder& builder)
+	{
+		auto rtpParameters = RTC::RtpParameters();
+		auto codec         = RTC::RtpCodecParameters();
+		auto encoding      = RTC::RtpEncodingParameters();
+
+		codec.mimeType.SetMimeType("audio/opus");
+		codec.payloadType = payloadType;
+
+		encoding.ssrc = 1234567890;
+
+		rtpParameters.mid = "mid";
+		rtpParameters.codecs.emplace_back(codec);
+		rtpParameters.encodings.emplace_back(encoding);
+		rtpParameters.headerExtensions = std::vector<RtpHeaderExtensionParameters>();
+
+		return rtpParameters.FillBuffer(builder);
+	};
+
+	static std::unique_ptr<RTC::SimpleConsumer> createConsumer(ConsumerListener* listener)
+	{
+		flatbuffers::FlatBufferBuilder bufferBuilder;
+
+		auto consumerId          = bufferBuilder.CreateString("consumerId");
+		auto producerId          = bufferBuilder.CreateString("producerId");
+		auto rtpParameters       = createRtpParameters(bufferBuilder);
+		auto consumableEncodings = createRtpEncodingParameters(bufferBuilder);
+
+		auto consumeRequestBuilder = FBS::Transport::ConsumeRequestBuilder(bufferBuilder);
+
+		consumeRequestBuilder.add_consumerId(consumerId);
+		consumeRequestBuilder.add_producerId(producerId);
+		consumeRequestBuilder.add_kind(FBS::RtpParameters::MediaKind::AUDIO);
+		consumeRequestBuilder.add_rtpParameters(rtpParameters);
+		consumeRequestBuilder.add_type(FBS::RtpParameters::Type::SIMPLE);
+		consumeRequestBuilder.add_consumableRtpEncodings(consumableEncodings);
+		consumeRequestBuilder.add_paused(false);
+		consumeRequestBuilder.add_preferredLayers(0);
+		consumeRequestBuilder.add_ignoreDtx(false);
+
+		auto offset = consumeRequestBuilder.Finish();
+		bufferBuilder.Finish(offset);
+
+		auto* buf = bufferBuilder.GetBufferPointer();
+
+		const auto* consumeRequest = flatbuffers::GetRoot<FBS::Transport::ConsumeRequest>(buf);
+
+		return std::make_unique<SimpleConsumer>(
+		  &shared,
+		  consumeRequest->consumerId()->str(),
+		  consumeRequest->producerId()->str(),
+		  listener,
+		  consumeRequest);
 	}
 
-	std::unique_ptr<ConsumerListener> listener;
-	std::unique_ptr<SimpleConsumer> consumer;
-	std::unique_ptr<RTP::RtpStreamRecv> rtpStream;
-};
+	static std::unique_ptr<RTP::RtpStreamRecv> createRtpStreamRecv()
+	{
+		RtpStreamRecvListener streamRecvListener;
+		RTP::RtpStream::Params params;
+
+		return std::make_unique<RTP::RtpStreamRecv>(&streamRecvListener, params, 0u, false);
+	}
+
+	/**
+	 * Centralize common setup and helper methods.
+	 */
+	class Fixture
+	{
+	public:
+		Fixture()
+		  : listener(std::make_unique<ConsumerListener>()), consumer(createConsumer(listener.get())),
+		    rtpStream(createRtpStreamRecv())
+		{
+			// Set producer scores and producer stream.
+			std::vector<uint8_t> scores{ 10 };
+			consumer->ProducerRtpStreamScores(&scores);
+			consumer->ProducerNewRtpStream(rtpStream.get(), 1234);
+		}
+
+		std::unique_ptr<ConsumerListener> listener;
+		std::unique_ptr<SimpleConsumer> consumer;
+		std::unique_ptr<RTP::RtpStreamRecv> rtpStream;
+	};
+} // namespace
 
 SCENARIO("SimpleConsumer", "[rtp][consumer]")
 {
@@ -230,7 +233,7 @@ SCENARIO("SimpleConsumer", "[rtp][consumer]")
 		auto* packet = RTP::Packet::Parse(buffer, originalPacketLength + 64);
 		RTP::SharedPacket sharedPacket(packet);
 
-		packet->SetPayloadType(PayloadType);
+		packet->SetPayloadType(payloadType);
 
 		fixture.consumer->SendRtpPacket(packet, sharedPacket);
 
@@ -249,7 +252,7 @@ SCENARIO("SimpleConsumer", "[rtp][consumer]")
 		auto* packet = RTP::Packet::Parse(buffer, originalPacketLength + 64);
 		RTP::SharedPacket sharedPacket(packet);
 
-		packet->SetPayloadType(PayloadType + 1);
+		packet->SetPayloadType(payloadType + 1);
 
 		fixture.consumer->SendRtpPacket(packet, sharedPacket);
 		fixture.listener->Verify(0);
@@ -267,7 +270,7 @@ SCENARIO("SimpleConsumer", "[rtp][consumer]")
 		auto* packet = RTP::Packet::Parse(buffer, originalPacketLength + 0);
 		RTP::SharedPacket sharedPacket(packet);
 
-		packet->SetPayloadType(PayloadType + 1);
+		packet->SetPayloadType(payloadType + 1);
 
 		fixture.consumer->SendRtpPacket(packet, sharedPacket);
 		fixture.listener->Verify(0);
@@ -288,7 +291,7 @@ SCENARIO("SimpleConsumer", "[rtp][consumer]")
 		uint16_t seq{ 1 };
 
 		packet->SetSequenceNumber(seq++);
-		packet->SetPayloadType(PayloadType);
+		packet->SetPayloadType(payloadType);
 		sharedPacket.Assign(packet);
 
 		fixture.consumer->SendRtpPacket(packet, sharedPacket);

--- a/worker/test/src/RTC/TestTransportCongestionControlServer.cpp
+++ b/worker/test/src/RTC/TestTransportCongestionControlServer.cpp
@@ -8,130 +8,132 @@
 
 using namespace RTC;
 
-struct TestTransportCongestionControlServerInput
-{
-	uint16_t wideSeqNumber;
-	uint64_t nowMs;
-};
-
-struct TestTransportCongestionControlServerResult
-{
-	uint16_t wideSeqNumber;
-	bool received;
-	uint64_t timestamp;
-};
-
-using TestResults = std::deque<std::vector<TestTransportCongestionControlServerResult>>;
-
-class TestTransportCongestionControlServerListener : public TransportCongestionControlServer::Listener
-{
-public:
-	virtual void OnTransportCongestionControlServerSendRtcpPacket(
-	  RTC::TransportCongestionControlServer* tccServer, RTC::RTCP::Packet* packet) override
-	{
-		auto* tccPacket = dynamic_cast<RTCP::FeedbackRtpTransportPacket*>(packet);
-
-		if (!tccPacket)
-		{
-			return;
-		}
-
-		auto packetResults = tccPacket->GetPacketResults();
-
-		REQUIRE(!this->results.empty());
-
-		auto testResults = this->results.front();
-		this->results.pop_front();
-
-		REQUIRE(testResults.size() == packetResults.size());
-
-		auto packetResultIt = packetResults.begin();
-		auto testResultIt   = testResults.begin();
-
-		for (; packetResultIt != packetResults.end() && testResultIt != testResults.end();
-		     ++packetResultIt, ++testResultIt)
-		{
-			REQUIRE(packetResultIt->sequenceNumber == testResultIt->wideSeqNumber);
-			REQUIRE(packetResultIt->received == testResultIt->received);
-
-			if (packetResultIt->received)
-			{
-				REQUIRE(packetResultIt->receivedAtMs == static_cast<int64_t>(testResultIt->timestamp));
-			}
-		}
-	}
-
-public:
-	void SetResults(TestResults& results)
-	{
-		this->results = results;
-	}
-
-	void Check()
-	{
-		REQUIRE(this->results.empty());
-	}
-
-private:
-	TestResults results;
-};
-
-// clang-format off
-uint8_t buffer[] =
-{
-	0x90, 0x01, 0x00, 0x01,
-	0x00, 0x00, 0x00, 0x04,
-	0x00, 0x00, 0x00, 0x05,
-	0xbe, 0xde, 0x00, 0x01,	// Header Extensions
-	0x51, 0x60, 0xee, 0x00  // TCC Feedback
-};
-// clang-format on
-
-void validate(std::vector<TestTransportCongestionControlServerInput>& inputs, TestResults& results)
-{
-	TestTransportCongestionControlServerListener listener;
-	auto tccServer =
-	  TransportCongestionControlServer(&listener, RTC::BweType::TRANSPORT_CC, RTC::Consts::MtuSize);
-
-	tccServer.SetMaxIncomingBitrate(150000);
-	tccServer.TransportConnected();
-
-	std::unique_ptr<RTP::Packet> packet{ RTP::Packet::Parse(buffer, sizeof(buffer)) };
-
-	RTP::HeaderExtensionIds headerExtensionIds{};
-
-	headerExtensionIds.transportWideCc01 = 5;
-
-	packet->AssignExtensionIds(headerExtensionIds);
-	packet->SetSequenceNumber(1);
-
-	// Save results.
-	listener.SetResults(results);
-
-	uint64_t startTs = inputs[0].nowMs;
-	uint64_t TransportCcFeedbackSendInterval{ 100u }; // In ms.
-
-	for (auto input : inputs)
-	{
-		// Periodic sending TCC packets.
-		uint64_t diffTs = input.nowMs - startTs;
-
-		if (diffTs >= TransportCcFeedbackSendInterval)
-		{
-			tccServer.FillAndSendTransportCcFeedback();
-			startTs = input.nowMs;
-		}
-
-		packet->UpdateTransportWideCc01(input.wideSeqNumber);
-		tccServer.IncomingPacket(input.nowMs, packet.get());
-	}
-
-	tccServer.FillAndSendTransportCcFeedback();
-	listener.Check();
-};
-
 SCENARIO("TransportCongestionControlServer", "[rtp]")
 {
+	struct TestTransportCongestionControlServerInput
+	{
+		uint16_t wideSeqNumber;
+		uint64_t nowMs;
+	};
+
+	struct TestTransportCongestionControlServerResult
+	{
+		uint16_t wideSeqNumber;
+		bool received;
+		uint64_t timestamp;
+	};
+
+	using TestResults = std::deque<std::vector<TestTransportCongestionControlServerResult>>;
+
+	class TestTransportCongestionControlServerListener
+	  : public TransportCongestionControlServer::Listener
+	{
+	public:
+		virtual void OnTransportCongestionControlServerSendRtcpPacket(
+		  RTC::TransportCongestionControlServer* tccServer, RTC::RTCP::Packet* packet) override
+		{
+			auto* tccPacket = dynamic_cast<RTCP::FeedbackRtpTransportPacket*>(packet);
+
+			if (!tccPacket)
+			{
+				return;
+			}
+
+			auto packetResults = tccPacket->GetPacketResults();
+
+			REQUIRE(!this->results.empty());
+
+			auto testResults = this->results.front();
+			this->results.pop_front();
+
+			REQUIRE(testResults.size() == packetResults.size());
+
+			auto packetResultIt = packetResults.begin();
+			auto testResultIt   = testResults.begin();
+
+			for (; packetResultIt != packetResults.end() && testResultIt != testResults.end();
+			     ++packetResultIt, ++testResultIt)
+			{
+				REQUIRE(packetResultIt->sequenceNumber == testResultIt->wideSeqNumber);
+				REQUIRE(packetResultIt->received == testResultIt->received);
+
+				if (packetResultIt->received)
+				{
+					REQUIRE(packetResultIt->receivedAtMs == static_cast<int64_t>(testResultIt->timestamp));
+				}
+			}
+		}
+
+	public:
+		void SetResults(TestResults& results)
+		{
+			this->results = results;
+		}
+
+		void Check()
+		{
+			REQUIRE(this->results.empty());
+		}
+
+	private:
+		TestResults results;
+	};
+
+	// clang-format off
+	uint8_t buffer[] =
+	{
+		0x90, 0x01, 0x00, 0x01,
+		0x00, 0x00, 0x00, 0x04,
+		0x00, 0x00, 0x00, 0x05,
+		0xbe, 0xde, 0x00, 0x01,	// Header Extensions
+		0x51, 0x60, 0xee, 0x00  // TCC Feedback
+	};
+	// clang-format on
+
+	auto validate =
+	  [&buffer](std::vector<TestTransportCongestionControlServerInput>& inputs, TestResults& results)
+	{
+		TestTransportCongestionControlServerListener listener;
+		auto tccServer =
+		  TransportCongestionControlServer(&listener, RTC::BweType::TRANSPORT_CC, RTC::Consts::MtuSize);
+
+		tccServer.SetMaxIncomingBitrate(150000);
+		tccServer.TransportConnected();
+
+		std::unique_ptr<RTP::Packet> packet{ RTP::Packet::Parse(buffer, sizeof(buffer)) };
+
+		RTP::HeaderExtensionIds headerExtensionIds{};
+
+		headerExtensionIds.transportWideCc01 = 5;
+
+		packet->AssignExtensionIds(headerExtensionIds);
+		packet->SetSequenceNumber(1);
+
+		// Save results.
+		listener.SetResults(results);
+
+		uint64_t startTs = inputs[0].nowMs;
+		uint64_t TransportCcFeedbackSendInterval{ 100u }; // In ms.
+
+		for (auto input : inputs)
+		{
+			// Periodic sending TCC packets.
+			uint64_t diffTs = input.nowMs - startTs;
+
+			if (diffTs >= TransportCcFeedbackSendInterval)
+			{
+				tccServer.FillAndSendTransportCcFeedback();
+				startTs = input.nowMs;
+			}
+
+			packet->UpdateTransportWideCc01(input.wideSeqNumber);
+			tccServer.IncomingPacket(input.nowMs, packet.get());
+		}
+
+		tccServer.FillAndSendTransportCcFeedback();
+		listener.Check();
+	};
+
 	SECTION("normal time and sequence")
 	{
 		// clang-format off

--- a/worker/test/src/RTC/TestTransportTuple.cpp
+++ b/worker/test/src/RTC/TestTransportTuple.cpp
@@ -7,67 +7,67 @@
 
 using namespace RTC;
 
-class UdpSocketListener : public UdpSocket::Listener
+SCENARIO("TransportTuple", "[transport-tuple]")
 {
-public:
-	void OnUdpSocketPacketReceived(
-	  UdpSocket* /*socket*/,
-	  const uint8_t* /*data*/,
-	  size_t /*len*/,
-	  size_t /*bufferLen*/,
-	  const struct sockaddr* /*remoteAddr*/) override
+	class UdpSocketListener : public UdpSocket::Listener
 	{
-	}
-};
-
-static std::unique_ptr<UdpSocket> makeUdpSocket(const std::string& ip, uint16_t minPort, uint16_t maxPort)
-{
-	UdpSocketListener listener;
-	auto flags = Transport::SocketFlags{ .ipv6Only = false, .udpReusePort = false };
-	uint64_t portRangeHash{ 0u };
-	auto* udpSocket = new UdpSocket(
-	  std::addressof(listener), const_cast<std::string&>(ip), minPort, maxPort, flags, portRangeHash);
-
-	return std::unique_ptr<UdpSocket>(udpSocket);
-}
-
-static std::unique_ptr<sockaddr> makeUdpSockAddr(int family, const std::string& ip, uint16_t port)
-{
-	if (family == AF_INET)
-	{
-		auto addr = std::make_unique<sockaddr_in>();
-
-		addr->sin_family = AF_INET;
-		addr->sin_port   = htons(port);
-
-		if (uv_inet_pton(AF_INET, ip.c_str(), std::addressof(addr->sin_addr)) != 0)
+	public:
+		void OnUdpSocketPacketReceived(
+		  UdpSocket* /*socket*/,
+		  const uint8_t* /*data*/,
+		  size_t /*len*/,
+		  size_t /*bufferLen*/,
+		  const struct sockaddr* /*remoteAddr*/) override
 		{
-			throw std::runtime_error("invalid IPv4 address");
 		}
+	};
 
-		return std::unique_ptr<sockaddr>(reinterpret_cast<sockaddr*>(addr.release()));
-	}
-	else if (family == AF_INET6)
+	auto makeUdpSocket = [](const std::string& ip, uint16_t minPort, uint16_t maxPort)
 	{
-		auto addr6         = std::make_unique<sockaddr_in6>();
-		addr6->sin6_family = AF_INET6;
-		addr6->sin6_port   = htons(port);
+		UdpSocketListener listener;
+		auto flags = Transport::SocketFlags{ .ipv6Only = false, .udpReusePort = false };
+		uint64_t portRangeHash{ 0u };
+		auto* udpSocket = new UdpSocket(
+		  std::addressof(listener), const_cast<std::string&>(ip), minPort, maxPort, flags, portRangeHash);
 
-		if (uv_inet_pton(AF_INET6, ip.c_str(), std::addressof(addr6->sin6_addr)) != 0)
+		return std::unique_ptr<UdpSocket>(udpSocket);
+	};
+
+	auto makeUdpSockAddr = [](int family, const std::string& ip, uint16_t port)
+	{
+		if (family == AF_INET)
 		{
-			throw std::runtime_error("invalid IPv6 address");
+			auto addr = std::make_unique<sockaddr_in>();
+
+			addr->sin_family = AF_INET;
+			addr->sin_port   = htons(port);
+
+			if (uv_inet_pton(AF_INET, ip.c_str(), std::addressof(addr->sin_addr)) != 0)
+			{
+				throw std::runtime_error("invalid IPv4 address");
+			}
+
+			return std::unique_ptr<sockaddr>(reinterpret_cast<sockaddr*>(addr.release()));
 		}
+		else if (family == AF_INET6)
+		{
+			auto addr6         = std::make_unique<sockaddr_in6>();
+			addr6->sin6_family = AF_INET6;
+			addr6->sin6_port   = htons(port);
 
-		return std::unique_ptr<sockaddr>(reinterpret_cast<sockaddr*>(addr6.release()));
-	}
-	else
-	{
-		throw std::runtime_error("invalid network family");
-	}
-}
+			if (uv_inet_pton(AF_INET6, ip.c_str(), std::addressof(addr6->sin6_addr)) != 0)
+			{
+				throw std::runtime_error("invalid IPv6 address");
+			}
 
-SCENARIO("TransportTuples have unique hashes", "[transporttuple]")
-{
+			return std::unique_ptr<sockaddr>(reinterpret_cast<sockaddr*>(addr6.release()));
+		}
+		else
+		{
+			throw std::runtime_error("invalid network family");
+		}
+	};
+
 	SECTION("2 tuples with same local and remote IP:port have the same hash")
 	{
 		auto udpSocket      = makeUdpSocket("0.0.0.0", 10000, 50000);

--- a/worker/test/src/Utils/TestBits.cpp
+++ b/worker/test/src/Utils/TestBits.cpp
@@ -2,19 +2,22 @@
 #include "Utils.hpp"
 #include <catch2/catch_test_macros.hpp>
 
-SCENARIO("Utils::Bits::CountSetBits()", "[utils][bits]")
+SCENARIO("Utils::Bits", "[utils][bits]")
 {
-	uint16_t mask;
+	SECTION("CountSetBits()")
+	{
+		uint16_t mask;
 
-	mask = 0b0000000000000000;
-	REQUIRE(Utils::Bits::CountSetBits(mask) == 0);
+		mask = 0b0000000000000000;
+		REQUIRE(Utils::Bits::CountSetBits(mask) == 0);
 
-	mask = 0b0000000000000001;
-	REQUIRE(Utils::Bits::CountSetBits(mask) == 1);
+		mask = 0b0000000000000001;
+		REQUIRE(Utils::Bits::CountSetBits(mask) == 1);
 
-	mask = 0b1000000000000001;
-	REQUIRE(Utils::Bits::CountSetBits(mask) == 2);
+		mask = 0b1000000000000001;
+		REQUIRE(Utils::Bits::CountSetBits(mask) == 2);
 
-	mask = 0b1111111111111111;
-	REQUIRE(Utils::Bits::CountSetBits(mask) == 16);
+		mask = 0b1111111111111111;
+		REQUIRE(Utils::Bits::CountSetBits(mask) == 16);
+	}
 }

--- a/worker/test/src/Utils/TestByte.cpp
+++ b/worker/test/src/Utils/TestByte.cpp
@@ -19,19 +19,19 @@ SCENARIO("Utils::Byte", "[utils][byte]")
 	};
 	// clang-format on
 
-	SECTION("Utils::Byte::Get3Bytes()")
+	SECTION("Get3Bytes()")
 	{
 		// Bytes 4,5 and 6 in the array are number 8405024.
 		REQUIRE(Utils::Byte::Get3Bytes(buffer, 4) == 8405024);
 	}
 
-	SECTION("Utils::Byte::Set3Bytes()")
+	SECTION("Set3Bytes()")
 	{
 		Utils::Byte::Set3Bytes(buffer, 4, 5666777);
 		REQUIRE(Utils::Byte::Get3Bytes(buffer, 4) == 5666777);
 	}
 
-	SECTION("Utils::Byte::Get3BytesSigned()")
+	SECTION("Get3BytesSigned()")
 	{
 		// Bytes 8, 9 and 10 in the array are number 8388607 since first bit is 0 and
 		// all other bits are 1, so it must be maximum positive 24 bits signed integer,
@@ -47,7 +47,7 @@ SCENARIO("Utils::Byte", "[utils][byte]")
 		REQUIRE(Utils::Byte::Get3BytesSigned(buffer, 16) == -8388608);
 	}
 
-	SECTION("Utils::Byte::Set3BytesSigned()")
+	SECTION("Set3BytesSigned()")
 	{
 		Utils::Byte::Set3BytesSigned(buffer, 0, 8388607);
 		REQUIRE(Utils::Byte::Get3BytesSigned(buffer, 0) == 8388607);
@@ -59,7 +59,7 @@ SCENARIO("Utils::Byte", "[utils][byte]")
 		REQUIRE(Utils::Byte::Get3BytesSigned(buffer, 0) == -8388608);
 	}
 
-	SECTION("Utils::Byte::IsPaddedTo4Bytes()")
+	SECTION("IsPaddedTo4Bytes()")
 	{
 		REQUIRE(Utils::Byte::IsPaddedTo4Bytes(uint8_t{ 0u }) == true);
 		REQUIRE(Utils::Byte::IsPaddedTo4Bytes(uint8_t{ 1u }) == false);
@@ -149,7 +149,7 @@ SCENARIO("Utils::Byte", "[utils][byte]")
 		}
 	}
 
-	SECTION("Utils::Byte::IsPaddedTo8Bytes()")
+	SECTION("IsPaddedTo8Bytes()")
 	{
 		REQUIRE(Utils::Byte::IsPaddedTo8Bytes(uint8_t{ 0u }) == true);
 		REQUIRE(Utils::Byte::IsPaddedTo8Bytes(uint8_t{ 1u }) == false);
@@ -239,7 +239,7 @@ SCENARIO("Utils::Byte", "[utils][byte]")
 		}
 	}
 
-	SECTION("Utils::Byte::PadTo4Bytes()")
+	SECTION("PadTo4Bytes()")
 	{
 		REQUIRE(Utils::Byte::PadTo4Bytes(uint8_t{ 0u }) == 0u);
 		REQUIRE(Utils::Byte::PadTo4Bytes(uint8_t{ 1u }) == 4u);
@@ -338,7 +338,7 @@ SCENARIO("Utils::Byte", "[utils][byte]")
 		}
 	}
 
-	SECTION("Utils::Byte::PadTo8Bytes()")
+	SECTION("PadTo8Bytes()")
 	{
 		REQUIRE(Utils::Byte::PadTo8Bytes(uint8_t{ 0u }) == 0u);
 		REQUIRE(Utils::Byte::PadTo8Bytes(uint8_t{ 1u }) == 8u);

--- a/worker/test/src/Utils/TestCrypto.cpp
+++ b/worker/test/src/Utils/TestCrypto.cpp
@@ -2,9 +2,11 @@
 #include "Utils.hpp"
 #include <catch2/catch_test_macros.hpp>
 
-SCENARIO("Utils::Crypto::GetCRC32()", "[utils][crypto]")
+SCENARIO("Utils::Crypto", "[utils][crypto]")
 {
-	// clang-format off
+	SECTION("GetCRC32()")
+	{
+		// clang-format off
 	uint8_t dataEmpty[]  = {};
 	uint8_t dataZero[]   = { 0 };
 	uint8_t dataRandom[] =
@@ -12,19 +14,19 @@ SCENARIO("Utils::Crypto::GetCRC32()", "[utils][crypto]")
 		0xFF, 0x00, 0xAB, 0xCD, 0x12, 0x39, 0x54, 0xBB, 0xDD,
 		0xEE, 0x01, 0x01, 0x01, 0x01, 0x88, 0x88, 0xAA
 	};
-	// clang-format on
+		// clang-format on
 
-	REQUIRE(Utils::Crypto::GetCRC32(dataEmpty, sizeof(dataEmpty)) == 0U);
-	REQUIRE(Utils::Crypto::GetCRC32(dataZero, sizeof(dataZero)) == 0xD202EF8D);
-	REQUIRE(Utils::Crypto::GetCRC32(dataRandom, sizeof(dataRandom)) == 0xEEE31378);
-}
+		REQUIRE(Utils::Crypto::GetCRC32(dataEmpty, sizeof(dataEmpty)) == 0U);
+		REQUIRE(Utils::Crypto::GetCRC32(dataZero, sizeof(dataZero)) == 0xD202EF8D);
+		REQUIRE(Utils::Crypto::GetCRC32(dataRandom, sizeof(dataRandom)) == 0xEEE31378);
+	}
 
-SCENARIO("Utils::Crypto::GetCRC32c()", "[utils][crypto]")
-{
-	// Tests copied from dcSCTP code in libwebrtc:
-	// https://webrtc.googlesource.com/src//+/refs/heads/main/net/dcsctp/packet/crc32c_test.cc
+	SECTION("GetCRC32c()")
+	{
+		// Tests copied from dcSCTP code in libwebrtc:
+		// https://webrtc.googlesource.com/src//+/refs/heads/main/net/dcsctp/packet/crc32c_test.cc
 
-	// clang-format off
+		// clang-format off
 	uint8_t dataEmpty[]     = {};
 	uint8_t dataZero[]      = { 0 };
 	uint8_t dataManyZeros[] = { 0, 0, 0, 0 };
@@ -57,17 +59,18 @@ SCENARIO("Utils::Crypto::GetCRC32c()", "[utils][crypto]")
 		0x00, 0x00, 0x00, 0x14, 0x00, 0x00, 0x00, 0x18, 0x28, 0x00, 0x00, 0x00,
 		0x00, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00
 	};
-	// clang-format on
+		// clang-format on
 
-	REQUIRE(Utils::Crypto::GetCRC32c(dataEmpty, sizeof(dataEmpty)) == 0);
-	REQUIRE(Utils::Crypto::GetCRC32c(dataZero, sizeof(dataZero)) == 0x51537d52);
-	REQUIRE(Utils::Crypto::GetCRC32c(dataManyZeros, sizeof(dataManyZeros)) == 0xC74B6748);
-	REQUIRE(Utils::Crypto::GetCRC32c(dataShort, sizeof(dataShort)) == 0xF48C3029);
-	REQUIRE(Utils::Crypto::GetCRC32c(dataLong, sizeof(dataLong)) == 0x811F8946);
-	// https://tools.ietf.org/html/rfc3720#appendix-B.4
-	REQUIRE(Utils::Crypto::GetCRC32c(data32Zeros, sizeof(data32Zeros)) == 0xAA36918A);
-	REQUIRE(Utils::Crypto::GetCRC32c(data32Ones, sizeof(data32Ones)) == 0x43ABA862);
-	REQUIRE(Utils::Crypto::GetCRC32c(data32Incrementing, sizeof(data32Incrementing)) == 0x4E79DD46);
-	REQUIRE(Utils::Crypto::GetCRC32c(data32Decrementing, sizeof(data32Decrementing)) == 0x5CDB3F11);
-	REQUIRE(Utils::Crypto::GetCRC32c(dataSCSICommandPDU, sizeof(dataSCSICommandPDU)) == 0x563A96D9);
+		REQUIRE(Utils::Crypto::GetCRC32c(dataEmpty, sizeof(dataEmpty)) == 0);
+		REQUIRE(Utils::Crypto::GetCRC32c(dataZero, sizeof(dataZero)) == 0x51537d52);
+		REQUIRE(Utils::Crypto::GetCRC32c(dataManyZeros, sizeof(dataManyZeros)) == 0xC74B6748);
+		REQUIRE(Utils::Crypto::GetCRC32c(dataShort, sizeof(dataShort)) == 0xF48C3029);
+		REQUIRE(Utils::Crypto::GetCRC32c(dataLong, sizeof(dataLong)) == 0x811F8946);
+		// https://tools.ietf.org/html/rfc3720#appendix-B.4
+		REQUIRE(Utils::Crypto::GetCRC32c(data32Zeros, sizeof(data32Zeros)) == 0xAA36918A);
+		REQUIRE(Utils::Crypto::GetCRC32c(data32Ones, sizeof(data32Ones)) == 0x43ABA862);
+		REQUIRE(Utils::Crypto::GetCRC32c(data32Incrementing, sizeof(data32Incrementing)) == 0x4E79DD46);
+		REQUIRE(Utils::Crypto::GetCRC32c(data32Decrementing, sizeof(data32Decrementing)) == 0x5CDB3F11);
+		REQUIRE(Utils::Crypto::GetCRC32c(dataSCSICommandPDU, sizeof(dataSCSICommandPDU)) == 0x563A96D9);
+	}
 }

--- a/worker/test/src/Utils/TestIP.cpp
+++ b/worker/test/src/Utils/TestIP.cpp
@@ -114,7 +114,7 @@ SCENARIO("Utils::IP", "[utils][ip]")
 
 	SECTION("GetAddressInfo()")
 	{
-		struct sockaddr_in sin;
+		struct sockaddr_in sin{};
 
 		std::memset(&sin, 0, sizeof(sin));
 

--- a/worker/test/src/Utils/TestIP.cpp
+++ b/worker/test/src/Utils/TestIP.cpp
@@ -3,138 +3,134 @@
 #include "Utils.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memset()
-#ifdef _WIN32
-#include <winsock2.h>
-#else
-#include <arpa/inet.h>  // htonl(), htons(), ntohl(), ntohs()
-#include <netinet/in.h> // sockaddr_in, sockaddr_in6
-#include <sys/socket.h> // struct sockaddr, struct sockaddr_storage, AF_INET, AF_INET6
-#endif
 
 using namespace Utils;
 
-SCENARIO("Utils::IP::GetFamily()", "[utils][ip]")
+SCENARIO("Utils::IP", "[utils][ip]")
 {
-	std::string ip;
+	SECTION("GetFamily()")
+	{
+		std::string ip;
 
-	ip = "1.2.3.4";
-	REQUIRE(IP::GetFamily(ip) == AF_INET);
+		ip = "1.2.3.4";
+		REQUIRE(IP::GetFamily(ip) == AF_INET);
 
-	ip = "127.0.0.1";
-	REQUIRE(IP::GetFamily(ip) == AF_INET);
+		ip = "127.0.0.1";
+		REQUIRE(IP::GetFamily(ip) == AF_INET);
 
-	ip = "255.255.255.255";
-	REQUIRE(IP::GetFamily(ip) == AF_INET);
+		ip = "255.255.255.255";
+		REQUIRE(IP::GetFamily(ip) == AF_INET);
 
-	ip = "1::1";
-	REQUIRE(IP::GetFamily(ip) == AF_INET6);
+		ip = "1::1";
+		REQUIRE(IP::GetFamily(ip) == AF_INET6);
 
-	ip = "a:b:c:D::0";
-	REQUIRE(IP::GetFamily(ip) == AF_INET6);
+		ip = "a:b:c:D::0";
+		REQUIRE(IP::GetFamily(ip) == AF_INET6);
 
-	ip = "0000:0000:0000:0000:0000:ffff:192.168.100.228";
-	REQUIRE(IP::GetFamily(ip) == AF_INET6);
+		ip = "0000:0000:0000:0000:0000:ffff:192.168.100.228";
+		REQUIRE(IP::GetFamily(ip) == AF_INET6);
 
-	ip = "::0:";
-	REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
+		ip = "::0:";
+		REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
 
-	ip = "3::3:1:";
-	REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
+		ip = "3::3:1:";
+		REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
 
-	ip = "chicken";
-	REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
+		ip = "chicken";
+		REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
 
-	ip = "1.2.3.256";
-	REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
+		ip = "1.2.3.256";
+		REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
 
-	ip = "1.2.3.1111";
-	REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
+		ip = "1.2.3.1111";
+		REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
 
-	ip = "1.2.3.01";
-	REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
+		ip = "1.2.3.01";
+		REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
 
-	ip = "1::abcde";
-	REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
+		ip = "1::abcde";
+		REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
 
-	ip = "1:::";
-	REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
+		ip = "1:::";
+		REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
 
-	ip = "1.2.3.4 ";
-	REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
+		ip = "1.2.3.4 ";
+		REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
 
-	ip = " ::1";
-	REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
+		ip = " ::1";
+		REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
 
-	ip = "";
-	REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
+		ip = "";
+		REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
 
-	ip = "0000:0000:0000:0000:0000:ffff:192.168.100.228.4567";
-	REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
-}
+		ip = "0000:0000:0000:0000:0000:ffff:192.168.100.228.4567";
+		REQUIRE(IP::GetFamily(ip) == AF_UNSPEC);
+	}
 
-SCENARIO("Utils::IP::NormalizeIp()", "[utils][ip]")
-{
-	std::string ip;
+	SECTION("NormalizeIp()")
+	{
+		std::string ip;
 
-	ip = "1.2.3.4";
-	IP::NormalizeIp(ip);
-	REQUIRE(ip == "1.2.3.4");
+		ip = "1.2.3.4";
+		IP::NormalizeIp(ip);
+		REQUIRE(ip == "1.2.3.4");
 
-	ip = "255.255.255.255";
-	IP::NormalizeIp(ip);
-	REQUIRE(ip == "255.255.255.255");
+		ip = "255.255.255.255";
+		IP::NormalizeIp(ip);
+		REQUIRE(ip == "255.255.255.255");
 
-	ip = "aA::8";
-	IP::NormalizeIp(ip);
-	REQUIRE(ip == "aa::8");
+		ip = "aA::8";
+		IP::NormalizeIp(ip);
+		REQUIRE(ip == "aa::8");
 
-	ip = "aA::0:0008";
-	IP::NormalizeIp(ip);
-	REQUIRE(ip == "aa::8");
+		ip = "aA::0:0008";
+		IP::NormalizeIp(ip);
+		REQUIRE(ip == "aa::8");
 
-	ip = "001.2.3.4";
-	REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
+		ip = "001.2.3.4";
+		REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
 
-	ip = "0255.255.255.255";
-	REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
+		ip = "0255.255.255.255";
+		REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
 
-	ip = "1::2::3";
-	REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
+		ip = "1::2::3";
+		REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
 
-	ip = "::1 ";
-	REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
+		ip = "::1 ";
+		REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
 
-	ip = "0.0.0.";
-	REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
+		ip = "0.0.0.";
+		REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
 
-	ip = "::0:";
-	REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
+		ip = "::0:";
+		REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
 
-	ip = "3::3:1:";
-	REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
+		ip = "3::3:1:";
+		REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
 
-	ip = "";
-	REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
-}
+		ip = "";
+		REQUIRE_THROWS_AS(IP::NormalizeIp(ip), MediaSoupTypeError);
+	}
 
-SCENARIO("Utils::IP::GetAddressInfo()", "[utils][ip]")
-{
-	struct sockaddr_in sin;
+	SECTION("GetAddressInfo()")
+	{
+		struct sockaddr_in sin;
 
-	std::memset(&sin, 0, sizeof(sin));
+		std::memset(&sin, 0, sizeof(sin));
 
-	sin.sin_family      = AF_INET;
-	sin.sin_port        = htons(10251);
-	sin.sin_addr.s_addr = inet_addr("82.99.219.114");
+		sin.sin_family      = AF_INET;
+		sin.sin_port        = htons(10251);
+		sin.sin_addr.s_addr = inet_addr("82.99.219.114");
 
-	const auto* addr = reinterpret_cast<const struct sockaddr*>(&sin);
-	int family;
-	std::string ip;
-	uint16_t port;
+		const auto* addr = reinterpret_cast<const struct sockaddr*>(&sin);
+		int family;
+		std::string ip;
+		uint16_t port;
 
-	IP::GetAddressInfo(addr, family, ip, port);
+		IP::GetAddressInfo(addr, family, ip, port);
 
-	REQUIRE(family == AF_INET);
-	REQUIRE(ip == "82.99.219.114");
-	REQUIRE(port == 10251);
+		REQUIRE(family == AF_INET);
+		REQUIRE(ip == "82.99.219.114");
+		REQUIRE(port == 10251);
+	}
 }

--- a/worker/test/src/Utils/TestNumber.cpp
+++ b/worker/test/src/Utils/TestNumber.cpp
@@ -7,7 +7,7 @@ using namespace Utils;
 
 SCENARIO("Utils::Number", "[utils][number]")
 {
-	SECTION("Utils::Number::IsEqualThan()")
+	SECTION("IsEqualThan()")
 	{
 		// 0 is not equal than 16.
 		REQUIRE(Utils::Number<uint16_t>::IsEqualThan(0, 16) == false);
@@ -25,7 +25,7 @@ SCENARIO("Utils::Number", "[utils][number]")
 		REQUIRE(Utils::Number<uint64_t, 7>::IsEqualThan(0, 128) == true);
 	}
 
-	SECTION("Utils::Number::IsHigherThan()")
+	SECTION("IsHigherThan()")
 	{
 		// 10 is higher than std::numeric_limits<uint8_t>::max().
 		REQUIRE(Utils::Number<uint8_t>::IsHigherThan(10, std::numeric_limits<uint8_t>::max()) == true);
@@ -58,7 +58,7 @@ SCENARIO("Utils::Number", "[utils][number]")
 		REQUIRE(Utils::Number<uint64_t, 6>::IsHigherThan(0, 64) == false);
 	}
 
-	SECTION("Utils::Number::IsLowerThan()")
+	SECTION("IsLowerThan()")
 	{
 		// 1 is lower than 2.
 		REQUIRE(Utils::Number<uint8_t>::IsLowerThan(1, 2) == true);
@@ -97,7 +97,7 @@ SCENARIO("Utils::Number", "[utils][number]")
 		REQUIRE(Utils::Number<uint64_t, 2>::IsLowerThan(3, 1) == true);
 	}
 
-	SECTION("Utils::Number::IsHigherOrEqualThan()")
+	SECTION("IsHigherOrEqualThan()")
 	{
 		// 0 is greater or equal than std::numeric_limits<uint64_t>::max().
 		REQUIRE(
@@ -110,7 +110,7 @@ SCENARIO("Utils::Number", "[utils][number]")
 		REQUIRE(Utils::Number<uint64_t, 5>::IsHigherOrEqualThan(0, 32) == true);
 	}
 
-	SECTION("Utils::Number::IsLowerOrEqualThan()")
+	SECTION("IsLowerOrEqualThan()")
 	{
 		// std::numeric_limits<uint64_t>::max() is lower or equal than 0.
 		REQUIRE(

--- a/worker/test/src/Utils/TestString.cpp
+++ b/worker/test/src/Utils/TestString.cpp
@@ -5,74 +5,77 @@
 
 using namespace Utils;
 
-SCENARIO("String::ToLowerCase()", "[utils][string]")
+SCENARIO("Utils::String", "[utils][string]")
 {
-	std::string str;
-
-	str = "Foo";
-	String::ToLowerCase(str);
-	REQUIRE(str == "foo");
-
-	str = "Foo!œ";
-	String::ToLowerCase(str);
-	REQUIRE(str == "foo!œ");
-}
-
-SCENARIO("String::Base64Encode() and String::Base64Decode()", "[utils][string]")
-{
-	std::string data;
-	std::string encoded;
-	size_t outLen;
-	uint8_t* decodedPtr;
-	std::string decoded;
-
-	// NOTE: This is dangerous because we are using a string as binary.
-	data       = "abcd";
-	encoded    = String::Base64Encode(data);
-	decodedPtr = String::Base64Decode(encoded, outLen);
-	decoded    = std::string(reinterpret_cast<char*>(decodedPtr), outLen);
-	REQUIRE(encoded == "YWJjZA==");
-	REQUIRE(decoded == data);
-
-	// NOTE: This is dangerous because we are using a string as binary.
-	data       = "Iñaki";
-	encoded    = String::Base64Encode(data);
-	decodedPtr = String::Base64Decode(encoded, outLen);
-	decoded    = std::string(reinterpret_cast<char*>(decodedPtr), outLen);
-	REQUIRE(encoded == "ScOxYWtp");
-	REQUIRE(decoded == data);
-	REQUIRE(encoded == String::Base64Encode(decoded));
-
-	// NOTE: This is dangerous because we are using a string as binary.
-	data =
-	  "kjsh 23 å∫∂ is89 ∫¶ §∂¶ i823y kjahsd 234u asd kasjhdii7682342 asdkjhaskjsahd   k jashd kajsdhaksjdh skadhkjhkjh       askdjhasdkjahs uyqiwey aså∫∂¢∞¬∫∂ ashksajdh kjasdhkajshda s kjahsdkjas 987897as897 97898623 9s kjsgå∫∂ 432å∫ƒ∂ å∫#¢ ouyqwiuyais kajsdhiuye  ajshkkSAH SDFYÑÑÑ å∫∂Ω 87253847b asdbuiasdi as kasuœæ€\n321";
-	encoded    = String::Base64Encode(data);
-	decodedPtr = String::Base64Decode(encoded, outLen);
-	decoded    = std::string(reinterpret_cast<char*>(decodedPtr), outLen);
-	REQUIRE(
-	  encoded ==
-	  "a2pzaCAyMyDDpeKIq+KIgiBpczg5IOKIq8K2IMKn4oiCwrYgaTgyM3kga2phaHNkIDIzNHUgYXNkIGthc2poZGlpNzY4MjM0MiBhc2Rramhhc2tqc2FoZCAgIGsgamFzaGQga2Fqc2RoYWtzamRoIHNrYWRoa2poa2poICAgICAgIGFza2RqaGFzZGtqYWhzIHV5cWl3ZXkgYXPDpeKIq+KIgsKi4oiewqziiKviiIIgYXNoa3NhamRoIGtqYXNkaGthanNoZGEgcyBramFoc2RramFzIDk4Nzg5N2FzODk3IDk3ODk4NjIzIDlzIGtqc2fDpeKIq+KIgiA0MzLDpeKIq8aS4oiCIMOl4oirI8KiIG91eXF3aXV5YWlzIGthanNkaGl1eWUgIGFqc2hra1NBSCBTREZZw5HDkcORIMOl4oir4oiCzqkgODcyNTM4NDdiIGFzZGJ1aWFzZGkgYXMga2FzdcWTw6bigqwKMzIx");
-	REQUIRE(decoded == data);
-	REQUIRE(encoded == String::Base64Encode(decoded));
-
-	encoded    = "1WfmbWJXSlhTbGhUYkdoVVlrZG9WVmxyWkc5Vw==";
-	decodedPtr = String::Base64Decode(encoded, outLen);
-	REQUIRE(outLen == 28);
-	encoded = String::Base64Encode(decodedPtr, outLen);
-	REQUIRE(encoded == "1WfmbWJXSlhTbGhUYkdoVVlrZG9WVmxyWkc5Vw==");
-
-	// clang-format off
-	uint8_t rtpPacket[] =
+	SECTION("ToLowerCase()")
 	{
-		0xBE, 0xDE, 0, 3, // Header Extension
-		0b00010000, 0xFF, 0b00100001, 0xFF,
-		0xFF, 0, 0, 0b00110011,
-		0xFF, 0xFF, 0xFF, 0xFF
-	};
-	// clang-format on
+		std::string str;
 
-	encoded    = String::Base64Encode(rtpPacket, sizeof(rtpPacket));
-	decodedPtr = String::Base64Decode(encoded, outLen);
-	REQUIRE(outLen == sizeof(rtpPacket));
-	REQUIRE(std::memcmp(decodedPtr, rtpPacket, outLen) == 0);
+		str = "Foo";
+		String::ToLowerCase(str);
+		REQUIRE(str == "foo");
+
+		str = "Foo!œ";
+		String::ToLowerCase(str);
+		REQUIRE(str == "foo!œ");
+	}
+
+	SECTION("Base64Encode() and Base64Decode()")
+	{
+		std::string data;
+		std::string encoded;
+		size_t outLen;
+		uint8_t* decodedPtr;
+		std::string decoded;
+
+		// NOTE: This is dangerous because we are using a string as binary.
+		data       = "abcd";
+		encoded    = String::Base64Encode(data);
+		decodedPtr = String::Base64Decode(encoded, outLen);
+		decoded    = std::string(reinterpret_cast<char*>(decodedPtr), outLen);
+		REQUIRE(encoded == "YWJjZA==");
+		REQUIRE(decoded == data);
+
+		// NOTE: This is dangerous because we are using a string as binary.
+		data       = "Iñaki";
+		encoded    = String::Base64Encode(data);
+		decodedPtr = String::Base64Decode(encoded, outLen);
+		decoded    = std::string(reinterpret_cast<char*>(decodedPtr), outLen);
+		REQUIRE(encoded == "ScOxYWtp");
+		REQUIRE(decoded == data);
+		REQUIRE(encoded == String::Base64Encode(decoded));
+
+		// NOTE: This is dangerous because we are using a string as binary.
+		data =
+		  "kjsh 23 å∫∂ is89 ∫¶ §∂¶ i823y kjahsd 234u asd kasjhdii7682342 asdkjhaskjsahd   k jashd kajsdhaksjdh skadhkjhkjh       askdjhasdkjahs uyqiwey aså∫∂¢∞¬∫∂ ashksajdh kjasdhkajshda s kjahsdkjas 987897as897 97898623 9s kjsgå∫∂ 432å∫ƒ∂ å∫#¢ ouyqwiuyais kajsdhiuye  ajshkkSAH SDFYÑÑÑ å∫∂Ω 87253847b asdbuiasdi as kasuœæ€\n321";
+		encoded    = String::Base64Encode(data);
+		decodedPtr = String::Base64Decode(encoded, outLen);
+		decoded    = std::string(reinterpret_cast<char*>(decodedPtr), outLen);
+		REQUIRE(
+		  encoded ==
+		  "a2pzaCAyMyDDpeKIq+KIgiBpczg5IOKIq8K2IMKn4oiCwrYgaTgyM3kga2phaHNkIDIzNHUgYXNkIGthc2poZGlpNzY4MjM0MiBhc2Rramhhc2tqc2FoZCAgIGsgamFzaGQga2Fqc2RoYWtzamRoIHNrYWRoa2poa2poICAgICAgIGFza2RqaGFzZGtqYWhzIHV5cWl3ZXkgYXPDpeKIq+KIgsKi4oiewqziiKviiIIgYXNoa3NhamRoIGtqYXNkaGthanNoZGEgcyBramFoc2RramFzIDk4Nzg5N2FzODk3IDk3ODk4NjIzIDlzIGtqc2fDpeKIq+KIgiA0MzLDpeKIq8aS4oiCIMOl4oirI8KiIG91eXF3aXV5YWlzIGthanNkaGl1eWUgIGFqc2hra1NBSCBTREZZw5HDkcORIMOl4oir4oiCzqkgODcyNTM4NDdiIGFzZGJ1aWFzZGkgYXMga2FzdcWTw6bigqwKMzIx");
+		REQUIRE(decoded == data);
+		REQUIRE(encoded == String::Base64Encode(decoded));
+
+		encoded    = "1WfmbWJXSlhTbGhUYkdoVVlrZG9WVmxyWkc5Vw==";
+		decodedPtr = String::Base64Decode(encoded, outLen);
+		REQUIRE(outLen == 28);
+		encoded = String::Base64Encode(decodedPtr, outLen);
+		REQUIRE(encoded == "1WfmbWJXSlhTbGhUYkdoVVlrZG9WVmxyWkc5Vw==");
+
+		// clang-format off
+		uint8_t rtpPacket[] =
+		{
+			0xBE, 0xDE, 0, 3, // Header Extension
+			0b00010000, 0xFF, 0b00100001, 0xFF,
+			0xFF, 0, 0, 0b00110011,
+			0xFF, 0xFF, 0xFF, 0xFF
+		};
+		// clang-format on
+
+		encoded    = String::Base64Encode(rtpPacket, sizeof(rtpPacket));
+		decodedPtr = String::Base64Decode(encoded, outLen);
+		REQUIRE(outLen == sizeof(rtpPacket));
+		REQUIRE(std::memcmp(decodedPtr, rtpPacket, outLen) == 0);
+	}
 }

--- a/worker/test/src/Utils/TestTime.cpp
+++ b/worker/test/src/Utils/TestTime.cpp
@@ -7,12 +7,12 @@ using namespace Utils;
 
 SCENARIO("Utils::Time", "[utils][time]")
 {
-	SECTION("Utils::Time::Ntp2TimeMs()")
+	SECTION("Ntp2TimeMs()")
 	{
-		auto nowMs  = DepLibUV::GetTimeMs();
-		auto ntp    = Time::TimeMs2Ntp(nowMs);
-		auto nowMs2 = Time::Ntp2TimeMs(ntp);
-		auto ntp2   = Time::TimeMs2Ntp(nowMs2);
+		const auto nowMs  = DepLibUV::GetTimeMs();
+		const auto ntp    = Time::TimeMs2Ntp(nowMs);
+		const auto nowMs2 = Time::Ntp2TimeMs(ntp);
+		const auto ntp2   = Time::TimeMs2Ntp(nowMs2);
 
 		REQUIRE(nowMs2 == nowMs);
 		REQUIRE(ntp2.seconds == ntp.seconds);

--- a/worker/test/src/testHelpers.cpp
+++ b/worker/test/src/testHelpers.cpp
@@ -8,10 +8,11 @@
 
 namespace helpers
 {
-	bool ReadBinaryFile(const char* file, uint8_t* buffer, size_t* len)
+	bool readBinaryFile(const char* file, uint8_t* buffer, size_t* len)
 	{
 		MS_TRACE();
 
+		// NOLINTNEXTLINE(misc-const-correctness)
 		std::string filePath = "test/" + std::string(file);
 
 #ifdef _WIN32
@@ -34,62 +35,7 @@ namespace helpers
 		return true;
 	}
 
-	bool AddToBuffer(uint8_t* buf, size_t* size, const uint8_t* data, size_t len)
-	{
-		MS_TRACE();
-
-		static size_t bufferSize{ 65536 };
-
-		if (*size + len > bufferSize)
-		{
-			return false;
-		}
-
-		size_t i{ 0 };
-
-		if (len == 1)
-		{
-			buf[*size] = *data;
-		}
-		else
-		{
-			for (i = 0; i < len; ++i)
-			{
-				buf[*size + i] = data[i];
-			}
-		}
-
-		*size += len;
-
-		return true;
-	}
-
-	bool ReadPayloadData(const char* file, int pos, int bytes, uint8_t* payload)
-	{
-		MS_TRACE();
-
-		std::string filePath = "test/" + std::string(file);
-
-#ifdef _WIN32
-		std::replace(filePath.begin(), filePath.end(), '/', '\\');
-#endif
-
-		std::ifstream in(filePath, std::ios::ate | std::ios::binary);
-
-		if (!in)
-		{
-			return false;
-		}
-
-		in.seekg(pos, std::ios::beg);
-		in.read(reinterpret_cast<char*>(payload), bytes);
-
-		in.close();
-
-		return true;
-	}
-
-	bool AreBuffersEqual(const uint8_t* data1, size_t size1, const uint8_t* data2, size_t size2)
+	bool areBuffersEqual(const uint8_t* data1, size_t size1, const uint8_t* data2, size_t size2)
 	{
 		MS_TRACE();
 

--- a/worker/test/src/tests.cpp
+++ b/worker/test/src/tests.cpp
@@ -52,7 +52,7 @@ int main(int argc, char* argv[])
 
 	Catch::Session session;
 
-	int status = session.run(argc, argv);
+	const int status = session.run(argc, argv);
 
 	// Free static stuff.
 	DepLibSRTP::ClassDestroy();


### PR DESCRIPTION
# Details

- Partially completes #1711.
- Adapt/modernize all worker tests files.
- _NOTE:_ Not all test files have been tested with clang-tidy because it's endless. And clang-tidy doesn't now even pass normal worker src files yet so no difference here.