### PR TITLE
clang-tidy for worker/fuzzer

### DIFF
--- a/worker/.clang-tidy
+++ b/worker/.clang-tidy
@@ -70,6 +70,7 @@ Checks: "*,\
   -modernize-pass-by-value,\
   -modernize-use-nodiscard, \
   -modernize-use-trailing-return-type,\
+  -performance-avoid-endl,\
   -performance-no-int-to-ptr,\
   -portability-template-virtual-member-function,\
   -readability-convert-member-functions-to-static,\

--- a/worker/fuzzer/include/FuzzerUtils.hpp
+++ b/worker/fuzzer/include/FuzzerUtils.hpp
@@ -3,12 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerUtils
 {
-	namespace Utils
-	{
-		void Fuzz(const uint8_t* data, size_t len);
-	} // namespace Utils
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+} // namespace FuzzerUtils
 
 #endif

--- a/worker/fuzzer/include/RTC/FuzzerDtlsTransport.hpp
+++ b/worker/fuzzer/include/RTC/FuzzerDtlsTransport.hpp
@@ -4,36 +4,30 @@
 #include "common.hpp"
 #include "RTC/DtlsTransport.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcDtlsTransport
 {
-	namespace RTC
+	class DtlsTransportListener : public RTC::DtlsTransport::Listener
 	{
-		namespace DtlsTransport
-		{
-			class DtlsTransportListener : public ::RTC::DtlsTransport::Listener
-			{
-				/* Pure virtual methods inherited from RTC::DtlsTransport::Listener. */
-			public:
-				void OnDtlsTransportConnecting(const ::RTC::DtlsTransport* dtlsTransport) override;
-				void OnDtlsTransportConnected(
-				  const ::RTC::DtlsTransport* dtlsTransport,
-				  ::RTC::SrtpSession::CryptoSuite srtpCryptoSuite,
-				  uint8_t* srtpLocalKey,
-				  size_t srtpLocalKeyLen,
-				  uint8_t* srtpRemoteKey,
-				  size_t srtpRemoteKeyLen,
-				  std::string& remoteCert) override;
-				void OnDtlsTransportFailed(const ::RTC::DtlsTransport* dtlsTransport) override;
-				void OnDtlsTransportClosed(const ::RTC::DtlsTransport* dtlsTransport) override;
-				void OnDtlsTransportSendData(
-				  const ::RTC::DtlsTransport* dtlsTransport, const uint8_t* data, size_t len) override;
-				void OnDtlsTransportApplicationDataReceived(
-				  const ::RTC::DtlsTransport* dtlsTransport, const uint8_t* data, size_t len) override;
-			};
+		/* Pure virtual methods inherited from RTC::DtlsTransport::Listener. */
+	public:
+		void OnDtlsTransportConnecting(const ::RTC::DtlsTransport* dtlsTransport) override;
+		void OnDtlsTransportConnected(
+		  const ::RTC::DtlsTransport* dtlsTransport,
+		  ::RTC::SrtpSession::CryptoSuite srtpCryptoSuite,
+		  uint8_t* srtpLocalKey,
+		  size_t srtpLocalKeyLen,
+		  uint8_t* srtpRemoteKey,
+		  size_t srtpRemoteKeyLen,
+		  std::string& remoteCert) override;
+		void OnDtlsTransportFailed(const ::RTC::DtlsTransport* dtlsTransport) override;
+		void OnDtlsTransportClosed(const ::RTC::DtlsTransport* dtlsTransport) override;
+		void OnDtlsTransportSendData(
+		  const ::RTC::DtlsTransport* dtlsTransport, const uint8_t* data, size_t len) override;
+		void OnDtlsTransportApplicationDataReceived(
+		  const ::RTC::DtlsTransport* dtlsTransport, const uint8_t* data, size_t len) override;
+	};
 
-			void Fuzz(const uint8_t* data, size_t len);
-		} // namespace DtlsTransport
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+} // namespace FuzzerRtcDtlsTransport
 
 #endif

