### PR TITLE
Update required C++ STD version to 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Worker: Improve `Utils::Crypto::GetRandomUInt()` ([PR #1725](https://github.com/versatica/mediasoup/pull/1725).
 - Convert `WORKER_CLOSE` into a notification ([PR #1729](https://github.com/versatica/mediasoup/pull/1729).
 - Node tests: Replace `sctp` unmaintained library with `werift-sctp` ([PR #1732](https://github.com/versatica/mediasoup/pull/1732), thanks to @shinyoshiaki for his help with `werift-sctp`.
+- Worker: Require C++20 ([PR #1741](https://github.com/versatica/mediasoup/pull/1741).
 
 ### 3.19.17
 

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -2,7 +2,7 @@ project(
   'mediasoup-worker',
   ['c', 'cpp'],
   default_options : [
-    'cpp_std=c++17',
+    'cpp_std=c++20',
     'warning_level=1',
     'default_library=static',
   ],


### PR DESCRIPTION
# Details

- `meson.build`: Require `cpp_std=c++20`.
- Good for having [std::span](https://en.cppreference.com/w/cpp/container/span.html).
- And because AFAIR this is year 2026.