### PR TITLE
Fix "SCTP failed" if no DataChannel is created on a Transport with `enableSctp: true`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Convert `WORKER_CLOSE` into a notification ([PR #1729](https://github.com/versatica/mediasoup/pull/1729).
 - Node tests: Replace `sctp` unmaintained library with `werift-sctp` ([PR #1732](https://github.com/versatica/mediasoup/pull/1732), thanks to @shinyoshiaki for his help with `werift-sctp`.
 - Worker: Require C++20 ([PR #1741](https://github.com/versatica/mediasoup/pull/1741).
+- Fix "SCTP failed" if no DataChannel is created on a Transport with `enableSctp: true` ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX).
 
 ### 3.19.17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - Convert `WORKER_CLOSE` into a notification ([PR #1729](https://github.com/versatica/mediasoup/pull/1729).
 - Node tests: Replace `sctp` unmaintained library with `werift-sctp` ([PR #1732](https://github.com/versatica/mediasoup/pull/1732), thanks to @shinyoshiaki for his help with `werift-sctp`.
 - Worker: Require C++20 ([PR #1741](https://github.com/versatica/mediasoup/pull/1741).
-- Fix "SCTP failed" if no DataChannel is created on a Transport with `enableSctp: true` ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX).
+- Fix "SCTP failed" if no DataChannel is created on a Transport with `enableSctp: true` ([PR #1749](https://github.com/versatica/mediasoup/pull/1749).
 
 ### 3.19.17
 

--- a/node/src/test/test-werift-sctp.ts
+++ b/node/src/test/test-werift-sctp.ts
@@ -35,6 +35,9 @@ beforeEach(async () => {
 		numSctpStreams: { OS: 256, MIS: 256 },
 	});
 
+	// Create an explicit SCTP outgoing stream id.
+	ctx.sctpSendStreamId = 123;
+
 	ctx.sctpClient = SCTP.client(
 		createSctpUdpTransport(createSocket('udp4'), {
 			port: ctx.plainTransport.tuple.localPort,
@@ -42,24 +45,7 @@ beforeEach(async () => {
 		})
 	);
 
-	await ctx.sctpClient.start(5000);
-
-	let connectionTimeoutTimer: NodeJS.Timeout | undefined;
-
-	await Promise.race([
-		ctx.sctpClient.stateChanged.connected.asPromise(),
-		new Promise<void>((resolve, reject) => {
-			connectionTimeoutTimer = setTimeout(
-				() => reject(new Error('SCTP connection timeout')),
-				3000
-			);
-		}),
-	]);
-
-	clearTimeout(connectionTimeoutTimer);
-
-	// Create an explicit SCTP outgoing stream id.
-	ctx.sctpSendStreamId = 123;
+	ctx.sctpClient.start(5000);
 
 	// Create a DataProducer with the corresponding SCTP stream id.
 	ctx.dataProducer = await ctx.plainTransport.produceData({
@@ -76,6 +62,37 @@ beforeEach(async () => {
 	ctx.dataConsumer = await ctx.plainTransport.consumeData({
 		dataProducerId: ctx.dataProducer.id,
 	});
+
+	let connectionTimeoutTimer: NodeJS.Timeout | undefined;
+
+	await Promise.race([
+		// Wait for SCTP to become connected in both the PlainTransport and in the
+		// werift-sctp client.
+		Promise.all([
+			ctx.sctpClient.stateChanged.connected.asPromise(),
+			new Promise<void>((resolve, reject) => {
+				if (ctx.plainTransport?.sctpState === 'connected') {
+					resolve();
+				} else {
+					ctx.plainTransport?.on('sctpstatechange', state => {
+						if (state === 'connected') {
+							resolve();
+						} else if (state === 'failed' || state === 'closed') {
+							reject('SCTP connection in PlainTransport failed or was closed');
+						}
+					});
+				}
+			}),
+		]),
+		new Promise<void>((resolve, reject) => {
+			connectionTimeoutTimer = setTimeout(
+				() => reject(new Error('SCTP connection timeout')),
+				3000
+			);
+		}),
+	]);
+
+	clearTimeout(connectionTimeoutTimer);
 });
 
 afterEach(async () => {

--- a/node/src/test/test-werift-sctp.ts
+++ b/node/src/test/test-werift-sctp.ts
@@ -45,7 +45,9 @@ beforeEach(async () => {
 		})
 	);
 
-	ctx.sctpClient.start(5000);
+	// NOTE: We don't await it on purpose since we don't want to block here until
+	// SCTP connects.
+	void ctx.sctpClient.start(5000);
 
 	// Create a DataProducer with the corresponding SCTP stream id.
 	ctx.dataProducer = await ctx.plainTransport.produceData({
@@ -78,7 +80,11 @@ beforeEach(async () => {
 						if (state === 'connected') {
 							resolve();
 						} else if (state === 'failed' || state === 'closed') {
-							reject('SCTP connection in PlainTransport failed or was closed');
+							reject(
+								new Error(
+									'SCTP connection in PlainTransport failed or was closed'
+								)
+							);
 						}
 					});
 				}

--- a/worker/include/RTC/SctpAssociation.hpp
+++ b/worker/include/RTC/SctpAssociation.hpp
@@ -81,6 +81,7 @@ namespace RTC
 		flatbuffers::Offset<FBS::SctpParameters::SctpParameters> FillBuffer(
 		  flatbuffers::FlatBufferBuilder& builder) const;
 		void TransportConnected();
+		void TransportDisconnected();
 		SctpState GetState() const
 		{
 			return this->state;
@@ -89,18 +90,20 @@ namespace RTC
 		{
 			return this->sctpBufferedAmount;
 		}
-		void ProcessSctpData(const uint8_t* data, size_t len) const;
+		void ProcessSctpData(const uint8_t* data, size_t len);
 		void SendSctpMessage(
 		  RTC::DataConsumer* dataConsumer,
 		  const uint8_t* msg,
 		  size_t len,
 		  uint32_t ppid,
 		  onQueuedCallback* cb = nullptr);
+		void HandleDataProducer(RTC::DataProducer* dataProducer);
 		void HandleDataConsumer(RTC::DataConsumer* dataConsumer);
 		void DataProducerClosed(RTC::DataProducer* dataProducer);
 		void DataConsumerClosed(RTC::DataConsumer* dataConsumer);
 
 	private:
+		void MayConnect();
 		void ResetSctpStream(uint16_t streamId, StreamDirection direction) const;
 		void AddOutgoingStreams(bool force = false);
 
@@ -131,6 +134,12 @@ namespace RTC
 		struct socket* socket{ nullptr };
 		uint16_t desiredOs{ 0u };
 		size_t messageBufferLen{ 0u };
+		bool transportConnected{ false };
+		// Whether at least one SCTP stream (AKA DataProducer or DataConsumer) has
+		// already been created, no matter it's still alive.
+		bool firstStreamCreated{ false };
+		// Whether we have received STCP data from the remote peer.
+		bool sctpDataReceived{ false };
 		uint16_t lastSsnReceived{ 0u }; // Valid for us since no SCTP I-DATA support.
 	};
 } // namespace RTC

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -486,7 +486,7 @@ namespace RTC
 
 	inline bool PipeTransport::IsConnected() const
 	{
-		return this->tuple;
+		return this->tuple ? true : false;
 	}
 
 	inline bool PipeTransport::HasSrtp() const

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -6,6 +6,10 @@
 #include "MediaSoupErrors.hpp"
 #include "Settings.hpp"
 #include "Utils.hpp"
+// TODO: For testing purposes. Must be removed.
+#ifdef MS_SCTP_STACK
+#include "RTC/SCTP/packet/Packet.hpp"
+#endif
 
 namespace RTC
 {
@@ -913,8 +917,28 @@ namespace RTC
 
 		if (!IsConnected())
 		{
+			MS_WARN_TAG(sctp, "not connected, cannot send SCTP data");
+
 			return;
 		}
+
+// TODO: For testing purposes. Must be removed.
+#ifdef MS_SCTP_STACK
+		MS_DUMP(">>> sending SCTP packet...");
+
+		const auto* packet = RTC::SCTP::Packet::Parse(data, len);
+
+		if (packet)
+		{
+			packet->Dump();
+
+			delete packet;
+		}
+		else
+		{
+			MS_ABORT("RTC::SCTP::Packet::Parse() failed to parse sent SCTP data");
+		}
+#endif
 
 		this->tuple->Send(data, len);
 
@@ -1208,6 +1232,24 @@ namespace RTC
 
 			return;
 		}
+
+// TODO: For testing purposes. Must be removed.
+#ifdef MS_SCTP_STACK
+		MS_DUMP("<<< received SCTP packet...");
+
+		const auto* packet = RTC::SCTP::Packet::Parse(data, len);
+
+		if (packet)
+		{
+			packet->Dump();
+
+			delete packet;
+		}
+		else
+		{
+			MS_ABORT("RTC::SCTP::Packet::Parse() failed to parse received SCTP data");
+		}
+#endif
 
 		// Pass it to the parent transport.
 		RTC::Transport::ReceiveSctpData(data, len);

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -792,7 +792,7 @@ namespace RTC
 
 	inline bool PlainTransport::IsConnected() const
 	{
-		return this->tuple;
+		return this->tuple ? true : false;
 	}
 
 	inline bool PlainTransport::HasSrtp() const

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -290,60 +290,16 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// Just run the SCTP stack if our state is 'new'.
-		if (this->state != SctpState::NEW)
-		{
-			return;
-		}
+		this->transportConnected = true;
 
-		try
-		{
-			int ret;
-			struct sockaddr_conn rconn{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+		MayConnect();
+	}
 
-			std::memset(&rconn, 0, sizeof(rconn));
-			rconn.sconn_family = AF_CONN;
-			rconn.sconn_port   = htons(5000);
-			rconn.sconn_addr   = reinterpret_cast<void*>(this->id);
-#ifdef HAVE_SCONN_LEN
-			rconn.sconn_len = sizeof(rconn);
-#endif
+	void SctpAssociation::TransportDisconnected()
+	{
+		MS_TRACE();
 
-			ret = usrsctp_connect(this->socket, reinterpret_cast<struct sockaddr*>(&rconn), sizeof(rconn));
-
-			if (ret < 0 && errno != EINPROGRESS)
-			{
-				MS_THROW_ERROR("usrsctp_connect() failed: %s", std::strerror(errno));
-			}
-
-			// Disable MTU discovery.
-			sctp_paddrparams peerAddrParams{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
-
-			std::memset(&peerAddrParams, 0, sizeof(peerAddrParams));
-			std::memcpy(&peerAddrParams.spp_address, &rconn, sizeof(rconn));
-			peerAddrParams.spp_flags = SPP_PMTUD_DISABLE;
-
-			// The MTU value provided specifies the space available for chunks in the
-			// packet, so let's subtract the SCTP header size.
-			peerAddrParams.spp_pathmtu = SctpMtu - sizeof(struct sctp_common_header);
-
-			ret = usrsctp_setsockopt(
-			  this->socket, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, &peerAddrParams, sizeof(peerAddrParams));
-
-			if (ret < 0)
-			{
-				MS_THROW_ERROR("usrsctp_setsockopt(SCTP_PEER_ADDR_PARAMS) failed: %s", std::strerror(errno));
-			}
-
-			// Announce connecting state.
-			this->state = SctpState::CONNECTING;
-			this->listener->OnSctpAssociationConnecting(this);
-		}
-		catch (const MediaSoupError& /*error*/)
-		{
-			this->state = SctpState::FAILED;
-			this->listener->OnSctpAssociationFailed(this);
-		}
+		this->transportConnected = false;
 	}
 
 	flatbuffers::Offset<FBS::SctpParameters::SctpParameters> SctpAssociation::FillBuffer(
@@ -369,12 +325,17 @@ namespace RTC
 		  this->isDataChannel);
 	}
 
-	void SctpAssociation::ProcessSctpData(const uint8_t* data, size_t len) const
+	void SctpAssociation::ProcessSctpData(const uint8_t* data, size_t len)
 	{
 		MS_TRACE();
 
+		this->sctpDataReceived = true;
+
+		MayConnect();
+
 #if MS_LOG_DEV_LEVEL == 3
-		MS_DUMP_DATA(data, len);
+		// NOTE: Only uncomment this during local debugging if needed.
+		// MS_DUMP_DATA(data, len);
 #endif
 
 		usrsctp_conninput(reinterpret_cast<void*>(this->id), data, len, 0);
@@ -445,7 +406,7 @@ namespace RTC
 			// SCTP send buffer being full is legit, not an error.
 			if (sctpSendBufferFull)
 			{
-				MS_DEBUG_DEV(
+				MS_WARN_DEV(
 				  "error sending SCTP message [sid:%" PRIu16 ", ppid:%" PRIu32 ", message size:%zu]: %s",
 				  parameters.streamId,
 				  ppid,
@@ -481,9 +442,22 @@ namespace RTC
 		}
 	}
 
+	void SctpAssociation::HandleDataProducer(RTC::DataProducer* /*dataProducer*/)
+	{
+		MS_TRACE();
+
+		this->firstStreamCreated = true;
+
+		MayConnect();
+	}
+
 	void SctpAssociation::HandleDataConsumer(RTC::DataConsumer* dataConsumer)
 	{
 		MS_TRACE();
+
+		this->firstStreamCreated = true;
+
+		MayConnect();
 
 		auto streamId = dataConsumer->GetSctpStreamParameters().streamId;
 
@@ -520,6 +494,95 @@ namespace RTC
 
 		// Send SCTP_RESET_STREAMS to the remote.
 		ResetSctpStream(streamId, StreamDirection::OUTGOING);
+	}
+
+	void SctpAssociation::MayConnect()
+	{
+		MS_TRACE();
+
+		// Just run the SCTP stack if our state is 'new'.
+		// Notice that once MayConnect() is called (and the code below is executed),
+		// SCTP state will no longer be "NEW".
+		if (this->state != SctpState::NEW)
+		{
+			MS_DEBUG_DEV("ignoring because SCTP state is not NEW");
+
+			return;
+		}
+		// If the transport is not connected and has never been connected, don't do
+		// anything.
+		else if (!this->transportConnected)
+		{
+			MS_DEBUG_DEV("ignoring because transport is not connected");
+
+			return;
+		}
+		// If there are no SCTP streams yet and no SCTP data has been yet received
+		// from the remote peer, don't do anything.
+		// This is because the peer may never create a DataChannel so we shouldn't
+		// try to connect SCTP (SCTP INIT chunk, etc) since it will timeout and
+		// trigger "SCTP failed".
+		else if (!this->firstStreamCreated && !this->sctpDataReceived)
+		{
+			MS_DEBUG_DEV("ignoring because no SCTP stream has been created yet and no SCTP data has been received yet");
+
+			return;
+		}
+
+		MS_DEBUG_DEV("connecting SCTP");
+
+		try
+		{
+			int ret;
+			struct sockaddr_conn rconn{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+
+			std::memset(&rconn, 0, sizeof(rconn));
+			rconn.sconn_family = AF_CONN;
+			rconn.sconn_port   = htons(5000);
+			rconn.sconn_addr   = reinterpret_cast<void*>(this->id);
+#ifdef HAVE_SCONN_LEN
+			rconn.sconn_len = sizeof(rconn);
+#endif
+
+			ret = usrsctp_connect(this->socket, reinterpret_cast<struct sockaddr*>(&rconn), sizeof(rconn));
+
+			if (ret < 0 && errno != EINPROGRESS)
+			{
+				MS_THROW_ERROR("usrsctp_connect() failed: %s", std::strerror(errno));
+			}
+
+			// Disable MTU discovery.
+			sctp_paddrparams peerAddrParams{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+
+			std::memset(&peerAddrParams, 0, sizeof(peerAddrParams));
+			std::memcpy(&peerAddrParams.spp_address, &rconn, sizeof(rconn));
+			peerAddrParams.spp_flags = SPP_PMTUD_DISABLE;
+
+			// The MTU value provided specifies the space available for chunks in the
+			// packet, so let's subtract the SCTP header size.
+			peerAddrParams.spp_pathmtu = SctpMtu - sizeof(struct sctp_common_header);
+
+			ret = usrsctp_setsockopt(
+			  this->socket, IPPROTO_SCTP, SCTP_PEER_ADDR_PARAMS, &peerAddrParams, sizeof(peerAddrParams));
+
+			if (ret < 0)
+			{
+				MS_THROW_ERROR("usrsctp_setsockopt(SCTP_PEER_ADDR_PARAMS) failed: %s", std::strerror(errno));
+			}
+
+			// Announce connecting state.
+			MS_DEBUG_DEV("SCTP state switched to CONNECTING (in MayConnect())");
+
+			this->state = SctpState::CONNECTING;
+			this->listener->OnSctpAssociationConnecting(this);
+		}
+		catch (const MediaSoupError& /*error*/)
+		{
+			MS_DEBUG_DEV("SCTP state switched to FAILED (in MayConnect())");
+
+			this->state = SctpState::FAILED;
+			this->listener->OnSctpAssociationFailed(this);
+		}
 	}
 
 	void SctpAssociation::ResetSctpStream(uint16_t streamId, StreamDirection direction) const
@@ -655,7 +718,8 @@ namespace RTC
 		const uint8_t* data = static_cast<uint8_t*>(buffer);
 
 #if MS_LOG_DEV_LEVEL == 3
-		MS_DUMP_DATA(data, len);
+		// NOTE: Only uncomment this during local debugging if needed.
+		// MS_DUMP_DATA(data, len);
 #endif
 
 		this->listener->OnSctpAssociationSendData(this, data, len);
@@ -781,6 +845,8 @@ namespace RTC
 
 						if (this->state != SctpState::CONNECTED)
 						{
+							MS_DEBUG_DEV("SCTP state switched to CONNECTED (in SCTP_ASSOC_CHANGE)");
+
 							this->state = SctpState::CONNECTED;
 							this->listener->OnSctpAssociationConnected(this);
 						}
@@ -813,6 +879,8 @@ namespace RTC
 
 						if (this->state != SctpState::CLOSED)
 						{
+							MS_DEBUG_DEV("SCTP state switched to CLOSED (in SCTP_COMM_LOST)");
+
 							this->state = SctpState::CLOSED;
 							this->listener->OnSctpAssociationClosed(this);
 						}
@@ -839,6 +907,8 @@ namespace RTC
 
 						if (this->state != SctpState::CONNECTED)
 						{
+							MS_DEBUG_DEV("SCTP state switched to CONNECTED (in SCTP_RESTART)");
+
 							this->state = SctpState::CONNECTED;
 							this->listener->OnSctpAssociationConnected(this);
 						}
@@ -852,6 +922,8 @@ namespace RTC
 
 						if (this->state != SctpState::CLOSED)
 						{
+							MS_DEBUG_DEV("SCTP state switched to CLOSED (in SCTP_SHUTDOWN_COMP)");
+
 							this->state = SctpState::CLOSED;
 							this->listener->OnSctpAssociationClosed(this);
 						}
@@ -880,6 +952,8 @@ namespace RTC
 
 						if (this->state != SctpState::FAILED)
 						{
+							MS_DEBUG_DEV("SCTP state switched to FAILED (in SCTP_CANT_STR_ASSOC)");
+
 							this->state = SctpState::FAILED;
 							this->listener->OnSctpAssociationFailed(this);
 						}
@@ -933,6 +1007,8 @@ namespace RTC
 
 				if (this->state != SctpState::CLOSED)
 				{
+					MS_DEBUG_DEV("SCTP state switched to CLOSED (in SCTP_SHUTDOWN_EVENT)");
+
 					this->state = SctpState::CLOSED;
 					this->listener->OnSctpAssociationClosed(this);
 				}

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -513,7 +513,7 @@ namespace RTC
 		// anything.
 		else if (!this->transportConnected)
 		{
-			MS_DEBUG_DEV("ignoring because transport is not connected");
+			MS_DEBUG_DEV("transport is not connected, ignoring");
 
 			return;
 		}
@@ -525,12 +525,12 @@ namespace RTC
 		else if (!this->firstStreamCreated && !this->sctpDataReceived)
 		{
 			MS_DEBUG_DEV(
-			  "ignoring because no SCTP stream has been created yet and no SCTP data has been received yet");
+			  "no SCTP stream has been created yet and no SCTP data has been received yet, ignoring");
 
 			return;
 		}
 
-		MS_DEBUG_DEV("connecting SCTP");
+		MS_DEBUG_TAG(sctp, "connecting SCTP");
 
 		try
 		{

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -505,7 +505,7 @@ namespace RTC
 		// SCTP state will no longer be "NEW".
 		if (this->state != SctpState::NEW)
 		{
-			MS_DEBUG_DEV("ignoring because SCTP state is not NEW");
+			MS_DEBUG_DEV("SCTP state is not NEW, ignoring");
 
 			return;
 		}

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -524,7 +524,8 @@ namespace RTC
 		// trigger "SCTP failed".
 		else if (!this->firstStreamCreated && !this->sctpDataReceived)
 		{
-			MS_DEBUG_DEV("ignoring because no SCTP stream has been created yet and no SCTP data has been received yet");
+			MS_DEBUG_DEV(
+			  "ignoring because no SCTP stream has been created yet and no SCTP data has been received yet");
 
 			return;
 		}

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1139,6 +1139,12 @@ namespace RTC
 
 				request->Accept(FBS::Response::Body::DataProducer_DumpResponse, dumpOffset);
 
+				if (dataProducer->GetType() == RTC::DataProducer::Type::SCTP)
+				{
+					// Tell to the SCTP association.
+					this->sctpAssociation->HandleDataProducer(dataProducer);
+				}
+
 				break;
 			}
 
@@ -1532,6 +1538,12 @@ namespace RTC
 			auto* dataConsumer = kv.second;
 
 			dataConsumer->TransportDisconnected();
+		}
+
+		// Tell the SctpAssociation.
+		if (this->sctpAssociation)
+		{
+			this->sctpAssociation->TransportDisconnected();
 		}
 
 		// Stop the RTCP timer.

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -667,6 +667,12 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		// Dont' start DTLS handshake if ICE is not connected/completed.
+		if (!this->iceServer->GetSelectedTuple())
+		{
+			return;
+		}
+
 		// Do nothing if we have the same local DTLS role as the DTLS transport.
 		// NOTE: local role in DTLS transport can be NONE, but not ours.
 		if (this->dtlsTransport->GetLocalRole() == this->dtlsRole)


### PR DESCRIPTION
# Details

- Fixes https://github.com/versatica/mediasoup/issues/1748
- Bonus: Don't even try to start DTLS handshake if ICE is not yet connected/completed.