### PR TITLE
Update CI ZedThree/clang-tidy-review to 0.23.0

### DIFF
--- a/.github/workflows/mediasoup-worker-clang-tidy.yaml
+++ b/.github/workflows/mediasoup-worker-clang-tidy.yaml
@@ -36,7 +36,7 @@ jobs:
       - name: Normalize compile_commands.json paths
         run: npm run normalize-compile-commands --prefix worker/scripts --foreground-scripts
 
-      - uses: ZedThree/clang-tidy-review@v0.22.1
+      - uses: ZedThree/clang-tidy-review@v0.23.0
         id: review
         with:
           apt_packages: 'libclang-rt-21-dev'
@@ -49,7 +49,7 @@ jobs:
           include: 'worker/src/**/*.cpp,worker/test/src/**/*.cpp,worker/fuzzer/src/**/*.cpp'
 
       # Uploads an artifact containing clang_fixes.json.
-      - uses: ZedThree/clang-tidy-review/upload@v0.22.1
+      - uses: ZedThree/clang-tidy-review/upload@v0.23.0
         id: upload-review
 
       # If there are any comments, fail the check.

--- a/worker/src/RTC/RTP/Packet.cpp
+++ b/worker/src/RTC/RTP/Packet.cpp
@@ -154,6 +154,7 @@ namespace RTC
 			MS_TRACE();
 
 			MS_DUMP_CLEAN(indentation, "<RTP::Packet>");
+
 			MS_DUMP_CLEAN(indentation, "  length: %zu (buffer length: %zu)", GetLength(), GetBufferLength());
 			MS_DUMP_CLEAN(indentation, "  sequence number: %" PRIu16, GetSequenceNumber());
 			MS_DUMP_CLEAN(indentation, "  timestamp: %" PRIu32, GetTimestamp());


### PR DESCRIPTION
# Details

- https://github.com/ZedThree/clang-tidy-review/releases
- It also solves the problem with multi arguments given to `extra_arguments`: https://github.com/ZedThree/clang-tidy-review/pull/160
- Also cosmetic (good) changes in `RTP/Packet.cpp` to trigger tidy CI.