### PR TITLE
SCTP IDataChunk improvement

### DIFF
--- a/worker/include/RTC/SCTP/packet/chunks/DataChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/DataChunk.hpp
@@ -59,7 +59,7 @@ namespace RTC
 		 *   range is 0 to 65535. When a user message is fragmented by SCTP for
 		 *   transport, the same Stream Sequence Number MUST be carried in each of
 		 *   the fragments of the message.
-		 * - Payload Protocol Identifier (32 bits): This value represents an
+		 * - Payload Protocol Identifier (PPID) (32 bits): This value represents an
 		 *   application (or upper layer) specified protocol identifier.
 		 * - User Data (variable length): This is the payload user data. The
 		 *   implementation MUST pad the end of the data to a 4-byte boundary with

--- a/worker/include/RTC/SCTP/packet/chunks/IDataChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/IDataChunk.hpp
@@ -163,12 +163,39 @@ namespace RTC
 
 			void SetMessageIdentifier(uint32_t value);
 
-			uint32_t GetPayloadProtocolIdentifierOrFragmentSequenceNumber() const
+			uint32_t GetPayloadProtocolIdentifier() const
 			{
-				return Utils::Byte::Get4Bytes(GetBuffer(), 16);
+				if (GetB())
+				{
+					return Utils::Byte::Get4Bytes(GetBuffer(), 16);
+				}
+				else
+				{
+					return 0;
+				}
 			}
 
