### PR TITLE
Worker: Improve `Utils::Crypto::GetRandomUInt()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Worker: Improve `Utils::Crypto::GetRandomUInt()` ([PR #1725](https://github.com/versatica/mediasoup/pull/1725).
+
 ### 3.19.17
 
 - `ICE::StunPacket`: Fix wrong memory access in `GetXorMappedAddress()` method ([08c1ec9](https://github.com/versatica/mediasoup/commit/ea464d40ef77247c3ff7acd10e4a0118665fdd14)).

--- a/worker/fuzzer/src/FuzzerUtils.cpp
+++ b/worker/fuzzer/src/FuzzerUtils.cpp
@@ -64,7 +64,11 @@ void FuzzerUtils::Fuzz(const uint8_t* data, size_t len)
 
 	/* Crypto class. */
 
-	Utils::Crypto::GetRandomUInt(static_cast<uint32_t>(len), static_cast<uint32_t>(len + 1000000));
+	Utils::Crypto::GetRandomUInt<uint32_t>(
+	  static_cast<uint32_t>(len), static_cast<uint32_t>(len + 1000000));
+	Utils::Crypto::GetRandomUInt<uint64_t>(
+	  static_cast<uint64_t>(len), static_cast<uint64_t>(len + 1000000));
+	Utils::Crypto::GetRandomUInt<size_t>(len, len + 1000000);
 	Utils::Crypto::GetRandomString(len);
 	Utils::Crypto::GetCRC32(data2.get(), len);
 

--- a/worker/fuzzer/src/RTC/FuzzerDtlsTransport.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerDtlsTransport.cpp
@@ -51,10 +51,10 @@ void FuzzerRtcDtlsTransport::Fuzz(const uint8_t* data, size_t len)
 		// NOTE: Use a random integer in range 1..5 since FingerprintAlgorithm enum
 		// has 5 possible values starting with value 1.
 		dtlsRemoteFingerprint.algorithm = static_cast<RTC::DtlsTransport::FingerprintAlgorithm>(
-		  Utils::Crypto::GetRandomUInt<uint16_t>(1u, 5u));
+		  Utils::Crypto::GetRandomUInt<uint8_t>(1u, 5u));
 
 		dtlsRemoteFingerprint.value =
-		  Utils::Crypto::GetRandomString(Utils::Crypto::GetRandomUInt<uint16_t>(3u, 20u));
+		  Utils::Crypto::GetRandomString(Utils::Crypto::GetRandomUInt<uint8_t>(3u, 20u));
 
 		dtlsTransportSingleton->Run(localRole);
 		dtlsTransportSingleton->SetRemoteFingerprint(dtlsRemoteFingerprint);

--- a/worker/fuzzer/src/RTC/FuzzerDtlsTransport.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerDtlsTransport.cpp
@@ -51,10 +51,10 @@ void FuzzerRtcDtlsTransport::Fuzz(const uint8_t* data, size_t len)
 		// NOTE: Use a random integer in range 1..5 since FingerprintAlgorithm enum
 		// has 5 possible values starting with value 1.
 		dtlsRemoteFingerprint.algorithm = static_cast<RTC::DtlsTransport::FingerprintAlgorithm>(
-		  Utils::Crypto::GetRandomUInt<uint8_t>(1u, 5u));
+		  Utils::Crypto::GetRandomUInt<uint16_t>(1u, 5u));
 
 		dtlsRemoteFingerprint.value =
-		  Utils::Crypto::GetRandomString(Utils::Crypto::GetRandomUInt<uint8_t>(3u, 20u));
+		  Utils::Crypto::GetRandomString(Utils::Crypto::GetRandomUInt<uint16_t>(3u, 20u));
 
 		dtlsTransportSingleton->Run(localRole);
 		dtlsTransportSingleton->SetRemoteFingerprint(dtlsRemoteFingerprint);

--- a/worker/fuzzer/src/RTC/FuzzerDtlsTransport.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerDtlsTransport.cpp
@@ -50,11 +50,11 @@ void FuzzerRtcDtlsTransport::Fuzz(const uint8_t* data, size_t len)
 		// Remote DTLS fingerprint random generation.
 		// NOTE: Use a random integer in range 1..5 since FingerprintAlgorithm enum
 		// has 5 possible values starting with value 1.
-		dtlsRemoteFingerprint.algorithm =
-		  static_cast<RTC::DtlsTransport::FingerprintAlgorithm>(Utils::Crypto::GetRandomUInt(1u, 5u));
+		dtlsRemoteFingerprint.algorithm = static_cast<RTC::DtlsTransport::FingerprintAlgorithm>(
+		  Utils::Crypto::GetRandomUInt<uint8_t>(1u, 5u));
 
 		dtlsRemoteFingerprint.value =
-		  Utils::Crypto::GetRandomString(Utils::Crypto::GetRandomUInt(3u, 20u));
+		  Utils::Crypto::GetRandomString(Utils::Crypto::GetRandomUInt<uint8_t>(3u, 20u));
 
 		dtlsTransportSingleton->Run(localRole);
 		dtlsTransportSingleton->SetRemoteFingerprint(dtlsRemoteFingerprint);

--- a/worker/fuzzer/src/RTC/FuzzerRateCalculator.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerRateCalculator.cpp
@@ -34,10 +34,9 @@ void FuzzerRtcRateCalculator::Fuzz(const uint8_t* data, size_t len)
 		return;
 	}
 
-	auto size = static_cast<size_t>(
-	  Utils::Crypto::GetRandomUInt(0u, static_cast<uint32_t>(RTC::Consts::MtuSize)));
+	auto size = Utils::Crypto::GetRandomUInt<size_t>(0u, static_cast<uint32_t>(RTC::Consts::MtuSize));
 
-	nowMs += Utils::Crypto::GetRandomUInt(0u, 1000u);
+	nowMs += Utils::Crypto::GetRandomUInt<uint64_t>(0u, 1000u);
 
 	rateCalculator.Update(size, nowMs);
 

--- a/worker/fuzzer/src/RTC/SCTP/association/FuzzerStateCookie.cpp
+++ b/worker/fuzzer/src/RTC/SCTP/association/FuzzerStateCookie.cpp
@@ -17,7 +17,7 @@ void FuzzerRtcSctpStateCookie::Fuzz(const uint8_t* data, size_t len)
 	// random data matches it.
 	if (len > RTC::SCTP::StateCookie::StateCookieLength)
 	{
-		len = Utils::Crypto::GetRandomUInt(
+		len = Utils::Crypto::GetRandomUInt<size_t>(
 		  RTC::SCTP::StateCookie::StateCookieLength, RTC::SCTP::StateCookie::StateCookieLength + 10);
 
 		if (len < RTC::SCTP::StateCookie::StateCookieLength + 5)

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -238,9 +238,9 @@ namespace Utils
 		static T GetRandomUInt(T min, T max)
 		{
 			static_assert(
-			  std::is_same_v<T, uint16_t> || std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t> ||
-			    std::is_same_v<T, size_t>,
-			  "T must be uint16_t, uint32_t, uint64_t, size_t");
+			  std::is_same_v<T, uint8_t> || std::is_same_v<T, uint16_t> || std::is_same_v<T, uint32_t> ||
+			    std::is_same_v<T, uint64_t> || std::is_same_v<T, size_t>,
+			  "T must be uint8_t, uint16_t, uint32_t, uint64_t, size_t");
 
 			std::uniform_int_distribution<T> dist(min, max);
 

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -8,8 +8,9 @@
 #include <cstdint>
 #include <cstring> // std::memcmp(), std::memcpy()
 #include <limits>  // std::numeric_limits
+#include <random>  // std::mt19937_64, std::uniform_int_distribution, std::random_device
 #include <string>
-#include <type_traits> // std::enable_if, std::is_same_v
+#include <type_traits> // std::enable_if, std::is_same_v, std::is_unsigned
 #ifdef _WIN32
 #include <ws2ipdef.h>
 // https://stackoverflow.com/a/24550632/2085408
@@ -233,7 +234,13 @@ namespace Utils
 		static void ClassInit();
 		static void ClassDestroy();
 
-		static uint32_t GetRandomUInt(uint32_t min, uint32_t max);
+		template<typename T>
+		typename std::enable_if<std::is_unsigned<T>::value, T>::type static GetRandomUInt(T min, T max)
+		{
+			std::uniform_int_distribution<T> dist(min, max);
+
+			return dist(Crypto::rng);
+		}
 
 		static std::string GetRandomString(size_t len);
 
@@ -246,7 +253,7 @@ namespace Utils
 		static void WriteRandomBytes(uint8_t* buffer, size_t len);
 
 	private:
-		thread_local static uint32_t seed;
+		thread_local static std::mt19937_64 rng;
 		thread_local static EVP_MAC* mac;
 		thread_local static EVP_MAC_CTX* hmacSha1Ctx;
 		thread_local static uint8_t hmacSha1Buffer[];

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -238,9 +238,9 @@ namespace Utils
 		static T GetRandomUInt(T min, T max)
 		{
 			static_assert(
-			  std::is_same_v<T, uint8_t> || std::is_same_v<T, uint16_t> || std::is_same_v<T, uint32_t> ||
-			    std::is_same_v<T, uint64_t> || std::is_same_v<T, size_t>,
-			  "T must be uint8_t, uint16_t, uint32_t, uint64_t, size_t");
+			  std::is_same_v<T, uint16_t> || std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t> ||
+			    std::is_same_v<T, size_t>,
+			  "T must be uint16_t, uint32_t, uint64_t, size_t");
 
 			std::uniform_int_distribution<T> dist(min, max);
 

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -235,8 +235,13 @@ namespace Utils
 		static void ClassDestroy();
 
 		template<typename T>
-		typename std::enable_if<std::is_unsigned<T>::value, T>::type static GetRandomUInt(T min, T max)
+		static T GetRandomUInt(T min, T max)
 		{
+			static_assert(
+			  std::is_same_v<T, uint16_t> || std::is_same_v<T, uint32_t> || std::is_same_v<T, uint64_t> ||
+			    std::is_same_v<T, size_t>,
+			  "T must be uint16_t, uint32_t, uint64_t, size_t");
+
 			std::uniform_int_distribution<T> dist(min, max);
 
 			return dist(Crypto::rng);

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -356,7 +356,8 @@ namespace RTC
 		int ret{ 0 };
 		X509_NAME* certName{ nullptr };
 		const std::string subject =
-		  std::string("mediasoup") + std::to_string(Utils::Crypto::GetRandomUInt(100000, 999999));
+		  std::string("mediasoup") +
+		  std::to_string(Utils::Crypto::GetRandomUInt<uint32_t>(100000, 999999));
 
 		// Create key with curve.
 		// NOLINTNEXTLINE(cppcoreguidelines-pro-type-cstyle-cast)
@@ -385,7 +386,7 @@ namespace RTC
 		// Set serial number (avoid default 0).
 		ASN1_INTEGER_set(
 		  X509_get_serialNumber(DtlsTransport::certificate),
-		  static_cast<uint64_t>(Utils::Crypto::GetRandomUInt(1000000, 9999999)));
+		  Utils::Crypto::GetRandomUInt<uint64_t>(1000000, 9999999));
 
 		// Set valid period.
 		X509_gmtime_adj(X509_get_notBefore(DtlsTransport::certificate), -315360000); // -10 years.

--- a/worker/src/RTC/PipeConsumer.cpp
+++ b/worker/src/RTC/PipeConsumer.cpp
@@ -827,7 +827,7 @@ namespace RTC
 			// libsrtp bug:
 			// https://github.com/versatica/mediasoup/issues/1437
 			const uint16_t initialOutputSeq =
-			  Utils::Crypto::GetRandomUInt(1000u, std::numeric_limits<uint16_t>::max() / 2);
+			  Utils::Crypto::GetRandomUInt<uint16_t>(1000u, std::numeric_limits<uint16_t>::max() / 2);
 
 			this->mapRtpStreamRtpSeqManager[rtpStream] = RTC::SeqManager<uint16_t>(initialOutputSeq);
 

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -330,8 +330,8 @@ namespace RTC
 		const uint8_t bitFlags = ConvertSocketFlags(flags, protocol, family);
 
 		// Choose a random port index to start from.
-		portIdx = static_cast<size_t>(
-		  Utils::Crypto::GetRandomUInt(static_cast<uint32_t>(0), static_cast<uint32_t>(numPorts - 1)));
+		portIdx = Utils::Crypto::GetRandomUInt<size_t>(
+		  static_cast<uint32_t>(0), static_cast<uint32_t>(numPorts - 1));
 
 		// Iterate all ports until getting one available. Fail if none found and also
 		// if bind() fails N times in theoretically available ports.

--- a/worker/src/RTC/RTP/Packet.cpp
+++ b/worker/src/RTC/RTP/Packet.cpp
@@ -18,7 +18,7 @@ namespace RTC
 	{
 		/* Class variables. */
 
-		thread_local uint32_t Packet::nextMediasoupPacketId{ Utils::Crypto::GetRandomUInt(
+		thread_local uint32_t Packet::nextMediasoupPacketId{ Utils::Crypto::GetRandomUInt<uint32_t>(
 			0, std::numeric_limits<uint32_t>::max() / 2) };
 
 		/* Class methods. */

--- a/worker/src/RTC/RTP/ProbationGenerator.cpp
+++ b/worker/src/RTC/RTP/ProbationGenerator.cpp
@@ -47,11 +47,10 @@ namespace RTC
 			this->probationPacket->SetSsrc(ProbationGenerator::Ssrc);
 
 			// Set random initial RTP seq number.
-			this->probationPacket->SetSequenceNumber(
-			  static_cast<uint16_t>(Utils::Crypto::GetRandomUInt(0, 65535)));
+			this->probationPacket->SetSequenceNumber(Utils::Crypto::GetRandomUInt<uint16_t>(0, 65535));
 
 			// Set random initial RTP timestamp.
-			this->probationPacket->SetTimestamp(Utils::Crypto::GetRandomUInt(0, 4294967295));
+			this->probationPacket->SetTimestamp(Utils::Crypto::GetRandomUInt<uint32_t>(0, 4294967295));
 
 			// Add BWE related RTP header extensions.
 			std::vector<RTP::Packet::Extension> extensions;

--- a/worker/src/RTC/RTP/RtpStreamSend.cpp
+++ b/worker/src/RTC/RTP/RtpStreamSend.cpp
@@ -98,7 +98,7 @@ namespace RTC
 
 			RTP::RtpStream::SetRtx(payloadType, ssrc);
 
-			this->rtxSeq = Utils::Crypto::GetRandomUInt(0u, 0xFFFF);
+			this->rtxSeq = Utils::Crypto::GetRandomUInt<uint16_t>(0u, 0xFFFF);
 		}
 
 		RtpStreamSend::ReceivePacketResult RtpStreamSend::ReceivePacket(

--- a/worker/src/RTC/SimpleConsumer.cpp
+++ b/worker/src/RTC/SimpleConsumer.cpp
@@ -49,7 +49,7 @@ namespace RTC
 		// libsrtp bug:
 		// https://github.com/versatica/mediasoup/issues/1437
 		const uint16_t initialOutputSeq =
-		  Utils::Crypto::GetRandomUInt(1000u, std::numeric_limits<uint16_t>::max() / 2);
+		  Utils::Crypto::GetRandomUInt<uint16_t>(1000u, std::numeric_limits<uint16_t>::max() / 2);
 
 		this->rtpSeqManager = RTC::SeqManager<uint16_t>(initialOutputSeq);
 

--- a/worker/src/RTC/SimulcastConsumer.cpp
+++ b/worker/src/RTC/SimulcastConsumer.cpp
@@ -109,7 +109,7 @@ namespace RTC
 		// libsrtp bug:
 		// https://github.com/versatica/mediasoup/issues/1437
 		const uint16_t initialOutputSeq =
-		  Utils::Crypto::GetRandomUInt(1000u, std::numeric_limits<uint16_t>::max() / 2);
+		  Utils::Crypto::GetRandomUInt<uint16_t>(1000u, std::numeric_limits<uint16_t>::max() / 2);
 
 		this->rtpSeqManager = RTC::SeqManager<uint16_t>(initialOutputSeq);
 

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -89,7 +89,7 @@ namespace RTC
 		// libsrtp bug:
 		// https://github.com/versatica/mediasoup/issues/1437
 		const uint16_t initialOutputSeq =
-		  Utils::Crypto::GetRandomUInt(1000u, std::numeric_limits<uint16_t>::max() / 2);
+		  Utils::Crypto::GetRandomUInt<uint16_t>(1000u, std::numeric_limits<uint16_t>::max() / 2);
 
 		this->rtpSeqManager = RTC::SeqManager<uint16_t>(initialOutputSeq);
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -3082,7 +3082,7 @@ namespace RTC
 			 * [1.0, 1.5] times the calculated interval to avoid unintended
 			 * synchronization of all participants.
 			 */
-			interval *= static_cast<float>(Utils::Crypto::GetRandomUInt(10, 15)) / 10;
+			interval *= static_cast<float>(Utils::Crypto::GetRandomUInt<uint8_t>(10, 15)) / 10;
 
 			this->rtcpTimer->Start(interval);
 		}

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -3082,7 +3082,7 @@ namespace RTC
 			 * [1.0, 1.5] times the calculated interval to avoid unintended
 			 * synchronization of all participants.
 			 */
-			interval *= static_cast<float>(Utils::Crypto::GetRandomUInt<uint8_t>(10, 15)) / 10;
+			interval *= static_cast<float>(Utils::Crypto::GetRandomUInt<uint16_t>(10, 15)) / 10;
 
 			this->rtcpTimer->Start(interval);
 		}

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -3082,7 +3082,7 @@ namespace RTC
 			 * [1.0, 1.5] times the calculated interval to avoid unintended
 			 * synchronization of all participants.
 			 */
-			interval *= static_cast<float>(Utils::Crypto::GetRandomUInt<uint16_t>(10, 15)) / 10;
+			interval *= static_cast<float>(Utils::Crypto::GetRandomUInt<uint8_t>(10, 15)) / 10;
 
 			this->rtcpTimer->Start(interval);
 		}

--- a/worker/src/Utils/Crypto.cpp
+++ b/worker/src/Utils/Crypto.cpp
@@ -10,7 +10,7 @@ namespace Utils
 {
 	/* Static variables. */
 
-	thread_local uint32_t Crypto::seed;
+	thread_local std::mt19937_64 Crypto::rng;
 	thread_local EVP_MAC* Crypto::mac{ nullptr };
 	thread_local EVP_MAC_CTX* Crypto::hmacSha1Ctx{ nullptr };
 	thread_local uint8_t Crypto::hmacSha1Buffer[SHA_DIGEST_LENGTH];
@@ -95,9 +95,11 @@ namespace Utils
 	{
 		MS_TRACE();
 
-		// Init the crypto seed with a random number taken from the address
-		// of the seed variable itself (which is random).
-		Crypto::seed = static_cast<uint32_t>(reinterpret_cast<uintptr_t>(std::addressof(Crypto::seed)));
+		std::random_device rd;
+
+		const uint64_t seed = (uint64_t(rd()) << 32) | uint64_t(rd());
+
+		Crypto::rng.seed(seed);
 
 		// Create an OpenSSL HMAC_CTX context for HMAC SHA1 calculation.
 		Crypto::mac         = EVP_MAC_fetch(nullptr, "HMAC", nullptr);
@@ -119,28 +121,6 @@ namespace Utils
 		}
 	}
 
-	uint32_t Crypto::GetRandomUInt(uint32_t min, uint32_t max)
-	{
-		MS_TRACE();
-
-		// NOTE: This is the original, but produces very small values.
-		// Crypto::seed = (214013 * Crypto::seed) + 2531011;
-		// return (((Crypto::seed>>16)&0x7FFF) % (max - min + 1)) + min;
-
-		// This seems to produce better results.
-		Crypto::seed = uint32_t{ ((214013 * Crypto::seed) + 2531011) };
-
-		// Special case.
-		if (max == 4294967295)
-		{
-			--max;
-		}
-
-		min = std::min(min, max);
-
-		return (((Crypto::seed >> 4) & 0x7FFF7FFF) % (max - min + 1)) + min;
-	}
-
 	std::string Crypto::GetRandomString(size_t len)
 	{
 		MS_TRACE();
@@ -154,7 +134,7 @@ namespace Utils
 
 		for (size_t i{ 0 }; i < len; ++i)
 		{
-			buffer[i] = Chars[GetRandomUInt(0, sizeof(Chars) - 1)];
+			buffer[i] = Chars[GetRandomUInt<size_t>(0, sizeof(Chars) - 1)];
 		}
 
 		return { buffer, len };

--- a/worker/src/Utils/Crypto.cpp
+++ b/worker/src/Utils/Crypto.cpp
@@ -96,7 +96,6 @@ namespace Utils
 		MS_TRACE();
 
 		std::random_device rd;
-
 		const uint64_t seed = (uint64_t(rd()) << 32) | uint64_t(rd());
 
 		Crypto::rng.seed(seed);


### PR DESCRIPTION
# Details

- Fixes #1693
- Bonus track: Now `GetRandomUInt()` is a template function that accepts the type of output. Example:
  ```c++
  auto randomNumber = Utils::Crypto::GetRandomUInt<uint64_t>(0, 10000000);
  ```

## Notes

- `Utils::Crypto::GetRandomUInt<T>(T min, T max)` doesn't accept `T = uint8_t` because `uint8_t` is not a valid argument for `std::uniform_int_distribution<T> dist(min, max)` in Windows (see [CI failing](https://github.com/versatica/mediasoup/actions/runs/21782612837/job/62848935879#step:5:3475) in previous commits).