--- a/worker/fuzzer/include/RTC/FuzzerRateCalculator.hpp
+++ b/worker/fuzzer/include/RTC/FuzzerRateCalculator.hpp
@@ -3,15 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRateCalculator
 {
-	namespace RTC
-	{
-		namespace RateCalculator
-		{
-			void Fuzz(const uint8_t* data, size_t len);
-		}
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/FuzzerSeqManager.hpp
+++ b/worker/fuzzer/include/RTC/FuzzerSeqManager.hpp
@@ -3,15 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcSeqManager
 {
-	namespace RTC
-	{
-		namespace SeqManager
-		{
-			void Fuzz(const uint8_t* data, size_t len);
-		}
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/FuzzerTrendCalculator.hpp
+++ b/worker/fuzzer/include/RTC/FuzzerTrendCalculator.hpp
@@ -3,15 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcTrendCalculator
 {
-	namespace RTC
-	{
-		namespace TrendCalculator
-		{
-			void Fuzz(const uint8_t* data, size_t len);
-		}
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/ICE/FuzzerStunPacket.hpp
+++ b/worker/fuzzer/include/RTC/ICE/FuzzerStunPacket.hpp
@@ -3,18 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcIceStunPacket
 {
-	namespace RTC
-	{
-		namespace ICE
-		{
-			namespace StunPacket
-			{
-				void Fuzz(const uint8_t* data, size_t len);
-			}
-		} // namespace ICE
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerBye.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerBye.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/Bye.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpBye
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace Bye
-			{
-				void Fuzz(::RTC::RTCP::ByePacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::ByePacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPs.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPs.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/Packet.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackPs
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackPs
-			{
-				void Fuzz(::RTC::RTCP::Packet* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::Packet* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsAfb.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsAfb.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsAfb.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackPsAfb
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackPsAfb
-			{
-				void Fuzz(::RTC::RTCP::FeedbackPsAfbPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackPsAfbPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsFir.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsFir.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsFir.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackPsFir
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackPsFir
-			{
-				void Fuzz(::RTC::RTCP::FeedbackPsFirPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackPsFirPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsLei.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsLei.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsLei.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackPsLei
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackPsLei
-			{
-				void Fuzz(::RTC::RTCP::FeedbackPsLeiPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackPsLeiPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsPli.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsPli.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsPli.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackPsPli
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackPsPli
-			{
-				void Fuzz(::RTC::RTCP::FeedbackPsPliPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackPsPliPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsRemb.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsRemb.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsRemb.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackPsRemb
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackPsRemb
-			{
-				void Fuzz(::RTC::RTCP::FeedbackPsRembPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackPsRembPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsRpsi.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsRpsi.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsRpsi.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackPsRpsi
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackPsRpsi
-			{
-				void Fuzz(::RTC::RTCP::FeedbackPsRpsiPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackPsRpsiPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsSli.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsSli.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsSli.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackPsSli
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackPsSli
-			{
-				void Fuzz(::RTC::RTCP::FeedbackPsSliPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackPsSliPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsTst.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsTst.hpp
@@ -4,23 +4,14 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsTst.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackPsTstn
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackPsTstn
-			{
-				void Fuzz(::RTC::RTCP::FeedbackPsTstnPacket* packet);
-			}
+	void Fuzz(RTC::RTCP::FeedbackPsTstnPacket* packet);
+}
 
-			namespace FeedbackPsTstr
-			{
-				void Fuzz(::RTC::RTCP::FeedbackPsTstrPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackPsTstr
+{
+	void Fuzz(RTC::RTCP::FeedbackPsTstrPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsVbcm.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackPsVbcm.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackPsVbcm.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackPsVbcm
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackPsVbcm
-			{
-				void Fuzz(::RTC::RTCP::FeedbackPsVbcmPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackPsVbcmPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtp.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtp.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtp.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackRtp
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackRtp
-			{
-				void Fuzz(::RTC::RTCP::Packet* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::Packet* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpEcn.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpEcn.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtpEcn.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackRtpEcn
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackRtpEcn
-			{
-				void Fuzz(::RTC::RTCP::FeedbackRtpEcnPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackRtpEcnPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpNack.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpNack.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtpNack.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackRtpNack
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackRtpNack
-			{
-				void Fuzz(::RTC::RTCP::FeedbackRtpNackPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackRtpNackPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpSrReq.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpSrReq.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtpSrReq.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackRtpSrReq
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackRtpSrReq
-			{
-				void Fuzz(::RTC::RTCP::FeedbackRtpSrReqPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackRtpSrReqPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTllei.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTllei.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtpTllei.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackRtpTllei
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackRtpTllei
-			{
-				void Fuzz(::RTC::RTCP::FeedbackRtpTlleiPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackRtpTlleiPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTmmb.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTmmb.hpp
@@ -4,23 +4,14 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtpTmmb.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackRtpTmmbn
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackRtpTmmbn
-			{
-				void Fuzz(::RTC::RTCP::FeedbackRtpTmmbnPacket* packet);
-			}
+	void Fuzz(RTC::RTCP::FeedbackRtpTmmbnPacket* packet);
+}
 
-			namespace FeedbackRtpTmmbr
-			{
-				void Fuzz(::RTC::RTCP::FeedbackRtpTmmbrPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackRtpTmmbr
+{
+	void Fuzz(RTC::RTCP::FeedbackRtpTmmbrPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTransport.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerFeedbackRtpTransport.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtpTransport.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpFeedbackRtpTransport
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace FeedbackRtpTransport
-			{
-				void Fuzz(::RTC::RTCP::FeedbackRtpTransportPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::FeedbackRtpTransportPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerPacket.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerPacket.hpp
@@ -3,18 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpPacket
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace Packet
-			{
-				void Fuzz(const uint8_t* data, size_t len);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerReceiverReport.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerReceiverReport.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/ReceiverReport.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpReceiverReport
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace ReceiverReport
-			{
-				void Fuzz(::RTC::RTCP::ReceiverReportPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::ReceiverReportPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerSdes.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerSdes.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/Sdes.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpSdes
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace Sdes
-			{
-				void Fuzz(::RTC::RTCP::SdesPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::SdesPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerSenderReport.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerSenderReport.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/SenderReport.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpSenderReport
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace SenderReport
-			{
-				void Fuzz(::RTC::RTCP::SenderReportPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::SenderReportPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTCP/FuzzerXr.hpp
+++ b/worker/fuzzer/include/RTC/RTCP/FuzzerXr.hpp
@@ -4,18 +4,9 @@
 #include "common.hpp"
 #include "RTC/RTCP/XR.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcpExtendedReport
 {
-	namespace RTC
-	{
-		namespace RTCP
-		{
-			namespace ExtendedReport
-			{
-				void Fuzz(::RTC::RTCP::ExtendedReportPacket* packet);
-			}
-		} // namespace RTCP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(RTC::RTCP::ExtendedReportPacket* packet);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTP/Codecs/FuzzerAV1.hpp
+++ b/worker/fuzzer/include/RTC/RTP/Codecs/FuzzerAV1.hpp
@@ -3,21 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtpCodecsAV1
 {
-	namespace RTC
-	{
-		namespace RTP
-		{
-			namespace Codecs
-			{
-				namespace AV1
-				{
-					void Fuzz(const uint8_t* data, size_t len);
-				} // namespace AV1
-			} // namespace Codecs
-		} // namespace RTP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTP/Codecs/FuzzerDependencyDescriptor.hpp
+++ b/worker/fuzzer/include/RTC/RTP/Codecs/FuzzerDependencyDescriptor.hpp
@@ -2,22 +2,19 @@
 #define MS_FUZZER_RTC_RTP_CODECS_DEPENDENCY_DESCRIPTOR_HPP
 
 #include "common.hpp"
+#include "RTC/RTP/Codecs/DependencyDescriptor.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtpCodecsDependencyDescriptor
 {
-	namespace RTC
+	class DependencyDescriptorListener : public RTC::RTP::Codecs::DependencyDescriptor::Listener
 	{
-		namespace RTP
+	public:
+		void OnDependencyDescriptorUpdated(const uint8_t* data, size_t len) override
 		{
-			namespace Codecs
-			{
-				namespace DependencyDescriptor
-				{
-					void Fuzz(const uint8_t* data, size_t len);
-				} // namespace DependencyDescriptor
-			} // namespace Codecs
-		} // namespace RTP
-	} // namespace RTC
-} // namespace Fuzzer
+		}
+	};
+
+	void Fuzz(const uint8_t* data, size_t len);
+} // namespace FuzzerRtcRtpCodecsDependencyDescriptor
 
 #endif

--- a/worker/fuzzer/include/RTC/RTP/Codecs/FuzzerH264.hpp
+++ b/worker/fuzzer/include/RTC/RTP/Codecs/FuzzerH264.hpp
@@ -3,21 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtpCodecsH264
 {
-	namespace RTC
-	{
-		namespace RTP
-		{
-			namespace Codecs
-			{
-				namespace H264
-				{
-					void Fuzz(const uint8_t* data, size_t len);
-				}
-			} // namespace Codecs
-		} // namespace RTP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTP/Codecs/FuzzerOpus.hpp
+++ b/worker/fuzzer/include/RTC/RTP/Codecs/FuzzerOpus.hpp
@@ -3,21 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtpCodecsOpus
 {
-	namespace RTC
-	{
-		namespace RTP
-		{
-			namespace Codecs
-			{
-				namespace Opus
-				{
-					void Fuzz(const uint8_t* data, size_t len);
-				}
-			} // namespace Codecs
-		} // namespace RTP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTP/Codecs/FuzzerVP8.hpp
+++ b/worker/fuzzer/include/RTC/RTP/Codecs/FuzzerVP8.hpp
@@ -3,21 +3,10 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtpCodecsVP8
 {
-	namespace RTC
-	{
-		namespace RTP
-		{
-			namespace Codecs
-			{
-				namespace VP8
-				{
-					void Fuzz(const uint8_t* data, size_t len);
-				}
-			} // namespace Codecs
-		} // namespace RTP
-	} // namespace RTC
-} // namespace Fuzzer
+
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTP/Codecs/FuzzerVP9.hpp
+++ b/worker/fuzzer/include/RTC/RTP/Codecs/FuzzerVP9.hpp
@@ -3,21 +3,10 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtpCodecsVP9
 {
-	namespace RTC
-	{
-		namespace RTP
-		{
-			namespace Codecs
-			{
-				namespace VP9
-				{
-					void Fuzz(const uint8_t* data, size_t len);
-				}
-			} // namespace Codecs
-		} // namespace RTP
-	} // namespace RTC
-} // namespace Fuzzer
+
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTP/FuzzerPacket.hpp
+++ b/worker/fuzzer/include/RTC/RTP/FuzzerPacket.hpp
@@ -3,18 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtcPacket
 {
-	namespace RTC
-	{
-		namespace RTP
-		{
-			namespace Packet
-			{
-				void Fuzz(const uint8_t* data, size_t len);
-			}
-		} // namespace RTP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTP/FuzzerProbationGenerator.hpp
+++ b/worker/fuzzer/include/RTC/RTP/FuzzerProbationGenerator.hpp
@@ -3,18 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtpProbationGenerator
 {
-	namespace RTC
-	{
-		namespace RTP
-		{
-			namespace ProbationGenerator
-			{
-				void Fuzz(const uint8_t* data, size_t len);
-			}
-		} // namespace RTP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTP/FuzzerRetransmissionBuffer.hpp
+++ b/worker/fuzzer/include/RTC/RTP/FuzzerRetransmissionBuffer.hpp
@@ -3,18 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtpRetransmissionBuffer
 {
-	namespace RTC
-	{
-		namespace RTP
-		{
-			namespace RetransmissionBuffer
-			{
-				void Fuzz(const uint8_t* data, size_t len);
-			}
-		} // namespace RTP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+}
 
 #endif

--- a/worker/fuzzer/include/RTC/RTP/FuzzerRtpStreamSend.hpp
+++ b/worker/fuzzer/include/RTC/RTP/FuzzerRtpStreamSend.hpp
@@ -2,19 +2,26 @@
 #define MS_FUZZER_RTC_RTP_STREAM_SEND_HPP
 
 #include "common.hpp"
+#include "RTC/RTP/Packet.hpp"
+#include "RTC/RTP/RtpStreamSend.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcRtpStreamSend
 {
-	namespace RTC
+	class TestRtpStreamListener : public RTC::RTP::RtpStreamSend::Listener
 	{
-		namespace RTP
+	public:
+		void OnRtpStreamScore(
+		  RTC::RTP::RtpStream* /*rtpStream*/, uint8_t /*score*/, uint8_t /*previousScore*/) override
 		{
-			namespace RtpStreamSend
-			{
-				void Fuzz(const uint8_t* data, size_t len);
-			}
-		} // namespace RTP
-	} // namespace RTC
-} // namespace Fuzzer
+		}
+
+		void OnRtpStreamRetransmitRtpPacket(
+		  RTC::RTP::RtpStreamSend* /*rtpStream*/, RTC::RTP::Packet* packet) override
+		{
+		}
+	};
+
+	void Fuzz(const uint8_t* data, size_t len);
+} // namespace FuzzerRtcRtpStreamSend
 
 #endif

--- a/worker/fuzzer/include/RTC/SCTP/association/FuzzerStateCookie.hpp
+++ b/worker/fuzzer/include/RTC/SCTP/association/FuzzerStateCookie.hpp
@@ -3,18 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcSctpStateCookie
 {
-	namespace RTC
-	{
-		namespace SCTP
-		{
-			namespace StateCookie
-			{
-				void Fuzz(const uint8_t* data, size_t len);
-			}
-		} // namespace SCTP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+} // namespace FuzzerRtcSctpStateCookie
 
 #endif

--- a/worker/fuzzer/include/RTC/SCTP/packet/FuzzerPacket.hpp
+++ b/worker/fuzzer/include/RTC/SCTP/packet/FuzzerPacket.hpp
@@ -3,18 +3,9 @@
 
 #include "common.hpp"
 
-namespace Fuzzer
+namespace FuzzerRtcSctpPacket
 {
-	namespace RTC
-	{
-		namespace SCTP
-		{
-			namespace Packet
-			{
-				void Fuzz(const uint8_t* data, size_t len);
-			}
-		} // namespace SCTP
-	} // namespace RTC
-} // namespace Fuzzer
+	void Fuzz(const uint8_t* data, size_t len);
+} // namespace FuzzerRtcSctpPacket
 
 #endif

--- a/worker/fuzzer/src/FuzzerUtils.cpp
+++ b/worker/fuzzer/src/FuzzerUtils.cpp
@@ -4,10 +4,10 @@
 #include <cstring> // std::memory()
 #include <string>
 
-void Fuzzer::Utils::Fuzz(const uint8_t* data, size_t len)
+void FuzzerUtils::Fuzz(const uint8_t* data, size_t len)
 {
 	// For some fuzzers below.
-	std::unique_ptr<uint8_t[]> data2(new uint8_t[len + (INET6_ADDRSTRLEN * 3)]);
+	const std::unique_ptr<uint8_t[]> data2(new uint8_t[len + (INET6_ADDRSTRLEN * 3)]);
 
 	std::memcpy(data2.get(), data, len);
 
@@ -16,57 +16,57 @@ void Fuzzer::Utils::Fuzz(const uint8_t* data, size_t len)
 	std::string ip;
 
 	ip = std::string(reinterpret_cast<const char*>(data2.get()), INET6_ADDRSTRLEN / 2);
-	::Utils::IP::GetFamily(ip);
+	Utils::IP::GetFamily(ip);
 
 	ip = std::string(reinterpret_cast<const char*>(data2.get()), INET6_ADDRSTRLEN);
-	::Utils::IP::GetFamily(ip);
+	Utils::IP::GetFamily(ip);
 
 	ip = std::string(reinterpret_cast<const char*>(data2.get()), INET6_ADDRSTRLEN * 2);
-	::Utils::IP::GetFamily(ip);
+	Utils::IP::GetFamily(ip);
 
 	// Protect with try/catch since throws are legit.
 	try
 	{
 		auto ip = std::string(reinterpret_cast<const char*>(data2.get()), len);
 
-		::Utils::IP::NormalizeIp(ip);
+		Utils::IP::NormalizeIp(ip);
 	}
-	catch (const MediaSoupError& error)
+	catch (const MediaSoupError& error) // NOLINT(bugprone-empty-catch)
 	{
 	}
 
 	/* Byte class. */
 
-	::Utils::Byte::Get1Byte(data2.get(), len);
-	::Utils::Byte::Get2Bytes(data2.get(), len);
-	::Utils::Byte::Get3Bytes(data2.get(), len);
-	::Utils::Byte::Get4Bytes(data2.get(), len);
-	::Utils::Byte::Get8Bytes(data2.get(), len);
-	::Utils::Byte::Set1Byte(data2.get(), len, uint8_t{ 6u });
-	::Utils::Byte::Set2Bytes(data2.get(), len, uint16_t{ 66u });
-	::Utils::Byte::Set3Bytes(data2.get(), len, uint32_t{ 666u });
-	::Utils::Byte::Set4Bytes(data2.get(), len, uint32_t{ 666u });
-	::Utils::Byte::Set8Bytes(data2.get(), len, uint64_t{ 6666u });
-	::Utils::Byte::PadTo4Bytes(static_cast<uint8_t>(len));
-	::Utils::Byte::PadTo4Bytes(static_cast<uint16_t>(len));
-	::Utils::Byte::PadTo4Bytes(static_cast<uint32_t>(len));
-	::Utils::Byte::PadTo4Bytes(static_cast<uint64_t>(len));
-	::Utils::Byte::PadTo4Bytes(len);
-	::Utils::Byte::PadTo8Bytes(static_cast<uint8_t>(len));
-	::Utils::Byte::PadTo8Bytes(static_cast<uint16_t>(len));
-	::Utils::Byte::PadTo8Bytes(static_cast<uint32_t>(len));
-	::Utils::Byte::PadTo8Bytes(static_cast<uint64_t>(len));
-	::Utils::Byte::PadTo8Bytes(len);
+	Utils::Byte::Get1Byte(data2.get(), len);
+	Utils::Byte::Get2Bytes(data2.get(), len);
+	Utils::Byte::Get3Bytes(data2.get(), len);
+	Utils::Byte::Get4Bytes(data2.get(), len);
+	Utils::Byte::Get8Bytes(data2.get(), len);
+	Utils::Byte::Set1Byte(data2.get(), len, uint8_t{ 6u });
+	Utils::Byte::Set2Bytes(data2.get(), len, uint16_t{ 66u });
+	Utils::Byte::Set3Bytes(data2.get(), len, uint32_t{ 666u });
+	Utils::Byte::Set4Bytes(data2.get(), len, uint32_t{ 666u });
+	Utils::Byte::Set8Bytes(data2.get(), len, uint64_t{ 6666u });
+	Utils::Byte::PadTo4Bytes(static_cast<uint8_t>(len));
+	Utils::Byte::PadTo4Bytes(static_cast<uint16_t>(len));
+	Utils::Byte::PadTo4Bytes(static_cast<uint32_t>(len));
+	Utils::Byte::PadTo4Bytes(static_cast<uint64_t>(len));
+	Utils::Byte::PadTo4Bytes(len);
+	Utils::Byte::PadTo8Bytes(static_cast<uint8_t>(len));
+	Utils::Byte::PadTo8Bytes(static_cast<uint16_t>(len));
+	Utils::Byte::PadTo8Bytes(static_cast<uint32_t>(len));
+	Utils::Byte::PadTo8Bytes(static_cast<uint64_t>(len));
+	Utils::Byte::PadTo8Bytes(len);
 
 	/* Bits class. */
 
-	::Utils::Bits::CountSetBits(static_cast<uint16_t>(len));
+	Utils::Bits::CountSetBits(static_cast<uint16_t>(len));
 
 	/* Crypto class. */
 
-	::Utils::Crypto::GetRandomUInt(static_cast<uint32_t>(len), static_cast<uint32_t>(len + 1000000));
-	::Utils::Crypto::GetRandomString(len);
-	::Utils::Crypto::GetCRC32(data2.get(), len);
+	Utils::Crypto::GetRandomUInt(static_cast<uint32_t>(len), static_cast<uint32_t>(len + 1000000));
+	Utils::Crypto::GetRandomString(len);
+	Utils::Crypto::GetCRC32(data2.get(), len);
 
 	/* String class. */
 
@@ -75,17 +75,17 @@ void Fuzzer::Utils::Fuzz(const uint8_t* data, size_t len)
 	{
 		size_t outLen;
 
-		::Utils::String::Base64Encode(data2.get(), len);
-		::Utils::String::Base64Decode(data2.get(), len, outLen);
+		Utils::String::Base64Encode(data2.get(), len);
+		Utils::String::Base64Decode(data2.get(), len, outLen);
 	}
-	catch (const MediaSoupError& error)
+	catch (const MediaSoupError& error) // NOLINT(bugprone-empty-catch)
 	{
 	}
 
 	/* Time class. */
 
-	auto ntp = ::Utils::Time::TimeMs2Ntp(static_cast<uint64_t>(len));
+	auto ntp = Utils::Time::TimeMs2Ntp(static_cast<uint64_t>(len));
 
-	::Utils::Time::Ntp2TimeMs(ntp);
-	::Utils::Time::TimeMsToAbsSendTime(static_cast<uint64_t>(len));
+	Utils::Time::Ntp2TimeMs(ntp);
+	Utils::Time::TimeMsToAbsSendTime(static_cast<uint64_t>(len));
 }

--- a/worker/fuzzer/src/RTC/FuzzerDtlsTransport.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerDtlsTransport.cpp
@@ -1,22 +1,25 @@
-#define MS_CLASS "Fuzzer::RTC::DtlsTransport"
+#define MS_CLASS "FuzzerRtcDtlsTransport"
 // #define MS_LOG_DEV_LEVEL 3
 
 #include "RTC/FuzzerDtlsTransport.hpp"
 #include "Logger.hpp"
 #include "Utils.hpp"
 
-// DtlsTransport singleton. It's reset every time DTLS handshake fails or DTLS
-// is closed.
-thread_local static ::RTC::DtlsTransport* dtlsTransportSingleton{ nullptr };
-// DtlsTransport Listener singleton. It's reset every time the DtlsTransport
-// singletonDTLS is reset.
-thread_local static Fuzzer::RTC::DtlsTransport::DtlsTransportListener* dtlsTransportListenerSingleton{
-	nullptr
-};
-
-void Fuzzer::RTC::DtlsTransport::Fuzz(const uint8_t* data, size_t len)
+namespace
 {
-	if (!::RTC::DtlsTransport::IsDtls(data, len))
+	// NOLINTBEGIN(readability-identifier-naming)
+	// DtlsTransport instance. It's reset every time DTLS handshake fails or DTLS
+	// is closed.
+	thread_local RTC::DtlsTransport* dtlsTransportSingleton{ nullptr };
+	// DtlsTransport Listener instance. It's reset every time the DtlsTransport
+	// singletonDTLS is reset.
+	thread_local FuzzerRtcDtlsTransport::DtlsTransportListener* dtlsTransportListenerSingleton{ nullptr };
+	// NOLINTEND(readability-identifier-naming)
+} // namespace
+
+void FuzzerRtcDtlsTransport::Fuzz(const uint8_t* data, size_t len)
+{
+	if (!RTC::DtlsTransport::IsDtls(data, len))
 	{
 		return;
 	}
@@ -28,30 +31,30 @@ void Fuzzer::RTC::DtlsTransport::Fuzz(const uint8_t* data, size_t len)
 		delete dtlsTransportListenerSingleton;
 		dtlsTransportListenerSingleton = new DtlsTransportListener();
 
-		dtlsTransportSingleton = new ::RTC::DtlsTransport(dtlsTransportListenerSingleton);
+		dtlsTransportSingleton = new RTC::DtlsTransport(dtlsTransportListenerSingleton);
 
-		::RTC::DtlsTransport::Role localRole;
-		::RTC::DtlsTransport::Fingerprint dtlsRemoteFingerprint;
+		RTC::DtlsTransport::Role localRole;
+		RTC::DtlsTransport::Fingerprint dtlsRemoteFingerprint;
 
 		// Local DTLS role must be 'server' or 'client'. Choose it based on
 		// randomness of first given byte.
 		if (data[0] / 2 == 0)
 		{
-			localRole = ::RTC::DtlsTransport::Role::SERVER;
+			localRole = RTC::DtlsTransport::Role::SERVER;
 		}
 		else
 		{
-			localRole = ::RTC::DtlsTransport::Role::CLIENT;
+			localRole = RTC::DtlsTransport::Role::CLIENT;
 		}
 
 		// Remote DTLS fingerprint random generation.
 		// NOTE: Use a random integer in range 1..5 since FingerprintAlgorithm enum
 		// has 5 possible values starting with value 1.
 		dtlsRemoteFingerprint.algorithm =
-		  static_cast<::RTC::DtlsTransport::FingerprintAlgorithm>(::Utils::Crypto::GetRandomUInt(1u, 5u));
+		  static_cast<RTC::DtlsTransport::FingerprintAlgorithm>(Utils::Crypto::GetRandomUInt(1u, 5u));
 
 		dtlsRemoteFingerprint.value =
-		  ::Utils::Crypto::GetRandomString(::Utils::Crypto::GetRandomUInt(3u, 20u));
+		  Utils::Crypto::GetRandomString(Utils::Crypto::GetRandomUInt(3u, 20u));
 
 		dtlsTransportSingleton->Run(localRole);
 		dtlsTransportSingleton->SetRemoteFingerprint(dtlsRemoteFingerprint);
@@ -61,8 +64,8 @@ void Fuzzer::RTC::DtlsTransport::Fuzz(const uint8_t* data, size_t len)
 
 	// DTLS may have failed or closed after ProcessDtlsData(). If so, unset it.
 	if (
-	  dtlsTransportSingleton->GetState() == ::RTC::DtlsTransport::DtlsState::FAILED ||
-	  dtlsTransportSingleton->GetState() == ::RTC::DtlsTransport::DtlsState::CLOSED)
+	  dtlsTransportSingleton->GetState() == RTC::DtlsTransport::DtlsState::FAILED ||
+	  dtlsTransportSingleton->GetState() == RTC::DtlsTransport::DtlsState::CLOSED)
 	{
 		MS_DEBUG_DEV("DtlsTransport singleton state is 'failed' or 'closed', unsetting it");
 
@@ -75,15 +78,15 @@ void Fuzzer::RTC::DtlsTransport::Fuzz(const uint8_t* data, size_t len)
 	}
 }
 
-void Fuzzer::RTC::DtlsTransport::DtlsTransportListener::OnDtlsTransportConnecting(
-  const ::RTC::DtlsTransport* /*dtlsTransport*/)
+void FuzzerRtcDtlsTransport::DtlsTransportListener::OnDtlsTransportConnecting(
+  const RTC::DtlsTransport* /*dtlsTransport*/)
 {
 	MS_DEBUG_DEV("DtlsTransport singleton connecting");
 }
 
-void Fuzzer::RTC::DtlsTransport::DtlsTransportListener::OnDtlsTransportConnected(
-  const ::RTC::DtlsTransport* /*dtlsTransport*/,
-  ::RTC::SrtpSession::CryptoSuite /*srtpCryptoSuite*/,
+void FuzzerRtcDtlsTransport::DtlsTransportListener::OnDtlsTransportConnected(
+  const RTC::DtlsTransport* /*dtlsTransport*/,
+  RTC::SrtpSession::CryptoSuite /*srtpCryptoSuite*/,
   uint8_t* /*srtpLocalKey*/,
   size_t /*srtpLocalKeyLen*/,
   uint8_t* /*srtpRemoteKey*/,
@@ -93,26 +96,26 @@ void Fuzzer::RTC::DtlsTransport::DtlsTransportListener::OnDtlsTransportConnected
 	MS_DEBUG_DEV("DtlsTransport singleton connected");
 }
 
-void Fuzzer::RTC::DtlsTransport::DtlsTransportListener::OnDtlsTransportFailed(
-  const ::RTC::DtlsTransport* /*dtlsTransport*/)
+void FuzzerRtcDtlsTransport::DtlsTransportListener::OnDtlsTransportFailed(
+  const RTC::DtlsTransport* /*dtlsTransport*/)
 {
 	MS_DEBUG_DEV("DtlsTransport singleton failed");
 }
 
-void Fuzzer::RTC::DtlsTransport::DtlsTransportListener::OnDtlsTransportClosed(
-  const ::RTC::DtlsTransport* /*dtlsTransport*/)
+void FuzzerRtcDtlsTransport::DtlsTransportListener::OnDtlsTransportClosed(
+  const RTC::DtlsTransport* /*dtlsTransport*/)
 {
 	MS_DEBUG_DEV("DtlsTransport singleton closed");
 }
 
-void Fuzzer::RTC::DtlsTransport::DtlsTransportListener::OnDtlsTransportSendData(
-  const ::RTC::DtlsTransport* /*dtlsTransport*/, const uint8_t* /*data*/, size_t /*len*/)
+void FuzzerRtcDtlsTransport::DtlsTransportListener::OnDtlsTransportSendData(
+  const RTC::DtlsTransport* /*dtlsTransport*/, const uint8_t* /*data*/, size_t /*len*/)
 {
 	MS_DEBUG_DEV("DtlsTransport singleton wants to send data");
 }
 
-void Fuzzer::RTC::DtlsTransport::DtlsTransportListener::OnDtlsTransportApplicationDataReceived(
-  const ::RTC::DtlsTransport* /*dtlsTransport*/, const uint8_t* /*data*/, size_t /*len*/)
+void FuzzerRtcDtlsTransport::DtlsTransportListener::OnDtlsTransportApplicationDataReceived(
+  const RTC::DtlsTransport* /*dtlsTransport*/, const uint8_t* /*data*/, size_t /*len*/)
 {
 	MS_DEBUG_DEV("DtlsTransport singleton received application data");
 }

--- a/worker/fuzzer/src/RTC/FuzzerRateCalculator.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerRateCalculator.cpp
@@ -4,17 +4,26 @@
 #include "RTC/Consts.hpp"
 #include "RTC/RateCalculator.hpp"
 
-static ::RTC::RateCalculator rateCalculator;
-static uint64_t nowMs;
+namespace
+{
+	// NOLINTBEGIN(readability-identifier-naming)
+	RTC::RateCalculator rateCalculator;
+	uint64_t nowMs;
+	// NOLINTEND(readability-identifier-naming)
 
-// This Init() function must be declared static, otherwise linking will fail if
-// another source file defines same non static Init() function.
-static int Init();
+	int init()
+	{
+		nowMs = DepLibUV::GetTimeMs();
 
-void Fuzzer::RTC::RateCalculator::Fuzz(const uint8_t* data, size_t len)
+		return 0;
+	}
+} // namespace
+
+void FuzzerRtcRateCalculator::Fuzz(const uint8_t* data, size_t len)
 {
 	// Trick to initialize our stuff just once.
-	static int unused = Init();
+	// NOLINTNEXTLINE(readability-identifier-naming)
+	thread_local const int unused = init();
 
 	// Avoid [-Wunused-variable].
 	(void)unused;
@@ -26,7 +35,7 @@ void Fuzzer::RTC::RateCalculator::Fuzz(const uint8_t* data, size_t len)
 	}
 
 	auto size = static_cast<size_t>(
-	  Utils::Crypto::GetRandomUInt(0u, static_cast<uint32_t>(::RTC::Consts::MtuSize)));
+	  Utils::Crypto::GetRandomUInt(0u, static_cast<uint32_t>(RTC::Consts::MtuSize)));
 
 	nowMs += Utils::Crypto::GetRandomUInt(0u, 1000u);
 
@@ -37,11 +46,4 @@ void Fuzzer::RTC::RateCalculator::Fuzz(const uint8_t* data, size_t len)
 	{
 		rateCalculator.GetRate(nowMs);
 	}
-}
-
-int Init()
-{
-	nowMs = DepLibUV::GetTimeMs();
-
-	return 0;
 }

--- a/worker/fuzzer/src/RTC/FuzzerSeqManager.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerSeqManager.cpp
@@ -3,14 +3,14 @@
 #include "RTC/SeqManager.hpp"
 #include <iostream>
 
-void Fuzzer::RTC::SeqManager::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcSeqManager::Fuzz(const uint8_t* data, size_t len)
 {
 	if (len < 10)
 	{
 		return;
 	}
 
-	::RTC::SeqManager<uint16_t> seqManager;
+	RTC::SeqManager<uint16_t> seqManager;
 
 	uint16_t output;
 

--- a/worker/fuzzer/src/RTC/FuzzerTrendCalculator.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerTrendCalculator.cpp
@@ -3,15 +3,15 @@
 #include "Utils.hpp"
 #include "RTC/TrendCalculator.hpp"
 
-void Fuzzer::RTC::TrendCalculator::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcTrendCalculator::Fuzz(const uint8_t* data, size_t len)
 {
-	::RTC::TrendCalculator trend;
+	RTC::TrendCalculator trend;
 	auto now = DepLibUV::GetTimeMs();
 	size_t offset{ 0u };
 
 	while (len >= 4u)
 	{
-		auto value = Utils::Byte::Get4Bytes(data, offset);
+		const auto value = Utils::Byte::Get4Bytes(data, offset);
 
 		trend.Update(value, now);
 		trend.GetValue();

--- a/worker/fuzzer/src/RTC/ICE/FuzzerStunPacket.cpp
+++ b/worker/fuzzer/src/RTC/ICE/FuzzerStunPacket.cpp
@@ -3,20 +3,20 @@
 #include <string_view>
 
 static constexpr size_t ResponseFactoryBufferLength{ 65536 };
-thread_local static uint8_t ResponseFactoryBuffer[ResponseFactoryBufferLength];
+thread_local uint8_t ResponseFactoryBuffer[ResponseFactoryBufferLength];
 static constexpr size_t SerializeBufferLength{ 65536 };
-thread_local static uint8_t SerializeBuffer[SerializeBufferLength];
+thread_local uint8_t SerializeBuffer[SerializeBufferLength];
 static constexpr size_t CloneBufferLength{ 65536 };
-thread_local static uint8_t CloneBuffer[CloneBufferLength];
+thread_local uint8_t CloneBuffer[CloneBufferLength];
 
-void Fuzzer::RTC::ICE::StunPacket::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcIceStunPacket::Fuzz(const uint8_t* data, size_t len)
 {
-	if (!::RTC::ICE::StunPacket::IsStun(data, len))
+	if (!RTC::ICE::StunPacket::IsStun(data, len))
 	{
 		return;
 	}
 
-	auto* packet = ::RTC::ICE::StunPacket::Parse(data, len);
+	auto* packet = RTC::ICE::StunPacket::Parse(data, len);
 
 	if (!packet)
 	{
@@ -30,7 +30,7 @@ void Fuzzer::RTC::ICE::StunPacket::Fuzz(const uint8_t* data, size_t len)
 	packet->GetClass();
 	packet->GetMethod();
 	packet->GetTransactionId();
-	packet->HasAttribute(::RTC::ICE::StunPacket::AttributeType::USERNAME);
+	packet->HasAttribute(RTC::ICE::StunPacket::AttributeType::USERNAME);
 	packet->GetUsername();
 	packet->GetPriority();
 	packet->GetIceControlling();
@@ -46,7 +46,7 @@ void Fuzzer::RTC::ICE::StunPacket::Fuzz(const uint8_t* data, size_t len)
 	{
 		packet->AddUsername("foo");
 	}
-	catch (...)
+	catch (...) // NOLINT(bugprone-empty-catch)
 	{
 	}
 
@@ -54,7 +54,7 @@ void Fuzzer::RTC::ICE::StunPacket::Fuzz(const uint8_t* data, size_t len)
 	{
 		packet->AddPriority(123456);
 	}
-	catch (...)
+	catch (...) // NOLINT(bugprone-empty-catch)
 	{
 	}
 
@@ -62,7 +62,7 @@ void Fuzzer::RTC::ICE::StunPacket::Fuzz(const uint8_t* data, size_t len)
 	{
 		packet->AddIceControlling(98989232u);
 	}
-	catch (...)
+	catch (...) // NOLINT(bugprone-empty-catch)
 	{
 	}
 
@@ -70,7 +70,7 @@ void Fuzzer::RTC::ICE::StunPacket::Fuzz(const uint8_t* data, size_t len)
 	{
 		packet->AddIceControlled(87823823u);
 	}
-	catch (...)
+	catch (...) // NOLINT(bugprone-empty-catch)
 	{
 	}
 
@@ -78,7 +78,7 @@ void Fuzzer::RTC::ICE::StunPacket::Fuzz(const uint8_t* data, size_t len)
 	{
 		packet->AddUseCandidate();
 	}
-	catch (...)
+	catch (...) // NOLINT(bugprone-empty-catch)
 	{
 	}
 
@@ -86,7 +86,7 @@ void Fuzzer::RTC::ICE::StunPacket::Fuzz(const uint8_t* data, size_t len)
 	{
 		packet->AddNomination(7623547u);
 	}
-	catch (...)
+	catch (...) // NOLINT(bugprone-empty-catch)
 	{
 	}
 
@@ -95,7 +95,7 @@ void Fuzzer::RTC::ICE::StunPacket::Fuzz(const uint8_t* data, size_t len)
 		packet->AddXorMappedAddress(
 		  reinterpret_cast<struct sockaddr*>(std::addressof(xorMappedAddressStorage)));
 	}
-	catch (...)
+	catch (...) // NOLINT(bugprone-empty-catch)
 	{
 	}
 
@@ -103,7 +103,7 @@ void Fuzzer::RTC::ICE::StunPacket::Fuzz(const uint8_t* data, size_t len)
 	{
 		packet->AddErrorCode(555, "ERROR å∫∂æ®€å∂ƒ∫");
 	}
-	catch (...)
+	catch (...) // NOLINT(bugprone-empty-catch)
 	{
 	}
 
@@ -111,7 +111,7 @@ void Fuzzer::RTC::ICE::StunPacket::Fuzz(const uint8_t* data, size_t len)
 	{
 		packet->Protect("askjhdakjsd");
 	}
-	catch (...)
+	catch (...) // NOLINT(bugprone-empty-catch)
 	{
 	}
 
@@ -119,11 +119,11 @@ void Fuzzer::RTC::ICE::StunPacket::Fuzz(const uint8_t* data, size_t len)
 	{
 		packet->Protect();
 	}
-	catch (...)
+	catch (...) // NOLINT(bugprone-empty-catch)
 	{
 	}
 
-	if (packet->GetClass() == ::RTC::ICE::StunPacket::Class::REQUEST)
+	if (packet->GetClass() == RTC::ICE::StunPacket::Class::REQUEST)
 	{
 		auto* successResponse =
 		  packet->CreateSuccessResponse(ResponseFactoryBuffer, sizeof(ResponseFactoryBuffer));

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerBye.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerBye.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerBye.hpp"
 
-void Fuzzer::RTC::RTCP::Bye::Fuzz(::RTC::RTCP::ByePacket* packet)
+void FuzzerRtcRtcpBye::Fuzz(RTC::RTCP::ByePacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 	packet->AddSsrc(1111);

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPs.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPs.cpp
@@ -9,9 +9,9 @@
 #include "RTC/RTCP/FuzzerFeedbackPsTst.hpp"
 #include "RTC/RTCP/FuzzerFeedbackPsVbcm.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackPs::Fuzz(::RTC::RTCP::Packet* packet)
+void FuzzerRtcRtcpFeedbackPs::Fuzz(RTC::RTCP::Packet* packet)
 {
-	auto* fbps = dynamic_cast<::RTC::RTCP::FeedbackPsPacket*>(packet);
+	auto* fbps = dynamic_cast<RTC::RTCP::FeedbackPsPacket*>(packet);
 
 	fbps->GetMessageType();
 	fbps->GetSenderSsrc();
@@ -21,83 +21,83 @@ void Fuzzer::RTC::RTCP::FeedbackPs::Fuzz(::RTC::RTCP::Packet* packet)
 
 	switch (fbps->GetMessageType())
 	{
-		case ::RTC::RTCP::FeedbackPs::MessageType::PLI:
+		case RTC::RTCP::FeedbackPs::MessageType::PLI:
 		{
-			auto* pli = dynamic_cast<::RTC::RTCP::FeedbackPsPliPacket*>(fbps);
+			auto* pli = dynamic_cast<RTC::RTCP::FeedbackPsPliPacket*>(fbps);
 
-			Fuzzer::RTC::RTCP::FeedbackPsPli::Fuzz(pli);
+			FuzzerRtcRtcpFeedbackPsPli::Fuzz(pli);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackPs::MessageType::SLI:
+		case RTC::RTCP::FeedbackPs::MessageType::SLI:
 		{
-			auto* sli = dynamic_cast<::RTC::RTCP::FeedbackPsSliPacket*>(fbps);
+			auto* sli = dynamic_cast<RTC::RTCP::FeedbackPsSliPacket*>(fbps);
 
-			Fuzzer::RTC::RTCP::FeedbackPsSli::Fuzz(sli);
+			FuzzerRtcRtcpFeedbackPsSli::Fuzz(sli);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackPs::MessageType::RPSI:
+		case RTC::RTCP::FeedbackPs::MessageType::RPSI:
 		{
-			auto* rpsi = dynamic_cast<::RTC::RTCP::FeedbackPsRpsiPacket*>(fbps);
+			auto* rpsi = dynamic_cast<RTC::RTCP::FeedbackPsRpsiPacket*>(fbps);
 
-			Fuzzer::RTC::RTCP::FeedbackPsRpsi::Fuzz(rpsi);
+			FuzzerRtcRtcpFeedbackPsRpsi::Fuzz(rpsi);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackPs::MessageType::FIR:
+		case RTC::RTCP::FeedbackPs::MessageType::FIR:
 		{
-			auto* fir = dynamic_cast<::RTC::RTCP::FeedbackPsFirPacket*>(fbps);
+			auto* fir = dynamic_cast<RTC::RTCP::FeedbackPsFirPacket*>(fbps);
 
-			Fuzzer::RTC::RTCP::FeedbackPsFir::Fuzz(fir);
+			FuzzerRtcRtcpFeedbackPsFir::Fuzz(fir);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackPs::MessageType::TSTR:
+		case RTC::RTCP::FeedbackPs::MessageType::TSTR:
 		{
-			auto* tstr = dynamic_cast<::RTC::RTCP::FeedbackPsTstrPacket*>(fbps);
+			auto* tstr = dynamic_cast<RTC::RTCP::FeedbackPsTstrPacket*>(fbps);
 
-			Fuzzer::RTC::RTCP::FeedbackPsTstr::Fuzz(tstr);
+			FuzzerRtcRtcpFeedbackPsTstr::Fuzz(tstr);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackPs::MessageType::TSTN:
+		case RTC::RTCP::FeedbackPs::MessageType::TSTN:
 		{
-			auto* tstn = dynamic_cast<::RTC::RTCP::FeedbackPsTstnPacket*>(fbps);
+			auto* tstn = dynamic_cast<RTC::RTCP::FeedbackPsTstnPacket*>(fbps);
 
-			Fuzzer::RTC::RTCP::FeedbackPsTstn::Fuzz(tstn);
+			FuzzerRtcRtcpFeedbackPsTstn::Fuzz(tstn);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackPs::MessageType::VBCM:
+		case RTC::RTCP::FeedbackPs::MessageType::VBCM:
 		{
-			auto* vbcm = dynamic_cast<::RTC::RTCP::FeedbackPsVbcmPacket*>(fbps);
+			auto* vbcm = dynamic_cast<RTC::RTCP::FeedbackPsVbcmPacket*>(fbps);
 
-			Fuzzer::RTC::RTCP::FeedbackPsVbcm::Fuzz(vbcm);
+			FuzzerRtcRtcpFeedbackPsVbcm::Fuzz(vbcm);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackPs::MessageType::PSLEI:
+		case RTC::RTCP::FeedbackPs::MessageType::PSLEI:
 		{
-			auto* lei = dynamic_cast<::RTC::RTCP::FeedbackPsLeiPacket*>(fbps);
+			auto* lei = dynamic_cast<RTC::RTCP::FeedbackPsLeiPacket*>(fbps);
 
-			Fuzzer::RTC::RTCP::FeedbackPsLei::Fuzz(lei);
+			FuzzerRtcRtcpFeedbackPsLei::Fuzz(lei);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackPs::MessageType::AFB:
+		case RTC::RTCP::FeedbackPs::MessageType::AFB:
 		{
-			auto* afb = dynamic_cast<::RTC::RTCP::FeedbackPsAfbPacket*>(fbps);
+			auto* afb = dynamic_cast<RTC::RTCP::FeedbackPsAfbPacket*>(fbps);
 
-			Fuzzer::RTC::RTCP::FeedbackPsAfb::Fuzz(afb);
+			FuzzerRtcRtcpFeedbackPsAfb::Fuzz(afb);
 
 			break;
 		}

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsAfb.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsAfb.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerFeedbackPsAfb.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackPsAfb::Fuzz(::RTC::RTCP::FeedbackPsAfbPacket* packet)
+void FuzzerRtcRtcpFeedbackPsAfb::Fuzz(RTC::RTCP::FeedbackPsAfbPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetSize();
 	packet->GetApplication();
 }

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsFir.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsFir.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerFeedbackPsFir.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackPsFir::Fuzz(::RTC::RTCP::FeedbackPsFirPacket* packet)
+void FuzzerRtcRtcpFeedbackPsFir::Fuzz(RTC::RTCP::FeedbackPsFirPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -14,8 +13,7 @@ void Fuzzer::RTC::RTCP::FeedbackPsFir::Fuzz(::RTC::RTCP::FeedbackPsFirPacket* pa
 	{
 		auto& item = (*it);
 
-		// item->Dump();
-		item->Serialize(::RTC::RTCP::SerializationBuffer);
+		item->Serialize(RTC::RTCP::SerializationBuffer);
 		item->GetSize();
 		item->GetSsrc();
 		item->GetSequenceNumber();

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsLei.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsLei.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerFeedbackPsLei.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackPsLei::Fuzz(::RTC::RTCP::FeedbackPsLeiPacket* packet)
+void FuzzerRtcRtcpFeedbackPsLei::Fuzz(RTC::RTCP::FeedbackPsLeiPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -14,8 +13,7 @@ void Fuzzer::RTC::RTCP::FeedbackPsLei::Fuzz(::RTC::RTCP::FeedbackPsLeiPacket* pa
 	{
 		auto& item = (*it);
 
-		// item->Dump();
-		item->Serialize(::RTC::RTCP::SerializationBuffer);
+		item->Serialize(RTC::RTCP::SerializationBuffer);
 		item->GetSize();
 		item->GetSsrc();
 	}

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsPli.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsPli.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerFeedbackPsPli.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackPsPli::Fuzz(::RTC::RTCP::FeedbackPsPliPacket* packet)
+void FuzzerRtcRtcpFeedbackPsPli::Fuzz(RTC::RTCP::FeedbackPsPliPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 }

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsRemb.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsRemb.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerFeedbackPsRemb.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackPsRemb::Fuzz(::RTC::RTCP::FeedbackPsRembPacket* packet)
+void FuzzerRtcRtcpFeedbackPsRemb::Fuzz(RTC::RTCP::FeedbackPsRembPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 	packet->IsCorrect();

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsRpsi.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsRpsi.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerFeedbackPsRpsi.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackPsRpsi::Fuzz(::RTC::RTCP::FeedbackPsRpsiPacket* packet)
+void FuzzerRtcRtcpFeedbackPsRpsi::Fuzz(RTC::RTCP::FeedbackPsRpsiPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -14,8 +13,7 @@ void Fuzzer::RTC::RTCP::FeedbackPsRpsi::Fuzz(::RTC::RTCP::FeedbackPsRpsiPacket* 
 	{
 		auto& item = (*it);
 
-		// item->Dump();
-		item->Serialize(::RTC::RTCP::SerializationBuffer);
+		item->Serialize(RTC::RTCP::SerializationBuffer);
 		item->GetSize();
 		item->IsCorrect();
 		item->GetPayloadType();

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsSli.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsSli.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerFeedbackPsSli.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackPsSli::Fuzz(::RTC::RTCP::FeedbackPsSliPacket* packet)
+void FuzzerRtcRtcpFeedbackPsSli::Fuzz(RTC::RTCP::FeedbackPsSliPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -14,8 +13,7 @@ void Fuzzer::RTC::RTCP::FeedbackPsSli::Fuzz(::RTC::RTCP::FeedbackPsSliPacket* pa
 	{
 		auto& item = (*it);
 
-		// item->Dump();
-		item->Serialize(::RTC::RTCP::SerializationBuffer);
+		item->Serialize(RTC::RTCP::SerializationBuffer);
 		item->GetSize();
 		item->GetFirst();
 		item->SetFirst(1111);

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsTst.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsTst.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerFeedbackPsTst.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackPsTstn::Fuzz(::RTC::RTCP::FeedbackPsTstnPacket* packet)
+void FuzzerRtcRtcpFeedbackPsTstn::Fuzz(RTC::RTCP::FeedbackPsTstnPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -14,8 +13,7 @@ void Fuzzer::RTC::RTCP::FeedbackPsTstn::Fuzz(::RTC::RTCP::FeedbackPsTstnPacket* 
 	{
 		auto& item = (*it);
 
-		// item->Dump();
-		item->Serialize(::RTC::RTCP::SerializationBuffer);
+		item->Serialize(RTC::RTCP::SerializationBuffer);
 		item->GetSize();
 		item->GetSsrc();
 		item->GetSequenceNumber();
@@ -23,10 +21,9 @@ void Fuzzer::RTC::RTCP::FeedbackPsTstn::Fuzz(::RTC::RTCP::FeedbackPsTstnPacket* 
 	}
 }
 
-void Fuzzer::RTC::RTCP::FeedbackPsTstr::Fuzz(::RTC::RTCP::FeedbackPsTstrPacket* packet)
+void FuzzerRtcRtcpFeedbackPsTstr::Fuzz(RTC::RTCP::FeedbackPsTstrPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -37,8 +34,7 @@ void Fuzzer::RTC::RTCP::FeedbackPsTstr::Fuzz(::RTC::RTCP::FeedbackPsTstrPacket* 
 	{
 		auto& item = (*it);
 
-		// item->Dump();
-		item->Serialize(::RTC::RTCP::SerializationBuffer);
+		item->Serialize(RTC::RTCP::SerializationBuffer);
 		item->GetSize();
 		item->GetSsrc();
 		item->GetSequenceNumber();

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsVbcm.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackPsVbcm.cpp
@@ -1,11 +1,10 @@
 #include "RTC/RTCP/FuzzerFeedbackPsVbcm.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackPsVbcm::Fuzz(::RTC::RTCP::FeedbackPsVbcmPacket* packet)
+void FuzzerRtcRtcpFeedbackPsVbcm::Fuzz(RTC::RTCP::FeedbackPsVbcmPacket* packet)
 {
-	// packet->Dump();
 	// Triggers a crash in fuzzer.
 	// TODO: Verify that there is buffer enough for the announce length.
-	// packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	// packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -16,9 +15,8 @@ void Fuzzer::RTC::RTCP::FeedbackPsVbcm::Fuzz(::RTC::RTCP::FeedbackPsVbcmPacket* 
 	{
 		auto& item = (*it);
 
-		// item->Dump();
 		// Triggers a crash in fuzzer.
-		// item->Serialize(::RTC::RTCP::SerializationBuffer);
+		// item->Serialize(RTC::RTCP::SerializationBuffer);
 		item->GetSize();
 		item->GetSsrc();
 		item->GetSequenceNumber();

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtp.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtp.cpp
@@ -6,9 +6,9 @@
 #include "RTC/RTCP/FuzzerFeedbackRtpTmmb.hpp"
 #include "RTC/RTCP/FuzzerFeedbackRtpTransport.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackRtp::Fuzz(::RTC::RTCP::Packet* packet)
+void FuzzerRtcRtcpFeedbackRtp::Fuzz(RTC::RTCP::Packet* packet)
 {
-	auto* fbrtp = dynamic_cast<::RTC::RTCP::FeedbackRtpPacket*>(packet);
+	auto* fbrtp = dynamic_cast<RTC::RTCP::FeedbackRtpPacket*>(packet);
 
 	fbrtp->GetMessageType();
 	fbrtp->GetSenderSsrc();
@@ -18,65 +18,65 @@ void Fuzzer::RTC::RTCP::FeedbackRtp::Fuzz(::RTC::RTCP::Packet* packet)
 
 	switch (fbrtp->GetMessageType())
 	{
-		case ::RTC::RTCP::FeedbackRtp::MessageType::NACK:
+		case RTC::RTCP::FeedbackRtp::MessageType::NACK:
 		{
-			auto* nack = dynamic_cast<::RTC::RTCP::FeedbackRtpNackPacket*>(fbrtp);
+			auto* nack = dynamic_cast<RTC::RTCP::FeedbackRtpNackPacket*>(fbrtp);
 
-			Fuzzer::RTC::RTCP::FeedbackRtpNack::Fuzz(nack);
+			FuzzerRtcRtcpFeedbackRtpNack::Fuzz(nack);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackRtp::MessageType::TMMBR:
+		case RTC::RTCP::FeedbackRtp::MessageType::TMMBR:
 		{
-			auto* tmmbr = dynamic_cast<::RTC::RTCP::FeedbackRtpTmmbrPacket*>(fbrtp);
+			auto* tmmbr = dynamic_cast<RTC::RTCP::FeedbackRtpTmmbrPacket*>(fbrtp);
 
-			Fuzzer::RTC::RTCP::FeedbackRtpTmmbr::Fuzz(tmmbr);
+			FuzzerRtcRtcpFeedbackRtpTmmbr::Fuzz(tmmbr);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackRtp::MessageType::TMMBN:
+		case RTC::RTCP::FeedbackRtp::MessageType::TMMBN:
 		{
-			auto* tmmbn = dynamic_cast<::RTC::RTCP::FeedbackRtpTmmbnPacket*>(fbrtp);
+			auto* tmmbn = dynamic_cast<RTC::RTCP::FeedbackRtpTmmbnPacket*>(fbrtp);
 
-			Fuzzer::RTC::RTCP::FeedbackRtpTmmbn::Fuzz(tmmbn);
+			FuzzerRtcRtcpFeedbackRtpTmmbn::Fuzz(tmmbn);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackRtp::MessageType::SR_REQ:
+		case RTC::RTCP::FeedbackRtp::MessageType::SR_REQ:
 		{
-			auto* srReq = dynamic_cast<::RTC::RTCP::FeedbackRtpSrReqPacket*>(fbrtp);
+			auto* srReq = dynamic_cast<RTC::RTCP::FeedbackRtpSrReqPacket*>(fbrtp);
 
-			Fuzzer::RTC::RTCP::FeedbackRtpSrReq::Fuzz(srReq);
+			FuzzerRtcRtcpFeedbackRtpSrReq::Fuzz(srReq);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackRtp::MessageType::TLLEI:
+		case RTC::RTCP::FeedbackRtp::MessageType::TLLEI:
 		{
-			auto* tllei = dynamic_cast<::RTC::RTCP::FeedbackRtpTlleiPacket*>(fbrtp);
+			auto* tllei = dynamic_cast<RTC::RTCP::FeedbackRtpTlleiPacket*>(fbrtp);
 
-			Fuzzer::RTC::RTCP::FeedbackRtpTllei::Fuzz(tllei);
+			FuzzerRtcRtcpFeedbackRtpTllei::Fuzz(tllei);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackRtp::MessageType::ECN:
+		case RTC::RTCP::FeedbackRtp::MessageType::ECN:
 		{
-			auto* ecn = dynamic_cast<::RTC::RTCP::FeedbackRtpEcnPacket*>(fbrtp);
+			auto* ecn = dynamic_cast<RTC::RTCP::FeedbackRtpEcnPacket*>(fbrtp);
 
-			Fuzzer::RTC::RTCP::FeedbackRtpEcn::Fuzz(ecn);
+			FuzzerRtcRtcpFeedbackRtpEcn::Fuzz(ecn);
 
 			break;
 		}
 
-		case ::RTC::RTCP::FeedbackRtp::MessageType::TCC:
+		case RTC::RTCP::FeedbackRtp::MessageType::TCC:
 		{
-			auto* feedback = dynamic_cast<::RTC::RTCP::FeedbackRtpTransportPacket*>(fbrtp);
+			auto* feedback = dynamic_cast<RTC::RTCP::FeedbackRtpTransportPacket*>(fbrtp);
 
-			Fuzzer::RTC::RTCP::FeedbackRtpTransport::Fuzz(feedback);
+			FuzzerRtcRtcpFeedbackRtpTransport::Fuzz(feedback);
 
 			break;
 		}

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpEcn.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpEcn.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerFeedbackRtpEcn.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackRtpEcn::Fuzz(::RTC::RTCP::FeedbackRtpEcnPacket* packet)
+void FuzzerRtcRtcpFeedbackRtpEcn::Fuzz(RTC::RTCP::FeedbackRtpEcnPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -14,8 +13,7 @@ void Fuzzer::RTC::RTCP::FeedbackRtpEcn::Fuzz(::RTC::RTCP::FeedbackRtpEcnPacket* 
 	{
 		auto& item = (*it);
 
-		// item->Dump();
-		item->Serialize(::RTC::RTCP::SerializationBuffer);
+		item->Serialize(RTC::RTCP::SerializationBuffer);
 		item->GetSize();
 		item->GetSequenceNumber();
 		item->GetEct0Counter();

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpNack.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpNack.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerFeedbackRtpNack.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackRtpNack::Fuzz(::RTC::RTCP::FeedbackRtpNackPacket* packet)
+void FuzzerRtcRtcpFeedbackRtpNack::Fuzz(RTC::RTCP::FeedbackRtpNackPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -14,8 +13,7 @@ void Fuzzer::RTC::RTCP::FeedbackRtpNack::Fuzz(::RTC::RTCP::FeedbackRtpNackPacket
 	{
 		auto& item = (*it);
 
-		// item->Dump();
-		item->Serialize(::RTC::RTCP::SerializationBuffer);
+		item->Serialize(RTC::RTCP::SerializationBuffer);
 		item->GetSize();
 		item->GetPacketId();
 		item->GetLostPacketBitmask();

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpSrReq.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpSrReq.cpp
@@ -1,6 +1,6 @@
 #include "RTC/RTCP/FuzzerFeedbackRtpSrReq.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackRtpSrReq::Fuzz(::RTC::RTCP::FeedbackRtpSrReqPacket* packet)
+void FuzzerRtcRtcpFeedbackRtpSrReq::Fuzz(RTC::RTCP::FeedbackRtpSrReqPacket* packet)
 {
-	// packet->Dump();
+	// TODO
 }

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpTllei.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpTllei.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerFeedbackRtpTllei.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackRtpTllei::Fuzz(::RTC::RTCP::FeedbackRtpTlleiPacket* packet)
+void FuzzerRtcRtcpFeedbackRtpTllei::Fuzz(RTC::RTCP::FeedbackRtpTlleiPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -14,8 +13,7 @@ void Fuzzer::RTC::RTCP::FeedbackRtpTllei::Fuzz(::RTC::RTCP::FeedbackRtpTlleiPack
 	{
 		auto& item = (*it);
 
-		// item->Dump();
-		item->Serialize(::RTC::RTCP::SerializationBuffer);
+		item->Serialize(RTC::RTCP::SerializationBuffer);
 		item->GetSize();
 		item->GetPacketId();
 		item->GetLostPacketBitmask();

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpTmmb.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpTmmb.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerFeedbackRtpTmmb.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackRtpTmmbn::Fuzz(::RTC::RTCP::FeedbackRtpTmmbnPacket* packet)
+void FuzzerRtcRtcpFeedbackRtpTmmbn::Fuzz(RTC::RTCP::FeedbackRtpTmmbnPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -14,8 +13,7 @@ void Fuzzer::RTC::RTCP::FeedbackRtpTmmbn::Fuzz(::RTC::RTCP::FeedbackRtpTmmbnPack
 	{
 		auto& item = (*it);
 
-		// item->Dump();
-		item->Serialize(::RTC::RTCP::SerializationBuffer);
+		item->Serialize(RTC::RTCP::SerializationBuffer);
 		item->GetSize();
 		item->GetSsrc();
 		item->SetSsrc(1111);
@@ -26,10 +24,9 @@ void Fuzzer::RTC::RTCP::FeedbackRtpTmmbn::Fuzz(::RTC::RTCP::FeedbackRtpTmmbnPack
 	}
 }
 
-void Fuzzer::RTC::RTCP::FeedbackRtpTmmbr::Fuzz(::RTC::RTCP::FeedbackRtpTmmbrPacket* packet)
+void FuzzerRtcRtcpFeedbackRtpTmmbr::Fuzz(RTC::RTCP::FeedbackRtpTmmbrPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -40,8 +37,7 @@ void Fuzzer::RTC::RTCP::FeedbackRtpTmmbr::Fuzz(::RTC::RTCP::FeedbackRtpTmmbrPack
 	{
 		auto& item = (*it);
 
-		// item->Dump();
-		item->Serialize(::RTC::RTCP::SerializationBuffer);
+		item->Serialize(RTC::RTCP::SerializationBuffer);
 		item->GetSize();
 		item->GetSsrc();
 		item->SetSsrc(1111);

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpTransport.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpTransport.cpp
@@ -1,8 +1,7 @@
 #include "RTC/RTCP/FuzzerFeedbackRtpTransport.hpp"
 
-void Fuzzer::RTC::RTCP::FeedbackRtpTransport::Fuzz(::RTC::RTCP::FeedbackRtpTransportPacket* packet)
+void FuzzerRtcRtcpFeedbackRtpTransport::Fuzz(RTC::RTCP::FeedbackRtpTransportPacket* packet)
 {
-	// packet->Dump();
 	packet->GetCount();
 	packet->GetSize();
 	packet->IsFull();
@@ -17,5 +16,5 @@ void Fuzzer::RTC::RTCP::FeedbackRtpTransport::Fuzz(::RTC::RTCP::FeedbackRtpTrans
 	packet->GetLatestTimestamp();
 	packet->GetPacketResults();
 	packet->GetPacketFractionLost();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 }

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerPacket.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerPacket.cpp
@@ -8,20 +8,20 @@
 #include "RTC/RTCP/FuzzerXr.hpp"
 #include "RTC/RTCP/Packet.hpp"
 
-void Fuzzer::RTC::RTCP::Packet::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcRtcpPacket::Fuzz(const uint8_t* data, size_t len)
 {
-	if (!::RTC::RTCP::Packet::IsRtcp(data, len))
+	if (!RTC::RTCP::Packet::IsRtcp(data, len))
 	{
 		return;
 	}
 
 	// We need to clone the given data into a separate buffer because setters
 	// below will try to write into packet memory.
-	std::unique_ptr<uint8_t[]> data2(new uint8_t[len]);
+	const std::unique_ptr<uint8_t[]> data2(new uint8_t[len]);
 
 	std::memcpy(data2.get(), data, len);
 
-	::RTC::RTCP::Packet* packet = ::RTC::RTCP::Packet::Parse(data2.get(), len);
+	RTC::RTCP::Packet* packet = RTC::RTCP::Packet::Parse(data2.get(), len);
 
 	if (!packet)
 	{
@@ -32,63 +32,63 @@ void Fuzzer::RTC::RTCP::Packet::Fuzz(const uint8_t* data, size_t len)
 	{
 		auto* previousPacket = packet;
 
-		switch (::RTC::RTCP::Type(packet->GetType()))
+		switch (RTC::RTCP::Type(packet->GetType()))
 		{
-			case ::RTC::RTCP::Type::SR:
+			case RTC::RTCP::Type::SR:
 			{
-				auto* sr = dynamic_cast<::RTC::RTCP::SenderReportPacket*>(packet);
+				auto* sr = dynamic_cast<RTC::RTCP::SenderReportPacket*>(packet);
 
-				RTC::RTCP::SenderReport::Fuzz(sr);
+				FuzzerRtcRtcpSenderReport::Fuzz(sr);
 
 				break;
 			}
 
-			case ::RTC::RTCP::Type::RR:
+			case RTC::RTCP::Type::RR:
 			{
-				auto* rr = dynamic_cast<::RTC::RTCP::ReceiverReportPacket*>(packet);
+				auto* rr = dynamic_cast<RTC::RTCP::ReceiverReportPacket*>(packet);
 
-				RTC::RTCP::ReceiverReport::Fuzz(rr);
+				FuzzerRtcRtcpReceiverReport::Fuzz(rr);
 
 				break;
 			}
 
-			case ::RTC::RTCP::Type::SDES:
+			case RTC::RTCP::Type::SDES:
 			{
-				auto* sdes = dynamic_cast<::RTC::RTCP::SdesPacket*>(packet);
+				auto* sdes = dynamic_cast<RTC::RTCP::SdesPacket*>(packet);
 
-				RTC::RTCP::Sdes::Fuzz(sdes);
+				FuzzerRtcRtcpSdes::Fuzz(sdes);
 
 				break;
 			}
 
-			case ::RTC::RTCP::Type::BYE:
+			case RTC::RTCP::Type::BYE:
 			{
-				auto* bye = dynamic_cast<::RTC::RTCP::ByePacket*>(packet);
+				auto* bye = dynamic_cast<RTC::RTCP::ByePacket*>(packet);
 
-				RTC::RTCP::Bye::Fuzz(bye);
+				FuzzerRtcRtcpBye::Fuzz(bye);
 
 				break;
 			}
 
-			case ::RTC::RTCP::Type::RTPFB:
+			case RTC::RTCP::Type::RTPFB:
 			{
-				RTC::RTCP::FeedbackRtp::Fuzz(packet);
+				FuzzerRtcRtcpFeedbackRtp::Fuzz(packet);
 
 				break;
 			}
 
-			case ::RTC::RTCP::Type::PSFB:
+			case RTC::RTCP::Type::PSFB:
 			{
-				RTC::RTCP::FeedbackPs::Fuzz(packet);
+				FuzzerRtcRtcpFeedbackPs::Fuzz(packet);
 
 				break;
 			}
 
-			case ::RTC::RTCP::Type::XR:
+			case RTC::RTCP::Type::XR:
 			{
-				auto* xr = dynamic_cast<::RTC::RTCP::ExtendedReportPacket*>(packet);
+				auto* xr = dynamic_cast<RTC::RTCP::ExtendedReportPacket*>(packet);
 
-				RTC::RTCP::ExtendedReport::Fuzz(xr);
+				FuzzerRtcRtcpExtendedReport::Fuzz(xr);
 
 				break;
 			}

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerReceiverReport.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerReceiverReport.cpp
@@ -1,10 +1,9 @@
 #include "RTC/RTCP/FuzzerReceiverReport.hpp"
 #include "RTC/RTCP/Packet.hpp"
 
-void Fuzzer::RTC::RTCP::ReceiverReport::Fuzz(::RTC::RTCP::ReceiverReportPacket* packet)
+void FuzzerRtcRtcpReceiverReport::Fuzz(RTC::RTCP::ReceiverReportPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -18,8 +17,7 @@ void Fuzzer::RTC::RTCP::ReceiverReport::Fuzz(::RTC::RTCP::ReceiverReportPacket* 
 	{
 		auto& report = (*it);
 
-		// report->Dump();
-		report->Serialize(::RTC::RTCP::SerializationBuffer);
+		report->Serialize(RTC::RTCP::SerializationBuffer);
 		report->GetSize();
 		report->GetSsrc();
 		report->SetSsrc(1111);

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerSdes.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerSdes.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerSdes.hpp"
 
-void Fuzzer::RTC::RTCP::Sdes::Fuzz(::RTC::RTCP::SdesPacket* packet)
+void FuzzerRtcRtcpSdes::Fuzz(RTC::RTCP::SdesPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -14,8 +13,7 @@ void Fuzzer::RTC::RTCP::Sdes::Fuzz(::RTC::RTCP::SdesPacket* packet)
 	{
 		auto& chunk = (*it);
 
-		// chunk->Dump();
-		chunk->Serialize(::RTC::RTCP::SerializationBuffer);
+		chunk->Serialize(RTC::RTCP::SerializationBuffer);
 		chunk->GetSize();
 		chunk->GetSsrc();
 		chunk->SetSsrc(1111);
@@ -27,8 +25,7 @@ void Fuzzer::RTC::RTCP::Sdes::Fuzz(::RTC::RTCP::SdesPacket* packet)
 		{
 			auto& item = (*it2);
 
-			// item->Dump();
-			item->Serialize(::RTC::RTCP::SerializationBuffer);
+			item->Serialize(RTC::RTCP::SerializationBuffer);
 			item->GetSize();
 			item->GetType();
 			item->GetLength();

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerSenderReport.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerSenderReport.cpp
@@ -1,15 +1,14 @@
 #include "RTC/RTCP/FuzzerSenderReport.hpp"
 #include "RTC/RTCP/Packet.hpp"
 
-void Fuzzer::RTC::RTCP::SenderReport::Fuzz(::RTC::RTCP::SenderReportPacket* packet)
+void FuzzerRtcRtcpSenderReport::Fuzz(RTC::RTCP::SenderReportPacket* packet)
 {
 	// A well formed packet must have a single report.
 	if (packet->GetCount() == 1)
 	{
-		packet->Serialize(::RTC::RTCP::SerializationBuffer);
+		packet->Serialize(RTC::RTCP::SerializationBuffer);
 	}
 
-	// packet->Dump();
 	packet->GetCount();
 	packet->GetSize();
 
@@ -20,8 +19,7 @@ void Fuzzer::RTC::RTCP::SenderReport::Fuzz(::RTC::RTCP::SenderReportPacket* pack
 	{
 		auto& report = (*it);
 
-		// report->Dump();
-		report->Serialize(::RTC::RTCP::SerializationBuffer);
+		report->Serialize(RTC::RTCP::SerializationBuffer);
 		report->GetSize();
 		report->GetSsrc();
 		report->SetSsrc(1111);

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerXr.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerXr.cpp
@@ -1,9 +1,8 @@
 #include "RTC/RTCP/FuzzerXr.hpp"
 
-void Fuzzer::RTC::RTCP::ExtendedReport::Fuzz(::RTC::RTCP::ExtendedReportPacket* packet)
+void FuzzerRtcRtcpExtendedReport::Fuzz(RTC::RTCP::ExtendedReportPacket* packet)
 {
-	// packet->Dump();
-	packet->Serialize(::RTC::RTCP::SerializationBuffer);
+	packet->Serialize(RTC::RTCP::SerializationBuffer);
 	packet->GetCount();
 	packet->GetSize();
 
@@ -14,8 +13,7 @@ void Fuzzer::RTC::RTCP::ExtendedReport::Fuzz(::RTC::RTCP::ExtendedReportPacket* 
 	{
 		auto& report = (*it);
 
-		// report->Dump();
-		report->Serialize(::RTC::RTCP::SerializationBuffer);
+		report->Serialize(RTC::RTCP::SerializationBuffer);
 		report->GetSize();
 		report->GetType();
 	}

--- a/worker/fuzzer/src/RTC/RTP/Codecs/FuzzerAV1.cpp
+++ b/worker/fuzzer/src/RTC/RTP/Codecs/FuzzerAV1.cpp
@@ -1,7 +1,7 @@
 #include "RTC/RTP/Codecs/FuzzerAV1.hpp"
 #include "RTC/RTP/Codecs/AV1.hpp"
 
-class Listener : public ::RTC::RTP::Codecs::DependencyDescriptor::Listener
+class Listener : public RTC::RTP::Codecs::DependencyDescriptor::Listener
 {
 public:
 	void OnDependencyDescriptorUpdated(const uint8_t* data, size_t len) override
@@ -9,17 +9,17 @@ public:
 	}
 };
 
-void Fuzzer::RTC::RTP::Codecs::AV1::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcRtpCodecsAV1::Fuzz(const uint8_t* data, size_t len)
 {
 	Listener listener;
-	std::unique_ptr<::RTC::RTP::Codecs::DependencyDescriptor::TemplateDependencyStructure>
+	std::unique_ptr<RTC::RTP::Codecs::DependencyDescriptor::TemplateDependencyStructure>
 	  templateDependencyStructure;
 
-	auto dependencyDescriptor = std::unique_ptr<::RTC::RTP::Codecs::DependencyDescriptor>(
-	  ::RTC::RTP::Codecs::DependencyDescriptor::Parse(
+	auto dependencyDescriptor = std::unique_ptr<RTC::RTP::Codecs::DependencyDescriptor>(
+	  RTC::RTP::Codecs::DependencyDescriptor::Parse(
 	    data, len, std::addressof(listener), templateDependencyStructure));
 
-	auto* descriptor = ::RTC::RTP::Codecs::AV1::Parse(dependencyDescriptor);
+	auto* descriptor = RTC::RTP::Codecs::AV1::Parse(dependencyDescriptor);
 
 	if (!descriptor)
 	{

--- a/worker/fuzzer/src/RTC/RTP/Codecs/FuzzerDependencyDescriptor.cpp
+++ b/worker/fuzzer/src/RTC/RTP/Codecs/FuzzerDependencyDescriptor.cpp
@@ -1,22 +1,13 @@
 #include "RTC/RTP/Codecs/FuzzerDependencyDescriptor.hpp"
-#include "RTC/RTP/Codecs/DependencyDescriptor.hpp"
 
-class Listener : public ::RTC::RTP::Codecs::DependencyDescriptor::Listener
+void FuzzerRtcRtpCodecsDependencyDescriptor::Fuzz(const uint8_t* data, size_t len)
 {
-public:
-	void OnDependencyDescriptorUpdated(const uint8_t* data, size_t len) override
-	{
-	}
-};
-
-void Fuzzer::RTC::RTP::Codecs::DependencyDescriptor::Fuzz(const uint8_t* data, size_t len)
-{
-	std::unique_ptr<::RTC::RTP::Codecs::DependencyDescriptor::TemplateDependencyStructure>
+	std::unique_ptr<RTC::RTP::Codecs::DependencyDescriptor::TemplateDependencyStructure>
 	  templateDependencyStructure;
 
-	Listener listener;
+	DependencyDescriptorListener listener;
 
-	auto* descriptor = ::RTC::RTP::Codecs::DependencyDescriptor::Parse(
+	auto* descriptor = RTC::RTP::Codecs::DependencyDescriptor::Parse(
 	  data, len, std::addressof(listener), templateDependencyStructure);
 
 	if (!descriptor)

--- a/worker/fuzzer/src/RTC/RTP/Codecs/FuzzerH264.cpp
+++ b/worker/fuzzer/src/RTC/RTP/Codecs/FuzzerH264.cpp
@@ -1,12 +1,12 @@
 #include "RTC/RTP/Codecs/FuzzerH264.hpp"
 #include "RTC/RTP/Codecs/H264.hpp"
 
-void Fuzzer::RTC::RTP::Codecs::H264::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcRtpCodecsH264::Fuzz(const uint8_t* data, size_t len)
 {
-	::RTC::RTP::Codecs::DependencyDescriptor* dependencyDescriptor{ nullptr };
+	RTC::RTP::Codecs::DependencyDescriptor* dependencyDescriptor{ nullptr };
 
-	::RTC::RTP::Codecs::H264::PayloadDescriptor* descriptor =
-	  ::RTC::RTP::Codecs::H264::Parse(data, len, dependencyDescriptor);
+	const RTC::RTP::Codecs::H264::PayloadDescriptor* descriptor =
+	  RTC::RTP::Codecs::H264::Parse(data, len, dependencyDescriptor);
 
 	if (!descriptor)
 	{

--- a/worker/fuzzer/src/RTC/RTP/Codecs/FuzzerOpus.cpp
+++ b/worker/fuzzer/src/RTC/RTP/Codecs/FuzzerOpus.cpp
@@ -1,10 +1,10 @@
 #include "RTC/RTP/Codecs/FuzzerOpus.hpp"
 #include "RTC/RTP/Codecs/Opus.hpp"
 
-void Fuzzer::RTC::RTP::Codecs::Opus::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcRtpCodecsOpus::Fuzz(const uint8_t* data, size_t len)
 {
-	::RTC::RTP::Codecs::Opus::PayloadDescriptor* descriptor =
-	  ::RTC::RTP::Codecs::Opus::Parse(data, len);
+	const RTC::RTP::Codecs::Opus::PayloadDescriptor* descriptor =
+	  RTC::RTP::Codecs::Opus::Parse(data, len);
 
 	if (!descriptor)
 	{

--- a/worker/fuzzer/src/RTC/RTP/Codecs/FuzzerVP8.cpp
+++ b/worker/fuzzer/src/RTC/RTP/Codecs/FuzzerVP8.cpp
@@ -1,9 +1,10 @@
 #include "RTC/RTP/Codecs/FuzzerVP8.hpp"
 #include "RTC/RTP/Codecs/VP8.hpp"
 
-void Fuzzer::RTC::RTP::Codecs::VP8::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcRtpCodecsVP8::Fuzz(const uint8_t* data, size_t len)
 {
-	::RTC::RTP::Codecs::VP8::PayloadDescriptor* descriptor = ::RTC::RTP::Codecs::VP8::Parse(data, len);
+	const RTC::RTP::Codecs::VP8::PayloadDescriptor* descriptor =
+	  RTC::RTP::Codecs::VP8::Parse(data, len);
 
 	if (!descriptor)
 	{

--- a/worker/fuzzer/src/RTC/RTP/Codecs/FuzzerVP9.cpp
+++ b/worker/fuzzer/src/RTC/RTP/Codecs/FuzzerVP9.cpp
@@ -1,9 +1,10 @@
 #include "RTC/RTP/Codecs/FuzzerVP9.hpp"
 #include "RTC/RTP/Codecs/VP9.hpp"
 
-void Fuzzer::RTC::RTP::Codecs::VP9::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcRtpCodecsVP9::Fuzz(const uint8_t* data, size_t len)
 {
-	::RTC::RTP::Codecs::VP9::PayloadDescriptor* descriptor = ::RTC::RTP::Codecs::VP9::Parse(data, len);
+	const RTC::RTP::Codecs::VP9::PayloadDescriptor* descriptor =
+	  RTC::RTP::Codecs::VP9::Parse(data, len);
 
 	if (!descriptor)
 	{

--- a/worker/fuzzer/src/RTC/RTP/FuzzerPacket.cpp
+++ b/worker/fuzzer/src/RTC/RTP/FuzzerPacket.cpp
@@ -5,14 +5,14 @@
 #include <string>
 #include <vector>
 
-void Fuzzer::RTC::RTP::Packet::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcRtcPacket::Fuzz(const uint8_t* data, size_t len)
 {
-	if (!::RTC::RTP::Packet::IsRtp(data, len))
+	if (!RTC::RTP::Packet::IsRtp(data, len))
 	{
 		return;
 	}
 
-	std::unique_ptr<::RTC::RTP::Packet> packet{ ::RTC::RTP::Packet::Parse(data, len, len) };
+	std::unique_ptr<RTC::RTP::Packet> packet{ RTC::RTP::Packet::Parse(data, len, len) };
 
 	if (!packet)
 	{
@@ -23,11 +23,11 @@ void Fuzzer::RTC::RTP::Packet::Fuzz(const uint8_t* data, size_t len)
 	// below will try to write into packet memory.
 	//
 	// NOTE: Let's make the buffer bigger to test API that increases packet size.
-	std::unique_ptr<uint8_t[]> buffer(new uint8_t[len + 512]);
+	const std::unique_ptr<uint8_t[]> buffer(new uint8_t[len + 512]);
 
 	packet->Serialize(buffer.get(), len + 512);
 
-	std::vector<::RTC::RTP::Packet::Extension> extensions;
+	std::vector<RTC::RTP::Packet::Extension> extensions;
 	uint8_t extenLen;
 	bool voice;
 	uint8_t volume;
@@ -67,7 +67,7 @@ void Fuzzer::RTC::RTP::Packet::Fuzz(const uint8_t* data, size_t len)
 	packet->HasOneByteExtensions();
 	packet->HasTwoBytesExtensions();
 
-	::RTC::RTP::HeaderExtensionIds headerExtensionIds{};
+	RTC::RTP::HeaderExtensionIds headerExtensionIds{};
 
 	headerExtensionIds.mid               = 5;
 	headerExtensionIds.rid               = 6;
@@ -124,67 +124,67 @@ void Fuzzer::RTC::RTP::Packet::Fuzz(const uint8_t* data, size_t len)
 	uint8_t value1[] = { 0x01, 0x02, 0x03, 0x04 };
 
 	extensions.emplace_back(
-	  ::RTC::RtpHeaderExtensionUri::Type::MID, // type
-	  1,                                       // id
-	  4,                                       // len
-	  value1                                   // value
+	  RTC::RtpHeaderExtensionUri::Type::MID, // type
+	  1,                                     // id
+	  4,                                     // len
+	  value1                                 // value
 	);
 
 	uint8_t value2[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x10, 0x11 };
 
 	extensions.emplace_back(
-	  ::RTC::RtpHeaderExtensionUri::Type::RTP_STREAM_ID, // type
-	  2,                                                 // id
-	  11,                                                // len
-	  value2                                             // value
+	  RTC::RtpHeaderExtensionUri::Type::RTP_STREAM_ID, // type
+	  2,                                               // id
+	  11,                                              // len
+	  value2                                           // value
 	);
 
-	packet->SetExtensions(::RTC::RTP::Packet::ExtensionsType::OneByte, extensions);
-	packet->SetExtensions(::RTC::RTP::Packet::ExtensionsType::TwoBytes, extensions);
-	packet->SetExtensions(::RTC::RTP::Packet::ExtensionsType::Auto, extensions);
+	packet->SetExtensions(RTC::RTP::Packet::ExtensionsType::OneByte, extensions);
+	packet->SetExtensions(RTC::RTP::Packet::ExtensionsType::TwoBytes, extensions);
+	packet->SetExtensions(RTC::RTP::Packet::ExtensionsType::Auto, extensions);
 
 	extensions.clear();
 
-	packet->SetExtensions(::RTC::RTP::Packet::ExtensionsType::TwoBytes, extensions);
-	packet->SetExtensions(::RTC::RTP::Packet::ExtensionsType::OneByte, extensions);
-	packet->SetExtensions(::RTC::RTP::Packet::ExtensionsType::Auto, extensions);
+	packet->SetExtensions(RTC::RTP::Packet::ExtensionsType::TwoBytes, extensions);
+	packet->SetExtensions(RTC::RTP::Packet::ExtensionsType::OneByte, extensions);
+	packet->SetExtensions(RTC::RTP::Packet::ExtensionsType::Auto, extensions);
 
 	uint8_t value3[] = { 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0A, 0x0B, 0x0C,
 		                   0x0D, 0x0E, 0x0F, 0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18 };
 
 	extensions.emplace_back(
-	  ::RTC::RtpHeaderExtensionUri::Type::MID, // type
-	  14,                                      // id
-	  24,                                      // len
-	  value3                                   // value
+	  RTC::RtpHeaderExtensionUri::Type::MID, // type
+	  14,                                    // id
+	  24,                                    // len
+	  value3                                 // value
 	);
 
 	extensions.emplace_back(
-	  ::RTC::RtpHeaderExtensionUri::Type::RTP_STREAM_ID, // type
-	  15,                                                // id
-	  24,                                                // len
-	  value3                                             // value
+	  RTC::RtpHeaderExtensionUri::Type::RTP_STREAM_ID, // type
+	  15,                                              // id
+	  24,                                              // len
+	  value3                                           // value
 	);
 
 	extensions.emplace_back(
-	  ::RTC::RtpHeaderExtensionUri::Type::REPAIRED_RTP_STREAM_ID, // type
-	  22,                                                         // id
-	  24,                                                         // len
-	  value3                                                      // value
+	  RTC::RtpHeaderExtensionUri::Type::REPAIRED_RTP_STREAM_ID, // type
+	  22,                                                       // id
+	  24,                                                       // len
+	  value3                                                    // value
 	);
 
 	extensions.emplace_back(
-	  ::RTC::RtpHeaderExtensionUri::Type::DEPENDENCY_DESCRIPTOR, // type
-	  100,                                                       // id
-	  24,                                                        // len
-	  value3                                                     // value
+	  RTC::RtpHeaderExtensionUri::Type::DEPENDENCY_DESCRIPTOR, // type
+	  100,                                                     // id
+	  24,                                                      // len
+	  value3                                                   // value
 	);
 
 	// NOTE: Cannot use One-Byte Extensions because we are using big ids and
 	// lengths.
-	// packet->SetExtensions(::RTC::RTP::Packet::ExtensionsType::OneByte, extensions);
-	packet->SetExtensions(::RTC::RTP::Packet::ExtensionsType::TwoBytes, extensions);
-	packet->SetExtensions(::RTC::RTP::Packet::ExtensionsType::Auto, extensions);
+	// packet->SetExtensions(RTC::RTP::Packet::ExtensionsType::OneByte, extensions);
+	packet->SetExtensions(RTC::RTP::Packet::ExtensionsType::TwoBytes, extensions);
+	packet->SetExtensions(RTC::RTP::Packet::ExtensionsType::Auto, extensions);
 
 	packet->HasExtension(13);
 	packet->GetExtensionValue(13, extenLen);
@@ -247,7 +247,7 @@ void Fuzzer::RTC::RTP::Packet::Fuzz(const uint8_t* data, size_t len)
 	// packet->GetSpatialLayer();
 	// packet->GetTemporalLayer();
 
-	std::unique_ptr<uint8_t[]> buffer2(new uint8_t[len + 512]);
+	const std::unique_ptr<uint8_t[]> buffer2(new uint8_t[len + 512]);
 
 	packet.reset(packet->Clone(buffer2.get(), len + 512));
 

--- a/worker/fuzzer/src/RTC/RTP/FuzzerProbationGenerator.cpp
+++ b/worker/fuzzer/src/RTC/RTP/FuzzerProbationGenerator.cpp
@@ -1,10 +1,10 @@
 #include "RTC/RTP/FuzzerProbationGenerator.hpp"
 #include "RTC/RTP/ProbationGenerator.hpp"
 
-void Fuzzer::RTC::RTP::ProbationGenerator::Fuzz(const uint8_t* /*data*/, size_t len)
+void FuzzerRtcRtpProbationGenerator::Fuzz(const uint8_t* /*data*/, size_t len)
 {
-	std::unique_ptr<::RTC::RTP::ProbationGenerator> probationGenerator{
-		new ::RTC::RTP::ProbationGenerator()
+	std::unique_ptr<RTC::RTP::ProbationGenerator> probationGenerator{
+		new RTC::RTP::ProbationGenerator()
 	};
 
 	probationGenerator->GetNextPacket(len);

--- a/worker/fuzzer/src/RTC/RTP/FuzzerRetransmissionBuffer.cpp
+++ b/worker/fuzzer/src/RTC/RTP/FuzzerRetransmissionBuffer.cpp
@@ -4,14 +4,14 @@
 #include "RTC/RTP/RetransmissionBuffer.hpp"
 #include "RTC/RTP/SharedPacket.hpp"
 
-void Fuzzer::RTC::RTP::RetransmissionBuffer::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcRtpRetransmissionBuffer::Fuzz(const uint8_t* data, size_t len)
 {
-	uint16_t maxItems{ 2500u };
-	uint32_t maxRetransmissionDelayMs{ 2000u };
-	uint32_t clockRate{ 90000 };
+	const uint16_t maxItems{ 2500u };
+	const uint32_t maxRetransmissionDelayMs{ 2000u };
+	const uint32_t clockRate{ 90000 };
 
 	// Trick to initialize our stuff just once (use static).
-	static ::RTC::RTP::RetransmissionBuffer retransmissionBuffer(
+	static RTC::RTP::RetransmissionBuffer retransmissionBuffer(
 	  maxItems, maxRetransmissionDelayMs, clockRate);
 
 	// clang-format off
@@ -24,12 +24,12 @@ void Fuzzer::RTC::RTP::RetransmissionBuffer::Fuzz(const uint8_t* data, size_t le
 	// clang-format on
 
 	// Create base RtpPacket instance.
-	auto* packet = ::RTC::RTP::Packet::Parse(buffer, 12);
+	auto* packet = RTC::RTP::Packet::Parse(buffer, 12);
 	size_t offset{ 0u };
 
 	while (len >= 4u)
 	{
-		::RTC::RTP::SharedPacket sharedPacket;
+		const RTC::RTP::SharedPacket sharedPacket;
 
 		// Set 'random' sequence number and timestamp.
 		packet->SetSequenceNumber(Utils::Byte::Get2Bytes(data, offset));

--- a/worker/fuzzer/src/RTC/RTP/FuzzerRtpStreamSend.cpp
+++ b/worker/fuzzer/src/RTC/RTP/FuzzerRtpStreamSend.cpp
@@ -1,24 +1,8 @@
 #include "RTC/RTP/FuzzerRtpStreamSend.hpp"
 #include "Utils.hpp"
-#include "RTC/RTP/Packet.hpp"
-#include "RTC/RTP/RtpStreamSend.hpp"
 #include "RTC/RTP/SharedPacket.hpp"
 
-class TestRtpStreamListener : public RTC::RTP::RtpStreamSend::Listener
-{
-public:
-	void OnRtpStreamScore(
-	  ::RTC::RTP::RtpStream* /*rtpStream*/, uint8_t /*score*/, uint8_t /*previousScore*/) override
-	{
-	}
-
-	void OnRtpStreamRetransmitRtpPacket(
-	  RTC::RTP::RtpStreamSend* /*rtpStream*/, ::RTC::RTP::Packet* packet) override
-	{
-	}
-};
-
-void Fuzzer::RTC::RTP::RtpStreamSend::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcRtpStreamSend::Fuzz(const uint8_t* data, size_t len)
 {
 	// clang-format off
 	uint8_t buffer[] =
@@ -30,28 +14,28 @@ void Fuzzer::RTC::RTP::RtpStreamSend::Fuzz(const uint8_t* data, size_t len)
 	// clang-format on
 
 	// Create base RtpPacket instance.
-	auto* packet = ::RTC::RTP::Packet::Parse(buffer, 12);
+	auto* packet = RTC::RTP::Packet::Parse(buffer, 12);
 
 	// Create a RtpStreamSend instance.
 	TestRtpStreamListener testRtpStreamListener;
 
 	// Create RtpStreamSend instance.
-	::RTC::RTP::RtpStream::Params params;
+	RTC::RTP::RtpStream::Params params;
 
 	params.ssrc          = 1111;
 	params.clockRate     = 90000;
 	params.useNack       = true;
-	params.mimeType.type = ::RTC::RtpCodecMimeType::Type::VIDEO;
+	params.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
 
 	packet->SetSsrc(params.ssrc);
 
 	std::string mid;
-	auto* stream = new ::RTC::RTP::RtpStreamSend(&testRtpStreamListener, params, mid);
+	auto* stream = new RTC::RTP::RtpStreamSend(&testRtpStreamListener, params, mid);
 	size_t offset{ 0u };
 
 	while (len >= 4u)
 	{
-		::RTC::RTP::SharedPacket sharedPacket;
+		const RTC::RTP::SharedPacket sharedPacket;
 
 		// Set 'random' sequence number and timestamp.
 		packet->SetSequenceNumber(Utils::Byte::Get2Bytes(data, offset));

--- a/worker/fuzzer/src/RTC/SCTP/association/FuzzerStateCookie.cpp
+++ b/worker/fuzzer/src/RTC/SCTP/association/FuzzerStateCookie.cpp
@@ -4,30 +4,30 @@
 #include <cstdlib> // std::malloc(), std::free()
 #include <cstring> // std::memcpy()
 
-thread_local static uint8_t StateCookieSerializeBuffer[65536];
-thread_local static uint8_t StateCookieCloneBuffer[65536];
+thread_local uint8_t StateCookieSerializeBuffer[65536];
+thread_local uint8_t StateCookieCloneBuffer[65536];
 
-void Fuzzer::RTC::SCTP::StateCookie::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcSctpStateCookie::Fuzz(const uint8_t* data, size_t len)
 {
 	auto* clonedData = static_cast<uint8_t*>(std::malloc(len));
 
 	std::memcpy(clonedData, data, len);
 
-	// We need to force `data` to be a StateCookie since it's too hard that random
-	// data matches it.
-	if (len > ::RTC::SCTP::StateCookie::StateCookieLength)
+	// We need to force `data` to be a StateCookie since it's too hard that
+	// random data matches it.
+	if (len > RTC::SCTP::StateCookie::StateCookieLength)
 	{
-		len = ::Utils::Crypto::GetRandomUInt(
-		  ::RTC::SCTP::StateCookie::StateCookieLength, ::RTC::SCTP::StateCookie::StateCookieLength + 10);
+		len = Utils::Crypto::GetRandomUInt(
+		  RTC::SCTP::StateCookie::StateCookieLength, RTC::SCTP::StateCookie::StateCookieLength + 10);
 
-		if (len < ::RTC::SCTP::StateCookie::StateCookieLength + 5)
+		if (len < RTC::SCTP::StateCookie::StateCookieLength + 5)
 		{
-			::Utils::Byte::Set4Bytes(clonedData, 0, ::RTC::SCTP::StateCookie::MagicValue1);
-			::Utils::Byte::Set2Bytes(clonedData, 34, ::RTC::SCTP::StateCookie::MagicValue2);
+			Utils::Byte::Set4Bytes(clonedData, 0, RTC::SCTP::StateCookie::MagicValue1);
+			Utils::Byte::Set2Bytes(clonedData, 34, RTC::SCTP::StateCookie::MagicValue2);
 		}
 	}
 
-	::RTC::SCTP::StateCookie* stateCookie = ::RTC::SCTP::StateCookie::Parse(clonedData, len);
+	RTC::SCTP::StateCookie* stateCookie = RTC::SCTP::StateCookie::Parse(clonedData, len);
 
 	if (!stateCookie)
 	{

--- a/worker/fuzzer/src/RTC/SCTP/packet/FuzzerPacket.cpp
+++ b/worker/fuzzer/src/RTC/SCTP/packet/FuzzerPacket.cpp
@@ -1,12 +1,12 @@
 #include "RTC/SCTP/packet/FuzzerPacket.hpp"
 #include "RTC/SCTP/packet/Packet.hpp"
 
-thread_local static uint8_t PacketSerializeBuffer[65536];
-thread_local static uint8_t PacketCloneBuffer[65536];
+thread_local uint8_t PacketSerializeBuffer[65536];
+thread_local uint8_t PacketCloneBuffer[65536];
 
-void Fuzzer::RTC::SCTP::Packet::Fuzz(const uint8_t* data, size_t len)
+void FuzzerRtcSctpPacket::Fuzz(const uint8_t* data, size_t len)
 {
-	::RTC::SCTP::Packet* packet = ::RTC::SCTP::Packet::Parse(data, len);
+	RTC::SCTP::Packet* packet = RTC::SCTP::Packet::Parse(data, len);
 
 	if (!packet)
 	{

--- a/worker/fuzzer/src/fuzzer.cpp
+++ b/worker/fuzzer/src/fuzzer.cpp
@@ -1,5 +1,6 @@
 #define MS_CLASS "fuzzer"
 
+#include "common.hpp"
 #include "DepLibSRTP.hpp"
 #include "DepLibUV.hpp"
 #include "DepLibWebRTC.hpp"
@@ -30,184 +31,184 @@
 #include <cstdlib> // std::getenv()
 #include <iostream>
 #include <sstream> // std::istringstream()
-#include <stddef.h>
-#include <stdint.h>
 #include <string>
 #include <vector>
 
-bool fuzzStun   = false;
-bool fuzzDtls   = false;
-bool fuzzSctp   = false;
-bool fuzzRtp    = false;
-bool fuzzRtcp   = false;
-bool fuzzCodecs = false;
-bool fuzzUtils  = false;
+namespace
+{
+	// NOLINTBEGIN(readability-identifier-naming)
+	bool fuzzStun   = false;
+	bool fuzzDtls   = false;
+	bool fuzzSctp   = false;
+	bool fuzzRtp    = false;
+	bool fuzzRtcp   = false;
+	bool fuzzCodecs = false;
+	bool fuzzUtils  = false;
+	// NOLINTEND(readability-identifier-naming)
 
-// This Init() function must be declared static, otherwise linking will fail if
-// another source file defines same non static Init() function.
-static int Init();
+	int init()
+	{
+		std::string logLevel{ "none" };
+		std::vector<std::string> logTags = { "info" };
+
+		const auto* logLevelPtr = std::getenv("MS_FUZZ_LOG_LEVEL");
+		const auto* logTagsPtr  = std::getenv("MS_FUZZ_LOG_TAGS");
+
+		// Get logLevel from ENV variable.
+		if (logLevelPtr)
+		{
+			logLevel = std::string(logLevelPtr);
+		}
+
+		// Get logTags from ENV variable.
+		if (logTagsPtr)
+		{
+			auto logTagsStr = std::string(logTagsPtr);
+			std::istringstream iss(logTagsStr);
+			std::string logTag;
+
+			while (iss >> logTag)
+			{
+				logTags.push_back(logTag);
+			}
+		}
+
+		Settings::SetLogLevel(logLevel);
+		Settings::SetLogTags(logTags);
+		Settings::PrintConfiguration();
+
+		// Select what to fuzz.
+
+		if (std::getenv("MS_FUZZ_STUN"))
+		{
+			std::cout << "[fuzzer] STUN fuzzer enabled" << std::endl;
+
+			fuzzStun = true;
+		}
+
+		if (std::getenv("MS_FUZZ_DTLS"))
+		{
+			std::cout << "[fuzzer] DTLS fuzzer enabled" << std::endl;
+
+			fuzzDtls = true;
+		}
+
+		if (std::getenv("MS_FUZZ_SCTP"))
+		{
+			std::cout << "[fuzzer] SCTP fuzzer enabled" << std::endl;
+
+			fuzzSctp = true;
+		}
+
+		if (std::getenv("MS_FUZZ_RTP"))
+		{
+			std::cout << "[fuzzer] RTP fuzzer enabled" << std::endl;
+
+			fuzzRtp = true;
+		}
+
+		if (std::getenv("MS_FUZZ_RTCP"))
+		{
+			std::cout << "[fuzzer] RTCP fuzzer enabled" << std::endl;
+
+			fuzzRtcp = true;
+		}
+
+		if (std::getenv("MS_FUZZ_CODECS"))
+		{
+			std::cout << "[fuzzer] codecs fuzzer enabled" << std::endl;
+
+			fuzzCodecs = true;
+		}
+
+		if (std::getenv("MS_FUZZ_UTILS"))
+		{
+			std::cout << "[fuzzer] Utils fuzzer enabled" << std::endl;
+
+			fuzzUtils = true;
+		}
+
+		if (!fuzzStun && !fuzzDtls && !fuzzSctp && !fuzzRtp && !fuzzRtcp && !fuzzCodecs && !fuzzUtils)
+		{
+			std::cout << "[fuzzer] all fuzzers enabled" << std::endl;
+
+			fuzzStun   = true;
+			fuzzDtls   = true;
+			fuzzSctp   = true;
+			fuzzRtp    = true;
+			fuzzRtcp   = true;
+			fuzzCodecs = true;
+			fuzzUtils  = true;
+		}
+
+		// Initialize static stuff.
+		DepLibUV::ClassInit();
+		DepOpenSSL::ClassInit();
+		DepLibSRTP::ClassInit();
+		DepUsrSCTP::ClassInit();
+		DepLibWebRTC::ClassInit();
+		Utils::Crypto::ClassInit();
+		RTC::DtlsTransport::ClassInit();
+
+		return 0;
+	}
+} // namespace
 
 extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t len)
 {
 	// Trick to initialize our stuff just once.
-	static int unused = Init();
+	// NOLINTNEXTLINE(readability-identifier-naming)
+	thread_local const int unused = init();
 
 	// Avoid [-Wunused-variable].
 	(void)unused;
 
 	if (fuzzStun)
 	{
-		Fuzzer::RTC::ICE::StunPacket::Fuzz(data, len);
+		FuzzerRtcIceStunPacket::Fuzz(data, len);
 	}
 
 	if (fuzzDtls)
 	{
-		Fuzzer::RTC::DtlsTransport::Fuzz(data, len);
+		FuzzerRtcDtlsTransport::Fuzz(data, len);
 	}
 
 	if (fuzzSctp)
 	{
-		Fuzzer::RTC::SCTP::Packet::Fuzz(data, len);
-		Fuzzer::RTC::SCTP::StateCookie::Fuzz(data, len);
+		FuzzerRtcSctpPacket::Fuzz(data, len);
+		FuzzerRtcSctpStateCookie::Fuzz(data, len);
 	}
 
 	if (fuzzRtp)
 	{
-		Fuzzer::RTC::RTP::Packet::Fuzz(data, len);
-		Fuzzer::RTC::RTP::RtpStreamSend::Fuzz(data, len);
-		Fuzzer::RTC::RTP::RetransmissionBuffer::Fuzz(data, len);
-		Fuzzer::RTC::RTP::ProbationGenerator::Fuzz(data, len);
-		Fuzzer::RTC::SeqManager::Fuzz(data, len);
-		Fuzzer::RTC::RateCalculator::Fuzz(data, len);
+		FuzzerRtcRtcPacket::Fuzz(data, len);
+		FuzzerRtcRtpStreamSend::Fuzz(data, len);
+		FuzzerRtcRtpRetransmissionBuffer::Fuzz(data, len);
+		FuzzerRtcRtpProbationGenerator::Fuzz(data, len);
+		FuzzerRtcSeqManager::Fuzz(data, len);
+		FuzzerRtcRateCalculator::Fuzz(data, len);
 	}
 
 	if (fuzzRtcp)
 	{
-		Fuzzer::RTC::RTCP::Packet::Fuzz(data, len);
+		FuzzerRtcRtcpPacket::Fuzz(data, len);
 	}
 
 	if (fuzzCodecs)
 	{
-		Fuzzer::RTC::RTP::Codecs::Opus::Fuzz(data, len);
-		Fuzzer::RTC::RTP::Codecs::VP8::Fuzz(data, len);
-		Fuzzer::RTC::RTP::Codecs::VP9::Fuzz(data, len);
-		Fuzzer::RTC::RTP::Codecs::H264::Fuzz(data, len);
-		Fuzzer::RTC::RTP::Codecs::AV1::Fuzz(data, len);
-		Fuzzer::RTC::RTP::Codecs::DependencyDescriptor::Fuzz(data, len);
+		FuzzerRtcRtpCodecsOpus::Fuzz(data, len);
+		FuzzerRtcRtpCodecsVP8::Fuzz(data, len);
+		FuzzerRtcRtpCodecsVP9::Fuzz(data, len);
+		FuzzerRtcRtpCodecsH264::Fuzz(data, len);
+		FuzzerRtcRtpCodecsAV1::Fuzz(data, len);
+		FuzzerRtcRtpCodecsDependencyDescriptor::Fuzz(data, len);
 	}
 
 	if (fuzzUtils)
 	{
-		Fuzzer::Utils::Fuzz(data, len);
-		Fuzzer::RTC::TrendCalculator::Fuzz(data, len);
+		FuzzerUtils::Fuzz(data, len);
+		FuzzerRtcTrendCalculator::Fuzz(data, len);
 	}
-
-	return 0;
-}
-
-int Init()
-{
-	std::string logLevel{ "none" };
-	std::vector<std::string> logTags = { "info" };
-
-	const auto* logLevelPtr = std::getenv("MS_FUZZ_LOG_LEVEL");
-	const auto* logTagsPtr  = std::getenv("MS_FUZZ_LOG_TAGS");
-
-	// Get logLevel from ENV variable.
-	if (logLevelPtr)
-	{
-		logLevel = std::string(logLevelPtr);
-	}
-
-	// Get logTags from ENV variable.
-	if (logTagsPtr)
-	{
-		auto logTagsStr = std::string(logTagsPtr);
-		std::istringstream iss(logTagsStr);
-		std::string logTag;
-
-		while (iss >> logTag)
-		{
-			logTags.push_back(logTag);
-		}
-	}
-
-	Settings::SetLogLevel(logLevel);
-	Settings::SetLogTags(logTags);
-	Settings::PrintConfiguration();
-
-	// Select what to fuzz.
-
-	if (std::getenv("MS_FUZZ_STUN") && std::string(std::getenv("MS_FUZZ_STUN")) == "1")
-	{
-		std::cout << "[fuzzer] STUN fuzzer enabled" << std::endl;
-
-		fuzzStun = true;
-	}
-
-	if (std::getenv("MS_FUZZ_DTLS") && std::string(std::getenv("MS_FUZZ_DTLS")) == "1")
-	{
-		std::cout << "[fuzzer] DTLS fuzzer enabled" << std::endl;
-
-		fuzzDtls = true;
-	}
-
-	if (std::getenv("MS_FUZZ_SCTP") && std::string(std::getenv("MS_FUZZ_SCTP")) == "1")
-	{
-		std::cout << "[fuzzer] SCTP fuzzer enabled" << std::endl;
-
-		fuzzSctp = true;
-	}
-
-	if (std::getenv("MS_FUZZ_RTP") && std::string(std::getenv("MS_FUZZ_RTP")) == "1")
-	{
-		std::cout << "[fuzzer] RTP fuzzer enabled" << std::endl;
-
-		fuzzRtp = true;
-	}
-
-	if (std::getenv("MS_FUZZ_RTCP") && std::string(std::getenv("MS_FUZZ_RTCP")) == "1")
-	{
-		std::cout << "[fuzzer] RTCP fuzzer enabled" << std::endl;
-
-		fuzzRtcp = true;
-	}
-
-	if (std::getenv("MS_FUZZ_CODECS") && std::string(std::getenv("MS_FUZZ_CODECS")) == "1")
-	{
-		std::cout << "[fuzzer] codecs fuzzer enabled" << std::endl;
-
-		fuzzCodecs = true;
-	}
-
-	if (std::getenv("MS_FUZZ_UTILS") && std::string(std::getenv("MS_FUZZ_UTILS")) == "1")
-	{
-		std::cout << "[fuzzer] Utils fuzzer enabled" << std::endl;
-
-		fuzzUtils = true;
-	}
-
-	if (!fuzzStun && !fuzzDtls && !fuzzSctp && !fuzzRtp && !fuzzRtcp && !fuzzCodecs && !fuzzUtils)
-	{
-		std::cout << "[fuzzer] all fuzzers enabled" << std::endl;
-
-		fuzzStun   = true;
-		fuzzDtls   = true;
-		fuzzSctp   = true;
-		fuzzRtp    = true;
-		fuzzRtcp   = true;
-		fuzzCodecs = true;
-		fuzzUtils  = true;
-	}
-
-	// Initialize static stuff.
-	DepLibUV::ClassInit();
-	DepOpenSSL::ClassInit();
-	DepLibSRTP::ClassInit();
-	DepUsrSCTP::ClassInit();
-	DepLibWebRTC::ClassInit();
-	Utils::Crypto::ClassInit();
-	::RTC::DtlsTransport::ClassInit();
 
 	return 0;
 }

--- a/worker/scripts/clang-scripts.mjs
+++ b/worker/scripts/clang-scripts.mjs
@@ -21,8 +21,7 @@ const CLANG_FORMAT_PATHS = [
 const CLANG_TIDY_PATHS = [
 	'../src/**/*.cpp',
 	'../test/src/**/*.cpp',
-	// TODO
-	// '../fuzzer/src/**/*.cpp',
+	'../fuzzer/src/**/*.cpp',
 ];
 
 const task = process.argv.slice(2).join(' ');

--- a/worker/src/RTC/ICE/IceServer.cpp
+++ b/worker/src/RTC/ICE/IceServer.cpp
@@ -12,7 +12,7 @@ namespace RTC
 		/* Static. */
 
 		static constexpr size_t StunResponseFactoryBufferLength{ 65536 };
-		thread_local static uint8_t StunResponseFactoryBuffer[StunResponseFactoryBufferLength];
+		thread_local uint8_t StunResponseFactoryBuffer[StunResponseFactoryBufferLength];
 		static constexpr size_t MaxTuples{ 8 };
 		static constexpr uint8_t ConsentCheckMinTimeoutSec{ 10u };
 		static constexpr uint8_t ConsentCheckMaxTimeoutSec{ 60u };
@@ -559,7 +559,7 @@ namespace RTC
 			}
 			else
 			{
-				thread_local static std::string_view errorReasonPhrase;
+				thread_local std::string_view errorReasonPhrase;
 
 				response->GetErrorCode(errorReasonPhrase);
 

--- a/worker/src/RTC/ICE/StunPacket.cpp
+++ b/worker/src/RTC/ICE/StunPacket.cpp
@@ -15,7 +15,7 @@ namespace RTC
 		/* Static. */
 
 		static constexpr size_t AttributeFactoryBufferLength{ 65536 };
-		thread_local static uint8_t AttributeFactoryBuffer[AttributeFactoryBufferLength];
+		thread_local uint8_t AttributeFactoryBuffer[AttributeFactoryBufferLength];
 
 		/* Class variables. */
 

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -21,7 +21,7 @@ namespace RTC
 	/* Static */
 
 	static constexpr size_t ProducerSendBufferSize{ 65536 };
-	thread_local static uint8_t ProducerSendBuffer[ProducerSendBufferSize];
+	thread_local uint8_t ProducerSendBuffer[ProducerSendBufferSize];
 	static constexpr unsigned int SendNackDelay{ 10u }; // In ms.
 
 	/* Instance methods. */
@@ -1194,8 +1194,8 @@ namespace RTC
 
 		// Mangle RTP header extensions.
 		{
-			thread_local static uint8_t buffer[4096];
-			thread_local static std::vector<RTC::RTP::Packet::Extension> extensions;
+			thread_local uint8_t buffer[4096];
+			thread_local std::vector<RTC::RTP::Packet::Extension> extensions;
 
 			// This happens just once.
 			if (extensions.capacity() != 24)

--- a/worker/src/RTC/RTP/ProbationGenerator.cpp
+++ b/worker/src/RTC/RTP/ProbationGenerator.cpp
@@ -14,9 +14,9 @@ namespace RTC
 	{
 		/* Static. */
 
-		thread_local static uint8_t ProbationPacketBuffer[ProbationGenerator::ProbationPacketMaxLength];
+		thread_local uint8_t ProbationPacketBuffer[ProbationGenerator::ProbationPacketMaxLength];
 		static constexpr size_t ProbationPacketExtensionsBufferLength{ 200 };
-		thread_local static uint8_t ProbationPacketExtensionsBuffer[ProbationPacketExtensionsBufferLength];
+		thread_local uint8_t ProbationPacketExtensionsBuffer[ProbationPacketExtensionsBufferLength];
 		// 8 bytes, same as RTC::Consts::MidRtpExtensionMaxLength.
 		static const std::string MidValue{ "probator" };
 
@@ -27,7 +27,7 @@ namespace RTC
 			MS_TRACE();
 
 			// Trick to only fill the padding with zeroes once.
-			thread_local static bool mustInitializePayload{ true };
+			thread_local bool mustInitializePayload{ true };
 
 			if (mustInitializePayload)
 			{

--- a/worker/src/RTC/RTP/RtpStreamSend.cpp
+++ b/worker/src/RTC/RTP/RtpStreamSend.cpp
@@ -9,6 +9,7 @@
 #include "Utils.hpp"
 #include "RTC/Consts.hpp"
 #include "RTC/RtpDictionaries.hpp"
+#include <vector>
 
 namespace RTC
 {
@@ -20,7 +21,7 @@ namespace RTC
 		static constexpr size_t RetransmissionBufferMaxItems{ 2500u };
 		// 17: 16 bit mask + the initial sequence number.
 		static constexpr size_t MaxRequestedPackets{ 17u };
-		thread_local static std::vector<RTP::RetransmissionBuffer::Item*> RetransmissionContainer(
+		thread_local std::vector<RTP::RetransmissionBuffer::Item*> RetransmissionContainer(
 		  MaxRequestedPackets + 1);
 		static constexpr uint32_t DefaultRtt{ 100u };
 

--- a/worker/src/RTC/RTP/SharedPacket.cpp
+++ b/worker/src/RTC/RTP/SharedPacket.cpp
@@ -16,7 +16,7 @@ namespace RTC
 		static constexpr size_t PacketBufferLengthIncrement{ 100 };
 		// Callback to pass to every cloned RTP Packet to deallocate its buffer once
 		// the Packet releases its buffer (for example when the Packet is destroyed).
-		static thread_local Serializable::BufferReleasedListener PacketBufferReleasedListener =
+		thread_local Serializable::BufferReleasedListener PacketBufferReleasedListener =
 		  // NOLINTNEXTLINE(misc-unused-parameters, readability-non-const-parameter)
 		  [](const Serializable* packet, uint8_t* buffer)
 		{

--- a/worker/src/RTC/SCTP/association/Socket.cpp
+++ b/worker/src/RTC/SCTP/association/Socket.cpp
@@ -8,11 +8,6 @@ namespace RTC
 {
 	namespace SCTP
 	{
-		/* Static. */
-
-		// static constexpr size_t FactoryBufferLength{ 65536 };
-		// thread_local static uint8_t FactoryBuffer[FactoryBufferLength];
-
 		/* Instance methods. */
 
 		Socket::Socket(Socket::SocketOptions options) : options(options)

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -793,7 +793,7 @@ namespace RTC
 						if (notification->sn_header.sn_length > 0)
 						{
 							static const size_t BufferSize{ 1024 };
-							thread_local static char buffer[BufferSize];
+							thread_local char buffer[BufferSize];
 
 							const uint32_t len =
 							  notification->sn_assoc_change.sac_length - sizeof(struct sctp_assoc_change);
@@ -864,7 +864,7 @@ namespace RTC
 						if (notification->sn_header.sn_length > 0)
 						{
 							static const size_t BufferSize{ 1024 };
-							thread_local static char buffer[BufferSize];
+							thread_local char buffer[BufferSize];
 
 							const uint32_t len =
 							  notification->sn_assoc_change.sac_length - sizeof(struct sctp_assoc_change);
@@ -906,7 +906,7 @@ namespace RTC
 			case SCTP_REMOTE_ERROR:
 			{
 				static const size_t BufferSize{ 1024 };
-				thread_local static char buffer[BufferSize];
+				thread_local char buffer[BufferSize];
 
 				const uint32_t len =
 				  notification->sn_remote_error.sre_length - sizeof(struct sctp_remote_error);
@@ -943,7 +943,7 @@ namespace RTC
 			case SCTP_SEND_FAILED_EVENT:
 			{
 				static const size_t BufferSize{ 1024 };
-				thread_local static char buffer[BufferSize];
+				thread_local char buffer[BufferSize];
 
 				const uint32_t len =
 				  notification->sn_send_failed_event.ssfe_length - sizeof(struct sctp_send_failed_event);

--- a/worker/src/RTC/SrtpSession.cpp
+++ b/worker/src/RTC/SrtpSession.cpp
@@ -15,7 +15,7 @@ namespace RTC
 	/* Static. */
 
 	static constexpr size_t EncryptBufferSize{ 65536 };
-	thread_local static uint8_t EncryptBuffer[EncryptBufferSize];
+	thread_local uint8_t EncryptBuffer[EncryptBufferSize];
 
 	/* Class methods. */
 

--- a/worker/src/RTC/TcpConnection.cpp
+++ b/worker/src/RTC/TcpConnection.cpp
@@ -11,7 +11,7 @@ namespace RTC
 	/* Static. */
 
 	static constexpr size_t ReadBufferSize{ 65536 };
-	thread_local static uint8_t ReadBuffer[ReadBufferSize];
+	thread_local uint8_t ReadBuffer[ReadBufferSize];
 
 	/* Instance methods. */
 

--- a/worker/src/Utils/String.cpp
+++ b/worker/src/Utils/String.cpp
@@ -19,7 +19,7 @@
 /* Static. */
 
 static constexpr size_t BufferOutSize{ 65536 };
-thread_local static uint8_t BufferOut[BufferOutSize];
+thread_local uint8_t BufferOut[BufferOutSize];
 static const uint8_t Base64Table[65] =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 

--- a/worker/src/handles/UdpSocketHandle.cpp
+++ b/worker/src/handles/UdpSocketHandle.cpp
@@ -13,7 +13,7 @@
 /* Static. */
 
 static constexpr size_t ReadBufferSize{ 65536 };
-thread_local static uint8_t ReadBuffer[ReadBufferSize];
+thread_local uint8_t ReadBuffer[ReadBufferSize];
 
 /* Static methods for UV callbacks. */
 

--- a/worker/src/main.cpp
+++ b/worker/src/main.cpp
@@ -1,6 +1,7 @@
 #define MS_CLASS "mediasoup-worker"
 // #define MS_LOG_DEV_LEVEL 3
 
+#include "common.hpp"
 #include "Logger.hpp"
 #include "lib.hpp"
 #include <cstdlib> // std::_Exit()

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestSupportedExtensionsParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestSupportedExtensionsParameter.cpp
@@ -43,7 +43,7 @@ SCENARIO("Supported Extensions Parameter (32776)", "[sctp][serializable]")
 		REQUIRE(parameter->GetNumberOfChunkTypes() == 3);
 		REQUIRE(parameter->GetChunkTypeAt(0) == Chunk::ChunkType::RE_CONFIG);
 		REQUIRE(parameter->GetChunkTypeAt(1) == Chunk::ChunkType::ECNE);
-		REQUIRE(parameter->GetChunkTypeAt(2) == static_cast<Chunk::ChunkType>(0x42));
+		REQUIRE(static_cast<uint8_t>(parameter->GetChunkTypeAt(2)) == 0x42);
 
 		/* Serialize it. */
 
@@ -63,7 +63,7 @@ SCENARIO("Supported Extensions Parameter (32776)", "[sctp][serializable]")
 		REQUIRE(parameter->GetNumberOfChunkTypes() == 3);
 		REQUIRE(parameter->GetChunkTypeAt(0) == Chunk::ChunkType::RE_CONFIG);
 		REQUIRE(parameter->GetChunkTypeAt(1) == Chunk::ChunkType::ECNE);
-		REQUIRE(parameter->GetChunkTypeAt(2) == static_cast<Chunk::ChunkType>(0x42));
+		REQUIRE(static_cast<uint8_t>(parameter->GetChunkTypeAt(2)) == 0x42);
 
 		/* Clone it. */
 
@@ -85,7 +85,7 @@ SCENARIO("Supported Extensions Parameter (32776)", "[sctp][serializable]")
 		REQUIRE(clonedParameter->GetNumberOfChunkTypes() == 3);
 		REQUIRE(clonedParameter->GetChunkTypeAt(0) == Chunk::ChunkType::RE_CONFIG);
 		REQUIRE(clonedParameter->GetChunkTypeAt(1) == Chunk::ChunkType::ECNE);
-		REQUIRE(clonedParameter->GetChunkTypeAt(2) == static_cast<Chunk::ChunkType>(0x42));
+		REQUIRE(static_cast<uint8_t>(clonedParameter->GetChunkTypeAt(2)) == 0x42);
 
 		delete clonedParameter;
 	}
@@ -125,6 +125,7 @@ SCENARIO("Supported Extensions Parameter (32776)", "[sctp][serializable]")
 
 		parameter->AddChunkType(Chunk::ChunkType::OPERATION_ERROR);
 		parameter->AddChunkType(Chunk::ChunkType::COOKIE_ACK);
+		// NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
 		parameter->AddChunkType(static_cast<Chunk::ChunkType>(99));
 
 		CHECK_SCTP_PARAMETER(
@@ -141,7 +142,7 @@ SCENARIO("Supported Extensions Parameter (32776)", "[sctp][serializable]")
 		REQUIRE(parameter->GetChunkTypeAt(1) == Chunk::ChunkType::CWR);
 		REQUIRE(parameter->GetChunkTypeAt(2) == Chunk::ChunkType::OPERATION_ERROR);
 		REQUIRE(parameter->GetChunkTypeAt(3) == Chunk::ChunkType::COOKIE_ACK);
-		REQUIRE(parameter->GetChunkTypeAt(4) == static_cast<Chunk::ChunkType>(99));
+		REQUIRE(static_cast<uint8_t>(parameter->GetChunkTypeAt(4)) == 99);
 
 		/* Parse itself and compare. */
 
@@ -164,7 +165,7 @@ SCENARIO("Supported Extensions Parameter (32776)", "[sctp][serializable]")
 		REQUIRE(parsedParameter->GetChunkTypeAt(1) == Chunk::ChunkType::CWR);
 		REQUIRE(parsedParameter->GetChunkTypeAt(2) == Chunk::ChunkType::OPERATION_ERROR);
 		REQUIRE(parsedParameter->GetChunkTypeAt(3) == Chunk::ChunkType::COOKIE_ACK);
-		REQUIRE(parsedParameter->GetChunkTypeAt(4) == static_cast<Chunk::ChunkType>(99));
+		REQUIRE(static_cast<uint8_t>(parsedParameter->GetChunkTypeAt(4)) == 99);
 
 		delete parsedParameter;
 	}

--- a/worker/test/src/RTC/SCTP/packet/parameters/TestUnknownParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/parameters/TestUnknownParameter.cpp
@@ -35,6 +35,7 @@ SCENARIO("Unknown Parameter", "[sctp][serializable]")
 		  /*buffer*/ buffer,
 		  /*bufferLength*/ sizeof(buffer),
 		  /*length*/ 12,
+		  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
 		  /*parameterType*/ static_cast<Parameter::ParameterType>(49159),
 		  /*unknownType*/ true,
 		  /*actionForUnknownParameterType*/ Parameter::ActionForUnknownParameterType::SKIP_AND_REPORT);
@@ -63,6 +64,7 @@ SCENARIO("Unknown Parameter", "[sctp][serializable]")
 		  /*buffer*/ SerializeBuffer,
 		  /*bufferLength*/ sizeof(SerializeBuffer),
 		  /*length*/ 12,
+		  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
 		  /*parameterType*/ static_cast<Parameter::ParameterType>(49159),
 		  /*unknownType*/ true,
 		  /*actionForUnknownParameterType*/ Parameter::ActionForUnknownParameterType::SKIP_AND_REPORT);
@@ -92,6 +94,7 @@ SCENARIO("Unknown Parameter", "[sctp][serializable]")
 		  /*buffer*/ CloneBuffer,
 		  /*bufferLength*/ sizeof(CloneBuffer),
 		  /*length*/ 12,
+		  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
 		  /*parameterType*/ static_cast<Parameter::ParameterType>(49159),
 		  /*unknownType*/ true,
 		  /*actionForUnknownParameterType*/ Parameter::ActionForUnknownParameterType::SKIP_AND_REPORT);

--- a/worker/test/src/RTC/TestSimpleConsumer.cpp
+++ b/worker/test/src/RTC/TestSimpleConsumer.cpp
@@ -16,11 +16,13 @@ using namespace RTC;
 
 namespace
 {
+	// NOLINTBEGIN(readability-identifier-naming)
 	const uint8_t payloadType       = 111;
 	auto* channelMessageRegistrator = new ChannelMessageRegistrator();
 	auto* channelSocket             = new Channel::ChannelSocket();
 	auto* channelNotifier           = new Channel::ChannelNotifier(channelSocket);
 	auto shared                     = Shared(channelMessageRegistrator, channelNotifier);
+	// NOLINTEND(readability-identifier-naming)
 
 	class RtpStreamRecvListener : public RTP::RtpStreamRecv::Listener
 	{
@@ -112,7 +114,7 @@ namespace
 		return rtpParameters.FillBuffer(builder);
 	};
 
-	static std::unique_ptr<RTC::SimpleConsumer> createConsumer(ConsumerListener* listener)
+	std::unique_ptr<RTC::SimpleConsumer> createConsumer(ConsumerListener* listener)
 	{
 		flatbuffers::FlatBufferBuilder bufferBuilder;
 
@@ -148,7 +150,7 @@ namespace
 		  consumeRequest);
 	}
 
-	static std::unique_ptr<RTP::RtpStreamRecv> createRtpStreamRecv()
+	std::unique_ptr<RTP::RtpStreamRecv> createRtpStreamRecv()
 	{
 		RtpStreamRecvListener streamRecvListener;
 		RTP::RtpStream::Params params;
@@ -167,7 +169,8 @@ namespace
 		    rtpStream(createRtpStreamRecv())
 		{
 			// Set producer scores and producer stream.
-			std::vector<uint8_t> scores{ 10 };
+			const std::vector<uint8_t> scores{ 10 };
+
 			consumer->ProducerRtpStreamScores(&scores);
 			consumer->ProducerNewRtpStream(rtpStream.get(), 1234);
 		}
@@ -225,7 +228,7 @@ SCENARIO("SimpleConsumer", "[rtp][consumer]")
 	// clang-format on
 
 	// This is the size of the original packet.
-	size_t originalPacketLength{ 16 };
+	const size_t originalPacketLength{ 16 };
 
 	SECTION("RTP packets are not forwarded when the consumer is not active")
 	{

--- a/worker/test/src/tests.cpp
+++ b/worker/test/src/tests.cpp
@@ -1,3 +1,4 @@
+#include "common.hpp"
 #include "DepLibSRTP.hpp"
 #include "DepLibUV.hpp"
 #include "DepLibWebRTC.hpp"


### PR DESCRIPTION
# Details

- Zero fuzzer errors in `worker/fuzzer/src`.
- Remove those terrible `Fuzzer::RTC::XXX` namespaces that made the code annoying.
- Instead create separate namespaces for each fuzzer, such as `FuzzerRtcRtpPacket`.
- Fixes #1711
- Do not use `thread_local static` for local variables since is redundant. `thread_local` is enough.