-			void SetPayloadProtocolIdentifierOrFragmentSequenceNumber(uint32_t value);
+			/**
+			 * @throw MediaSoupError - If the B bit is not set.
+			 */
+			void SetPayloadProtocolIdentifier(uint32_t value);
+
+			uint32_t GetFragmentSequenceNumber() const
+			{
+				if (!GetB())
+				{
+					return Utils::Byte::Get4Bytes(GetBuffer(), 16);
+				}
+				else
+				{
+					return 0;
+				}
+			}
+
+			/**
+			 * @throw MediaSoupError - If the B bit is set.
+			 */
+			void SetFragmentSequenceNumber(uint32_t value);
 
 			bool HasUserData() const
 			{

--- a/worker/src/RTC/SCTP/packet/chunks/DataChunk.cpp
+++ b/worker/src/RTC/SCTP/packet/chunks/DataChunk.cpp
@@ -111,7 +111,7 @@ namespace RTC
 			MS_DUMP_CLEAN(indentation, "  stream identifier S: %" PRIu16, GetStreamIdentifierS());
 			MS_DUMP_CLEAN(indentation, "  stream sequence number n: %" PRIu16, GetStreamSequenceNumberN());
 			MS_DUMP_CLEAN(
-			  indentation, "  payload protocol identifier: %" PRIu32, GetPayloadProtocolIdentifier());
+			  indentation, "  payload protocol identifier (PPID): %" PRIu32, GetPayloadProtocolIdentifier());
 			MS_DUMP_CLEAN(
 			  indentation,
 			  "  user data length: %" PRIu16 " (has user data: %s)",

--- a/worker/src/RTC/SCTP/packet/chunks/IDataChunk.cpp
+++ b/worker/src/RTC/SCTP/packet/chunks/IDataChunk.cpp
@@ -52,7 +52,8 @@ namespace RTC
 			chunk->SetStreamIdentifier(0);
 			chunk->SetReserved();
 			chunk->SetMessageIdentifier(0);
-			chunk->SetPayloadProtocolIdentifierOrFragmentSequenceNumber(0);
+			// NOTE: BitB is not set so we must set FSN to 0 rather than setting PPID.
+			chunk->SetFragmentSequenceNumber(0);
 
 			// No need to invoke SetLength() since constructor invoked it with
 			// minimum IDataChunk length.
@@ -111,10 +112,18 @@ namespace RTC
 			MS_DUMP_CLEAN(indentation, "  tsn: %" PRIu32, GetTsn());
 			MS_DUMP_CLEAN(indentation, "  stream identifier: %" PRIu16, GetStreamIdentifier());
 			MS_DUMP_CLEAN(indentation, "  message identifier: %" PRIu32, GetMessageIdentifier());
-			MS_DUMP_CLEAN(
-			  indentation,
-			  "  payload protocol identifier / fragment sequence number: %" PRIu32,
-			  GetPayloadProtocolIdentifierOrFragmentSequenceNumber());
+			if (GetB())
+			{
+				MS_DUMP_CLEAN(
+				  indentation,
+				  "  payload protocol identifier (PPID): %" PRIu32,
+				  GetPayloadProtocolIdentifier());
+			}
+			else
+			{
+				MS_DUMP_CLEAN(
+				  indentation, "  fragment sequence number (FSN): %" PRIu32, GetFragmentSequenceNumber());
+			}
 			MS_DUMP_CLEAN(
 			  indentation,
 			  "  user data length: %" PRIu16 " (has user data: %s)",
@@ -184,9 +193,26 @@ namespace RTC
 			Utils::Byte::Set4Bytes(const_cast<uint8_t*>(GetBuffer()), 12, value);
 		}
 
-		void IDataChunk::SetPayloadProtocolIdentifierOrFragmentSequenceNumber(uint32_t value)
+		void IDataChunk::SetPayloadProtocolIdentifier(uint32_t value)
 		{
 			MS_TRACE();
+
+			if (!GetB())
+			{
+				MS_THROW_ERROR("cannot set payload protocol identifier (PPID) if bit B is not set");
+			}
+
+			Utils::Byte::Set4Bytes(const_cast<uint8_t*>(GetBuffer()), 16, value);
+		}
+
+		void IDataChunk::SetFragmentSequenceNumber(uint32_t value)
+		{
+			MS_TRACE();
+
+			if (GetB())
+			{
+				MS_THROW_ERROR("cannot set payload protocol identifier (PPID) if bit B is set");
+			}
 
 			Utils::Byte::Set4Bytes(const_cast<uint8_t*>(GetBuffer()), 16, value);
 		}

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestDataChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestDataChunk.cpp
@@ -272,12 +272,12 @@ SCENARIO("SCTP Payload Data Chunk (0)", "[serializable][sctp][chunk]")
 	SECTION("DataChunk::SetUserData() throws if userDataLength is too big")
 	{
 		auto* chunk =
-		  RTC::SCTP::DataChunk::Factory(sctpCommon::ThrowBuffer, sizeof(sctpCommon::ThrowBuffer));
+		  RTC::SCTP::DataChunk::Factory(sctpCommon::FactoryBuffer, sizeof(sctpCommon::FactoryBuffer));
 
 		CHECK_SCTP_CHUNK(
 		  /*chunk*/ chunk,
-		  /*buffer*/ sctpCommon::ThrowBuffer,
-		  /*bufferLength*/ sizeof(sctpCommon::ThrowBuffer),
+		  /*buffer*/ sctpCommon::FactoryBuffer,
+		  /*bufferLength*/ sizeof(sctpCommon::FactoryBuffer),
 		  /*length*/ 16,
 		  /*chunkType*/ RTC::SCTP::Chunk::ChunkType::DATA,
 		  /*unknownType*/ false,
@@ -292,8 +292,8 @@ SCENARIO("SCTP Payload Data Chunk (0)", "[serializable][sctp][chunk]")
 
 		CHECK_SCTP_CHUNK(
 		  /*chunk*/ chunk,
-		  /*buffer*/ sctpCommon::ThrowBuffer,
-		  /*bufferLength*/ sizeof(sctpCommon::ThrowBuffer),
+		  /*buffer*/ sctpCommon::FactoryBuffer,
+		  /*bufferLength*/ sizeof(sctpCommon::FactoryBuffer),
 		  /*length*/ 16,
 		  /*chunkType*/ RTC::SCTP::Chunk::ChunkType::DATA,
 		  /*unknownType*/ false,

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestIDataChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestIDataChunk.cpp
@@ -32,10 +32,11 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		};
 		// clang-format on
 
-		auto* chunk = RTC::SCTP::IDataChunk::Parse(buffer, sizeof(buffer));
+		std::unique_ptr<RTC::SCTP::IDataChunk> chunk{ RTC::SCTP::IDataChunk::Parse(
+			buffer, sizeof(buffer)) };
 
 		CHECK_SCTP_CHUNK(
-		  /*chunk*/ chunk,
+		  /*chunk*/ chunk.get(),
 		  /*buffer*/ buffer,
 		  /*bufferLength*/ sizeof(buffer),
 		  /*length*/ 24,
@@ -55,7 +56,7 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		REQUIRE(chunk->GetTsn() == 0x11223344);
 		REQUIRE(chunk->GetStreamIdentifier() == 5001);
 		REQUIRE(chunk->GetMessageIdentifier() == 1234567890);
-		// Bit B is set so we have PPID and we don't have FSN.
+		// Bit B is set so we have PPID instead of FSN.
 		REQUIRE(chunk->GetPayloadProtocolIdentifier() == 99887766);
 		REQUIRE(chunk->GetFragmentSequenceNumber() == 0);
 		REQUIRE(chunk->HasUserData() == true);
@@ -76,7 +77,7 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		std::memset(buffer, 0x00, sizeof(buffer));
 
 		CHECK_SCTP_CHUNK(
-		  /*chunk*/ chunk,
+		  /*chunk*/ chunk.get(),
 		  /*buffer*/ sctpCommon::SerializeBuffer,
 		  /*bufferLength*/ sizeof(sctpCommon::SerializeBuffer),
 		  /*length*/ 24,
@@ -96,7 +97,7 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		REQUIRE(chunk->GetTsn() == 0x11223344);
 		REQUIRE(chunk->GetStreamIdentifier() == 5001);
 		REQUIRE(chunk->GetMessageIdentifier() == 1234567890);
-		// Bit B is set so we have PPID and we don't have FSN.
+		// Bit B is set so we have PPID instead of FSN.
 		REQUIRE(chunk->GetPayloadProtocolIdentifier() == 99887766);
 		REQUIRE(chunk->GetFragmentSequenceNumber() == 0);
 		REQUIRE(chunk->HasUserData() == true);
@@ -109,14 +110,12 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 
 		/* Clone it. */
 
-		auto* clonedChunk = chunk->Clone(sctpCommon::CloneBuffer, sizeof(sctpCommon::CloneBuffer));
+		chunk.reset(chunk->Clone(sctpCommon::CloneBuffer, sizeof(sctpCommon::CloneBuffer)));
 
 		std::memset(sctpCommon::SerializeBuffer, 0x00, sizeof(sctpCommon::SerializeBuffer));
 
-		delete chunk;
-
 		CHECK_SCTP_CHUNK(
-		  /*chunk*/ clonedChunk,
+		  /*chunk*/ chunk.get(),
 		  /*buffer*/ sctpCommon::CloneBuffer,
 		  /*bufferLength*/ sizeof(sctpCommon::CloneBuffer),
 		  /*length*/ 24,
@@ -129,34 +128,32 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		  /*canHaveErrorCauses*/ false,
 		  /*errorCausesCount*/ 0);
 
-		REQUIRE(clonedChunk->GetI() == true);
-		REQUIRE(clonedChunk->GetU() == false);
-		REQUIRE(clonedChunk->GetB() == true);
-		REQUIRE(clonedChunk->GetE() == false);
-		REQUIRE(clonedChunk->GetTsn() == 0x11223344);
-		REQUIRE(clonedChunk->GetStreamIdentifier() == 5001);
-		REQUIRE(clonedChunk->GetMessageIdentifier() == 1234567890);
-		// Bit B is set so we have PPID and we don't have FSN.
+		REQUIRE(chunk->GetI() == true);
+		REQUIRE(chunk->GetU() == false);
+		REQUIRE(chunk->GetB() == true);
+		REQUIRE(chunk->GetE() == false);
+		REQUIRE(chunk->GetTsn() == 0x11223344);
+		REQUIRE(chunk->GetStreamIdentifier() == 5001);
+		REQUIRE(chunk->GetMessageIdentifier() == 1234567890);
+		// Bit B is set so we have PPID instead of FSN.
 		REQUIRE(chunk->GetPayloadProtocolIdentifier() == 99887766);
 		REQUIRE(chunk->GetFragmentSequenceNumber() == 0);
-		REQUIRE(clonedChunk->HasUserData() == true);
-		REQUIRE(clonedChunk->GetUserDataLength() == 3);
-		REQUIRE(clonedChunk->GetUserData()[0] == 0xAB);
-		REQUIRE(clonedChunk->GetUserData()[1] == 0xCD);
-		REQUIRE(clonedChunk->GetUserData()[2] == 0xEF);
+		REQUIRE(chunk->HasUserData() == true);
+		REQUIRE(chunk->GetUserDataLength() == 3);
+		REQUIRE(chunk->GetUserData()[0] == 0xAB);
+		REQUIRE(chunk->GetUserData()[1] == 0xCD);
+		REQUIRE(chunk->GetUserData()[2] == 0xEF);
 		// This should be padding.
-		REQUIRE(clonedChunk->GetUserData()[3] == 0x00);
-
-		delete clonedChunk;
+		REQUIRE(chunk->GetUserData()[3] == 0x00);
 	}
 
 	SECTION("IDataChunk::Factory() succeeds")
 	{
-		auto* chunk =
-		  RTC::SCTP::IDataChunk::Factory(sctpCommon::FactoryBuffer, sizeof(sctpCommon::FactoryBuffer));
+		std::unique_ptr<RTC::SCTP::IDataChunk> chunk{ RTC::SCTP::IDataChunk::Factory(
+			sctpCommon::FactoryBuffer, sizeof(sctpCommon::FactoryBuffer)) };
 
 		CHECK_SCTP_CHUNK(
-		  /*chunk*/ chunk,
+		  /*chunk*/ chunk.get(),
 		  /*buffer*/ sctpCommon::FactoryBuffer,
 		  /*bufferLength*/ sizeof(sctpCommon::FactoryBuffer),
 		  /*length*/ 20,
@@ -176,7 +173,7 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		REQUIRE(chunk->GetTsn() == 0);
 		REQUIRE(chunk->GetStreamIdentifier() == 0);
 		REQUIRE(chunk->GetMessageIdentifier() == 0);
-		// Bit B is not set so we don't have PPID and we have FSN.
+		// Bit B is not set so we don't have PPID but FSN.
 		REQUIRE(chunk->GetPayloadProtocolIdentifier() == 0);
 		REQUIRE(chunk->GetFragmentSequenceNumber() == 0);
 		REQUIRE(chunk->HasUserData() == false);
@@ -211,7 +208,7 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		chunk->SetUserData(sctpCommon::DataBuffer, 3);
 
 		CHECK_SCTP_CHUNK(
-		  /*chunk*/ chunk,
+		  /*chunk*/ chunk.get(),
 		  /*buffer*/ sctpCommon::FactoryBuffer,
 		  /*bufferLength*/ sizeof(sctpCommon::FactoryBuffer),
 		  /*length*/ 20 + 3 + 1,
@@ -231,7 +228,7 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		REQUIRE(chunk->GetTsn() == 12345678);
 		REQUIRE(chunk->GetStreamIdentifier() == 9988);
 		REQUIRE(chunk->GetMessageIdentifier() == 1234);
-		// Bit B is not set so we don't have PPID and we have FSN.
+		// Bit B is not set so we don't have PPID but FSN.
 		REQUIRE(chunk->GetPayloadProtocolIdentifier() == 0);
 		REQUIRE(chunk->GetFragmentSequenceNumber() == 987654321);
 		REQUIRE(chunk->HasUserData() == true);
@@ -244,12 +241,10 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 
 		/* Parse itself and compare. */
 
-		auto* parsedChunk = RTC::SCTP::IDataChunk::Parse(chunk->GetBuffer(), chunk->GetLength());
-
-		delete chunk;
+		chunk.reset(RTC::SCTP::IDataChunk::Parse(chunk->GetBuffer(), chunk->GetLength()));
 
 		CHECK_SCTP_CHUNK(
-		  /*chunk*/ parsedChunk,
+		  /*chunk*/ chunk.get(),
 		  /*buffer*/ sctpCommon::FactoryBuffer,
 		  /*bufferLength*/ 20 + 3 + 1,
 		  /*length*/ 20 + 3 + 1,
@@ -262,36 +257,34 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		  /*canHaveErrorCauses*/ false,
 		  /*errorCausesCount*/ 0);
 
-		REQUIRE(parsedChunk->GetI() == true);
-		REQUIRE(parsedChunk->GetU() == false);
-		REQUIRE(parsedChunk->GetB() == false);
-		REQUIRE(parsedChunk->GetE() == true);
-		REQUIRE(parsedChunk->GetTsn() == 12345678);
-		REQUIRE(parsedChunk->GetStreamIdentifier() == 9988);
-		REQUIRE(parsedChunk->GetMessageIdentifier() == 1234);
-		// Bit B is not set so we don't have PPID and we have FSN.
+		REQUIRE(chunk->GetI() == true);
+		REQUIRE(chunk->GetU() == false);
+		REQUIRE(chunk->GetB() == false);
+		REQUIRE(chunk->GetE() == true);
+		REQUIRE(chunk->GetTsn() == 12345678);
+		REQUIRE(chunk->GetStreamIdentifier() == 9988);
+		REQUIRE(chunk->GetMessageIdentifier() == 1234);
+		// Bit B is not set so we don't have PPID but FSN.
 		REQUIRE(chunk->GetPayloadProtocolIdentifier() == 0);
 		REQUIRE(chunk->GetFragmentSequenceNumber() == 987654321);
-		REQUIRE(parsedChunk->HasUserData() == true);
-		REQUIRE(parsedChunk->GetUserDataLength() == 3);
-		REQUIRE(parsedChunk->GetUserData()[0] == 0x00);
-		REQUIRE(parsedChunk->GetUserData()[1] == 0x01);
-		REQUIRE(parsedChunk->GetUserData()[2] == 0x02);
+		REQUIRE(chunk->HasUserData() == true);
+		REQUIRE(chunk->GetUserDataLength() == 3);
+		REQUIRE(chunk->GetUserData()[0] == 0x00);
+		REQUIRE(chunk->GetUserData()[1] == 0x01);
+		REQUIRE(chunk->GetUserData()[2] == 0x02);
 		// Last byte must be a zero byte padding.
-		REQUIRE(parsedChunk->GetUserData()[3] == 0x00);
-
-		delete parsedChunk;
+		REQUIRE(chunk->GetUserData()[3] == 0x00);
 	}
 
 	SECTION("IDataChunk::SetUserData() throws if userDataLength is too big")
 	{
-		auto* chunk =
-		  RTC::SCTP::IDataChunk::Factory(sctpCommon::ThrowBuffer, sizeof(sctpCommon::ThrowBuffer));
+		std::unique_ptr<RTC::SCTP::IDataChunk> chunk{ RTC::SCTP::IDataChunk::Factory(
+			sctpCommon::FactoryBuffer, sizeof(sctpCommon::FactoryBuffer)) };
 
 		CHECK_SCTP_CHUNK(
-		  /*chunk*/ chunk,
-		  /*buffer*/ sctpCommon::ThrowBuffer,
-		  /*bufferLength*/ sizeof(sctpCommon::ThrowBuffer),
+		  /*chunk*/ chunk.get(),
+		  /*buffer*/ sctpCommon::FactoryBuffer,
+		  /*bufferLength*/ sizeof(sctpCommon::FactoryBuffer),
 		  /*length*/ 20,
 		  /*chunkType*/ RTC::SCTP::Chunk::ChunkType::I_DATA,
 		  /*unknownType*/ false,
@@ -305,9 +298,9 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		REQUIRE_THROWS_AS(chunk->SetUserData(sctpCommon::DataBuffer, 65535), MediaSoupError);
 
 		CHECK_SCTP_CHUNK(
-		  /*chunk*/ chunk,
-		  /*buffer*/ sctpCommon::ThrowBuffer,
-		  /*bufferLength*/ sizeof(sctpCommon::ThrowBuffer),
+		  /*chunk*/ chunk.get(),
+		  /*buffer*/ sctpCommon::FactoryBuffer,
+		  /*bufferLength*/ sizeof(sctpCommon::FactoryBuffer),
 		  /*length*/ 20,
 		  /*chunkType*/ RTC::SCTP::Chunk::ChunkType::I_DATA,
 		  /*unknownType*/ false,
@@ -317,7 +310,5 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		  /*parametersCount*/ 0,
 		  /*canHaveErrorCauses*/ false,
 		  /*errorCausesCount*/ 0);
-
-		delete chunk;
 	}
 }

--- a/worker/test/src/RTC/SCTP/packet/chunks/TestIDataChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/chunks/TestIDataChunk.cpp
@@ -23,7 +23,7 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 			0x13, 0x89, 0x00, 0x00,
 			// Message Identifier: 1234567890
 			0x49, 0x96, 0x02, 0xD2,
-			// Payload Protocol Identifier / Fragment Sequence Number: 99887766
+			// Payload Protocol Identifier / Fragment Sequence Number: 99887766 (PPID)
 			0x05, 0xF4, 0x2A, 0x96,
 			// User Data (3 bytes): 0xABCDED, 1 byte of padding
 			0xAB, 0xCD, 0xEF, 0x00,
@@ -55,7 +55,9 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		REQUIRE(chunk->GetTsn() == 0x11223344);
 		REQUIRE(chunk->GetStreamIdentifier() == 5001);
 		REQUIRE(chunk->GetMessageIdentifier() == 1234567890);
-		REQUIRE(chunk->GetPayloadProtocolIdentifierOrFragmentSequenceNumber() == 99887766);
+		// Bit B is set so we have PPID and we don't have FSN.
+		REQUIRE(chunk->GetPayloadProtocolIdentifier() == 99887766);
+		REQUIRE(chunk->GetFragmentSequenceNumber() == 0);
 		REQUIRE(chunk->HasUserData() == true);
 		REQUIRE(chunk->GetUserDataLength() == 3);
 		REQUIRE(chunk->GetUserData()[0] == 0xAB);
@@ -63,6 +65,9 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		REQUIRE(chunk->GetUserData()[2] == 0xEF);
 		// This should be padding.
 		REQUIRE(chunk->GetUserData()[3] == 0x00);
+
+		// Bit B is not set so cannot set FSN.
+		REQUIRE_THROWS_AS(chunk->SetFragmentSequenceNumber(1234), MediaSoupError);
 
 		/* Serialize it. */
 
@@ -91,7 +96,9 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		REQUIRE(chunk->GetTsn() == 0x11223344);
 		REQUIRE(chunk->GetStreamIdentifier() == 5001);
 		REQUIRE(chunk->GetMessageIdentifier() == 1234567890);
-		REQUIRE(chunk->GetPayloadProtocolIdentifierOrFragmentSequenceNumber() == 99887766);
+		// Bit B is set so we have PPID and we don't have FSN.
+		REQUIRE(chunk->GetPayloadProtocolIdentifier() == 99887766);
+		REQUIRE(chunk->GetFragmentSequenceNumber() == 0);
 		REQUIRE(chunk->HasUserData() == true);
 		REQUIRE(chunk->GetUserDataLength() == 3);
 		REQUIRE(chunk->GetUserData()[0] == 0xAB);
@@ -129,7 +136,9 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		REQUIRE(clonedChunk->GetTsn() == 0x11223344);
 		REQUIRE(clonedChunk->GetStreamIdentifier() == 5001);
 		REQUIRE(clonedChunk->GetMessageIdentifier() == 1234567890);
-		REQUIRE(clonedChunk->GetPayloadProtocolIdentifierOrFragmentSequenceNumber() == 99887766);
+		// Bit B is set so we have PPID and we don't have FSN.
+		REQUIRE(chunk->GetPayloadProtocolIdentifier() == 99887766);
+		REQUIRE(chunk->GetFragmentSequenceNumber() == 0);
 		REQUIRE(clonedChunk->HasUserData() == true);
 		REQUIRE(clonedChunk->GetUserDataLength() == 3);
 		REQUIRE(clonedChunk->GetUserData()[0] == 0xAB);
@@ -162,12 +171,14 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 
 		REQUIRE(chunk->GetI() == false);
 		REQUIRE(chunk->GetU() == false);
-		REQUIRE(chunk->GetI() == false);
-		REQUIRE(chunk->GetI() == false);
+		REQUIRE(chunk->GetB() == false);
+		REQUIRE(chunk->GetE() == false);
 		REQUIRE(chunk->GetTsn() == 0);
 		REQUIRE(chunk->GetStreamIdentifier() == 0);
 		REQUIRE(chunk->GetMessageIdentifier() == 0);
-		REQUIRE(chunk->GetPayloadProtocolIdentifierOrFragmentSequenceNumber() == 0);
+		// Bit B is not set so we don't have PPID and we have FSN.
+		REQUIRE(chunk->GetPayloadProtocolIdentifier() == 0);
+		REQUIRE(chunk->GetFragmentSequenceNumber() == 0);
 		REQUIRE(chunk->HasUserData() == false);
 		REQUIRE(chunk->GetUserDataLength() == 0);
 
@@ -178,7 +189,10 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		chunk->SetTsn(12345678);
 		chunk->SetStreamIdentifier(9988);
 		chunk->SetMessageIdentifier(1234);
-		chunk->SetPayloadProtocolIdentifierOrFragmentSequenceNumber(987654321);
+		chunk->SetFragmentSequenceNumber(987654321);
+
+		// Bit B is not set so cannot set PPID.
+		REQUIRE_THROWS_AS(chunk->SetPayloadProtocolIdentifier(1234), MediaSoupError);
 
 		// Verify that replacing the value works.
 		chunk->SetUserData(sctpCommon::DataBuffer + 1000, 3000);
@@ -217,7 +231,9 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		REQUIRE(chunk->GetTsn() == 12345678);
 		REQUIRE(chunk->GetStreamIdentifier() == 9988);
 		REQUIRE(chunk->GetMessageIdentifier() == 1234);
-		REQUIRE(chunk->GetPayloadProtocolIdentifierOrFragmentSequenceNumber() == 987654321);
+		// Bit B is not set so we don't have PPID and we have FSN.
+		REQUIRE(chunk->GetPayloadProtocolIdentifier() == 0);
+		REQUIRE(chunk->GetFragmentSequenceNumber() == 987654321);
 		REQUIRE(chunk->HasUserData() == true);
 		REQUIRE(chunk->GetUserDataLength() == 3);
 		REQUIRE(chunk->GetUserData()[0] == 0x00);
@@ -253,7 +269,9 @@ SCENARIO("SCTP I-Data Chunk (64)", "[serializable][sctp][chunk]")
 		REQUIRE(parsedChunk->GetTsn() == 12345678);
 		REQUIRE(parsedChunk->GetStreamIdentifier() == 9988);
 		REQUIRE(parsedChunk->GetMessageIdentifier() == 1234);
-		REQUIRE(parsedChunk->GetPayloadProtocolIdentifierOrFragmentSequenceNumber() == 987654321);
+		// Bit B is not set so we don't have PPID and we have FSN.
+		REQUIRE(chunk->GetPayloadProtocolIdentifier() == 0);
+		REQUIRE(chunk->GetFragmentSequenceNumber() == 987654321);
 		REQUIRE(parsedChunk->HasUserData() == true);
 		REQUIRE(parsedChunk->GetUserDataLength() == 3);
 		REQUIRE(parsedChunk->GetUserData()[0] == 0x00);


### PR DESCRIPTION
# Details

- Split `Get/SetPayloadProtocolIdentifierOrFragmentSequenceNumber()` into two methods.