### PR TITLE
Convert WORKER_CLOSE into a notification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - Worker: Improve `Utils::Crypto::GetRandomUInt()` ([PR #1725](https://github.com/versatica/mediasoup/pull/1725).
+- Convert `WORKER_CLOSE` into a notification ([PR #1729](https://github.com/versatica/mediasoup/pull/1729).
 
 ### 3.19.17
 

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -27,6 +27,7 @@ import * as utils from './utils';
 import * as fbsUtils from './fbsUtils';
 import type { AppData } from './types';
 import { Event } from './fbs/notification';
+import * as FbsNotification from './fbs/notification';
 import * as FbsRequest from './fbs/request';
 import * as FbsWorker from './fbs/worker';
 import * as FbsTransport from './fbs/transport';
@@ -351,22 +352,11 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 		}
 		this.#webRtcServers.clear();
 
-		/* Send Request. */
-		this.#channel
-			.request(FbsRequest.Method.WORKER_CLOSE)
-			.then(() => {
-				// Close the Channel instance now.
-				this.#channel.close();
-			})
-			.catch(error => {
-				logger.error(
-					'close() | worker process failed to process the close request:',
-					error
-				);
+		// Send notification to worker process.
+		this.#channel.notify(FbsNotification.Event.WORKER_CLOSE);
 
-				// Close the Channel instance anyway.
-				this.#channel.close();
-			});
+		// Close the Channel instance now.
+		this.#channel.close();
 
 		// Emit observer event.
 		this.#observer.safeEmit('close');

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -5,6 +5,7 @@
 - `router.pipe_producer_to_router()` and `router.pipe_data_producer_to_router()` can now connect two `Routers` in the same `Worker` if `keep_id` is set to `false` (PR #1604).
 - Updates from mediasoup TypeScript `3.18.1.=3.19.0`.
 - Ensure that the order of acquiring the `paused` and `producer_paused` locks in `consumer.rs` is consistent at all times to avoid deadlock (PR #1605).
+- Convert `WORKER_CLOSE` into a notification (PR #1729).
 
 # 0.20.0
 

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -79,37 +79,6 @@ pub(crate) trait Notification: Debug {
 }
 
 #[derive(Debug)]
-pub(crate) struct WorkerCloseRequest {}
-
-impl Request for WorkerCloseRequest {
-    const METHOD: request::Method = request::Method::WorkerClose;
-    type HandlerId = &'static str;
-    type Response = ();
-
-    fn into_bytes(self, id: u32, handler_id: Self::HandlerId) -> Vec<u8> {
-        let mut builder = Builder::new();
-
-        let request = request::Request::create(
-            &mut builder,
-            id,
-            Self::METHOD,
-            handler_id.to_string(),
-            None::<request::Body>,
-        );
-        let message_body = message::Body::create_request(&mut builder, request);
-        let message = message::Message::create(&mut builder, message_body);
-
-        builder.finish(message, None).to_vec()
-    }
-
-    fn convert_response(
-        _response: Option<response::BodyRef<'_>>,
-    ) -> Result<Self::Response, Box<dyn Error + Send + Sync>> {
-        Ok(())
-    }
-}
-
-#[derive(Debug)]
 pub(crate) struct WorkerDumpRequest {}
 
 impl Request for WorkerDumpRequest {
@@ -259,6 +228,29 @@ impl Request for WorkerCreateWebRtcServerRequest {
         _response: Option<response::BodyRef<'_>>,
     ) -> Result<Self::Response, Box<dyn Error + Send + Sync>> {
         Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct WorkerCloseNotification {}
+
+impl Notification for WorkerCloseNotification {
+    const EVENT: notification::Event = notification::Event::WorkerClose;
+    type HandlerId = &'static str;
+
+    fn into_bytes(self, handler_id: Self::HandlerId) -> Vec<u8> {
+        let mut builder = Builder::new();
+
+        let notification = notification::Notification::create(
+            &mut builder,
+            handler_id.to_string(),
+            Self::EVENT,
+            None::<notification::Body>,
+        );
+        let message_body = message::Body::create_notification(&mut builder, notification);
+        let message = message::Message::create(&mut builder, message_body);
+
+        builder.finish(message, None).to_vec()
     }
 }
 

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -6,7 +6,7 @@ mod common;
 mod utils;
 
 use crate::messages::{
-    WorkerCloseRequest, WorkerCreateRouterRequest, WorkerCreateWebRtcServerRequest,
+    WorkerCloseNotification, WorkerCreateRouterRequest, WorkerCreateWebRtcServerRequest,
     WorkerDumpRequest, WorkerUpdateSettingsRequest,
 };
 pub use crate::ortc::RtpCapabilitiesError;
@@ -565,16 +565,7 @@ impl Inner {
         let already_closed = self.closed.swap(true, Ordering::SeqCst);
 
         if !already_closed {
-            let channel = self.channel.clone();
-
-            self.executor
-                .spawn(async move {
-                    let _ = channel.request("", WorkerCloseRequest {}).await;
-
-                    // Drop channels in here after response from worker
-                    drop(channel);
-                })
-                .detach();
+            let _ = self.channel.notify("", WorkerCloseNotification {});
 
             self.handlers.close.call_simple();
         }

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -565,7 +565,16 @@ impl Inner {
         let already_closed = self.closed.swap(true, Ordering::SeqCst);
 
         if !already_closed {
-            let _ = self.channel.notify("", WorkerCloseNotification {});
+            let channel = self.channel.clone();
+
+            self.executor
+                .spawn(async move {
+                    let _ = channel.notify("", WorkerCloseNotification {});
+
+                    // Drop channels in here after response from worker
+                    drop(channel);
+                })
+                .detach();
 
             self.handlers.close.call_simple();
         }

--- a/rust/src/worker.rs
+++ b/rust/src/worker.rs
@@ -571,7 +571,7 @@ impl Inner {
                 .spawn(async move {
                     let _ = channel.notify("", WorkerCloseNotification {});
 
-                    // Drop channels in here after response from worker
+                    // Drop channels in here after having sent the notification
                     drop(channel);
                 })
                 .detach();

--- a/rust/src/worker/channel.rs
+++ b/rust/src/worker/channel.rs
@@ -7,7 +7,7 @@ use atomic_take::AtomicTake;
 use hash_hasher::HashedMap;
 use log::{debug, error, trace, warn};
 use lru::LruCache;
-use mediasoup_sys::fbs::{message, notification, request, response};
+use mediasoup_sys::fbs::{message, notification, response};
 use mediasoup_sys::UvAsyncT;
 use parking_lot::Mutex;
 use planus::ReadAsRoot;
@@ -387,11 +387,8 @@ impl Channel {
                 .push_back(Arc::clone(&buffer));
             if let Some(handle) = outgoing_message_buffer.handle {
                 if self.inner.worker_closed.load(Ordering::Acquire) {
-                    // Forbid all requests after worker closing except one worker closing request
-                    // TODO: We were checking before that inner.closed.
-                    if R::METHOD != request::Method::WorkerClose {
-                        return Err(RequestError::ChannelClosed);
-                    }
+                    // Forbid all requests after worker closing
+                    return Err(RequestError::ChannelClosed);
                 }
                 unsafe {
                     // Notify worker that there is something to read
@@ -487,6 +484,7 @@ impl Channel {
                 .push_back(Arc::clone(&message));
             if let Some(handle) = outgoing_message_buffer.handle {
                 if self.inner.worker_closed.load(Ordering::Acquire) {
+                    // Forbid all notifications after worker closing
                     return Err(NotificationError::ChannelClosed);
                 }
                 unsafe {

--- a/rust/src/worker/channel.rs
+++ b/rust/src/worker/channel.rs
@@ -500,6 +500,7 @@ impl Channel {
 
         Ok(())
     }
+
     pub(crate) fn subscribe_to_notifications<F>(
         &self,
         target_id: SubscriptionTarget,

--- a/rust/src/worker/channel.rs
+++ b/rust/src/worker/channel.rs
@@ -484,8 +484,11 @@ impl Channel {
                 .push_back(Arc::clone(&message));
             if let Some(handle) = outgoing_message_buffer.handle {
                 if self.inner.worker_closed.load(Ordering::Acquire) {
-                    // Forbid all notifications after worker closing
-                    return Err(NotificationError::ChannelClosed);
+                    // Forbid all notifications after worker closing except one
+                    // worker closing request
+                    if N::EVENT != notification::Event::WorkerClose {
+                        return Err(NotificationError::ChannelClosed);
+                    }
                 }
                 unsafe {
                     // Notify worker that there is something to read

--- a/worker/fbs/notification.fbs
+++ b/worker/fbs/notification.fbs
@@ -12,7 +12,8 @@ namespace FBS.Notification;
 
 enum Event: uint8 {
     // Notifications to worker.
-    TRANSPORT_SEND_RTCP = 0,
+    WORKER_CLOSE = 0,
+    TRANSPORT_SEND_RTCP,
     PRODUCER_SEND,
     DATAPRODUCER_SEND,
 

--- a/worker/fbs/request.fbs
+++ b/worker/fbs/request.fbs
@@ -9,8 +9,7 @@ include "rtpObserver.fbs";
 namespace FBS.Request;
 
 enum Method: uint8 {
-    WORKER_CLOSE = 0,
-    WORKER_DUMP,
+    WORKER_DUMP = 0,
     WORKER_GET_RESOURCE_USAGE,
     WORKER_UPDATE_SETTINGS,
     WORKER_CREATE_WEBRTCSERVER,

--- a/worker/fbs/worker.fbs
+++ b/worker/fbs/worker.fbs
@@ -56,4 +56,3 @@ table CreateRouterRequest {
 table CloseRouterRequest {
     router_id: string (required);
 }
-

--- a/worker/src/Channel/ChannelNotification.cpp
+++ b/worker/src/Channel/ChannelNotification.cpp
@@ -12,6 +12,7 @@ namespace Channel
 	// clang-format off
 	const absl::flat_hash_map<FBS::Notification::Event, const char*> ChannelNotification::Event2String =
 	{
+		{ FBS::Notification::Event::WORKER_CLOSE,        "worker.close"       },
 		{ FBS::Notification::Event::TRANSPORT_SEND_RTCP, "transport.sendRtcp" },
 		{ FBS::Notification::Event::PRODUCER_SEND,       "producer.send"      },
 		{ FBS::Notification::Event::DATAPRODUCER_SEND,   "dataProducer.send"  },

--- a/worker/src/Channel/ChannelRequest.cpp
+++ b/worker/src/Channel/ChannelRequest.cpp
@@ -14,7 +14,6 @@ namespace Channel
 	// clang-format off
 	const absl::flat_hash_map<FBS::Request::Method, const char*> ChannelRequest::Method2String =
 	{
-		{ FBS::Request::Method::WORKER_CLOSE,                                   "worker.close"                               },
 		{ FBS::Request::Method::WORKER_DUMP,                                    "worker.dump"                                },
 		{ FBS::Request::Method::WORKER_GET_RESOURCE_USAGE,                      "worker.getResourceUsage"                    },
 		{ FBS::Request::Method::WORKER_UPDATE_SETTINGS,                         "worker.updateSettings"                      },

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -283,22 +283,6 @@ void Worker::HandleRequest(Channel::ChannelRequest* request)
 
 	switch (request->method)
 	{
-		case Channel::ChannelRequest::Method::WORKER_CLOSE:
-		{
-			if (this->closed)
-			{
-				return;
-			}
-
-			MS_DEBUG_DEV("closing Worker");
-
-			request->Accept();
-
-			Close();
-
-			break;
-		}
-
 		case Channel::ChannelRequest::Method::WORKER_DUMP:
 		{
 			auto dumpOffset = FillBuffer(request->GetBufferBuilder());
@@ -473,26 +457,46 @@ void Worker::HandleNotification(Channel::ChannelNotification* notification)
 
 	MS_DEBUG_DEV("Channel notification received [event:%s]", notification->eventCStr);
 
-	try
+	switch (notification->event)
 	{
-		auto* handler =
-		  this->shared->channelMessageRegistrator->GetChannelNotificationHandler(notification->handlerId);
-
-		if (handler == nullptr)
+		case Channel::ChannelNotification::Event::WORKER_CLOSE:
 		{
-			MS_THROW_ERROR(
-			  "Channel notification handler with ID %s not found", notification->handlerId.c_str());
+			if (this->closed)
+			{
+				return;
+			}
+
+			MS_DEBUG_DEV("closing Worker");
+
+			Close();
+
+			break;
 		}
 
-		handler->HandleNotification(notification);
-	}
-	catch (const MediaSoupTypeError& error)
-	{
-		MS_THROW_TYPE_ERROR("%s [event:%s]", error.what(), notification->eventCStr);
-	}
-	catch (const MediaSoupError& error)
-	{
-		MS_THROW_ERROR("%s [method:%s]", error.what(), notification->eventCStr);
+		default:
+		{
+			try
+			{
+				auto* handler = this->shared->channelMessageRegistrator->GetChannelNotificationHandler(
+				  notification->handlerId);
+
+				if (handler == nullptr)
+				{
+					MS_THROW_ERROR(
+					  "Channel notification handler with ID %s not found", notification->handlerId.c_str());
+				}
+
+				handler->HandleNotification(notification);
+			}
+			catch (const MediaSoupTypeError& error)
+			{
+				MS_THROW_TYPE_ERROR("%s [event:%s]", error.what(), notification->eventCStr);
+			}
+			catch (const MediaSoupError& error)
+			{
+				MS_THROW_ERROR("%s [event:%s]", error.what(), notification->eventCStr);
+			}
+		}
 	}
 }
 

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -18,7 +18,6 @@
 #include "Channel/ChannelSocket.hpp"
 #include "RTC/DtlsTransport.hpp"
 #include "RTC/SrtpSession.hpp"
-#include <uv.h>
 #include <absl/container/flat_hash_map.h>
 #include <csignal> // sigaction()
 #include <string>
@@ -172,12 +171,6 @@ extern "C" int mediasoup_worker_run(
 		RTC::DtlsTransport::ClassDestroy();
 		DepUsrSCTP::ClassDestroy();
 		DepLibUV::ClassDestroy();
-
-#ifdef MS_EXECUTABLE
-		// Wait a bit so pending messages to stdout/Channel arrive to the Node
-		// process.
-		uv_sleep(200);
-#endif
 
 		return 0;
 #ifndef MS_EXECUTABLE


### PR DESCRIPTION
# Details

- No reason for it to be a request. We don't need its response and having to wait for it is a hack since by design this message literally closes the signaling channel.
- So now we no longer need to wait 200 milliseconds in `lib.cpp` when the `Worker` instance is destroyed.
