### PR TITLE
Make CI job shields in README point to v3 branch and releases

### DIFF
--- a/.github/workflows/mediasoup-worker-clang-tidy.yaml
+++ b/.github/workflows/mediasoup-worker-clang-tidy.yaml
@@ -1,6 +1,19 @@
 name: mediasoup-worker-clang-tidy
 
 on:
+  push:
+    branches: [v3]
+    paths:
+      - 'worker/src/**/*.cpp'
+      - 'worker/include/**/*.hpp'
+      - 'worker/test/src/**/*.cpp'
+      - 'worker/test/include/**/*.hpp'
+      - 'worker/fuzzer/src/**/*.cpp'
+      - 'worker/fuzzer/include/**/*.hpp'
+      - 'worker/meson.build'
+      - 'worker/.clang-format'
+      - 'worker/.clang-tidy'
+      - '.github/workflows/mediasoup-worker-clang-tidy.yaml'
   pull_request:
     paths:
       - 'worker/src/**/*.cpp'
@@ -9,8 +22,11 @@ on:
       - 'worker/test/include/**/*.hpp'
       - 'worker/fuzzer/src/**/*.cpp'
       - 'worker/fuzzer/include/**/*.hpp'
+      - 'worker/meson.build'
+      - 'worker/.clang-format'
       - 'worker/.clang-tidy'
       - '.github/workflows/mediasoup-worker-clang-tidy.yaml'
+  workflow_dispatch:
 
 jobs:
   clang-tidy:

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@
 [![][github-actions-shield-mediasoup-worker]][github-actions-mediasoup-worker]
 [![][github-actions-shield-mediasoup-rust]][github-actions-mediasoup-rust]
 [![][github-actions-shield-mediasoup-worker-fuzzer]][github-actions-mediasoup-worker-fuzzer]
-[![][github-actions-shield-mediasoup-worker-prebuild]][github-actions-mediasoup-worker-prebuild]
 [![][github-actions-shield-mediasoup-worker-clang-tidy]][github-actions-mediasoup-worker-clang-tidy]
+[![][github-actions-shield-mediasoup-worker-prebuild]][github-actions-mediasoup-worker-prebuild]
 [![][codeql-shield-mediasoup]][codeql-mediasoup]
 
 ## Website and Documentation
@@ -95,20 +95,20 @@ You can support mediasoup by [sponsoring][sponsor] it. Thanks!
 [crates-mediasoup]: https://crates.io/crates/mediasoup
 [opencollective-shield-mediasoup]: https://img.shields.io/opencollective/all/mediasoup.svg
 [opencollective-mediasoup]: https://opencollective.com/mediasoup
-[github-actions-shield-mediasoup-node]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-node.yaml/badge.svg
-[github-actions-mediasoup-node]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-node.yaml
-[github-actions-shield-mediasoup-worker]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker.yaml/badge.svg
-[github-actions-mediasoup-worker]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker.yaml
-[github-actions-shield-mediasoup-rust]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-rust.yaml/badge.svg
-[github-actions-mediasoup-rust]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-rust.yaml
-[github-actions-shield-mediasoup-worker-fuzzer]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-fuzzer.yaml/badge.svg
-[github-actions-mediasoup-worker-fuzzer]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-fuzzer.yaml
-[github-actions-shield-mediasoup-worker-prebuild]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-prebuild.yaml/badge.svg
-[github-actions-mediasoup-worker-prebuild]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-prebuild.yaml
-[github-actions-shield-mediasoup-worker-clang-tidy]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-clang-tidy.yaml/badge.svg
-[github-actions-mediasoup-worker-clang-tidy]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-clang-tidy.yaml
-[codeql-shield-mediasoup]: https://github.com/versatica/mediasoup/actions/workflows/codeql.yaml/badge.svg
-[codeql-mediasoup]: https://github.com/versatica/mediasoup/actions/workflows/codeql.yaml
+[github-actions-shield-mediasoup-node]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-node.yaml/badge.svg?branch=v3
+[github-actions-mediasoup-node]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-node.yaml?query=branch%3Av3
+[github-actions-shield-mediasoup-worker]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker.yaml/badge.svg?branch=v3
+[github-actions-mediasoup-worker]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker.yaml?query=branch%3Av3
+[github-actions-shield-mediasoup-rust]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-rust.yaml/badge.svg?branch=v3
+[github-actions-mediasoup-rust]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-rust.yaml?query=branch%3Av3
+[github-actions-shield-mediasoup-worker-fuzzer]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-fuzzer.yaml/badge.svg?branch=v3
+[github-actions-mediasoup-worker-fuzzer]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-fuzzer.yaml?query=branch%3Av3
+[github-actions-shield-mediasoup-worker-clang-tidy]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-clang-tidy.yaml/badge.svg?branch=v3
+[github-actions-mediasoup-worker-clang-tidy]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-clang-tidy.yaml?query=branch%3Av3
+[github-actions-shield-mediasoup-worker-prebuild]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-prebuild.yaml/badge.svg?event=release
+[github-actions-mediasoup-worker-prebuild]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-prebuild.yaml?query=event%3Arelease
+[codeql-shield-mediasoup]: https://github.com/versatica/mediasoup/actions/workflows/codeql.yaml/badge.svg?branch=v3
+[codeql-mediasoup]: https://github.com/versatica/mediasoup/actions/workflows/codeql.yaml?query=branch%3Av3
 [sponsor]: https://mediasoup.org/sponsor
 [mediasoup-architecture]: /art/mediasoup-v3-architecture-01.svg
 [mediasoup-demo-screenshot]: /art/mediasoup-v3.png


### PR DESCRIPTION
# Details

- Stop showing red "CI failing" labels in README just because CI jobs of some random ongoing PR fail.
- Make those labels/shields point to v3 branch instead.
- Make the `mediasoup-worker-prebuild` CI shield point to "releases" since it doesn't run on v3 branch bu design.
- Also add some paths to `mediasoup-worker-clang-tidy.yaml`.
- Also make `mediasoup-worker-clang-tidy.yaml` CI job run on push on v3 branch so we display its status in v3 in the shield rather than the status of the latest ongoing PR.