### PR TITLE
SCTP part 5

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -62,10 +62,6 @@ jobs:
             cc: gcc
             cxx: g++
             meson_args: '-Db_sanitize=thread'
-          - os: macos-14
-            node: 22
-            cc: clang
-            cxx: clang++
           - os: macos-15
             node: 24
             cc: clang

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -6,11 +6,19 @@ on:
     paths:
       - 'node/**'
       - 'worker/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'npm-scripts.mjs'
       - '.github/workflows/mediasoup-node.yaml'
   pull_request:
     paths:
       - 'node/**'
       - 'worker/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'tsconfig.json'
+      - 'npm-scripts.mjs'
       - '.github/workflows/mediasoup-node.yaml'
   workflow_dispatch:
 

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -6,11 +6,17 @@ on:
     paths:
       - 'rust/**'
       - 'worker/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
       - '.github/workflows/mediasoup-rust.yaml'
   pull_request:
     paths:
       - 'rust/**'
       - 'worker/**'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
+      - 'rust-toolchain.toml'
       - '.github/workflows/mediasoup-rust.yaml'
   workflow_dispatch:
 

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -30,7 +30,6 @@ jobs:
         build:
           - os: ubuntu-24.04
           - os: ubuntu-24.04-arm
-          - os: macos-14
           - os: macos-15
           - os: windows-2022
           - os: windows-2025

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -114,16 +114,6 @@ jobs:
             run-test-asan-address: false
             run-test-asan-undefined: false
             run-test-asan-thread: false
-          - os: macos-14
-            cc: clang
-            cxx: clang++
-            build-type: Release
-            pip-break-system-packages: true
-            run-lint: false
-            run-test: true
-            run-test-asan-address: false
-            run-test-asan-undefined: false
-            run-test-asan-thread: false
           - os: macos-15
             cc: clang
             cxx: clang++

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -5,10 +5,14 @@ on:
     branches: [v3]
     paths:
       - 'worker/**'
+      - 'worker/scripts/package.json'
+      - 'worker/scripts/package-lock.json'
       - '.github/workflows/mediasoup-worker.yaml'
   pull_request:
     paths:
       - 'worker/**'
+      - 'worker/scripts/package.json'
+      - 'worker/scripts/package-lock.json'
       - '.github/workflows/mediasoup-worker.yaml'
   workflow_dispatch:
 

--- a/worker/fuzzer/src/fuzzer.cpp
+++ b/worker/fuzzer/src/fuzzer.cpp
@@ -5,7 +5,9 @@
 #include "DepLibUV.hpp"
 #include "DepLibWebRTC.hpp"
 #include "DepOpenSSL.hpp"
+#ifndef MS_SCTP_STACK
 #include "DepUsrSCTP.hpp"
+#endif
 #include "FuzzerUtils.hpp"
 #include "Settings.hpp"
 #include "Utils.hpp"
@@ -145,7 +147,9 @@ namespace
 		DepLibUV::ClassInit();
 		DepOpenSSL::ClassInit();
 		DepLibSRTP::ClassInit();
+#ifndef MS_SCTP_STACK
 		DepUsrSCTP::ClassInit();
+#endif
 		DepLibWebRTC::ClassInit();
 		Utils::Crypto::ClassInit();
 		RTC::DtlsTransport::ClassInit();

--- a/worker/include/RTC/DataConsumer.hpp
+++ b/worker/include/RTC/DataConsumer.hpp
@@ -102,7 +102,7 @@ namespace RTC
 		void SctpAssociationBufferedAmount(uint32_t bufferedAmount);
 		void SctpAssociationSendBufferFull();
 		void DataProducerClosed();
-		void SendMessage(
+		bool SendMessage(
 		  const uint8_t* msg,
 		  size_t len,
 		  uint32_t ppid,

--- a/worker/include/RTC/DataConsumer.hpp
+++ b/worker/include/RTC/DataConsumer.hpp
@@ -11,9 +11,11 @@
 
 namespace RTC
 {
+#ifndef MS_SCTP_STACK
 	// Define class here such that we can use it even though we don't know what it looks like yet
 	// (this is to avoid circular dependencies).
 	class SctpAssociation;
+#endif
 
 	class DataConsumer : public Channel::ChannelSocket::RequestHandler
 	{
@@ -48,7 +50,9 @@ namespace RTC
 		  RTC::Shared* shared,
 		  const std::string& id,
 		  const std::string& dataProducerId,
+#ifndef MS_SCTP_STACK
 		  RTC::SctpAssociation* sctpAssociation,
+#endif
 		  RTC::DataConsumer::Listener* listener,
 		  const FBS::Transport::ConsumeDataRequest* data,
 		  size_t maxMessageSize);
@@ -118,7 +122,9 @@ namespace RTC
 	private:
 		// Passed by argument.
 		RTC::Shared* shared{ nullptr };
+#ifndef MS_SCTP_STACK
 		RTC::SctpAssociation* sctpAssociation{ nullptr };
+#endif
 		RTC::DataConsumer::Listener* listener{ nullptr };
 		size_t maxMessageSize{ 0u };
 		// Others.

--- a/worker/include/RTC/DirectTransport.hpp
+++ b/worker/include/RTC/DirectTransport.hpp
@@ -36,7 +36,7 @@ namespace RTC
 		  size_t len,
 		  uint32_t ppid,
 		  onQueuedCallback* cb = nullptr) override;
-		void SendSctpData(const uint8_t* data, size_t len) override;
+		bool SendSctpData(const uint8_t* data, size_t len) override;
 		void RecvStreamClosed(uint32_t ssrc) override;
 		void SendStreamClosed(uint32_t ssrc) override;
 

--- a/worker/include/RTC/DtlsTransport.hpp
+++ b/worker/include/RTC/DtlsTransport.hpp
@@ -151,7 +151,8 @@ namespace RTC
 		{
 			return this->localRole;
 		}
-		void SendApplicationData(const uint8_t* data, size_t len);
+		// Returns a boolean indicating whether the data could be sent.
+		bool SendApplicationData(const uint8_t* data, size_t len);
 		// This method must be public since it's called within an OpenSSL callback.
 		void SendDtlsData(const uint8_t* data, size_t len);
 

--- a/worker/include/RTC/PipeTransport.hpp
+++ b/worker/include/RTC/PipeTransport.hpp
@@ -54,7 +54,7 @@ namespace RTC
 		  size_t len,
 		  uint32_t ppid,
 		  onQueuedCallback* cb = nullptr) override;
-		void SendSctpData(const uint8_t* data, size_t len) override;
+		bool SendSctpData(const uint8_t* data, size_t len) override;
 		void RecvStreamClosed(uint32_t ssrc) override;
 		void SendStreamClosed(uint32_t ssrc) override;
 		void OnPacketReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len, size_t bufferLen);

--- a/worker/include/RTC/PlainTransport.hpp
+++ b/worker/include/RTC/PlainTransport.hpp
@@ -48,7 +48,7 @@ namespace RTC
 		  size_t len,
 		  uint32_t ppid,
 		  onQueuedCallback* cb = nullptr) override;
-		void SendSctpData(const uint8_t* data, size_t len) override;
+		bool SendSctpData(const uint8_t* data, size_t len) override;
 		void RecvStreamClosed(uint32_t ssrc) override;
 		void SendStreamClosed(uint32_t ssrc) override;
 		void OnPacketReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len, size_t bufferLen);

--- a/worker/include/RTC/SCTP/TODO_SCTP.md
+++ b/worker/include/RTC/SCTP/TODO_SCTP.md
@@ -2,17 +2,13 @@
 
 ## Related to mediasoup SCTP implementation
 
-- Add `AssociationListener::OnAssociationFailed()`.
-
 - Why the hell does `DataConsumer` have a `RTC::SctpAssociation* sctpAssociation` member?
 
 - Probably add many more fields in `SctpOptions` given to the `Association` in `Transport.cpp`.
 
-- Do we need to pass `isDataChannel` to `SCTP::Association` constructor as we do in former `SctpAssociation`?
+- We to pass `isDataChannel` to `SCTP::Association` constructor as we do in former `SctpAssociation`. Also use it in `Association::FillBuffer()`.
 
-- In `Transport::FillBuffer()` we need `this->sctpAssociation->FillBuffer(builder)`.
-
-- There is no association state "NEW" or "FAILED" anymore, and this affects `Transport.cpp` and specially FBS types.
+- In `Association::FillBuffer()` we should not pass `this->sctpOptions.maxOutboundStreams/maxInboundStreams` but the current values (they may have been modified via "reconfig").
 
 - Look for "TODO: SCTP" and `MS_SCTP_STACK`.
 

--- a/worker/include/RTC/SCTP/TODO_SCTP.md
+++ b/worker/include/RTC/SCTP/TODO_SCTP.md
@@ -4,13 +4,23 @@
 
 - Why the hell does `DataConsumer` have a `RTC::SctpAssociation* sctpAssociation` member?
 
+- `OnAssociationFailed()` and `OnAssociationClosed()` should report an error (if present) to JS.
+
 - Probably add many more fields in `SctpOptions` given to the `Association` in `Transport.cpp`.
 
-- We to pass `isDataChannel` to `SCTP::Association` constructor as we do in former `SctpAssociation`. Also use it in `Association::FillBuffer()`.
+- We need to pass `isDataChannel` to `SCTP::Association` constructor as we do in former `SctpAssociation`. Also use it in `Association::FillBuffer()`.
 
 - In `Association::FillBuffer()` we should not pass `this->sctpOptions.maxOutboundStreams/maxInboundStreams` but the current values (they may have been modified via "reconfig").
 
-- We must call `association->Connect()` somewhere!
+- We must call `association->Connect()` somewhere when appropriate! Probably same as the `MayConnect()` in former `SctpAssociation`.
+
+- Test Chrome with I-DATA (message interleaving):
+
+  ```
+  open -a "Google Chrome Canary" \
+    --args \
+    --force-fieldtrials="WebRTC-DataChannelMessageInterleaving/Enabled/"
+  ```
 
 - Look for "TODO: SCTP" and `MS_SCTP_STACK`.
 

--- a/worker/include/RTC/SCTP/TODO_SCTP.md
+++ b/worker/include/RTC/SCTP/TODO_SCTP.md
@@ -2,14 +2,17 @@
 
 ## Related to mediasoup SCTP implementation
 
-- Missing `Association::IsSctp()`. Use it in `iceCommon.hpp` (tests). Should/may check `IsSctp()` in `WebRtcTransport::OnDtlsTransportApplicationDataReceived()` same as we do in `PlainTransport::OnPacketReceived()`.
-  - _NOTE:_ Maybe we don't need it at all since `association->ReceiveSctpData()` already checks it. And we can only check it if we force ports 5000.
-
 - Why the hell does `DataConsumer` have a `RTC::SctpAssociation* sctpAssociation` member?
 
 - Probably add many more fields in `SctpOptions` given to the `Association` in `Transport.cpp`.
 
 - Do we need to pass `isDataChannel` to `SCTP::Association` constructor as we do in former `SctpAssociation`?
+
+- In `Transport::FillBuffer()` we need `this->sctpAssociation->FillBuffer(builder)`.
+
+- There is no association state "NEW" or "FAILED" anymore, and this affects `Transport.cpp` and specially FBS types.
+
+- Look for "TODO: SCTP" and `MS_SCTP_STACK`.
 
 ## Related to dcsctp
 

--- a/worker/include/RTC/SCTP/TODO_SCTP.md
+++ b/worker/include/RTC/SCTP/TODO_SCTP.md
@@ -2,8 +2,6 @@
 
 ## Related to mediasoup SCTP implementation
 
-- `Chunk::BuildParameterInPlace/BuildErrorCauseInPlace()` should set a flag in the Chunk and throw if called again before previous parameter/errorCause was `consolidated.
-
 - Why the hell does `DataConsumer` have a `RTC::SctpAssociation* sctpAssociation` member?
 
 - Probably add many more fields in `SctpOptions` given to the `Association` in `Transport.cpp`.

--- a/worker/include/RTC/SCTP/TODO_SCTP.md
+++ b/worker/include/RTC/SCTP/TODO_SCTP.md
@@ -2,17 +2,15 @@
 
 ## Related to mediasoup SCTP implementation
 
+- Missing `Association::IsSctp()`. Use it in `iceCommon.hpp` (tests). Should/may check `IsSctp()` in `WebRtcTransport::OnDtlsTransportApplicationDataReceived()` same as we do in `PlainTransport::OnPacketReceived()`.
+  - _NOTE:_ Maybe we don't need it at all since `association->ReceiveSctpData()` already checks it. And we can only check it if we force ports 5000.
+
+- Why the hell does `DataConsumer` have a `RTC::SctpAssociation* sctpAssociation` member?
+
+- Probably add many more fields in `SctpOptions` given to the `Association` in `Transport.cpp`.
+
+- Do we need to pass `isDataChannel` to `SCTP::Association` constructor as we do in former `SctpAssociation`?
+
 ## Related to dcsctp
 
 - Investigate `DcSctpSocket::HandleTimeout()` which is only called from `media/sctp/dcsctp_transport.cc`.
-
-## Flow
-
-1. A DTLS packet arrives to `WebRtcTransport` where we check `DtlsTransport::IsDtls()`).
-2. It calls `OnDtlsDataReceived()` that calls `this->dtlsTransport->ProcessDtlsData()`.
-3. It calls `this->listener->OnDtlsTransportApplicationDataReceived()` in `WebRtcTransport`.
-4. It calls `Transport::ReceiveSctpData()` that calls `this->sctpAssociation->ProcessSctpData()`.
-
-However, in step 4 `WebRtcTransport::OnDtlsTransportApplicationDataReceived()` should instead call `RTC::SCTP::Packet::parse()` and `Transport::ReceiveSctpPacket()` with a `SCTP::Packet` instance instead than `data` and `len`. In fact it should be named `Transport::ReceiveSctpPacket()` instead of the current `Transport::ReceiveSctpData()`.
-
-Same in `PipeTransport` and `PlainTransport`.

--- a/worker/include/RTC/SCTP/TODO_SCTP.md
+++ b/worker/include/RTC/SCTP/TODO_SCTP.md
@@ -10,6 +10,8 @@
 
 - In `Association::FillBuffer()` we should not pass `this->sctpOptions.maxOutboundStreams/maxInboundStreams` but the current values (they may have been modified via "reconfig").
 
+- We must call `association->Connect()` somewhere!
+
 - Look for "TODO: SCTP" and `MS_SCTP_STACK`.
 
 ## Related to dcsctp

--- a/worker/include/RTC/SCTP/TODO_SCTP.md
+++ b/worker/include/RTC/SCTP/TODO_SCTP.md
@@ -2,6 +2,8 @@
 
 ## Related to mediasoup SCTP implementation
 
+- Add `AssociationListener::OnAssociationFailed()`.
+
 - Why the hell does `DataConsumer` have a `RTC::SctpAssociation* sctpAssociation` member?
 
 - Probably add many more fields in `SctpOptions` given to the `Association` in `Transport.cpp`.

--- a/worker/include/RTC/SCTP/TODO_SCTP.md
+++ b/worker/include/RTC/SCTP/TODO_SCTP.md
@@ -2,6 +2,8 @@
 
 ## Related to mediasoup SCTP implementation
 
+- `Chunk::BuildParameterInPlace/BuildErrorCauseInPlace()` should set a flag in the Chunk and throw if called again before previous parameter/errorCause was `consolidated.
+
 - Why the hell does `DataConsumer` have a `RTC::SctpAssociation* sctpAssociation` member?
 
 - Probably add many more fields in `SctpOptions` given to the `Association` in `Transport.cpp`.

--- a/worker/include/RTC/SCTP/association/Association.hpp
+++ b/worker/include/RTC/SCTP/association/Association.hpp
@@ -288,7 +288,7 @@ namespace RTC
 			 * message will be queued.
 			 *
 			 * This has identical semantics to `SendMessage()', except that it may
-			 * coalesce many messages into a single SCTP packet if they would fit.
+			 * coalesce many messages into a single SCTP Packet if they would fit.
 			 *
 			 * @remarks
 			 * - Same as in `SendMessage()`.
@@ -297,13 +297,9 @@ namespace RTC
 			  std::span<Message> messages, const SendMessageOptions& sendMessageOptions) override;
 
 			/**
-			 * Receive a Packet received from the remote peer.
-			 *
-			 * @remarks
-			 * - The caller is responsible of freeing given Packet once this method
-			 *   returns.
+			 * Receives SCTP data (hopefully an SCTP Packet) from the remote peer.
 			 */
-			void ReceivePacket(const Packet* receivedPacket) override;
+			void ReceiveSctpData(const uint8_t* data, size_t len) override;
 
 		private:
 			void InternalClose(Types::ErrorKind errorKind, const std::string_view& message);

--- a/worker/include/RTC/SCTP/association/Association.hpp
+++ b/worker/include/RTC/SCTP/association/Association.hpp
@@ -59,6 +59,7 @@ namespace RTC
 			 */
 			enum class State : uint8_t
 			{
+				NEW,
 				CLOSED,
 				COOKIE_WAIT,
 				// NOTE: TCB is valid in these states:
@@ -78,6 +79,11 @@ namespace RTC
 
 				switch (state)
 				{
+					case State::NEW:
+					{
+						return "NEW";
+					}
+
 					case State::CLOSED:
 					{
 						return "CLOSED";
@@ -452,7 +458,7 @@ namespace RTC
 			// AssociationDeferredListener which inherits from AssociationListener.
 			AssociationDeferredListener listener;
 			// SCTP association internal state.
-			State state{ State::CLOSED };
+			State state{ State::NEW };
 			// Private metrics.
 			AssociationPrivateMetrics privateMetrics{};
 			// The actual send queue implementation. As data can be sent before the

--- a/worker/include/RTC/SCTP/association/Association.hpp
+++ b/worker/include/RTC/SCTP/association/Association.hpp
@@ -37,6 +37,7 @@
 #include "RTC/SCTP/public/SctpOptions.hpp"
 #include "RTC/SCTP/public/SctpTypes.hpp"
 #include "handles/BackoffTimerHandle.hpp"
+#include <FBS/sctpParameters.h>
 #include <span>
 #include <string_view>
 #include <vector>
@@ -169,7 +170,11 @@ namespace RTC
 
 			~Association() override;
 
+		public:
 			void Dump(int indentation = 0) const override;
+
+			flatbuffers::Offset<FBS::SctpParameters::SctpParameters> FillBuffer(
+			  flatbuffers::FlatBufferBuilder& builder) const override;
 
 			Types::AssociationState GetAssociationState() const override;
 

--- a/worker/include/RTC/SCTP/association/Association.hpp
+++ b/worker/include/RTC/SCTP/association/Association.hpp
@@ -159,7 +159,7 @@ namespace RTC
 			};
 
 		public:
-			explicit Association(const SctpOptions& sctpOptions, AssociationListener& listener);
+			explicit Association(const SctpOptions& sctpOptions, AssociationListener* listener);
 
 			~Association() override;
 
@@ -262,7 +262,7 @@ namespace RTC
 			Types::ResetStreamsStatus ResetStreams(std::span<const uint16_t> outboundStreamIds) override;
 
 			/**
-			 * Sends a SCTP message using the provided send options. Sending a message
+			 * Sends an SCTP message using the provided send options. Sending a message
 			 * is an asynchronous operation, and the `OnAssociationError()` callback
 			 * may be invoked to indicate any errors in sending the message.
 			 *

--- a/worker/include/RTC/SCTP/association/AssociationDeferredListener.hpp
+++ b/worker/include/RTC/SCTP/association/AssociationDeferredListener.hpp
@@ -64,13 +64,13 @@ namespace RTC
 
 			void OnAssociationConnected() override;
 
-			void OnAssociationClosed() override;
+			void OnAssociationFailed(Types::ErrorKind errorKind, std::string_view errorMessage) override;
+
+			void OnAssociationClosed(Types::ErrorKind errorKind, std::string_view errorMessage) override;
 
 			void OnAssociationRestarted() override;
 
 			void OnAssociationError(Types::ErrorKind errorKind, std::string_view errorMessage) override;
-
-			void OnAssociationAborted(Types::ErrorKind errorKind, std::string_view errorMessage) override;
 
 			void OnAssociationMessageReceived(Message message) override;
 

--- a/worker/include/RTC/SCTP/association/AssociationDeferredListener.hpp
+++ b/worker/include/RTC/SCTP/association/AssociationDeferredListener.hpp
@@ -60,6 +60,8 @@ namespace RTC
 			/* Pure virtual methods inherited from RTC::STCP::AssociationListener. */
 			bool OnAssociationSendData(const uint8_t* data, size_t len) override;
 
+			void OnAssociationConnecting() override;
+
 			void OnAssociationConnected() override;
 
 			void OnAssociationClosed() override;

--- a/worker/include/RTC/SCTP/association/AssociationDeferredListener.hpp
+++ b/worker/include/RTC/SCTP/association/AssociationDeferredListener.hpp
@@ -64,7 +64,7 @@ namespace RTC
 
 			void OnAssociationClosed() override;
 
-			void OnAssociationConnectionRestarted() override;
+			void OnAssociationRestarted() override;
 
 			void OnAssociationError(Types::ErrorKind errorKind, std::string_view errorMessage) override;
 

--- a/worker/include/RTC/SCTP/association/AssociationDeferredListener.hpp
+++ b/worker/include/RTC/SCTP/association/AssociationDeferredListener.hpp
@@ -2,7 +2,6 @@
 #define MS_RTC_SCTP_ASSOCIATION_DEFERRED_LISTENER_HPP
 
 #include "common.hpp"
-#include "RTC/SCTP/packet/Packet.hpp"
 #include "RTC/SCTP/public/AssociationListener.hpp"
 #include "RTC/SCTP/public/Message.hpp"
 #include "RTC/SCTP/public/SctpTypes.hpp"
@@ -59,7 +58,7 @@ namespace RTC
 
 		public:
 			/* Pure virtual methods inherited from RTC::STCP::AssociationListener. */
-			bool OnAssociationSendPacket(Packet* packet) override;
+			bool OnAssociationSendData(const uint8_t* data, size_t len) override;
 
 			void OnAssociationConnected() override;
 

--- a/worker/include/RTC/SCTP/association/AssociationDeferredListener.hpp
+++ b/worker/include/RTC/SCTP/association/AssociationDeferredListener.hpp
@@ -46,10 +46,10 @@ namespace RTC
 			// variant can hold all cases of stored data.
 			using CallbackData = std::variant<std::monostate, Message, Error, StreamReset, uint16_t>;
 
-			using Callback = std::function<void(CallbackData, AssociationListener&)>;
+			using Callback = std::function<void(CallbackData, AssociationListener*)>;
 
 		public:
-			explicit AssociationDeferredListener(AssociationListener& innerListener);
+			explicit AssociationDeferredListener(AssociationListener* innerListener);
 
 		private:
 			void SetReady();
@@ -84,7 +84,7 @@ namespace RTC
 			void OnAssociationTotalBufferedAmountLow() override;
 
 		private:
-			AssociationListener& innerListener;
+			AssociationListener* innerListener;
 			bool ready{ false };
 			std::vector<std::pair<Callback, CallbackData>> deferredCallbacks;
 		};

--- a/worker/include/RTC/SCTP/packet/Chunk.hpp
+++ b/worker/include/RTC/SCTP/packet/Chunk.hpp
@@ -261,10 +261,15 @@ namespace RTC
 			 *
 			 * @remarks
 			 * - Once this method is called, the caller may want to free the original
-			 *   given Parameter (otherwise it will leak since the manages a clone of
-			 *   it).
+			 *   given Parameter (otherwise it will leak since the Chunk manages a clone
+			 *   of it).
 			 *
-			 * @throw MediaSoupError - If the Chunk subclass cannot have Parameters.
+			 * @throw
+			 * - MediaSoupError - If the Chunk subclass cannot have Parameters.
+			 * - MediaSoupError - If `BuildParameterInPlace()` or
+			 *   `BuildErrorCauseInPlace()` was called before and the caller didn't
+			 *   invoke `Consolidate()` on the returned Parameter or Error Cause yet.
+
 			 */
 			virtual void AddParameter(const Parameter* parameter) final;
 
@@ -276,15 +281,19 @@ namespace RTC
 			 *
 			 * @returns Pointer of the created Parameter specific class.
 			 *
-			 * @throw MediaSoupError - If the Chunk subclass cannot have Parameters.
+			 * @throw
+			 * - MediaSoupError - If the Chunk subclass cannot have Parameters.
+			 * - MediaSoupError - If `BuildParameterInPlace()` or
+			 *   `BuildErrorCauseInPlace()` was called before and the caller didn't
+			 *   invoke `Consolidate()` on the returned Parameter or Error Cause yet.
 			 *
 			 * @remarks
 			 * - The caller MUST invoke `Consolidate()` once the Parameter is
 			 *   completed.
-			 * - The caller MUST NOT call `BuildChunkInPlace()` while other Parameter
-			 *   is in progress.
 			 * - The caller MUST NOT free the obtained Parameter pointer since it's
 			 *   now part of the Chunk.
+			 * - The caller MUST free the obtained Parameter only in case the
+			 *   `Consolidate()` method on the Parameter throws.
 			 * - Method implemented in header file due to C++ template usage.
 			 *
 			 * @example
@@ -297,6 +306,7 @@ namespace RTC
 			T* BuildParameterInPlace()
 			{
 				AssertCanHaveParameters();
+				AssertDoesNotNeedConsolidation();
 
 				// The new Parameter will be added after other Parameters in the Chunk,
 				// this is, at the end of the Chunk, whose length we know it's padded to
@@ -374,7 +384,11 @@ namespace RTC
 			 *   given Error Cause (otherwise it will leak since the Chunk manages a
 			 *   clone of it).
 			 *
-			 * @throw MediaSoupError - If the Chunk subclass cannot have Error Causes.
+			 * @throw
+			 * - MediaSoupError - If the Chunk subclass cannot have Error Causes.
+			 * - MediaSoupError - If `BuildParameterInPlace()` or
+			 *   `BuildErrorCauseInPlace()` was called before and the caller didn't
+			 *   invoke `Consolidate()` on the returned Parameter or Error Cause yet.
 			 */
 			virtual void AddErrorCause(const ErrorCause* errorCause) final;
 
@@ -387,15 +401,19 @@ namespace RTC
 			 *
 			 * @returns Pointer of the created Error Cause specific class.
 			 *
-			 * @throw MediaSoupError - If the Chunk subclass cannot have Error Causes.
+			 * @throw
+			 * - MediaSoupError - If the Chunk subclass cannot have Error Causes.
+			 * - MediaSoupError - If `BuildParameterInPlace()` or
+			 *   `BuildErrorCauseInPlace()` was called before and the caller didn't
+			 *   invoke `Consolidate()` on the returned Parameter or Error Cause yet.
 			 *
 			 * @remarks
 			 * - The caller MUST invoke `Consolidate()` once the Error Cause is
 			 *   completed.
-			 * - The caller MUST NOT call `BuildChunkInPlace()` while other Error
-			 *   Cause is in progress.
 			 * - The caller MUST NOT free the obtained Error Cause pointer since it's
 			 *   now part of the Chunk.
+			 * - The caller MUST free the obtained Error Cause only in case the
+			 *   `Consolidate()` method on the Error Cause throws.
 			 * - Method implemented in header file due to C++ template usage.
 			 *
 			 * @example
@@ -408,6 +426,7 @@ namespace RTC
 			T* BuildErrorCauseInPlace()
 			{
 				AssertCanHaveErrorCauses();
+				AssertDoesNotNeedConsolidation();
 
 				// The new Error Cause will be added after other Error Causes in the
 				// Chunk, this is, at the end of the Chunk, whose length we know it's
@@ -426,6 +445,16 @@ namespace RTC
 				HandleInPlaceErrorCause(errorCause);
 
 				return errorCause;
+			}
+
+			/**
+			 * Whether `BuildParameterInPlace()` or `BuildErrorCauseInPlace()` was
+			 * called before and the caller didn't invoke `Consolidate()` on the
+			 * returned Parameter or Error Cause yet.
+			 */
+			virtual bool NeedsConsolidation() const final
+			{
+				return this->needsConsolidation;
 			}
 
 		protected:
@@ -557,8 +586,8 @@ namespace RTC
 			 *
 			 * @return True if no error happened while parsing Parameters.
 			 *
-			 * @throw MediaSoupError - If the Chunk subclass cannot have Chunk
-			 *   Parameters.
+			 * @throw
+			 * - MediaSoupError - If the Chunk subclass cannot have Chunk Parameters.
 			 */
 			virtual bool ParseParameters() final;
 
@@ -573,8 +602,8 @@ namespace RTC
 			 *
 			 * @return True if no error happened while parsing Error Causes.
 			 *
-			 * @throw MediaSoupError - If the Chunk subclass cannot have Chunk
-			 *   Parameters.
+			 * @throw
+			 * - MediaSoupError - If the Chunk subclass cannot have Chunk Parameters.
 			 */
 			virtual bool ParseErrorCauses() final;
 
@@ -611,11 +640,17 @@ namespace RTC
 
 			virtual void AssertCanHaveErrorCauses() const final;
 
+			virtual void AssertDoesNotNeedConsolidation() const final;
+
 		private:
 			// Parameters.
 			std::vector<Parameter*> parameters;
 			// Error Causes.
 			std::vector<ErrorCause*> errorCauses;
+			// Whether `BuildParameterInPlace()` or `BuildErrorCauseInPlace()` was
+			// called and the caller didn't invoke `Consolidate()` on the returned
+			// Parameter or Error Cause yet.
+			bool needsConsolidation{ false };
 		};
 	} // namespace SCTP
 } // namespace RTC

--- a/worker/include/RTC/SCTP/packet/Chunk.hpp
+++ b/worker/include/RTC/SCTP/packet/Chunk.hpp
@@ -208,12 +208,9 @@ namespace RTC
 
 			/**
 			 * Whether this type of Chunk can have Parameters. Subclasses must
-			 * override this method if they can have Parameters.
+			 * override this method.
 			 */
-			virtual bool CanHaveParameters() const
-			{
-				return false;
-			}
+			virtual bool CanHaveParameters() const = 0;
 
 			virtual bool HasParameters() const final
 			{
@@ -321,12 +318,9 @@ namespace RTC
 
 			/**
 			 * Whether this type of Chunk can have Error Causes. Subclasses must
-			 * override this method if they can have Error Causes.
+			 * override this method.
 			 */
-			virtual bool CanHaveErrorCauses() const
-			{
-				return false;
-			}
+			virtual bool CanHaveErrorCauses() const = 0;
 
 			virtual bool HasErrorCauses() const final
 			{

--- a/worker/include/RTC/SCTP/packet/Chunk.hpp
+++ b/worker/include/RTC/SCTP/packet/Chunk.hpp
@@ -90,7 +90,7 @@ namespace RTC
 			};
 
 			/**
-			 * Struct of a SCTP Chunk Header.
+			 * Struct of an SCTP Chunk Header.
 			 */
 			struct ChunkHeader
 			{

--- a/worker/include/RTC/SCTP/packet/ErrorCause.hpp
+++ b/worker/include/RTC/SCTP/packet/ErrorCause.hpp
@@ -66,7 +66,7 @@ namespace RTC
 			};
 
 			/**
-			 * Struct of a SCTP Error Cause Header.
+			 * Struct of an SCTP Error Cause Header.
 			 */
 			struct ErrorCauseHeader
 			{

--- a/worker/include/RTC/SCTP/packet/Packet.hpp
+++ b/worker/include/RTC/SCTP/packet/Packet.hpp
@@ -56,7 +56,7 @@ namespace RTC
 
 		public:
 			/**
-			 * Struct of a SCTP Packet Common Header.
+			 * Struct of an SCTP Packet Common Header.
 			 */
 			struct CommonHeader
 			{
@@ -70,13 +70,31 @@ namespace RTC
 			static const size_t CommonHeaderLength{ 12 };
 
 			/**
-			 * Parse a SCTP Packet.
+			 * Whether given buffer could be a valid SCTP Packet.
+			 *
+			 * @remarks
+			 * - `bufferLength` must be the exact length of the Packet.
+			 * - This check is very lazy. It should NEVER be done before checking if
+			 *   given buffer is an RTP or RTCP packet.
+			 */
+			static bool IsSctp(const uint8_t* buffer, size_t bufferLength);
+
+			/**
+			 * Parse an SCTP Packet.
 			 *
 			 * @remarks
 			 * - `bufferLength` must be the exact length of the Packet.
 			 */
 			static Packet* Parse(const uint8_t* buffer, size_t bufferLength);
 
+			/**
+			 * Create an SCTP Packet.
+			 *
+			 * @remarks
+			 * - `bufferLength` must be the exact length of the STUN Packet.
+			 * - If `transactionId` is not given then a random Transaction ID is
+			 *   generated.
+			 */
 			static Packet* Factory(uint8_t* buffer, size_t bufferLength);
 
 		private:

--- a/worker/include/RTC/SCTP/packet/Packet.hpp
+++ b/worker/include/RTC/SCTP/packet/Packet.hpp
@@ -192,6 +192,10 @@ namespace RTC
 			 * - Once this method is called, the caller may want to free the original
 			 *   given Chunk (otherwise it will leak since the Packet manages a clone
 			 *   of it).
+			 *
+			 * @throw
+			 * - MediaSoupError - If `BuildChunkInPlace()` was called before and the
+			 *   caller didn't invoke `Consolidate()` on the returned Chunk yet.
 			 */
 			void AddChunk(const Chunk* chunk);
 
@@ -203,12 +207,18 @@ namespace RTC
 			 *
 			 * @returns Pointer of the created Chunk specific class.
 			 *
+			 * @throw
+			 * - MediaSoupError - If `BuildChunkInPlace()` was called before and the
+			 *   caller didn't invoke `Consolidate()` on the returned Chunk yet.
+			 *
 			 * @remarks
 			 * - The caller MUST invoke `Consolidate()` once the Chunk is completed.
 			 * - The caller MUST NOT call `BuildChunkInPlace()` while other Chunk is
 			 *   in progress.
 			 * - The caller MUST NOT free the obtained Chunk pointer since it's now
 			 *   part of the Packet.
+			 * - The caller MUST free the obtained Chunk only in case the
+			 *   `Consolidate()` method on the Chunk throws.
 			 * - Method implemented in header file due to C++ template usage.
 			 *
 			 * @example
@@ -219,6 +229,8 @@ namespace RTC
 			template<typename T>
 			T* BuildChunkInPlace()
 			{
+				AssertDoesNotNeedConsolidation();
+
 				// The new Chunk will be added after other Chunks in the Packet, this is,
 				// at the end of the Packet,  whose length we know it's padded to 4
 				// bytes, and each Parameter total length is also multiple of 4 bytes.
@@ -235,6 +247,15 @@ namespace RTC
 				HandleInPlaceChunk(chunk);
 
 				return chunk;
+			}
+
+			/**
+			 * Whether `BuildChunkInPlace()` was called and the caller didn't invoke
+			 * `Consolidate()` on the returned Chunk yet.
+			 */
+			bool NeedsConsolidation() const
+			{
+				return this->needsConsolidation;
 			}
 
 			/**
@@ -265,9 +286,14 @@ namespace RTC
 
 			virtual void HandleInPlaceChunk(Chunk* chunk) final;
 
+			virtual void AssertDoesNotNeedConsolidation() const final;
+
 		private:
 			// Chunks.
 			std::vector<Chunk*> chunks;
+			// Whether `BuildChunkInPlace()` was called and the caller didn't invoke
+			// `Consolidate()` on the returned Chunk yet.
+			bool needsConsolidation{ false };
 		};
 	} // namespace SCTP
 } // namespace RTC

--- a/worker/include/RTC/SCTP/packet/Parameter.hpp
+++ b/worker/include/RTC/SCTP/packet/Parameter.hpp
@@ -80,7 +80,7 @@ namespace RTC
 			};
 
 			/**
-			 * Struct of a SCTP Parameter Header.
+			 * Struct of an SCTP Parameter Header.
 			 */
 			struct ParameterHeader
 			{

--- a/worker/include/RTC/SCTP/packet/TLV.hpp
+++ b/worker/include/RTC/SCTP/packet/TLV.hpp
@@ -12,7 +12,7 @@ namespace RTC
 		/**
 		 * SCTP TLV (Type-Length-Value).
 		 *
-		 * This is the base class of all items in a SCTP Packet, this is:
+		 * This is the base class of all items in an SCTP Packet, this is:
 		 * - SCTP Chunk,
 		 * - SCTP Parameter, and
 		 * - SCTP Error Cause.

--- a/worker/include/RTC/SCTP/packet/chunks/AbortAssociationChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/AbortAssociationChunk.hpp
@@ -88,6 +88,11 @@ namespace RTC
 
 			void SetT(bool flag);
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
 			bool CanHaveErrorCauses() const final
 			{
 				return true;

--- a/worker/include/RTC/SCTP/packet/chunks/CookieAckChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/CookieAckChunk.hpp
@@ -72,6 +72,16 @@ namespace RTC
 
 			CookieAckChunk* Clone(uint8_t* buffer, size_t bufferLength) const final;
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 		protected:
 			CookieAckChunk* SoftClone(const uint8_t* buffer) const final;
 		};

--- a/worker/include/RTC/SCTP/packet/chunks/CookieEchoChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/CookieEchoChunk.hpp
@@ -76,6 +76,16 @@ namespace RTC
 
 			CookieEchoChunk* Clone(uint8_t* buffer, size_t bufferLength) const final;
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 			bool HasCookie() const
 			{
 				return HasVariableLengthValue();

--- a/worker/include/RTC/SCTP/packet/chunks/DataChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/DataChunk.hpp
@@ -119,6 +119,16 @@ namespace RTC
 
 			DataChunk* Clone(uint8_t* buffer, size_t bufferLength) const final;
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 			bool GetI() const final
 			{
 				return GetBit3();

--- a/worker/include/RTC/SCTP/packet/chunks/ForwardTsnChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/ForwardTsnChunk.hpp
@@ -90,6 +90,16 @@ namespace RTC
 
 			ForwardTsnChunk* Clone(uint8_t* buffer, size_t bufferLength) const final;
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 			uint32_t GetNewCumulativeTsn() const final
 			{
 				return Utils::Byte::Get4Bytes(GetBuffer(), 4);

--- a/worker/include/RTC/SCTP/packet/chunks/HeartbeatAckChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/HeartbeatAckChunk.hpp
@@ -85,6 +85,11 @@ namespace RTC
 				return true;
 			}
 
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 		protected:
 			HeartbeatAckChunk* SoftClone(const uint8_t* buffer) const final;
 		};

--- a/worker/include/RTC/SCTP/packet/chunks/HeartbeatRequestChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/HeartbeatRequestChunk.hpp
@@ -85,6 +85,11 @@ namespace RTC
 				return true;
 			}
 
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 		protected:
 			HeartbeatRequestChunk* SoftClone(const uint8_t* buffer) const final;
 		};

--- a/worker/include/RTC/SCTP/packet/chunks/IDataChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/IDataChunk.hpp
@@ -116,6 +116,16 @@ namespace RTC
 
 			IDataChunk* Clone(uint8_t* buffer, size_t bufferLength) const final;
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 			bool GetI() const final
 			{
 				return GetBit3();

--- a/worker/include/RTC/SCTP/packet/chunks/IForwardTsnChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/IForwardTsnChunk.hpp
@@ -102,6 +102,16 @@ namespace RTC
 
 			IForwardTsnChunk* Clone(uint8_t* buffer, size_t bufferLength) const final;
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 			uint32_t GetNewCumulativeTsn() const final
 			{
 				return Utils::Byte::Get4Bytes(GetBuffer(), 4);

--- a/worker/include/RTC/SCTP/packet/chunks/InitAckChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/InitAckChunk.hpp
@@ -118,6 +118,11 @@ namespace RTC
 				return true;
 			}
 
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 			uint32_t GetInitiateTag() const final
 			{
 				return Utils::Byte::Get4Bytes(GetBuffer(), 4);

--- a/worker/include/RTC/SCTP/packet/chunks/InitChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/InitChunk.hpp
@@ -118,6 +118,11 @@ namespace RTC
 				return true;
 			}
 
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 			uint32_t GetInitiateTag() const final
 			{
 				return Utils::Byte::Get4Bytes(GetBuffer(), 4);

--- a/worker/include/RTC/SCTP/packet/chunks/OperationErrorChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/OperationErrorChunk.hpp
@@ -78,6 +78,11 @@ namespace RTC
 
 			OperationErrorChunk* Clone(uint8_t* buffer, size_t bufferLength) const final;
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
 			bool CanHaveErrorCauses() const final
 			{
 				return true;

--- a/worker/include/RTC/SCTP/packet/chunks/ReConfigChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/ReConfigChunk.hpp
@@ -93,6 +93,11 @@ namespace RTC
 				return true;
 			}
 
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 		protected:
 			ReConfigChunk* SoftClone(const uint8_t* buffer) const final;
 		};

--- a/worker/include/RTC/SCTP/packet/chunks/SackChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/SackChunk.hpp
@@ -139,6 +139,16 @@ namespace RTC
 
 			SackChunk* Clone(uint8_t* buffer, size_t bufferLength) const final;
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 			uint32_t GetCumulativeTsnAck() const
 			{
 				return Utils::Byte::Get4Bytes(GetBuffer(), 4);

--- a/worker/include/RTC/SCTP/packet/chunks/ShutdownAckChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/ShutdownAckChunk.hpp
@@ -72,6 +72,16 @@ namespace RTC
 
 			ShutdownAckChunk* Clone(uint8_t* buffer, size_t bufferLength) const final;
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 		protected:
 			ShutdownAckChunk* SoftClone(const uint8_t* buffer) const final;
 		};

--- a/worker/include/RTC/SCTP/packet/chunks/ShutdownChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/ShutdownChunk.hpp
@@ -81,6 +81,16 @@ namespace RTC
 
 			ShutdownChunk* Clone(uint8_t* buffer, size_t bufferLength) const final;
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 			uint32_t GetCumulativeTsnAck() const
 			{
 				return Utils::Byte::Get4Bytes(GetBuffer(), 4);

--- a/worker/include/RTC/SCTP/packet/chunks/ShutdownCompleteChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/ShutdownCompleteChunk.hpp
@@ -75,6 +75,16 @@ namespace RTC
 
 			ShutdownCompleteChunk* Clone(uint8_t* buffer, size_t bufferLength) const final;
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 			bool GetT() const
 			{
 				return GetBit0();

--- a/worker/include/RTC/SCTP/packet/chunks/UnknownChunk.hpp
+++ b/worker/include/RTC/SCTP/packet/chunks/UnknownChunk.hpp
@@ -62,6 +62,16 @@ namespace RTC
 
 			UnknownChunk* Clone(uint8_t* buffer, size_t bufferLength) const final;
 
+			bool CanHaveParameters() const final
+			{
+				return false;
+			}
+
+			bool CanHaveErrorCauses() const final
+			{
+				return false;
+			}
+
 			bool HasUnknownType() const override
 			{
 				return true;

--- a/worker/include/RTC/SCTP/public/AssociationInterface.hpp
+++ b/worker/include/RTC/SCTP/public/AssociationInterface.hpp
@@ -2,7 +2,6 @@
 #define MS_RTC_SCTP_ASSOCIATION_INTERFACE_HPP
 
 #include "common.hpp"
-#include "RTC/SCTP/packet/Packet.hpp"
 #include "RTC/SCTP/public/AssociationMetrics.hpp"
 #include "RTC/SCTP/public/Message.hpp"
 #include "RTC/SCTP/public/SctpOptions.hpp"
@@ -150,7 +149,7 @@ namespace RTC
 			 * message will be queued.
 			 *
 			 * This has identical semantics to `SendMessage()', except that it may
-			 * coalesce many messages into a single SCTP packet if they would fit.
+			 * coalesce many messages into a single SCTP Packet if they would fit.
 			 *
 			 * @remarks
 			 * - Same as in `SendMessage()`.
@@ -159,13 +158,9 @@ namespace RTC
 			  std::span<Message> messages, const SendMessageOptions& sendMessageOptions) = 0;
 
 			/**
-			 * Receive a Packet received from the remote peer.
-			 *
-			 * @remarks
-			 * - The caller is responsible of freeing given Packet once this method
-			 *   returns.
+			 * Receives SCTP data (hopefully an SCTP Packet) from the remote peer.
 			 */
-			virtual void ReceivePacket(const Packet* receivedPacket) = 0;
+			virtual void ReceiveSctpData(const uint8_t* data, size_t len) = 0;
 		};
 	} // namespace SCTP
 } // namespace RTC

--- a/worker/include/RTC/SCTP/public/AssociationInterface.hpp
+++ b/worker/include/RTC/SCTP/public/AssociationInterface.hpp
@@ -6,6 +6,7 @@
 #include "RTC/SCTP/public/Message.hpp"
 #include "RTC/SCTP/public/SctpOptions.hpp"
 #include "RTC/SCTP/public/SctpTypes.hpp"
+#include <FBS/sctpParameters.h>
 #include <span>
 #include <vector>
 
@@ -25,6 +26,9 @@ namespace RTC
 			virtual ~AssociationInterface() = default;
 
 			virtual void Dump(int indentation = 0) const = 0;
+
+			virtual flatbuffers::Offset<FBS::SctpParameters::SctpParameters> FillBuffer(
+			  flatbuffers::FlatBufferBuilder& builder) const = 0;
 
 			virtual Types::AssociationState GetAssociationState() const = 0;
 

--- a/worker/include/RTC/SCTP/public/AssociationInterface.hpp
+++ b/worker/include/RTC/SCTP/public/AssociationInterface.hpp
@@ -123,7 +123,7 @@ namespace RTC
 			virtual Types::ResetStreamsStatus ResetStreams(std::span<const uint16_t> outboundStreamIds) = 0;
 
 			/**
-			 * Sends a SCTP message using the provided send options. Sending a message
+			 * Sends an SCTP message using the provided send options. Sending a message
 			 * is an asynchronous operation, and the `OnAssociationError()` callback
 			 * may be invoked to indicate any errors in sending the message.
 			 *

--- a/worker/include/RTC/SCTP/public/AssociationListener.hpp
+++ b/worker/include/RTC/SCTP/public/AssociationListener.hpp
@@ -49,13 +49,25 @@ namespace RTC
 			virtual void OnAssociationConnected() = 0;
 
 			/**
-			 * Called when the Association is closed in a controlled way. No other
-			 * callbacks will be done after this callback, unless reconnecting.
+			 * Called when calling Connect() and also for incoming connection attempts
+			 * in case the association fails.
 			 *
 			 * @remarks
 			 * - It is allowed to call methods in Association within this callback.
 			 */
-			virtual void OnAssociationClosed() = 0;
+			virtual void OnAssociationFailed(Types::ErrorKind errorKind, std::string_view errorMessage) = 0;
+
+			/**
+			 * Called when the Association is closed in a controlled way or when the
+			 * Association has aborted - either as decided by this Association due to
+			 * e.g. too many retransmission attempts or by the peer when receiving an
+			 * ABORT command. No other callbacks will be done after this callback,
+			 * unless reconnecting.
+			 *
+			 * @remarks
+			 * - It is allowed to call methods in Association within this callback.
+			 */
+			virtual void OnAssociationClosed(Types::ErrorKind errorKind, std::string_view errorMessage) = 0;
 
 			/**
 			 * Called on connection restarted (by peer). This is just a notification,
@@ -77,17 +89,6 @@ namespace RTC
 			 * - It is allowed to call methods in Association within this callback.
 			 */
 			virtual void OnAssociationError(Types::ErrorKind errorKind, std::string_view errorMessage) = 0;
-
-			/**
-			 * Triggered when the Association has aborted - either as decided by this
-			 * Association due to e.g. too many retransmission attempts, or by the
-			 * peer when receiving an ABORT command. No other callbacks will be done
-			 * after this callback, unless reconnecting.
-			 *
-			 * @remarks
-			 * - It is allowed to call methods in Association within this callback.
-			 */
-			virtual void OnAssociationAborted(Types::ErrorKind errorKind, std::string_view errorMessage) = 0;
 
 			/**
 			 * Called when an SCTP message in full has been received.

--- a/worker/include/RTC/SCTP/public/AssociationListener.hpp
+++ b/worker/include/RTC/SCTP/public/AssociationListener.hpp
@@ -18,7 +18,7 @@ namespace RTC
 
 		public:
 			/**
-			 * Called when a SCTP Packet must be sent to the remote endpoint.
+			 * Called when an SCTP Packet must be sent to the remote endpoint.
 			 *
 			 * @return
 			 * - `true` if the packet was successfully sent. However, since

--- a/worker/include/RTC/SCTP/public/AssociationListener.hpp
+++ b/worker/include/RTC/SCTP/public/AssociationListener.hpp
@@ -32,6 +32,14 @@ namespace RTC
 			virtual bool OnAssociationSendData(const uint8_t* data, size_t len) = 0;
 
 			/**
+			 * Called when calling Connect() and also for incoming connection attempts.
+			 *
+			 * @remarks
+			 * - It is allowed to call methods in Association within this callback.
+			 */
+			virtual void OnAssociationConnecting() = 0;
+
+			/**
 			 * Called when calling Connect() succeeds and also for incoming successful
 			 * connection attempts.
 			 *

--- a/worker/include/RTC/SCTP/public/AssociationListener.hpp
+++ b/worker/include/RTC/SCTP/public/AssociationListener.hpp
@@ -57,7 +57,7 @@ namespace RTC
 			 * @remarks
 			 * - It is allowed to call methods in Association within this callback.
 			 */
-			virtual void OnAssociationConnectionRestarted() = 0;
+			virtual void OnAssociationRestarted() = 0;
 
 			/**
 			 * Triggered when an non-fatal error is reported by either this library or

--- a/worker/include/RTC/SCTP/public/AssociationListener.hpp
+++ b/worker/include/RTC/SCTP/public/AssociationListener.hpp
@@ -2,7 +2,6 @@
 #define MS_RTC_SCTP_ASSOCIATION_LISTENER_HPP
 
 #include "common.hpp"
-#include "RTC/SCTP/packet/Packet.hpp"
 #include "RTC/SCTP/public/Message.hpp"
 #include "RTC/SCTP/public/SctpTypes.hpp"
 #include <span>
@@ -30,7 +29,7 @@ namespace RTC
 			 * @remarks
 			 * - It is NOT allowed to call methods in Association within this callback.
 			 */
-			virtual bool OnAssociationSendPacket(Packet* packet) = 0;
+			virtual bool OnAssociationSendData(const uint8_t* data, size_t len) = 0;
 
 			/**
 			 * Called when calling Connect() succeeds and also for incoming successful

--- a/worker/include/RTC/SCTP/public/AssociationListener.hpp
+++ b/worker/include/RTC/SCTP/public/AssociationListener.hpp
@@ -32,7 +32,7 @@ namespace RTC
 			virtual bool OnAssociationSendData(const uint8_t* data, size_t len) = 0;
 
 			/**
-			 * Called when calling Connect() and also for incoming connection attempts.
+			 * Called when calling Connect().
 			 *
 			 * @remarks
 			 * - It is allowed to call methods in Association within this callback.

--- a/worker/include/RTC/SCTP/public/SctpOptions.hpp
+++ b/worker/include/RTC/SCTP/public/SctpOptions.hpp
@@ -41,7 +41,7 @@ namespace RTC
 			uint16_t maxInboundStreams{ 65535 };
 
 			/**
-			 * Maximum size of a SCTP Packet. It doesn't include any overhead of
+			 * Maximum size of an SCTP Packet. It doesn't include any overhead of
 			 * DTLS, TURN, UDP or IP headers.
 			 */
 			size_t mtu{ RTC::Consts::MaxSafeMtuSizeForSctp };

--- a/worker/include/RTC/SCTP/public/SctpTypes.hpp
+++ b/worker/include/RTC/SCTP/public/SctpTypes.hpp
@@ -16,6 +16,13 @@ namespace RTC
 			enum class AssociationState : uint8_t
 			{
 				/**
+				 * Initial state.
+				 *
+				 * @remarks
+				 * - Once state changes it will never transition to NEW again.
+				 */
+				NEW,
+				/**
 				 * The Association is closed.
 				 */
 				CLOSED,
@@ -43,24 +50,29 @@ namespace RTC
 			{
 				switch (associationState)
 				{
+					case AssociationState::NEW:
+					{
+						return "NEW";
+					}
+
 					case AssociationState::CLOSED:
 					{
-						return "Closed";
+						return "CLOSED";
 					}
 
 					case AssociationState::CONNECTING:
 					{
-						return "Connecting";
+						return "CONNECTING";
 					}
 
 					case AssociationState::CONNECTED:
 					{
-						return "Connected";
+						return "CONNECTED";
 					}
 
 					case AssociationState::SHUTTING_DOWN:
 					{
-						return "ShuttingDown";
+						return "SHUTTING_DOWN";
 					}
 
 						NO_DEFAULT_GCC();

--- a/worker/include/RTC/Serializable.hpp
+++ b/worker/include/RTC/Serializable.hpp
@@ -131,7 +131,7 @@ namespace RTC
 		 *
 		 * @see SetConsolidatedListener()
 		 */
-		virtual void Consolidate() final;
+		virtual void Consolidate() const final;
 
 		/**
 		 * Methods to be used by classes inheriting from Serializable.

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -297,7 +297,7 @@ namespace RTC
 		bool OnAssociationSendData(const uint8_t* data, size_t len) override;
 		void OnAssociationConnected() override;
 		void OnAssociationClosed() override;
-		void OnAssociationConnectionRestarted() override;
+		void OnAssociationRestarted() override;
 		void OnAssociationError(RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage) override;
 		void OnAssociationAborted(
 		  RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage) override;

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -219,7 +219,7 @@ namespace RTC
 		  size_t len,
 		  uint32_t ppid,
 		  onQueuedCallback* = nullptr)                             = 0;
-		virtual void SendSctpData(const uint8_t* data, size_t len) = 0;
+		virtual bool SendSctpData(const uint8_t* data, size_t len) = 0;
 		virtual void RecvStreamClosed(uint32_t ssrc)               = 0;
 		virtual void SendStreamClosed(uint32_t ssrc)               = 0;
 		void DistributeAvailableOutgoingBitrate();
@@ -308,7 +308,7 @@ namespace RTC
 		void OnAssociationInboundStreamsReset(std::span<const uint16_t> inboundStreamIds) override;
 		void OnAssociationStreamBufferedAmountLow(uint16_t streamId) override;
 		void OnAssociationTotalBufferedAmountLow() override;
-		// TODO: Add OnAssociationLifecycleMessageXxxxxx() methods.
+		// TODO: SCTP: Add OnAssociationLifecycleMessageXxxxxx() methods.
 #else
 		/* Pure virtual methods inherited from RTC::SctpAssociation::Listener. */
 	public:

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -295,6 +295,7 @@ namespace RTC
 		/* Pure virtual methods inherited from RTC::SCTP::AssociationListener. */
 	public:
 		bool OnAssociationSendData(const uint8_t* data, size_t len) override;
+		void OnAssociationConnecting() override;
 		void OnAssociationConnected() override;
 		void OnAssociationClosed() override;
 		void OnAssociationRestarted() override;

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -18,7 +18,14 @@
 #include "RTC/RTP/Packet.hpp"
 #include "RTC/RateCalculator.hpp"
 #include "RTC/RtpListener.hpp"
+#ifdef MS_SCTP_STACK
+#include "RTC/SCTP/public/AssociationInterface.hpp"
+#include "RTC/SCTP/public/AssociationListener.hpp"
+#include "RTC/SCTP/public/Message.hpp"
+#include "RTC/SCTP/public/SctpTypes.hpp"
+#else
 #include "RTC/SctpAssociation.hpp"
+#endif
 #include "RTC/SctpListener.hpp"
 #include "RTC/Shared.hpp"
 #ifdef ENABLE_RTC_SENDER_BANDWIDTH_ESTIMATOR
@@ -37,7 +44,11 @@ namespace RTC
 	                  public RTC::Consumer::Listener,
 	                  public RTC::DataProducer::Listener,
 	                  public RTC::DataConsumer::Listener,
+#ifdef MS_SCTP_STACK
+	                  public RTC::SCTP::AssociationListener,
+#else
 	                  public RTC::SctpAssociation::Listener,
+#endif
 	                  public RTC::TransportCongestionControlClient::Listener,
 	                  public RTC::TransportCongestionControlServer::Listener,
 	                  public Channel::ChannelSocket::RequestHandler,
@@ -280,6 +291,25 @@ namespace RTC
 		  onQueuedCallback* cb = nullptr) override;
 		void OnDataConsumerDataProducerClosed(RTC::DataConsumer* dataConsumer) override;
 
+#ifdef MS_SCTP_STACK
+		/* Pure virtual methods inherited from RTC::SCTP::AssociationListener. */
+	public:
+		bool OnAssociationSendData(const uint8_t* data, size_t len) override;
+		void OnAssociationConnected() override;
+		void OnAssociationClosed() override;
+		void OnAssociationConnectionRestarted() override;
+		void OnAssociationError(RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage) override;
+		void OnAssociationAborted(
+		  RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage) override;
+		void OnAssociationMessageReceived(RTC::SCTP::Message message) override;
+		void OnAssociationStreamsResetPerformed(std::span<const uint16_t> outboundStreamIds) override;
+		void OnAssociationStreamsResetFailed(
+		  std::span<const uint16_t> outboundStreamIds, std::string_view errorMessage) override;
+		void OnAssociationInboundStreamsReset(std::span<const uint16_t> inboundStreamIds) override;
+		void OnAssociationStreamBufferedAmountLow(uint16_t streamId) override;
+		void OnAssociationTotalBufferedAmountLow() override;
+		// TODO: Add OnAssociationLifecycleMessageXxxxxx() methods.
+#else
 		/* Pure virtual methods inherited from RTC::SctpAssociation::Listener. */
 	public:
 		void OnSctpAssociationConnecting(RTC::SctpAssociation* sctpAssociation) override;
@@ -296,6 +326,7 @@ namespace RTC
 		  uint32_t ppid) override;
 		void OnSctpAssociationBufferedAmount(
 		  RTC::SctpAssociation* sctpAssociation, uint32_t bufferedAmount) override;
+#endif
 
 		/* Pure virtual methods inherited from RTC::TransportCongestionControlClient::Listener. */
 	public:
@@ -333,7 +364,11 @@ namespace RTC
 		RTC::Shared* shared{ nullptr };
 		size_t maxMessageSize{ 262144u };
 		// Allocated by this.
+#ifdef MS_SCTP_STACK
+		std::unique_ptr<RTC::SCTP::AssociationInterface> sctpAssociation{ nullptr };
+#else
 		RTC::SctpAssociation* sctpAssociation{ nullptr };
+#endif
 
 	private:
 		// Passed by argument.

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -297,11 +297,10 @@ namespace RTC
 		bool OnAssociationSendData(const uint8_t* data, size_t len) override;
 		void OnAssociationConnecting() override;
 		void OnAssociationConnected() override;
-		void OnAssociationClosed() override;
+		void OnAssociationFailed(RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage) override;
+		void OnAssociationClosed(RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage) override;
 		void OnAssociationRestarted() override;
 		void OnAssociationError(RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage) override;
-		void OnAssociationAborted(
-		  RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage) override;
 		void OnAssociationMessageReceived(RTC::SCTP::Message message) override;
 		void OnAssociationStreamsResetPerformed(std::span<const uint16_t> outboundStreamIds) override;
 		void OnAssociationStreamsResetFailed(

--- a/worker/include/RTC/WebRtcTransport.hpp
+++ b/worker/include/RTC/WebRtcTransport.hpp
@@ -91,7 +91,7 @@ namespace RTC
 		  size_t len,
 		  uint32_t ppid,
 		  onQueuedCallback* cb = nullptr) override;
-		void SendSctpData(const uint8_t* data, size_t len) override;
+		bool SendSctpData(const uint8_t* data, size_t len) override;
 		void RecvStreamClosed(uint32_t ssrc) override;
 		void SendStreamClosed(uint32_t ssrc) override;
 		void OnPacketReceived(RTC::TransportTuple* tuple, const uint8_t* data, size_t len, size_t bufferLen);

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -462,6 +462,7 @@ test_sources = [
   'test/src/RTC/SCTP/tx/TestRetransmissionErrorCounter.cpp',
   'test/src/RTC/SCTP/tx/TestRetransmissionTimeout.cpp',
   'test/src/RTC/SCTP/packet/TestPacket.cpp',
+  'test/src/RTC/SCTP/packet/TestChunk.cpp',
   'test/src/RTC/SCTP/packet/chunks/TestDataChunk.cpp',
   'test/src/RTC/SCTP/packet/chunks/TestInitChunk.cpp',
   'test/src/RTC/SCTP/packet/chunks/TestInitAckChunk.cpp',

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -5,7 +5,9 @@
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
+#ifndef MS_SCTP_STACK
 #include "RTC/SctpAssociation.hpp"
+#endif
 
 namespace RTC
 {
@@ -529,7 +531,7 @@ namespace RTC
 		this->listener->OnDataConsumerDataProducerClosed(this);
 	}
 
-	void DataConsumer::SendMessage(
+	bool DataConsumer::SendMessage(
 	  const uint8_t* msg,
 	  size_t len,
 	  uint32_t ppid,
@@ -547,7 +549,7 @@ namespace RTC
 				delete cb;
 			}
 
-			return;
+			return false;
 		}
 
 		// If a required subchannel is given, verify that this data consumer is
@@ -562,7 +564,7 @@ namespace RTC
 				delete cb;
 			}
 
-			return;
+			return false;
 		}
 
 		// If subchannels are given, verify that this data consumer is subscribed
@@ -589,7 +591,7 @@ namespace RTC
 					delete cb;
 				}
 
-				return;
+				return false;
 			}
 		}
 
@@ -607,12 +609,14 @@ namespace RTC
 				delete cb;
 			}
 
-			return;
+			return false;
 		}
 
 		this->messagesSent++;
 		this->bytesSent += len;
 
 		this->listener->OnDataConsumerSendMessage(this, msg, len, ppid, cb);
+
+		return true;
 	}
 } // namespace RTC

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -15,14 +15,18 @@ namespace RTC
 	  RTC::Shared* shared,
 	  const std::string& id,
 	  const std::string& dataProducerId,
+#ifndef MS_SCTP_STACK
 	  RTC::SctpAssociation* sctpAssociation,
+#endif
 	  RTC::DataConsumer::Listener* listener,
 	  const FBS::Transport::ConsumeDataRequest* data,
 	  size_t maxMessageSize)
 	  : id(id),
 	    dataProducerId(dataProducerId),
 	    shared(shared),
+#ifndef MS_SCTP_STACK
 	    sctpAssociation(sctpAssociation),
+#endif
 	    listener(listener),
 	    maxMessageSize(maxMessageSize)
 	{
@@ -216,6 +220,9 @@ namespace RTC
 					MS_THROW_TYPE_ERROR("invalid DataConsumer type");
 				}
 
+#ifdef MS_SCTP_STACK
+				// TODO: SCTP
+#else
 				if (!this->sctpAssociation)
 				{
 					MS_THROW_ERROR("no SCTP association present");
@@ -226,6 +233,7 @@ namespace RTC
 				  request->GetBufferBuilder(), this->sctpAssociation->GetSctpBufferedAmount());
 
 				request->Accept(FBS::Response::Body::DataConsumer_GetBufferedAmountResponse, responseOffset);
+#endif
 
 				break;
 			}
@@ -275,10 +283,14 @@ namespace RTC
 					MS_THROW_TYPE_ERROR("invalid DataConsumer type");
 				}
 
+#ifdef MS_SCTP_STACK
+				// TODO: SCTP
+#else
 				if (!this->sctpAssociation)
 				{
 					MS_THROW_ERROR("no SCTP association present");
 				}
+#endif
 
 				const auto* body    = request->data->body_as<FBS::DataConsumer::SendRequest>();
 				const uint8_t* data = body->data()->Data();

--- a/worker/src/RTC/DirectTransport.cpp
+++ b/worker/src/RTC/DirectTransport.cpp
@@ -245,11 +245,13 @@ namespace RTC
 		RTC::Transport::DataSent(len);
 	}
 
-	void DirectTransport::SendSctpData(const uint8_t* /*data*/, size_t /*len*/)
+	bool DirectTransport::SendSctpData(const uint8_t* /*data*/, size_t /*len*/)
 	{
 		MS_TRACE();
 
 		// Do nothing.
+
+		return false;
 	}
 
 	void DirectTransport::RecvStreamClosed(uint32_t /*ssrc*/)

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -1022,7 +1022,7 @@ namespace RTC
 		}
 	}
 
-	void DtlsTransport::SendApplicationData(const uint8_t* data, size_t len)
+	bool DtlsTransport::SendApplicationData(const uint8_t* data, size_t len)
 	{
 		MS_TRACE();
 
@@ -1032,19 +1032,17 @@ namespace RTC
 		{
 			MS_WARN_TAG(dtls, "cannot send application data while DTLS is not fully connected");
 
-			return;
+			return false;
 		}
 
 		if (len == 0)
 		{
 			MS_WARN_TAG(dtls, "ignoring 0 length data");
 
-			return;
+			return false;
 		}
 
-		int written;
-
-		written = SSL_write(this->ssl, static_cast<const void*>(data), static_cast<int>(len));
+		const int written = SSL_write(this->ssl, static_cast<const void*>(data), static_cast<int>(len));
 
 		if (written < 0)
 		{
@@ -1052,14 +1050,18 @@ namespace RTC
 
 			if (!CheckStatus(written))
 			{
-				return;
+				return false;
 			}
 		}
 		else if (written != static_cast<int>(len))
 		{
 			MS_WARN_TAG(
 			  dtls, "OpenSSL SSL_write() wrote less (%d bytes) than given data (%zu bytes)", written, len);
+
+			return false;
 		}
+
+		return true;
 	}
 
 	/**

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -4,7 +4,11 @@
 #include "RTC/PipeTransport.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
+#include "Settings.hpp"
 #include "Utils.hpp"
+#ifdef MS_SCTP_STACK
+#include "RTC/SCTP/packet/Packet.hpp"
+#endif
 #include <cstring> // std::memcpy()
 
 namespace RTC
@@ -581,22 +585,28 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifdef MS_SCTP_STACK
+		// TODO: SCTP
+#else
 		this->sctpAssociation->SendSctpMessage(dataConsumer, msg, len, ppid, cb);
+#endif
 	}
 
-	void PipeTransport::SendSctpData(const uint8_t* data, size_t len)
+	bool PipeTransport::SendSctpData(const uint8_t* data, size_t len)
 	{
 		MS_TRACE();
 
 		if (!IsConnected())
 		{
-			return;
+			return false;
 		}
 
 		this->tuple->Send(data, len);
 
 		// Increase send transmission.
 		RTC::Transport::DataSent(len);
+
+		return true;
 	}
 
 	void PipeTransport::RecvStreamClosed(uint32_t ssrc)
@@ -638,7 +648,11 @@ namespace RTC
 			OnRtpDataReceived(tuple, data, len, bufferLen);
 		}
 		// Check if it's SCTP.
+#ifdef MS_SCTP_STACK
+		else if (RTC::SCTP::Packet::IsSctp(data, len))
+#else
 		else if (RTC::SctpAssociation::IsSctp(data, len))
+#endif
 		{
 			OnSctpDataReceived(tuple, data, len);
 		}

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -6,6 +6,10 @@
 #include "MediaSoupErrors.hpp"
 #include "Settings.hpp"
 #include "Utils.hpp"
+#ifdef MS_SCTP_STACK
+#include "RTC/SCTP/packet/Packet.hpp"
+#endif
+#include <cstring> // std::memcpy()
 
 namespace RTC
 {
@@ -901,10 +905,14 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifdef MS_SCTP_STACK
+		// TODO: SCTP
+#else
 		this->sctpAssociation->SendSctpMessage(dataConsumer, msg, len, ppid, cb);
+#endif
 	}
 
-	void PlainTransport::SendSctpData(const uint8_t* data, size_t len)
+	bool PlainTransport::SendSctpData(const uint8_t* data, size_t len)
 	{
 		MS_TRACE();
 
@@ -912,13 +920,15 @@ namespace RTC
 		{
 			MS_WARN_TAG(sctp, "not connected, cannot send SCTP data");
 
-			return;
+			return false;
 		}
 
 		this->tuple->Send(data, len);
 
 		// Increase send transmission.
 		RTC::Transport::DataSent(len);
+
+		return true;
 	}
 
 	void PlainTransport::RecvStreamClosed(uint32_t ssrc)
@@ -960,7 +970,11 @@ namespace RTC
 			OnRtpDataReceived(tuple, data, len, bufferLen);
 		}
 		// Check if it's SCTP.
+#ifdef MS_SCTP_STACK
+		else if (RTC::SCTP::Packet::IsSctp(data, len))
+#else
 		else if (RTC::SctpAssociation::IsSctp(data, len))
+#endif
 		{
 			OnSctpDataReceived(tuple, data, len);
 		}

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -6,10 +6,6 @@
 #include "MediaSoupErrors.hpp"
 #include "Settings.hpp"
 #include "Utils.hpp"
-// TODO: For testing purposes. Must be removed.
-#ifdef MS_SCTP_STACK
-#include "RTC/SCTP/packet/Packet.hpp"
-#endif
 
 namespace RTC
 {
@@ -919,24 +915,6 @@ namespace RTC
 			return;
 		}
 
-// TODO: For testing purposes. Must be removed.
-#ifdef MS_SCTP_STACK
-		MS_DUMP(">>> sending SCTP packet...");
-
-		const auto* packet = RTC::SCTP::Packet::Parse(data, len);
-
-		if (packet)
-		{
-			packet->Dump();
-
-			delete packet;
-		}
-		else
-		{
-			MS_ABORT("RTC::SCTP::Packet::Parse() failed to parse sent SCTP data");
-		}
-#endif
-
 		this->tuple->Send(data, len);
 
 		// Increase send transmission.
@@ -1229,24 +1207,6 @@ namespace RTC
 
 			return;
 		}
-
-// TODO: For testing purposes. Must be removed.
-#ifdef MS_SCTP_STACK
-		MS_DUMP("<<< received SCTP packet...");
-
-		const auto* packet = RTC::SCTP::Packet::Parse(data, len);
-
-		if (packet)
-		{
-			packet->Dump();
-
-			delete packet;
-		}
-		else
-		{
-			MS_ABORT("RTC::SCTP::Packet::Parse() failed to parse received SCTP data");
-		}
-#endif
 
 		// Pass it to the parent transport.
 		RTC::Transport::ReceiveSctpData(data, len);

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -114,6 +114,11 @@ namespace RTC
 
 			switch (this->state)
 			{
+				case State::NEW:
+				{
+					return Types::AssociationState::NEW;
+				}
+
 				case State::CLOSED:
 				{
 					return Types::AssociationState::CLOSED;
@@ -146,40 +151,44 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			const AssociationDeferredListener::ScopedDeferred deferrer(this->listener);
-
-			if (this->state == State::CLOSED)
-			{
-				this->preTcb.localVerificationTag =
-				  Utils::Crypto::GetRandomUInt<uint32_t>(MinVerificationTag, MaxVerificationTag);
-				this->preTcb.localInitialTsn =
-				  Utils::Crypto::GetRandomUInt<uint32_t>(MinInitialTsn, MaxInitialTsn);
-
-				SendInitChunk();
-
-				this->t1InitTimer->Start();
-
-				SetState(State::COOKIE_WAIT, "Connect() called");
-			}
-			else
+			// NOTE: We could only accept NEW state here so once closed the Association
+			// cannot be reused. However there is no real technical reason for it.
+			if (this->state != State::NEW && this->state != State::CLOSED)
 			{
 				const auto stateStringView = Association::StateToString(this->state);
 
 				MS_WARN_TAG(
 				  sctp,
-				  "cannot initiate the Association since internal state is not CLOSED but %.*s",
+				  "cannot initiate the Association since internal state is not NEW or CLOSED but %.*s",
 				  static_cast<int>(stateStringView.size()),
 				  stateStringView.data());
+
+				return;
 			}
 
+			const AssociationDeferredListener::ScopedDeferred deferrer(this->listener);
+
+			this->preTcb.localVerificationTag =
+			  Utils::Crypto::GetRandomUInt<uint32_t>(MinVerificationTag, MaxVerificationTag);
+			this->preTcb.localInitialTsn =
+			  Utils::Crypto::GetRandomUInt<uint32_t>(MinInitialTsn, MaxInitialTsn);
+
+			SendInitChunk();
+
+			this->t1InitTimer->Start();
+
+			SetState(State::COOKIE_WAIT, "Connect() called");
+
 			AssertStateIsConsistent();
+
+			this->listener.OnAssociationConnecting();
 		}
 
 		void Association::Shutdown()
 		{
 			MS_TRACE();
 
-			if (this->state == State::CLOSED)
+			if (this->state == State::NEW || this->state == State::CLOSED)
 			{
 				AssertStateIsConsistent();
 
@@ -226,7 +235,7 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			if (this->state == State::CLOSED)
+			if (this->state == State::NEW || this->state == State::CLOSED)
 			{
 				AssertStateIsConsistent();
 
@@ -379,7 +388,6 @@ namespace RTC
 			// this->tcb->GetStreamResetHandler().ResetStreams(outboundStreamIds);
 
 			MaySendResetStreamsRequest();
-
 			AssertStateIsConsistent();
 
 			return Types::ResetStreamsStatus::PERFORMED;
@@ -514,7 +522,7 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			if (this->state != State::CLOSED)
+			if (this->state != State::NEW && this->state != State::CLOSED)
 			{
 				this->t1InitTimer->Stop();
 				this->t1CookieTimer->Stop();
@@ -1314,9 +1322,10 @@ namespace RTC
 
 			switch (this->state)
 			{
+				case State::NEW:
 				case State::CLOSED:
 				{
-					MS_DEBUG_TAG(sctp, "INIT Chunk received in CLOSED state (normal scenario)");
+					MS_DEBUG_TAG(sctp, "INIT Chunk received in NEW or CLOSED state (normal scenario)");
 
 					localVerificationTag =
 					  Utils::Crypto::GetRandomUInt<uint32_t>(MinVerificationTag, MaxVerificationTag);
@@ -1506,6 +1515,7 @@ namespace RTC
 			// this->tcb->SendBufferedPackets(callbacks_.Now());
 
 			this->t1CookieTimer->Start();
+			this->listener.OnAssociationConnecting();
 		}
 
 		void Association::ProcessReceivedCookieEchoChunk(
@@ -1739,6 +1749,7 @@ namespace RTC
 
 			switch (this->state)
 			{
+				case State::NEW:
 				case State::CLOSED:
 				{
 					break;
@@ -2510,6 +2521,21 @@ namespace RTC
 
 			switch (this->state)
 			{
+				case State::NEW:
+				{
+					MS_ASSERT(!this->tcb, "internal state is NEW but there is TCB");
+					MS_ASSERT(
+					  !this->t1InitTimer->IsRunning(), "internal state is NEW but T1 Init timer is running");
+					MS_ASSERT(
+					  !this->t1CookieTimer->IsRunning(),
+					  "internal state is NEW but T1 Cookie timer is running");
+					MS_ASSERT(
+					  !this->t2ShutdownTimer->IsRunning(),
+					  "internal state is NEW but T2 Shutdown timer is running");
+
+					break;
+				}
+
 				case State::CLOSED:
 				{
 					MS_ASSERT(!this->tcb, "internal state is CLOSED but there is TCB");

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -642,13 +642,13 @@ namespace RTC
 				  chunk->BuildParameterInPlace<ForwardTsnSupportedParameter>();
 
 				// TODO: SCTP: Remove
-				MS_DUMP("--- forwardTsnSupportedParameter 1:");
+				MS_DUMP("--- forwardTsnSupportedParameter before Consolidate():");
 				forwardTsnSupportedParameter->Dump();
 
 				forwardTsnSupportedParameter->Consolidate();
 
 				// TODO: SCTP: Remove
-				MS_DUMP("--- forwardTsnSupportedParameter 2:");
+				MS_DUMP("--- forwardTsnSupportedParameter after Consolidate():");
 				forwardTsnSupportedParameter->Dump();
 			}
 

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -38,7 +38,7 @@ namespace RTC
 
 		/* Instance methods. */
 
-		Association::Association(const SctpOptions& sctpOptions, AssociationListener& listener)
+		Association::Association(const SctpOptions& sctpOptions, AssociationListener* listener)
 		  : sctpOptions(sctpOptions),
 		    // Our `listener` member is a `AssociationDeferredListener` which takes
 		    // `AssociationListener` as constructor argument.

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -499,6 +499,24 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			// TODO: SCTP: For testing purposes. Must be removed.
+			{
+				MS_DUMP("<<< received SCTP packet:");
+
+				const auto* packet = RTC::SCTP::Packet::Parse(data, len);
+
+				if (packet)
+				{
+					packet->Dump();
+
+					delete packet;
+				}
+				else
+				{
+					MS_ABORT("RTC::SCTP::Packet::Parse() failed to parse received SCTP data");
+				}
+			}
+
 			const AssociationDeferredListener::ScopedDeferred deferrer(this->listener);
 
 			this->privateMetrics.rxPacketsCount++;
@@ -620,10 +638,21 @@ namespace RTC
 			{
 				supportedExtensionsParameter->AddChunkType(Chunk::ChunkType::FORWARD_TSN);
 
-				auto* forwardTsnSupportedParameter =
+				// TODO: SCTP
+				MS_DUMP("TODO: UNCOMMENT!!");
+
+				const auto* forwardTsnSupportedParameter =
 				  chunk->BuildParameterInPlace<ForwardTsnSupportedParameter>();
 
+				// TODO: SCTP: Remove
+				MS_DUMP("--- forwardTsnSupportedParameter 1:");
+				forwardTsnSupportedParameter->Dump();
+
 				forwardTsnSupportedParameter->Consolidate();
+
+				// TODO: SCTP: Remove
+				MS_DUMP("--- forwardTsnSupportedParameter 2:");
+				forwardTsnSupportedParameter->Dump();
 			}
 
 			if (this->sctpOptions.enableMessageInterleaving)
@@ -732,8 +761,8 @@ namespace RTC
 
 			AssertHasTcb();
 
-			auto packet         = this->tcb->CreatePacket();
-			auto* shutdownChunk = packet->BuildChunkInPlace<ShutdownChunk>();
+			auto packet               = this->tcb->CreatePacket();
+			const auto* shutdownChunk = packet->BuildChunkInPlace<ShutdownChunk>();
 
 			// TODO: Implement it.
 			// shutdownChunk->SetCumulativeTsnAck(this->tcb->GetDataTracker().GetLastCumulativeAckedTsn());
@@ -748,8 +777,8 @@ namespace RTC
 
 			AssertHasTcb();
 
-			auto packet            = this->tcb->CreatePacket();
-			auto* shutdownAckChunk = packet->BuildChunkInPlace<ShutdownAckChunk>();
+			auto packet                  = this->tcb->CreatePacket();
+			const auto* shutdownAckChunk = packet->BuildChunkInPlace<ShutdownAckChunk>();
 
 			shutdownAckChunk->Consolidate();
 
@@ -1553,23 +1582,18 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			const auto* stateCookieParameter =
-			  receivedCookieEchoChunk->GetFirstParameterOfType<StateCookieParameter>();
-
-			if (!stateCookieParameter || !stateCookieParameter->GetCookie())
+			if (!receivedCookieEchoChunk->HasCookie())
 			{
-				MS_WARN_TAG(
-				  sctp, "ignoring received COOKIE_ECHO Chunk without StateCookieParameter or without Cookie");
+				MS_WARN_TAG(sctp, "ignoring received COOKIE_ECHO Chunk without Cookie");
 
 				this->listener.OnAssociationError(
-				  Types::ErrorKind::PARSE_FAILED,
-				  "received COOKIE_ECHO Chunk without StateCookieParameter or without Cookie");
+				  Types::ErrorKind::PARSE_FAILED, "received COOKIE_ECHO Chunk without Cookie");
 
 				return;
 			}
 
 			std::unique_ptr<StateCookie> cookie{ StateCookie::Parse(
-				stateCookieParameter->GetCookie(), stateCookieParameter->GetCookieLength()) };
+				receivedCookieEchoChunk->GetCookie(), receivedCookieEchoChunk->GetCookieLength()) };
 
 			if (!cookie)
 			{
@@ -1637,8 +1661,8 @@ namespace RTC
 				  cookie->GetNegotiatedCapabilities());
 			}
 
-			auto packet          = this->tcb->CreatePacket();
-			auto* cookieAckChunk = packet->BuildChunkInPlace<CookieAckChunk>();
+			auto packet                = this->tcb->CreatePacket();
+			const auto* cookieAckChunk = packet->BuildChunkInPlace<CookieAckChunk>();
 
 			cookieAckChunk->Consolidate();
 
@@ -1649,6 +1673,11 @@ namespace RTC
 			// packet."
 			// TODO: Implement it. Note that we pass Packet as argument!
 			// this->tcb->SendBufferedPackets(packet.get(), callbacks_.Now());
+
+			// TODO: SCTP: Remove this since COOKIE_ACK must be sent by
+			// tcb->SendBufferedPackets() call above.
+			MS_DUMP("TODO: REMOVE");
+			this->packetSender.SendPacket(packet.get());
 		}
 
 		bool Association::ProcessReceivedCookieEchoChunkWithTcb(
@@ -1678,12 +1707,12 @@ namespace RTC
 				if (this->state == State::SHUTDOWN_ACK_SENT)
 				{
 					auto packet = CreatePacketWithVerificationTag(cookie->GetRemoteVerificationTag());
-					auto* shutdownAckChunk = packet->BuildChunkInPlace<ShutdownAckChunk>();
+					const auto* shutdownAckChunk = packet->BuildChunkInPlace<ShutdownAckChunk>();
 
 					shutdownAckChunk->Consolidate();
 
 					auto* operationErrorChunk = packet->BuildChunkInPlace<OperationErrorChunk>();
-					auto* cookieReceivedWhileShuttingDownErrorCause =
+					const auto* cookieReceivedWhileShuttingDownErrorCause =
 					  operationErrorChunk->BuildErrorCauseInPlace<CookieReceivedWhileShuttingDownErrorCause>();
 
 					cookieReceivedWhileShuttingDownErrorCause->Consolidate();
@@ -1858,8 +1887,8 @@ namespace RTC
 				case State::SHUTDOWN_SENT:
 				case State::SHUTDOWN_ACK_SENT:
 				{
-					auto packet                 = this->tcb->CreatePacket();
-					auto* shutdownCompleteChunk = packet->BuildChunkInPlace<ShutdownCompleteChunk>();
+					auto packet                       = this->tcb->CreatePacket();
+					const auto* shutdownCompleteChunk = packet->BuildChunkInPlace<ShutdownCompleteChunk>();
 
 					// NOTE: Don't set bit T in the SHUTDOWN_COMPLETE chunk since TCB
 					// knows the Verification Tag expected by the remote.

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -247,10 +247,10 @@ namespace RTC
 					MaySendShutdownOrShutdownAckChunk();
 				}
 			}
-			// Connection closed before even starting to connect, or during the
+			// Association closed before even starting to connect, or during the
 			// initial connection phase. There is no outstanding data, so the
-			// Association can just be closed (stopping any connection timers, if
-			// any), as this is the application's intention when calling Shutdown().
+			// Association can just be closed (stopping any timers, if any), as this
+			// is the application's intention when calling Shutdown().
 			else
 			{
 				InternalClose(Types::ErrorKind::SUCCESS, "");
@@ -1535,8 +1535,8 @@ namespace RTC
 			const auto negotiatedCapabilities =
 			  NegotiatedCapabilities::Factory(this->sctpOptions, receivedInitAckChunk);
 
-			// If the connection is re-established (peer restarted, but re-used old
-			// connection), make sure that all message identifiers are reset and any
+			// If the Association is re-established (peer restarted, but re-used old
+			// Association), make sure that all message identifiers are reset and any
 			// partly sent message is re-sent in full. The same is true when the
 			// Association is closed and later re-opened, which never happens in
 			// WebRTC, but is a valid operation on the SCTP level.
@@ -1554,8 +1554,8 @@ namespace RTC
 
 			SetState(State::COOKIE_ECHOED, "INIT_ACK received");
 
-			// The connection isn't fully established just yet. Store the state cookie
-			// in the TCB.
+			// The Association isn't fully established just yet. Store the stat
+			// cookie in the TCB.
 			std::vector<uint8_t> remoteStateCookie(
 			  stateCookieParameter->GetCookie(),
 			  stateCookieParameter->GetCookie() + stateCookieParameter->GetCookieLength());
@@ -1635,8 +1635,8 @@ namespace RTC
 
 			if (!this->tcb)
 			{
-				// If the connection is re-established (peer restarted, but re-used old
-				// connection), make sure that all message identifiers are reset and any
+				// If the Association is re-established (peer restarted, but re-used old
+				// Association), make sure that all message identifiers are reset and any
 				// partly sent message is re-sent in full. The same is true when the
 				// Association is closed and later re-opened, which never happens in
 				// WebRTC, but is a valid operation on the SCTP level.
@@ -1732,7 +1732,7 @@ namespace RTC
 			{
 				// TODO: Handle the case in which remote Verification Tag is 0?
 
-				MS_DEBUG_DEV("received COOKIE_ECHO indicating simultaneous connections");
+				MS_DEBUG_DEV("received COOKIE_ECHO indicating simultaneous associations");
 
 				this->tcb = nullptr;
 			}
@@ -2013,7 +2013,7 @@ namespace RTC
 				return;
 			}
 
-			MS_WARN_TAG(sctp, "received ABORT Chunk, closing connection: %s", errorCausesStr.c_str());
+			MS_WARN_TAG(sctp, "received ABORT Chunk, closing Association: %s", errorCausesStr.c_str());
 
 			InternalClose(Types::ErrorKind::PEER_REPORTED, errorCausesStr);
 		}

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -1,5 +1,6 @@
 #define MS_CLASS "RTC::SCTP::Association"
-// #define MS_LOG_DEV_LEVEL 3
+// TODO: SCTP: COMMENT
+#define MS_LOG_DEV_LEVEL 3
 
 #include "RTC/SCTP/association/Association.hpp"
 #include "DepLibUV.hpp"
@@ -87,7 +88,7 @@ namespace RTC
 
 			MS_DUMP_CLEAN(
 			  indentation,
-			  "  SCTP association state: %.*s (internal state: %.*s)",
+			  "  association state: %.*s (internal state: %.*s)",
 			  static_cast<int>(associationStateStringView.size()),
 			  associationStateStringView.data(),
 			  static_cast<int>(stateStringView.size()),
@@ -583,7 +584,14 @@ namespace RTC
 
 			if (prevState == State::COOKIE_WAIT || prevState == State::COOKIE_ECHOED)
 			{
-				this->listener.OnAssociationFailed(errorKind, message);
+				if (errorKind == Types::ErrorKind::SUCCESS)
+				{
+					this->listener.OnAssociationClosed(errorKind, message);
+				}
+				else
+				{
+					this->listener.OnAssociationFailed(errorKind, message);
+				}
 			}
 			else
 			{
@@ -599,8 +607,7 @@ namespace RTC
 
 			if (state == this->state)
 			{
-				MS_WARN_TAG(
-				  sctp,
+				MS_WARN_DEV(
 				  "SCTP Association internal state is already %.*s (message: %.*s)",
 				  static_cast<int>(stateStringView.size()),
 				  stateStringView.data(),
@@ -612,7 +619,7 @@ namespace RTC
 
 			const auto previousStateStringView = Association::StateToString(this->state);
 
-			MS_WARN_TAG(
+			MS_DEBUG_TAG(
 			  sctp,
 			  "SCTP Association internal state changed from %.*s to %.*s (message: %.*s)",
 			  static_cast<int>(previousStateStringView.size()),

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -638,9 +638,6 @@ namespace RTC
 			{
 				supportedExtensionsParameter->AddChunkType(Chunk::ChunkType::FORWARD_TSN);
 
-				// TODO: SCTP
-				MS_DUMP("TODO: UNCOMMENT!!");
-
 				const auto* forwardTsnSupportedParameter =
 				  chunk->BuildParameterInPlace<ForwardTsnSupportedParameter>();
 

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -179,6 +179,13 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			if (this->state == State::CLOSED)
+			{
+				AssertStateIsConsistent();
+
+				return;
+			}
+
 			const AssociationDeferredListener::ScopedDeferred deferrer(this->listener);
 
 			// https://datatracker.ietf.org/doc/html/rfc9260#section-9.2
@@ -195,11 +202,11 @@ namespace RTC
 				// @see https://issues.webrtc.org/issues/42222897
 				if (this->state != State::SHUTDOWN_SENT && this->state != State::SHUTDOWN_ACK_SENT)
 				{
-					SetState(State::SHUTDOWN_PENDING, "Shutdown() called");
-
 					this->t1InitTimer->Stop();
 					this->t1CookieTimer->Stop();
 
+					// NOTE: We need to set state before calling method below.
+					SetState(State::SHUTDOWN_PENDING, "Shutdown() called");
 					MaySendShutdownOrShutdownAckChunk();
 				}
 			}
@@ -219,36 +226,35 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			if (this->state == State::CLOSED)
+			{
+				AssertStateIsConsistent();
+
+				return;
+			}
+
 			const AssociationDeferredListener::ScopedDeferred deferrer(this->listener);
 
-			if (this->state != State::CLOSED)
+			if (this->tcb)
 			{
-				if (this->tcb)
-				{
-					auto packet                 = this->tcb->CreatePacket();
-					auto* abortAssociationChunk = packet->BuildChunkInPlace<AbortAssociationChunk>();
+				auto packet                 = this->tcb->CreatePacket();
+				auto* abortAssociationChunk = packet->BuildChunkInPlace<AbortAssociationChunk>();
 
-					// NOTE: Don't set bit T in the ABORT chunk since TCB knows the
-					// Verification Tag expected by the remote.
+				// NOTE: Don't set bit T in the ABORT chunk since TCB knows the
+				// Verification Tag expected by the remote.
 
-					auto* userInitiatedAbortErrorCause =
-					  abortAssociationChunk->BuildErrorCauseInPlace<UserInitiatedAbortErrorCause>();
+				auto* userInitiatedAbortErrorCause =
+				  abortAssociationChunk->BuildErrorCauseInPlace<UserInitiatedAbortErrorCause>();
 
-					userInitiatedAbortErrorCause->SetUpperLayerAbortReason("Close() called");
+				userInitiatedAbortErrorCause->SetUpperLayerAbortReason("Close() called");
 
-					userInitiatedAbortErrorCause->Consolidate();
-					abortAssociationChunk->Consolidate();
+				userInitiatedAbortErrorCause->Consolidate();
+				abortAssociationChunk->Consolidate();
 
-					this->packetSender.SendPacket(packet.get());
-				}
-
-				InternalClose(Types::ErrorKind::SUCCESS, "");
-			}
-			else
-			{
-				MS_DEBUG_TAG(sctp, "Close() called on a closed Association");
+				this->packetSender.SendPacket(packet.get());
 			}
 
+			InternalClose(Types::ErrorKind::SUCCESS, "");
 			AssertStateIsConsistent();
 		}
 
@@ -751,7 +757,6 @@ namespace RTC
 			else if (this->state == State::SHUTDOWN_RECEIVED)
 			{
 				SendShutdownAckChunk();
-
 				SetState(State::SHUTDOWN_ACK_SENT, "no more outstanding data");
 			}
 		}
@@ -1655,7 +1660,7 @@ namespace RTC
 				MS_DEBUG_DEV("received COOKIE_ECHO indicating a restarted peer");
 
 				this->tcb = nullptr;
-				this->listener.OnAssociationConnectionRestarted();
+				this->listener.OnAssociationRestarted();
 			}
 			// "B) In this case, both sides might be attempting to start an association
 			// at about the same time, but the peer endpoint sent its INIT chunk after
@@ -1717,7 +1722,6 @@ namespace RTC
 			AssertHasTcb();
 
 			this->t1CookieTimer->Stop();
-
 			this->tcb->ClearRemoteStateCookie();
 
 			SetState(State::ESTABLISHED, "COOKIE_ACK received");

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -108,6 +108,34 @@ namespace RTC
 			MS_DUMP_CLEAN(indentation, "</SCTP::Association>");
 		}
 
+		flatbuffers::Offset<FBS::SctpParameters::SctpParameters> Association::FillBuffer(
+		  flatbuffers::FlatBufferBuilder& builder) const
+		{
+			MS_TRACE();
+
+			return FBS::SctpParameters::CreateSctpParameters(
+			  builder,
+			  // Add port.
+			  this->sctpOptions.sourcePort,
+			  // Add OS.
+			  // TODO: SCTP: We should put here current value which may be different after
+			  // negotiation with peer and reconfig.
+			  this->sctpOptions.maxOutboundStreams,
+			  // Add MIS.
+			  // TODO: SCTP: We should put here current value which may be different after
+			  // negotiation with peer and reconfig.
+			  this->sctpOptions.maxInboundStreams,
+			  // Add maxMessageSize.
+			  this->sctpOptions.maxSendMessageSize,
+			  // Add sendBufferSize.
+			  this->sctpOptions.maxSendBufferSize,
+			  // Add sctpBufferedAmountLowThreshold.
+			  this->sctpOptions.totalBufferedAmountLowThreshold,
+			  // Add isDataChannel.
+			  // TODO: SCTP: Have a member for this.
+			  /*isDataChannel*/ true);
+		}
+
 		Types::AssociationState Association::GetAssociationState() const
 		{
 			MS_TRACE();
@@ -531,15 +559,17 @@ namespace RTC
 				this->tcb = nullptr;
 			}
 
+			const auto prevState = this->state;
+
 			SetState(State::CLOSED, message);
 
-			if (errorKind == Types::ErrorKind::SUCCESS)
+			if (prevState == State::COOKIE_WAIT || prevState == State::COOKIE_ECHOED)
 			{
-				this->listener.OnAssociationClosed();
+				this->listener.OnAssociationFailed(errorKind, message);
 			}
 			else
 			{
-				this->listener.OnAssociationAborted(errorKind, message);
+				this->listener.OnAssociationClosed(errorKind, message);
 			}
 		}
 

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -637,25 +637,22 @@ namespace RTC
 			if (this->sctpOptions.enablePartialReliability)
 			{
 				supportedExtensionsParameter->AddChunkType(Chunk::ChunkType::FORWARD_TSN);
-
-				const auto* forwardTsnSupportedParameter =
-				  chunk->BuildParameterInPlace<ForwardTsnSupportedParameter>();
-
-				// TODO: SCTP: Remove
-				MS_DUMP("--- forwardTsnSupportedParameter before Consolidate():");
-				forwardTsnSupportedParameter->Dump();
-
-				forwardTsnSupportedParameter->Consolidate();
-
-				// TODO: SCTP: Remove
-				MS_DUMP("--- forwardTsnSupportedParameter after Consolidate():");
-				forwardTsnSupportedParameter->Dump();
 			}
 
 			if (this->sctpOptions.enableMessageInterleaving)
 			{
 				supportedExtensionsParameter->AddChunkType(Chunk::ChunkType::I_DATA);
 				supportedExtensionsParameter->AddChunkType(Chunk::ChunkType::I_FORWARD_TSN);
+			}
+
+			supportedExtensionsParameter->Consolidate();
+
+			if (this->sctpOptions.enablePartialReliability)
+			{
+				const auto* forwardTsnSupportedParameter =
+				  chunk->BuildParameterInPlace<ForwardTsnSupportedParameter>();
+
+				forwardTsnSupportedParameter->Consolidate();
 			}
 
 			if (
@@ -669,8 +666,6 @@ namespace RTC
 				  this->sctpOptions.zeroChecksumAlternateErrorDetectionMethod);
 				zeroChecksumAcceptableParameter->Consolidate();
 			}
-
-			supportedExtensionsParameter->Consolidate();
 		}
 
 		void Association::CreateTransmissionControlBlock(

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -453,7 +453,7 @@ namespace RTC
 			return statuses;
 		}
 
-		void Association::ReceivePacket(const Packet* receivedPacket)
+		void Association::ReceiveSctpData(const uint8_t* data, size_t len)
 		{
 			MS_TRACE();
 
@@ -461,20 +461,34 @@ namespace RTC
 
 			this->privateMetrics.rxPacketsCount++;
 
-			if (!ValidateReceivedPacket(receivedPacket))
+			std::unique_ptr<Packet> receivedPacket{ Packet::Parse(data, len) };
+
+			if (!receivedPacket)
+			{
+				MS_WARN_TAG(sctp, "failed to parse received SCTP packet");
+
+				this->listener.OnAssociationError(
+				  Types::ErrorKind::PARSE_FAILED, "failed to parse received SCTP packet");
+
+				AssertStateIsConsistent();
+
+				return;
+			}
+
+			if (!ValidateReceivedPacket(receivedPacket.get()))
 			{
 				MS_WARN_TAG(sctp, "Packet verification failed, discarded");
 
 				return;
 			}
 
-			MaySendShutdownOnPacketReceived(receivedPacket);
+			MaySendShutdownOnPacketReceived(receivedPacket.get());
 
 			for (auto it = receivedPacket->ChunksBegin(); it != receivedPacket->ChunksEnd(); ++it)
 			{
 				const auto* receivedChunk = *it;
 
-				if (!ProcessReceivedChunk(receivedPacket, receivedChunk))
+				if (!ProcessReceivedChunk(receivedPacket.get(), receivedChunk))
 				{
 					break;
 				}

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -161,11 +161,11 @@ namespace RTC
 
 				SetState(State::COOKIE_WAIT, "Connect() called");
 			}
-			if (this->state != State::CLOSED)
+			else
 			{
 				const auto stateStringView = Association::StateToString(this->state);
 
-				MS_DEBUG_TAG(
+				MS_WARN_TAG(
 				  sctp,
 				  "cannot initiate the Association since internal state is not CLOSED but %.*s",
 				  static_cast<int>(stateStringView.size()),
@@ -517,6 +517,8 @@ namespace RTC
 				this->tcb = nullptr;
 			}
 
+			SetState(State::CLOSED, message);
+
 			if (errorKind == Types::ErrorKind::SUCCESS)
 			{
 				this->listener.OnAssociationClosed();
@@ -525,8 +527,6 @@ namespace RTC
 			{
 				this->listener.OnAssociationAborted(errorKind, message);
 			}
-
-			SetState(State::CLOSED, message);
 		}
 
 		void Association::SetState(State state, const std::string_view& message)
@@ -1758,8 +1758,8 @@ namespace RTC
 				// state, restarting its T2-shutdown timer.
 				case State::SHUTDOWN_SENT:
 				{
-					SendShutdownAckChunk();
 					SetState(State::SHUTDOWN_ACK_SENT, "SHUTDOWN received");
+					SendShutdownAckChunk();
 
 					break;
 				}

--- a/worker/src/RTC/SCTP/association/AssociationDeferredListener.cpp
+++ b/worker/src/RTC/SCTP/association/AssociationDeferredListener.cpp
@@ -110,18 +110,36 @@ namespace RTC
 			  std::monostate{});
 		}
 
-		void AssociationDeferredListener::OnAssociationClosed()
+		void AssociationDeferredListener::OnAssociationFailed(
+		  Types::ErrorKind errorKind, std::string_view errorMessage)
 		{
 			MS_TRACE();
 
 			MS_ASSERT(this->ready, "not ready");
 
 			this->deferredCallbacks.emplace_back(
-			  [](CallbackData /*data*/, AssociationListener* listener)
+			  [](CallbackData data, AssociationListener* listener)
 			  {
-				  listener->OnAssociationClosed();
+				  const Error error = std::get<Error>(std::move(data));
+				  listener->OnAssociationFailed(error.errorKind, error.message);
 			  },
-			  std::monostate{});
+			  Error{ .errorKind = errorKind, .message = std::string(errorMessage) });
+		}
+
+		void AssociationDeferredListener::OnAssociationClosed(
+		  Types::ErrorKind errorKind, std::string_view errorMessage)
+		{
+			MS_TRACE();
+
+			MS_ASSERT(this->ready, "not ready");
+
+			this->deferredCallbacks.emplace_back(
+			  [](CallbackData data, AssociationListener* listener)
+			  {
+				  const Error error = std::get<Error>(std::move(data));
+				  listener->OnAssociationClosed(error.errorKind, error.message);
+			  },
+			  Error{ .errorKind = errorKind, .message = std::string(errorMessage) });
 		}
 
 		void AssociationDeferredListener::OnAssociationRestarted()
@@ -150,22 +168,6 @@ namespace RTC
 			  {
 				  const Error error = std::get<Error>(std::move(data));
 				  listener->OnAssociationError(error.errorKind, error.message);
-			  },
-			  Error{ .errorKind = errorKind, .message = std::string(errorMessage) });
-		}
-
-		void AssociationDeferredListener::OnAssociationAborted(
-		  Types::ErrorKind errorKind, std::string_view errorMessage)
-		{
-			MS_TRACE();
-
-			MS_ASSERT(this->ready, "not ready");
-
-			this->deferredCallbacks.emplace_back(
-			  [](CallbackData data, AssociationListener* listener)
-			  {
-				  const Error error = std::get<Error>(std::move(data));
-				  listener->OnAssociationAborted(error.errorKind, error.message);
 			  },
 			  Error{ .errorKind = errorKind, .message = std::string(errorMessage) });
 		}

--- a/worker/src/RTC/SCTP/association/AssociationDeferredListener.cpp
+++ b/worker/src/RTC/SCTP/association/AssociationDeferredListener.cpp
@@ -24,7 +24,7 @@ namespace RTC
 			this->deferredListener.TriggerDeferredCallbacks();
 		}
 
-		AssociationDeferredListener::AssociationDeferredListener(AssociationListener& innerListener)
+		AssociationDeferredListener::AssociationDeferredListener(AssociationListener* innerListener)
 		  : innerListener(innerListener)
 		{
 			MS_TRACE();
@@ -79,7 +79,7 @@ namespace RTC
 			MS_ASSERT(this->ready, "not ready");
 
 			// Will not be deferred but called directly.
-			return this->innerListener.OnAssociationSendData(data, len);
+			return this->innerListener->OnAssociationSendData(data, len);
 		}
 
 		void AssociationDeferredListener::OnAssociationConnected()
@@ -89,9 +89,9 @@ namespace RTC
 			MS_ASSERT(this->ready, "not ready");
 
 			this->deferredCallbacks.emplace_back(
-			  [](CallbackData /*data*/, AssociationListener& listener)
+			  [](CallbackData /*data*/, AssociationListener* listener)
 			  {
-				  listener.OnAssociationConnected();
+				  listener->OnAssociationConnected();
 			  },
 			  std::monostate{});
 		}
@@ -103,9 +103,9 @@ namespace RTC
 			MS_ASSERT(this->ready, "not ready");
 
 			this->deferredCallbacks.emplace_back(
-			  [](CallbackData /*data*/, AssociationListener& listener)
+			  [](CallbackData /*data*/, AssociationListener* listener)
 			  {
-				  listener.OnAssociationClosed();
+				  listener->OnAssociationClosed();
 			  },
 			  std::monostate{});
 		}
@@ -117,9 +117,9 @@ namespace RTC
 			MS_ASSERT(this->ready, "not ready");
 
 			this->deferredCallbacks.emplace_back(
-			  [](CallbackData /*data*/, AssociationListener& listener)
+			  [](CallbackData /*data*/, AssociationListener* listener)
 			  {
-				  listener.OnAssociationConnectionRestarted();
+				  listener->OnAssociationConnectionRestarted();
 			  },
 			  std::monostate{});
 		}
@@ -132,10 +132,10 @@ namespace RTC
 			MS_ASSERT(this->ready, "not ready");
 
 			this->deferredCallbacks.emplace_back(
-			  [](CallbackData data, AssociationListener& listener)
+			  [](CallbackData data, AssociationListener* listener)
 			  {
 				  const Error error = std::get<Error>(std::move(data));
-				  listener.OnAssociationError(error.errorKind, error.message);
+				  listener->OnAssociationError(error.errorKind, error.message);
 			  },
 			  Error{ .errorKind = errorKind, .message = std::string(errorMessage) });
 		}
@@ -148,10 +148,10 @@ namespace RTC
 			MS_ASSERT(this->ready, "not ready");
 
 			this->deferredCallbacks.emplace_back(
-			  [](CallbackData data, AssociationListener& listener)
+			  [](CallbackData data, AssociationListener* listener)
 			  {
 				  const Error error = std::get<Error>(std::move(data));
-				  listener.OnAssociationAborted(error.errorKind, error.message);
+				  listener->OnAssociationAborted(error.errorKind, error.message);
 			  },
 			  Error{ .errorKind = errorKind, .message = std::string(errorMessage) });
 		}
@@ -163,9 +163,9 @@ namespace RTC
 			MS_ASSERT(this->ready, "not ready");
 
 			this->deferredCallbacks.emplace_back(
-			  [](CallbackData data, AssociationListener& listener)
+			  [](CallbackData data, AssociationListener* listener)
 			  {
-				  listener.OnAssociationMessageReceived(std::get<Message>(std::move(data)));
+				  listener->OnAssociationMessageReceived(std::get<Message>(std::move(data)));
 			  },
 			  std::move(message));
 		}
@@ -178,10 +178,10 @@ namespace RTC
 			MS_ASSERT(this->ready, "not ready");
 
 			this->deferredCallbacks.emplace_back(
-			  [](CallbackData data, AssociationListener& listener)
+			  [](CallbackData data, AssociationListener* listener)
 			  {
 				  StreamReset streamReset = std::get<StreamReset>(std::move(data));
-				  listener.OnAssociationStreamsResetPerformed(streamReset.streamIds);
+				  listener->OnAssociationStreamsResetPerformed(streamReset.streamIds);
       },
 			  StreamReset{ .streamIds = { outboundStreamIds.begin(), outboundStreamIds.end() } });
 		}
@@ -194,10 +194,10 @@ namespace RTC
 			MS_ASSERT(this->ready, "not ready");
 
 			this->deferredCallbacks.emplace_back(
-			  [](CallbackData data, AssociationListener& listener)
+			  [](CallbackData data, AssociationListener* listener)
 			  {
 				  StreamReset streamReset = std::get<StreamReset>(std::move(data));
-				  listener.OnAssociationStreamsResetFailed(streamReset.streamIds, streamReset.errorMessage);
+				  listener->OnAssociationStreamsResetFailed(streamReset.streamIds, streamReset.errorMessage);
       },
 			  StreamReset{ .streamIds    = { outboundStreamIds.begin(), outboundStreamIds.end() },
 			               .errorMessage = std::string(errorMessage) });
@@ -211,10 +211,10 @@ namespace RTC
 			MS_ASSERT(this->ready, "not ready");
 
 			this->deferredCallbacks.emplace_back(
-			  [](CallbackData data, AssociationListener& listener)
+			  [](CallbackData data, AssociationListener* listener)
 			  {
 				  StreamReset streamReset = std::get<StreamReset>(std::move(data));
-				  listener.OnAssociationInboundStreamsReset(streamReset.streamIds);
+				  listener->OnAssociationInboundStreamsReset(streamReset.streamIds);
       },
 			  StreamReset{ .streamIds = { inboundStreamIds.begin(), inboundStreamIds.end() } });
 		}
@@ -226,9 +226,9 @@ namespace RTC
 			MS_ASSERT(this->ready, "not ready");
 
 			this->deferredCallbacks.emplace_back(
-			  [](CallbackData data, AssociationListener& listener)
+			  [](CallbackData data, AssociationListener* listener)
 			  {
-				  listener.OnAssociationStreamBufferedAmountLow(std::get<uint16_t>(std::move(data)));
+				  listener->OnAssociationStreamBufferedAmountLow(std::get<uint16_t>(std::move(data)));
 			  },
 			  streamId);
 		}
@@ -240,9 +240,9 @@ namespace RTC
 			MS_ASSERT(this->ready, "not ready");
 
 			this->deferredCallbacks.emplace_back(
-			  [](CallbackData /*data*/, AssociationListener& listener)
+			  [](CallbackData /*data*/, AssociationListener* listener)
 			  {
-				  listener.OnAssociationTotalBufferedAmountLow();
+				  listener->OnAssociationTotalBufferedAmountLow();
 			  },
 			  std::monostate{});
 		}

--- a/worker/src/RTC/SCTP/association/AssociationDeferredListener.cpp
+++ b/worker/src/RTC/SCTP/association/AssociationDeferredListener.cpp
@@ -82,6 +82,20 @@ namespace RTC
 			return this->innerListener->OnAssociationSendData(data, len);
 		}
 
+		void AssociationDeferredListener::OnAssociationConnecting()
+		{
+			MS_TRACE();
+
+			MS_ASSERT(this->ready, "not ready");
+
+			this->deferredCallbacks.emplace_back(
+			  [](CallbackData /*data*/, AssociationListener* listener)
+			  {
+				  listener->OnAssociationConnecting();
+			  },
+			  std::monostate{});
+		}
+
 		void AssociationDeferredListener::OnAssociationConnected()
 		{
 			MS_TRACE();

--- a/worker/src/RTC/SCTP/association/AssociationDeferredListener.cpp
+++ b/worker/src/RTC/SCTP/association/AssociationDeferredListener.cpp
@@ -72,14 +72,14 @@ namespace RTC
 			}
 		}
 
-		bool AssociationDeferredListener::OnAssociationSendPacket(Packet* packet)
+		bool AssociationDeferredListener::OnAssociationSendData(const uint8_t* data, size_t len)
 		{
 			MS_TRACE();
 
 			MS_ASSERT(this->ready, "not ready");
 
 			// Will not be deferred but called directly.
-			return this->innerListener.OnAssociationSendPacket(packet);
+			return this->innerListener.OnAssociationSendData(data, len);
 		}
 
 		void AssociationDeferredListener::OnAssociationConnected()

--- a/worker/src/RTC/SCTP/association/AssociationDeferredListener.cpp
+++ b/worker/src/RTC/SCTP/association/AssociationDeferredListener.cpp
@@ -110,7 +110,7 @@ namespace RTC
 			  std::monostate{});
 		}
 
-		void AssociationDeferredListener::OnAssociationConnectionRestarted()
+		void AssociationDeferredListener::OnAssociationRestarted()
 		{
 			MS_TRACE();
 
@@ -119,7 +119,7 @@ namespace RTC
 			this->deferredCallbacks.emplace_back(
 			  [](CallbackData /*data*/, AssociationListener* listener)
 			  {
-				  listener->OnAssociationConnectionRestarted();
+				  listener->OnAssociationRestarted();
 			  },
 			  std::monostate{});
 		}

--- a/worker/src/RTC/SCTP/association/PacketSender.cpp
+++ b/worker/src/RTC/SCTP/association/PacketSender.cpp
@@ -28,7 +28,8 @@ namespace RTC
 				packet->WriteCRC32cChecksum();
 			}
 
-			const bool sent = this->associationListener.OnAssociationSendPacket(packet);
+			const bool sent =
+			  this->associationListener.OnAssociationSendData(packet->GetBuffer(), packet->GetLength());
 
 			this->listener.OnPacketSenderPacketSent(this, packet, sent);
 

--- a/worker/src/RTC/SCTP/association/PacketSender.cpp
+++ b/worker/src/RTC/SCTP/association/PacketSender.cpp
@@ -28,6 +28,26 @@ namespace RTC
 				packet->WriteCRC32cChecksum();
 			}
 
+			// TODO: SCTP: For testing purposes. Must be removed.
+			{
+				MS_DUMP(">>> sending SCTP packet:");
+				packet->Dump();
+
+				const auto* parsedPacket = RTC::SCTP::Packet::Parse(packet->GetBuffer(), packet->GetLength());
+
+				if (parsedPacket)
+				{
+					MS_DUMP(">>> sending SCTP packet (parsed to verify):");
+					parsedPacket->Dump();
+
+					delete parsedPacket;
+				}
+				else
+				{
+					MS_ABORT("RTC::SCTP::Packet::Parse() failed to parse sending SCTP data");
+				}
+			}
+
 			const bool sent =
 			  this->associationListener.OnAssociationSendData(packet->GetBuffer(), packet->GetLength());
 

--- a/worker/src/RTC/SCTP/association/PacketSender.cpp
+++ b/worker/src/RTC/SCTP/association/PacketSender.cpp
@@ -31,21 +31,8 @@ namespace RTC
 			// TODO: SCTP: For testing purposes. Must be removed.
 			{
 				MS_DUMP(">>> sending SCTP packet:");
+
 				packet->Dump();
-
-				const auto* parsedPacket = RTC::SCTP::Packet::Parse(packet->GetBuffer(), packet->GetLength());
-
-				if (parsedPacket)
-				{
-					MS_DUMP(">>> sending SCTP packet (parsed to verify):");
-					parsedPacket->Dump();
-
-					delete parsedPacket;
-				}
-				else
-				{
-					MS_ABORT("RTC::SCTP::Packet::Parse() failed to parse sending SCTP data");
-				}
 			}
 
 			const bool sent =

--- a/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
+++ b/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
@@ -80,10 +80,8 @@ namespace RTC
 
 			this->negotiatedCapabilities.Dump(indentation + 1);
 
-			MS_DUMP_CLEAN(indentation, "  retransmission timeout:");
 			this->rto.Dump(indentation + 1);
 
-			MS_DUMP_CLEAN(indentation, "  tx error counter:");
 			this->txErrorCounter.Dump(indentation + 1);
 
 			MS_DUMP_CLEAN(indentation, "</SCTP::TransmissionControlBlock>");

--- a/worker/src/RTC/SCTP/packet/Chunk.cpp
+++ b/worker/src/RTC/SCTP/packet/Chunk.cpp
@@ -418,9 +418,6 @@ namespace RTC
 
 					case Parameter::ParameterType::FORWARD_TSN_SUPPORTED:
 					{
-						// TODO: SCTP: Remove.
-						MS_DUMP("----- Parameter::ParameterType::FORWARD_TSN_SUPPORTED | parameterLength:%u, padding:%u", parameterLength, padding);
-
 						parameter = ForwardTsnSupportedParameter::ParseStrict(
 						  ptr, parameterLength + padding, parameterLength, padding);
 

--- a/worker/src/RTC/SCTP/packet/Chunk.cpp
+++ b/worker/src/RTC/SCTP/packet/Chunk.cpp
@@ -418,6 +418,9 @@ namespace RTC
 
 					case Parameter::ParameterType::FORWARD_TSN_SUPPORTED:
 					{
+						// TODO: SCTP: Remove.
+						MS_DUMP("----- Parameter::ParameterType::FORWARD_TSN_SUPPORTED | parameterLength:%u, padding:%u", parameterLength, padding);
+
 						parameter = ForwardTsnSupportedParameter::ParseStrict(
 						  ptr, parameterLength + padding, parameterLength, padding);
 

--- a/worker/src/RTC/SCTP/packet/Chunk.cpp
+++ b/worker/src/RTC/SCTP/packet/Chunk.cpp
@@ -166,6 +166,7 @@ namespace RTC
 			MS_TRACE();
 
 			AssertCanHaveParameters();
+			AssertDoesNotNeedConsolidation();
 
 			const size_t previousLength = GetLength();
 
@@ -186,6 +187,7 @@ namespace RTC
 			MS_TRACE();
 
 			AssertCanHaveErrorCauses();
+			AssertDoesNotNeedConsolidation();
 
 			const size_t previousLength = GetLength();
 
@@ -708,20 +710,34 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			this->needsConsolidation = true;
+
 			// When the application completes the Parameter it must call
 			// `parameter->Consolidate()` and that will trigger this event.
 			parameter->SetConsolidatedListener(
 			  [this, parameter]()
 			  {
-				  // Fix buffer length assigned to the Parameter.
-				  parameter->SetBufferLength(parameter->GetLength());
+				  try
+				  {
+					  // Fix buffer length assigned to the Parameter.
+					  // NOTE: It may throw.
+					  parameter->SetBufferLength(parameter->GetLength());
 
-				  // This will update the total length and Length field of the Chunk.
-				  // NOTE: It may throw.
-				  AddItem(parameter);
+					  // This will update the total length and Length field of the Chunk.
+					  // NOTE: It may throw.
+					  AddItem(parameter);
 
-				  // Add the Parameter to the list.
-				  this->parameters.push_back(parameter);
+					  // Add the Parameter to the list.
+					  this->parameters.push_back(parameter);
+
+					  this->needsConsolidation = false;
+				  }
+				  catch (const MediaSoupError& error)
+				  {
+					  this->needsConsolidation = false;
+
+					  throw;
+				  }
 			  });
 		}
 
@@ -729,20 +745,33 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			this->needsConsolidation = true;
+
 			// When the application completes the Error Cause it must call
 			// `errorCause->Consolidate()` and that will trigger this event.
 			errorCause->SetConsolidatedListener(
 			  [this, errorCause]()
 			  {
-				  // Fix buffer length assigned to the Error Cause.
-				  errorCause->SetBufferLength(errorCause->GetLength());
+				  try
+				  {
+					  // Fix buffer length assigned to the Error Cause.
+					  errorCause->SetBufferLength(errorCause->GetLength());
 
-				  // This will update the total length and Length field of the Chunk.
-				  // NOTE: It may throw.
-				  AddItem(errorCause);
+					  // This will update the total length and Length field of the Chunk.
+					  // NOTE: It may throw.
+					  AddItem(errorCause);
 
-				  // Add the Error Cause to the list.
-				  this->errorCauses.push_back(errorCause);
+					  // Add the Error Cause to the list.
+					  this->errorCauses.push_back(errorCause);
+
+					  this->needsConsolidation = false;
+				  }
+				  catch (const MediaSoupError& error)
+				  {
+					  this->needsConsolidation = false;
+
+					  throw;
+				  }
 			  });
 		}
 
@@ -763,6 +792,16 @@ namespace RTC
 			if (!CanHaveErrorCauses())
 			{
 				MS_THROW_ERROR("this Chunk class cannot have Error Causes");
+			}
+		}
+
+		void Chunk::AssertDoesNotNeedConsolidation() const
+		{
+			MS_TRACE();
+
+			if (this->needsConsolidation)
+			{
+				MS_THROW_ERROR("Chunk needs consolidation of some ongoing Parameter or Error Cause");
 			}
 		}
 	} // namespace SCTP

--- a/worker/src/RTC/SCTP/packet/Chunk.cpp
+++ b/worker/src/RTC/SCTP/packet/Chunk.cpp
@@ -351,7 +351,7 @@ namespace RTC
 				if (!Parameter::IsParameter(
 				      ptr, parameterMaxBufferLength, parameterType, parameterLength, padding))
 				{
-					MS_WARN_TAG(sctp, "not a SCTP Parameter");
+					MS_WARN_TAG(sctp, "not an SCTP Parameter");
 
 					return false;
 				}
@@ -557,7 +557,7 @@ namespace RTC
 
 				if (!ErrorCause::IsErrorCause(ptr, errorCauseMaxBufferLength, causeCode, causeLength, padding))
 				{
-					MS_WARN_TAG(sctp, "not a SCTP Error Cause");
+					MS_WARN_TAG(sctp, "not an SCTP Error Cause");
 
 					return false;
 				}

--- a/worker/src/RTC/SCTP/packet/Packet.cpp
+++ b/worker/src/RTC/SCTP/packet/Packet.cpp
@@ -30,11 +30,17 @@ namespace RTC
 	{
 		/* Class methods. */
 
+		bool Packet::IsSctp(const uint8_t* buffer, size_t bufferLength)
+		{
+			return (
+			  bufferLength >= Packet::CommonHeaderLength && Utils::Byte::IsPaddedTo4Bytes(bufferLength));
+		}
+
 		Packet* Packet::Parse(const uint8_t* buffer, size_t bufferLength)
 		{
 			MS_TRACE();
 
-			if ((bufferLength < Packet::CommonHeaderLength) || !Utils::Byte::IsPaddedTo4Bytes(bufferLength))
+			if (!Packet::IsSctp(buffer, bufferLength))
 			{
 				MS_WARN_TAG(sctp, "not an SCTP Packet");
 
@@ -64,7 +70,7 @@ namespace RTC
 
 				if (!Chunk::IsChunk(ptr, chunkMaxBufferLength, chunkType, chunkLength, padding))
 				{
-					MS_WARN_TAG(sctp, "not a SCTP Chunk");
+					MS_WARN_TAG(sctp, "not an SCTP Chunk");
 
 					delete packet;
 					return nullptr;

--- a/worker/src/RTC/SCTP/packet/Packet.cpp
+++ b/worker/src/RTC/SCTP/packet/Packet.cpp
@@ -30,7 +30,7 @@ namespace RTC
 	{
 		/* Class methods. */
 
-		bool Packet::IsSctp(const uint8_t* buffer, size_t bufferLength)
+		bool Packet::IsSctp(const uint8_t* /*buffer*/, size_t bufferLength)
 		{
 			return (
 			  bufferLength >= Packet::CommonHeaderLength && Utils::Byte::IsPaddedTo4Bytes(bufferLength));

--- a/worker/src/RTC/SCTP/packet/Packet.cpp
+++ b/worker/src/RTC/SCTP/packet/Packet.cpp
@@ -377,6 +377,8 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			AssertDoesNotNeedConsolidation();
+
 			const size_t length = GetLength() + chunk->GetLength();
 
 			// Let's append the Chunk at the end of existing Chunks.
@@ -429,22 +431,44 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			this->needsConsolidation = true;
+
 			// When the application completes the Chunk it must call
 			// `chunk->Consolidate()` and that will trigger this event.
 			chunk->SetConsolidatedListener(
 			  [this, chunk]()
 			  {
-				  // Fix buffer length assigned to the Chunk.
-				  chunk->SetBufferLength(chunk->GetLength());
+				  try
+				  {
+					  // Fix buffer length assigned to the Chunk.
+					  chunk->SetBufferLength(chunk->GetLength());
 
-				  // Update Packet length.
-				  // NOTE: This will throw if there is no enough space in the Packet
-				  // buffer.
-				  SetLength(GetLength() + chunk->GetLength());
+					  // Update Packet length.
+					  // NOTE: This will throw if there is no enough space in the Packet
+					  // buffer.
+					  SetLength(GetLength() + chunk->GetLength());
 
-				  // Add the Chunk to the list.
-				  this->chunks.push_back(chunk);
+					  // Add the Chunk to the list.
+					  this->chunks.push_back(chunk);
+					  this->needsConsolidation = false;
+				  }
+				  catch (const MediaSoupError& error)
+				  {
+					  this->needsConsolidation = false;
+
+					  throw;
+				  }
 			  });
+		}
+
+		void Packet::AssertDoesNotNeedConsolidation() const
+		{
+			MS_TRACE();
+
+			if (this->needsConsolidation)
+			{
+				MS_THROW_ERROR("Packet needs consolidation of some ongoing Chunk");
+			}
 		}
 	} // namespace SCTP
 } // namespace RTC

--- a/worker/src/RTC/SCTP/packet/TLV.cpp
+++ b/worker/src/RTC/SCTP/packet/TLV.cpp
@@ -35,7 +35,7 @@ namespace RTC
 			}
 
 			// Item total length must be multiple of 4 bytes and must include padding
-			// bytes despite item Length field doesn't not include padding.
+			// bytes despite item Length field does not include padding.
 			// NOTE: We must cast to size_t, otherwise a maximum item Length value of
 			// 65535 would generate a padded length of 0 bytes!
 			const size_t paddedItemLength = Utils::Byte::PadTo4Bytes(size_t{ itemLength });

--- a/worker/src/RTC/SCTP/packet/TLV.cpp
+++ b/worker/src/RTC/SCTP/packet/TLV.cpp
@@ -40,6 +40,9 @@ namespace RTC
 			// 65535 would generate a padded length of 0 bytes!
 			const size_t paddedItemLength = Utils::Byte::PadTo4Bytes(size_t{ itemLength });
 
+			// TODO: SCTP: REMOVE
+			MS_DUMP("----- paddedItemLength: %zu", paddedItemLength);
+
 			if (bufferLength < paddedItemLength)
 			{
 				MS_WARN_TAG(
@@ -52,6 +55,9 @@ namespace RTC
 			}
 
 			padding = paddedItemLength - itemLength;
+
+			// TODO: SCTP: REMOVE
+			MS_DUMP("----- padding: %u", padding);
 
 			return true;
 		}

--- a/worker/src/RTC/SCTP/packet/TLV.cpp
+++ b/worker/src/RTC/SCTP/packet/TLV.cpp
@@ -40,9 +40,6 @@ namespace RTC
 			// 65535 would generate a padded length of 0 bytes!
 			const size_t paddedItemLength = Utils::Byte::PadTo4Bytes(size_t{ itemLength });
 
-			// TODO: SCTP: REMOVE
-			MS_DUMP("----- paddedItemLength: %zu", paddedItemLength);
-
 			if (bufferLength < paddedItemLength)
 			{
 				MS_WARN_TAG(
@@ -55,9 +52,6 @@ namespace RTC
 			}
 
 			padding = paddedItemLength - itemLength;
-
-			// TODO: SCTP: REMOVE
-			MS_DUMP("----- padding: %u", padding);
 
 			return true;
 		}

--- a/worker/src/RTC/SCTP/tx/RetransmissionErrorCounter.cpp
+++ b/worker/src/RTC/SCTP/tx/RetransmissionErrorCounter.cpp
@@ -28,7 +28,7 @@ namespace RTC
 			  "  limit: %s",
 			  this->limit ? std::to_string(this->limit.value()).c_str() : "Infinite");
 			MS_DUMP_CLEAN(indentation, "  counter: %zu", this->counter);
-			MS_DUMP_CLEAN(indentation, "  is exhausted: %s", IsExhausted() ? "yes" : "no");
+			MS_DUMP_CLEAN(indentation, "  exhausted: %s", IsExhausted() ? "yes" : "no");
 
 			MS_DUMP_CLEAN(indentation, "</SCTP::RetransmissionErrorCounter>");
 		}

--- a/worker/src/RTC/Serializable.cpp
+++ b/worker/src/RTC/Serializable.cpp
@@ -54,7 +54,7 @@ namespace RTC
 		this->bufferReleasedListener = listener;
 	}
 
-	void Serializable::Consolidate()
+	void Serializable::Consolidate() const
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2920,7 +2920,7 @@ namespace RTC
 		// TODO: SCTP
 	}
 
-	void Transport::OnAssociationConnectionRestarted()
+	void Transport::OnAssociationRestarted()
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2930,14 +2930,45 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// TODO: SCTP
+		// Notify the Node Transport.
+		auto sctpStateChangeOffset = FBS::Transport::CreateSctpStateChangeNotification(
+		  this->shared->channelNotifier->GetBufferBuilder(), FBS::SctpAssociation::SctpState::CONNECTING);
+
+		this->shared->channelNotifier->Emit(
+		  this->id,
+		  FBS::Notification::Event::TRANSPORT_SCTP_STATE_CHANGE,
+		  FBS::Notification::Body::Transport_SctpStateChangeNotification,
+		  sctpStateChangeOffset);
 	}
 
 	void Transport::OnAssociationConnected()
 	{
 		MS_TRACE();
 
-		// TODO: SCTP
+		// Tell all DataConsumers.
+		for (auto& kv : this->mapDataConsumers)
+		{
+			auto* dataConsumer = kv.second;
+
+			if (dataConsumer->GetType() == RTC::DataConsumer::Type::SCTP)
+			{
+				dataConsumer->SctpAssociationConnected();
+			}
+		}
+
+		// Notify the Node Transport.
+		auto sctpStateChangeOffset = FBS::Transport::CreateSctpStateChangeNotification(
+		  this->shared->channelNotifier->GetBufferBuilder(), FBS::SctpAssociation::SctpState::CONNECTED);
+
+		this->shared->channelNotifier->Emit(
+		  this->id,
+		  FBS::Notification::Event::TRANSPORT_SCTP_STATE_CHANGE,
+		  FBS::Notification::Body::Transport_SctpStateChangeNotification,
+		  sctpStateChangeOffset);
+
+		// TODO: SCTP: REMOVE
+		MS_DUMP("---- SCTP Association connected, dump():");
+		this->sctpAssociation->Dump();
 	}
 
 	void Transport::OnAssociationFailed(
@@ -2945,7 +2976,26 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// TODO: SCTP
+		// Tell all DataConsumers.
+		for (auto& kv : this->mapDataConsumers)
+		{
+			auto* dataConsumer = kv.second;
+
+			if (dataConsumer->GetType() == RTC::DataConsumer::Type::SCTP)
+			{
+				dataConsumer->SctpAssociationClosed();
+			}
+		}
+
+		// Notify the Node Transport.
+		auto sctpStateChangeOffset = FBS::Transport::CreateSctpStateChangeNotification(
+		  this->shared->channelNotifier->GetBufferBuilder(), FBS::SctpAssociation::SctpState::FAILED);
+
+		this->shared->channelNotifier->Emit(
+		  this->id,
+		  FBS::Notification::Event::TRANSPORT_SCTP_STATE_CHANGE,
+		  FBS::Notification::Body::Transport_SctpStateChangeNotification,
+		  sctpStateChangeOffset);
 	}
 
 	void Transport::OnAssociationClosed(
@@ -2953,7 +3003,26 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// TODO: SCTP
+		// Tell all DataConsumers.
+		for (auto& kv : this->mapDataConsumers)
+		{
+			auto* dataConsumer = kv.second;
+
+			if (dataConsumer->GetType() == RTC::DataConsumer::Type::SCTP)
+			{
+				dataConsumer->SctpAssociationClosed();
+			}
+		}
+
+		// Notify the Node Transport.
+		auto sctpStateChangeOffset = FBS::Transport::CreateSctpStateChangeNotification(
+		  this->shared->channelNotifier->GetBufferBuilder(), FBS::SctpAssociation::SctpState::CLOSED);
+
+		this->shared->channelNotifier->Emit(
+		  this->id,
+		  FBS::Notification::Event::TRANSPORT_SCTP_STATE_CHANGE,
+		  FBS::Notification::Body::Transport_SctpStateChangeNotification,
+		  sctpStateChangeOffset);
 	}
 
 	void Transport::OnAssociationRestarted()
@@ -2963,12 +3032,19 @@ namespace RTC
 		// TODO: SCTP
 	}
 
-	void Transport::OnAssociationError(
-	  RTC::SCTP::Types::ErrorKind /*errorKind*/, std::string_view /*errorMessage*/)
+	void Transport::OnAssociationError(RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage)
 	{
 		MS_TRACE();
 
-		// TODO: SCTP
+		const auto errorKindStringView = RTC::SCTP::Types::ErrorKindToString(errorKind);
+
+		MS_WARN_TAG(
+		  sctp,
+		  "SCTP Association error [kind:%.*s, message:%.*s]",
+		  static_cast<int>(errorKindStringView.size()),
+		  errorKindStringView.data(),
+		  static_cast<int>(errorMessage.size()),
+		  errorMessage.data());
 	}
 
 	void Transport::OnAssociationMessageReceived(RTC::SCTP::Message /*message*/)

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -19,6 +19,9 @@
 #include "RTC/RTCP/FeedbackRtpNack.hpp"
 #include "RTC/RTCP/FeedbackRtpTransport.hpp"
 #include "RTC/RTCP/XrDelaySinceLastRr.hpp"
+#ifdef MS_SCTP_STACK
+#include "RTC/SCTP/packet/Packet.hpp"
+#endif
 #include "RTC/RtpDictionaries.hpp"
 #include "RTC/SimpleConsumer.hpp"
 #include "RTC/SimulcastConsumer.hpp"
@@ -1682,6 +1685,24 @@ namespace RTC
 
 		// Pass it to the SctpAssociation.
 		this->sctpAssociation->ProcessSctpData(data, len);
+
+// TODO: For testing purposes. Must be removed.
+#ifdef MS_SCTP_STACK
+		MS_DUMP("<<< received SCTP packet...");
+
+		const auto* packet = RTC::SCTP::Packet::Parse(data, len);
+
+		if (packet)
+		{
+			packet->Dump();
+
+			delete packet;
+		}
+		else
+		{
+			MS_ERROR("RTC::SCTP::Packet::Parse() failed to parse received SCTP data");
+		}
+#endif
 	}
 
 	void Transport::CheckNoDataProducer(const std::string& dataProducerId) const
@@ -2893,6 +2914,24 @@ namespace RTC
 		{
 			SendSctpData(data, len);
 		}
+
+// TODO: For testing purposes. Must be removed.
+#ifdef MS_SCTP_STACK
+		MS_DUMP(">>> sending SCTP packet...");
+
+		const auto* packet = RTC::SCTP::Packet::Parse(data, len);
+
+		if (packet)
+		{
+			packet->Dump();
+
+			delete packet;
+		}
+		else
+		{
+			MS_ABORT("RTC::SCTP::Packet::Parse() failed to parse sent SCTP data");
+		}
+#endif
 	}
 
 	inline void Transport::OnSctpAssociationMessageReceived(

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -363,12 +363,39 @@ namespace RTC
 
 		if (this->sctpAssociation)
 		{
-#ifdef MS_SCTP_STACK
-			// TODO: SCTP
-#else
 			// Add sctpParameters.
 			sctpParameters = this->sctpAssociation->FillBuffer(builder);
 
+#ifdef MS_SCTP_STACK
+			// NOTE: There is never permanent FAILED state.
+			switch (this->sctpAssociation->GetAssociationState())
+			{
+				case RTC::SCTP::Types::AssociationState::NEW:
+				{
+					sctpState = FBS::SctpAssociation::SctpState::NEW;
+					break;
+				}
+
+				case RTC::SCTP::Types::AssociationState::CONNECTING:
+				{
+					sctpState = FBS::SctpAssociation::SctpState::CONNECTING;
+					break;
+				}
+
+				case RTC::SCTP::Types::AssociationState::CONNECTED:
+				{
+					sctpState = FBS::SctpAssociation::SctpState::CONNECTED;
+					break;
+				}
+
+				case RTC::SCTP::Types::AssociationState::SHUTTING_DOWN:
+				case RTC::SCTP::Types::AssociationState::CLOSED:
+				{
+					sctpState = FBS::SctpAssociation::SctpState::CLOSED;
+					break;
+				}
+			}
+#else
 			switch (this->sctpAssociation->GetState())
 			{
 				case RTC::SctpAssociation::SctpState::NEW:
@@ -401,9 +428,8 @@ namespace RTC
 					break;
 				}
 			}
-
-			sctpListener = this->sctpListener.FillBuffer(builder);
 #endif
+			sctpListener = this->sctpListener.FillBuffer(builder);
 		}
 
 		// Add traceEventTypes.
@@ -452,40 +478,34 @@ namespace RTC
 		{
 			// Add sctpState.
 #ifdef MS_SCTP_STACK
-			// TODO: SCTP: Our RTC::SCTP::Types::AssociationState values don't match
-			// existing values in FBS.
-			// switch (this->sctpAssociation->GetAssociationState())
-			// {
-			// 	case RTC::SCTP::Types::AssociationState::NEW:
-			// 	{
-			// 		sctpState = FBS::SctpAssociation::SctpState::NEW;
-			// 		break;
-			// 	}
+			// NOTE: There is never permanent FAILED state.
+			switch (this->sctpAssociation->GetAssociationState())
+			{
+				case RTC::SCTP::Types::AssociationState::NEW:
+				{
+					sctpState = FBS::SctpAssociation::SctpState::NEW;
+					break;
+				}
 
-			// 	case RTC::SCTP::Types::AssociationState::CONNECTING:
-			// 	{
-			// 		sctpState = FBS::SctpAssociation::SctpState::CONNECTING;
-			// 		break;
-			// 	}
+				case RTC::SCTP::Types::AssociationState::CONNECTING:
+				{
+					sctpState = FBS::SctpAssociation::SctpState::CONNECTING;
+					break;
+				}
 
-			// 	case RTC::SCTP::Types::AssociationState::CONNECTED:
-			// 	{
-			// 		sctpState = FBS::SctpAssociation::SctpState::CONNECTED;
-			// 		break;
-			// 	}
+				case RTC::SCTP::Types::AssociationState::CONNECTED:
+				{
+					sctpState = FBS::SctpAssociation::SctpState::CONNECTED;
+					break;
+				}
 
-			// 	case RTC::SCTP::Types::AssociationState::FAILED:
-			// 	{
-			// 		sctpState = FBS::SctpAssociation::SctpState::FAILED;
-			// 		break;
-			// 	}
-
-			// 	case RTC::SCTP::Types::AssociationState::CLOSED:
-			// 	{
-			// 		sctpState = FBS::SctpAssociation::SctpState::CLOSED;
-			// 		break;
-			// 	}
-			// }
+				case RTC::SCTP::Types::AssociationState::SHUTTING_DOWN:
+				case RTC::SCTP::Types::AssociationState::CLOSED:
+				{
+					sctpState = FBS::SctpAssociation::SctpState::CLOSED;
+					break;
+				}
+			}
 #else
 			switch (this->sctpAssociation->GetState())
 			{
@@ -2920,7 +2940,16 @@ namespace RTC
 		// TODO: SCTP
 	}
 
-	void Transport::OnAssociationClosed()
+	void Transport::OnAssociationFailed(
+	  RTC::SCTP::Types::ErrorKind /*errorKind*/, std::string_view /*errorMessage*/)
+	{
+		MS_TRACE();
+
+		// TODO: SCTP
+	}
+
+	void Transport::OnAssociationClosed(
+	  RTC::SCTP::Types::ErrorKind /*errorKind*/, std::string_view /*errorMessage*/)
 	{
 		MS_TRACE();
 
@@ -2934,28 +2963,22 @@ namespace RTC
 		// TODO: SCTP
 	}
 
-	void Transport::OnAssociationError(RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage)
+	void Transport::OnAssociationError(
+	  RTC::SCTP::Types::ErrorKind /*errorKind*/, std::string_view /*errorMessage*/)
 	{
 		MS_TRACE();
 
 		// TODO: SCTP
 	}
 
-	void Transport::OnAssociationAborted(RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage)
+	void Transport::OnAssociationMessageReceived(RTC::SCTP::Message /*message*/)
 	{
 		MS_TRACE();
 
 		// TODO: SCTP
 	}
 
-	void Transport::OnAssociationMessageReceived(RTC::SCTP::Message message)
-	{
-		MS_TRACE();
-
-		// TODO: SCTP
-	}
-
-	void Transport::OnAssociationStreamsResetPerformed(std::span<const uint16_t> outboundStreamIds)
+	void Transport::OnAssociationStreamsResetPerformed(std::span<const uint16_t> /*outboundStreamIds*/)
 	{
 		MS_TRACE();
 
@@ -2963,21 +2986,21 @@ namespace RTC
 	}
 
 	void Transport::OnAssociationStreamsResetFailed(
-	  std::span<const uint16_t> outboundStreamIds, std::string_view errorMessage)
+	  std::span<const uint16_t> /*outboundStreamIds*/, std::string_view /*errorMessage*/)
 	{
 		MS_TRACE();
 
 		// TODO: SCTP
 	}
 
-	void Transport::OnAssociationInboundStreamsReset(std::span<const uint16_t> inboundStreamIds)
+	void Transport::OnAssociationInboundStreamsReset(std::span<const uint16_t> /*inboundStreamIds*/)
 	{
 		MS_TRACE();
 
 		// TODO: SCTP
 	}
 
-	void Transport::OnAssociationStreamBufferedAmountLow(uint16_t streamId)
+	void Transport::OnAssociationStreamBufferedAmountLow(uint16_t /*streamId*/)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2906,6 +2906,13 @@ namespace RTC
 		}
 	}
 
+	void Transport::OnAssociationConnecting()
+	{
+		MS_TRACE();
+
+		// TODO: SCTP
+	}
+
 	void Transport::OnAssociationConnected()
 	{
 		MS_TRACE();

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1,4 +1,3 @@
-#include "flatbuffers/stl_emulation.h"
 #define MS_CLASS "RTC::Transport"
 // #define MS_LOG_DEV_LEVEL 3
 
@@ -19,10 +18,11 @@
 #include "RTC/RTCP/FeedbackRtpNack.hpp"
 #include "RTC/RTCP/FeedbackRtpTransport.hpp"
 #include "RTC/RTCP/XrDelaySinceLastRr.hpp"
-#ifdef MS_SCTP_STACK
-#include "RTC/SCTP/packet/Packet.hpp"
-#endif
 #include "RTC/RtpDictionaries.hpp"
+#ifdef MS_SCTP_STACK
+#include "RTC/SCTP/association/Association.hpp"
+#include "RTC/SCTP/public/SctpOptions.hpp"
+#endif
 #include "RTC/SimpleConsumer.hpp"
 #include "RTC/SimulcastConsumer.hpp"
 #include "RTC/SvcConsumer.hpp"
@@ -111,6 +111,18 @@ namespace RTC
 				sctpSendBufferSize = DefaultSctpSendBufferSize;
 			}
 
+#ifdef MS_SCTP_STACK
+			// TODO: Many interesting options missing.
+			const SctpOptions sctpOptions = { .sourcePort         = 5000,
+				                                .destinationPort    = 5000,
+				                                .maxOutboundStreams = 65535,
+				                                .maxInboundStreams  = options->numSctpStreams()->mis(),
+				                                // TODO: Sure?
+				                                .maxSendMessageSize = this->maxMessageSize,
+				                                .maxSendBufferSize  = sctpSendBufferSize };
+
+			this->sctpAssociation = std::make_unique<RTC::STCP::Association>(sctpOptions, this);
+#else
 			// This may throw.
 			this->sctpAssociation = new RTC::SctpAssociation(
 			  this,
@@ -119,6 +131,7 @@ namespace RTC
 			  this->maxMessageSize,
 			  sctpSendBufferSize,
 			  options->isDataChannel());
+#endif
 		}
 
 		// Create the RTCP timer.
@@ -1685,24 +1698,6 @@ namespace RTC
 
 		// Pass it to the SctpAssociation.
 		this->sctpAssociation->ProcessSctpData(data, len);
-
-// TODO: For testing purposes. Must be removed.
-#ifdef MS_SCTP_STACK
-		MS_DUMP("<<< received SCTP packet...");
-
-		const auto* packet = RTC::SCTP::Packet::Parse(data, len);
-
-		if (packet)
-		{
-			packet->Dump();
-
-			delete packet;
-		}
-		else
-		{
-			MS_ERROR("RTC::SCTP::Packet::Parse() failed to parse received SCTP data");
-		}
-#endif
 	}
 
 	void Transport::CheckNoDataProducer(const std::string& dataProducerId) const
@@ -2434,21 +2429,21 @@ namespace RTC
 		  notification);
 	}
 
-	inline void Transport::OnProducerPaused(RTC::Producer* producer)
+	void Transport::OnProducerPaused(RTC::Producer* producer)
 	{
 		MS_TRACE();
 
 		this->listener->OnTransportProducerPaused(this, producer);
 	}
 
-	inline void Transport::OnProducerResumed(RTC::Producer* producer)
+	void Transport::OnProducerResumed(RTC::Producer* producer)
 	{
 		MS_TRACE();
 
 		this->listener->OnTransportProducerResumed(this, producer);
 	}
 
-	inline void Transport::OnProducerNewRtpStream(
+	void Transport::OnProducerNewRtpStream(
 	  RTC::Producer* producer, RTC::RTP::RtpStreamRecv* rtpStream, uint32_t mappedSsrc)
 	{
 		MS_TRACE();
@@ -2456,7 +2451,7 @@ namespace RTC
 		this->listener->OnTransportProducerNewRtpStream(this, producer, rtpStream, mappedSsrc);
 	}
 
-	inline void Transport::OnProducerRtpStreamScore(
+	void Transport::OnProducerRtpStreamScore(
 	  RTC::Producer* producer, RTC::RTP::RtpStreamRecv* rtpStream, uint8_t score, uint8_t previousScore)
 	{
 		MS_TRACE();
@@ -2464,7 +2459,7 @@ namespace RTC
 		this->listener->OnTransportProducerRtpStreamScore(this, producer, rtpStream, score, previousScore);
 	}
 
-	inline void Transport::OnProducerRtcpSenderReport(
+	void Transport::OnProducerRtcpSenderReport(
 	  RTC::Producer* producer, RTC::RTP::RtpStreamRecv* rtpStream, bool first)
 	{
 		MS_TRACE();
@@ -2472,21 +2467,21 @@ namespace RTC
 		this->listener->OnTransportProducerRtcpSenderReport(this, producer, rtpStream, first);
 	}
 
-	inline void Transport::OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RTP::Packet* packet)
+	void Transport::OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RTP::Packet* packet)
 	{
 		MS_TRACE();
 
 		this->listener->OnTransportProducerRtpPacketReceived(this, producer, packet);
 	}
 
-	inline void Transport::OnProducerSendRtcpPacket(RTC::Producer* /*producer*/, RTC::RTCP::Packet* packet)
+	void Transport::OnProducerSendRtcpPacket(RTC::Producer* /*producer*/, RTC::RTCP::Packet* packet)
 	{
 		MS_TRACE();
 
 		SendRtcpPacket(packet);
 	}
 
-	inline void Transport::OnProducerNeedWorstRemoteFractionLost(
+	void Transport::OnProducerNeedWorstRemoteFractionLost(
 	  RTC::Producer* producer, uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost)
 	{
 		MS_TRACE();
@@ -2495,7 +2490,7 @@ namespace RTC
 		  this, producer, mappedSsrc, worstRemoteFractionLost);
 	}
 
-	inline void Transport::OnConsumerSendRtpPacket(RTC::Consumer* consumer, RTC::RTP::Packet* packet)
+	void Transport::OnConsumerSendRtpPacket(RTC::Consumer* consumer, RTC::RTP::Packet* packet)
 	{
 		MS_TRACE();
 
@@ -2590,7 +2585,7 @@ namespace RTC
 		this->sendRtpTransmission.Update(packet);
 	}
 
-	inline void Transport::OnConsumerRetransmitRtpPacket(RTC::Consumer* consumer, RTC::RTP::Packet* packet)
+	void Transport::OnConsumerRetransmitRtpPacket(RTC::Consumer* consumer, RTC::RTP::Packet* packet)
 	{
 		MS_TRACE();
 
@@ -2675,7 +2670,7 @@ namespace RTC
 		this->sendRtxTransmission.Update(packet);
 	}
 
-	inline void Transport::OnConsumerKeyFrameRequested(RTC::Consumer* consumer, uint32_t mappedSsrc)
+	void Transport::OnConsumerKeyFrameRequested(RTC::Consumer* consumer, uint32_t mappedSsrc)
 	{
 		MS_TRACE();
 
@@ -2689,7 +2684,7 @@ namespace RTC
 		this->listener->OnTransportConsumerKeyFrameRequested(this, consumer, mappedSsrc);
 	}
 
-	inline void Transport::OnConsumerNeedBitrateChange(RTC::Consumer* /*consumer*/)
+	void Transport::OnConsumerNeedBitrateChange(RTC::Consumer* /*consumer*/)
 	{
 		MS_TRACE();
 
@@ -2699,7 +2694,7 @@ namespace RTC
 		ComputeOutgoingDesiredBitrate();
 	}
 
-	inline void Transport::OnConsumerNeedZeroBitrate(RTC::Consumer* /*consumer*/)
+	void Transport::OnConsumerNeedZeroBitrate(RTC::Consumer* /*consumer*/)
 	{
 		MS_TRACE();
 
@@ -2711,7 +2706,7 @@ namespace RTC
 		ComputeOutgoingDesiredBitrate(/*forceBitrate*/ true);
 	}
 
-	inline void Transport::OnConsumerProducerClosed(RTC::Consumer* consumer)
+	void Transport::OnConsumerProducerClosed(RTC::Consumer* consumer)
 	{
 		MS_TRACE();
 
@@ -2747,7 +2742,7 @@ namespace RTC
 		}
 	}
 
-	inline void Transport::OnDataProducerMessageReceived(
+	void Transport::OnDataProducerMessageReceived(
 	  RTC::DataProducer* dataProducer,
 	  const uint8_t* msg,
 	  size_t len,
@@ -2761,21 +2756,21 @@ namespace RTC
 		  this, dataProducer, msg, len, ppid, subchannels, requiredSubchannel);
 	}
 
-	inline void Transport::OnDataProducerPaused(RTC::DataProducer* dataProducer)
+	void Transport::OnDataProducerPaused(RTC::DataProducer* dataProducer)
 	{
 		MS_TRACE();
 
 		this->listener->OnTransportDataProducerPaused(this, dataProducer);
 	}
 
-	inline void Transport::OnDataProducerResumed(RTC::DataProducer* dataProducer)
+	void Transport::OnDataProducerResumed(RTC::DataProducer* dataProducer)
 	{
 		MS_TRACE();
 
 		this->listener->OnTransportDataProducerResumed(this, dataProducer);
 	}
 
-	inline void Transport::OnDataConsumerSendMessage(
+	void Transport::OnDataConsumerSendMessage(
 	  RTC::DataConsumer* dataConsumer, const uint8_t* msg, size_t len, uint32_t ppid, onQueuedCallback* cb)
 	{
 		MS_TRACE();
@@ -2783,7 +2778,7 @@ namespace RTC
 		SendMessage(dataConsumer, msg, len, ppid, cb);
 	}
 
-	inline void Transport::OnDataConsumerDataProducerClosed(RTC::DataConsumer* dataConsumer)
+	void Transport::OnDataConsumerDataProducerClosed(RTC::DataConsumer* dataConsumer)
 	{
 		MS_TRACE();
 
@@ -2803,7 +2798,108 @@ namespace RTC
 		delete dataConsumer;
 	}
 
-	inline void Transport::OnSctpAssociationConnecting(RTC::SctpAssociation* /*sctpAssociation*/)
+#ifdef MS_SCTP_STACK
+	bool Transport::OnAssociationSendData(const uint8_t* data, size_t len)
+	{
+		MS_TRACE();
+
+		// TODO: Check if this is still true.
+		// Ignore if destroying.
+		// NOTE: This is because when the child class (i.e. WebRtcTransport) is deleted,
+		// its destructor is called first and then the parent Transport's destructor,
+		// and we would end here calling SendSctpData() which is an abstract method.
+		if (this->destroying)
+		{
+			return;
+		}
+
+		if (this->sctpAssociation)
+		{
+			SendSctpData(data, len);
+		}
+	}
+
+	void Transport::OnAssociationConnected()
+	{
+		MS_TRACE();
+
+		// TODO
+	}
+
+	void Transport::OnAssociationClosed()
+	{
+		MS_TRACE();
+
+		// TODO
+	}
+
+	void Transport::OnAssociationConnectionRestarted()
+	{
+		MS_TRACE();
+
+		// TODO
+	}
+
+	void Transport::OnAssociationError(RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage)
+	{
+		MS_TRACE();
+
+		// TODO
+	}
+
+	void Transport::OnAssociationAborted(RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage)
+	{
+		MS_TRACE();
+
+		// TODO
+	}
+
+	void Transport::OnAssociationMessageReceived(RTC::SCTP::Message message)
+	{
+		MS_TRACE();
+
+		// TODO
+	}
+
+	void Transport::OnAssociationStreamsResetPerformed(std::span<const uint16_t> outboundStreamIds)
+	{
+		MS_TRACE();
+
+		// TODO
+	}
+
+	void Transport::OnAssociationStreamsResetFailed(
+	  std::span<const uint16_t> outboundStreamIds, std::string_view errorMessage
+	  {
+		MS_TRACE();
+
+		// TODO
+	  }
+
+	void Transport::OnAssociationInboundStreamsReset(std::span<const uint16_t> inboundStreamIds)
+	{
+		MS_TRACE();
+
+		// TODO
+	}
+
+	void Transport::OnAssociationStreamBufferedAmountLow(uint16_t streamId)
+	{
+		MS_TRACE();
+
+		// TODO
+	}
+
+	void Transport::OnAssociationTotalBufferedAmountLow()
+	{
+		MS_TRACE();
+
+		// TODO
+	}
+
+	// TODO: Add OnAssociationLifecycleMessageXxxxxx() methods.
+#else
+	void Transport::OnSctpAssociationConnecting(RTC::SctpAssociation* /*sctpAssociation*/)
 	{
 		MS_TRACE();
 
@@ -2818,7 +2914,7 @@ namespace RTC
 		  sctpStateChangeOffset);
 	}
 
-	inline void Transport::OnSctpAssociationConnected(RTC::SctpAssociation* /*sctpAssociation*/)
+	void Transport::OnSctpAssociationConnected(RTC::SctpAssociation* /*sctpAssociation*/)
 	{
 		MS_TRACE();
 
@@ -2844,7 +2940,7 @@ namespace RTC
 		  sctpStateChangeOffset);
 	}
 
-	inline void Transport::OnSctpAssociationFailed(RTC::SctpAssociation* /*sctpAssociation*/)
+	void Transport::OnSctpAssociationFailed(RTC::SctpAssociation* /*sctpAssociation*/)
 	{
 		MS_TRACE();
 
@@ -2870,7 +2966,7 @@ namespace RTC
 		  sctpStateChangeOffset);
 	}
 
-	inline void Transport::OnSctpAssociationClosed(RTC::SctpAssociation* /*sctpAssociation*/)
+	void Transport::OnSctpAssociationClosed(RTC::SctpAssociation* /*sctpAssociation*/)
 	{
 		MS_TRACE();
 
@@ -2896,7 +2992,7 @@ namespace RTC
 		  sctpStateChangeOffset);
 	}
 
-	inline void Transport::OnSctpAssociationSendData(
+	void Transport::OnSctpAssociationSendData(
 	  RTC::SctpAssociation* /*sctpAssociation*/, const uint8_t* data, size_t len)
 	{
 		MS_TRACE();
@@ -2914,27 +3010,9 @@ namespace RTC
 		{
 			SendSctpData(data, len);
 		}
-
-// TODO: For testing purposes. Must be removed.
-#ifdef MS_SCTP_STACK
-		MS_DUMP(">>> sending SCTP packet...");
-
-		const auto* packet = RTC::SCTP::Packet::Parse(data, len);
-
-		if (packet)
-		{
-			packet->Dump();
-
-			delete packet;
-		}
-		else
-		{
-			MS_ABORT("RTC::SCTP::Packet::Parse() failed to parse sent SCTP data");
-		}
-#endif
 	}
 
-	inline void Transport::OnSctpAssociationMessageReceived(
+	void Transport::OnSctpAssociationMessageReceived(
 	  RTC::SctpAssociation* /*sctpAssociation*/,
 	  uint16_t streamId,
 	  const uint8_t* msg,
@@ -2971,7 +3049,7 @@ namespace RTC
 		}
 	}
 
-	inline void Transport::OnSctpAssociationBufferedAmount(
+	void Transport::OnSctpAssociationBufferedAmount(
 	  RTC::SctpAssociation* /*sctpAssociation*/, uint32_t bufferedAmount)
 	{
 		MS_TRACE();
@@ -2986,8 +3064,9 @@ namespace RTC
 			}
 		}
 	}
+#endif
 
-	inline void Transport::OnTransportCongestionControlClientBitrates(
+	void Transport::OnTransportCongestionControlClientBitrates(
 	  RTC::TransportCongestionControlClient* /*tccClient*/,
 	  RTC::TransportCongestionControlClient::Bitrates& bitrates)
 	{
@@ -3002,7 +3081,7 @@ namespace RTC
 		EmitTraceEventBweType(bitrates);
 	}
 
-	inline void Transport::OnTransportCongestionControlClientSendRtpPacket(
+	void Transport::OnTransportCongestionControlClientSendRtpPacket(
 	  RTC::TransportCongestionControlClient* /*tccClient*/,
 	  RTC::RTP::Packet* packet,
 	  const webrtc::PacedPacketInfo& pacingInfo)
@@ -3104,7 +3183,7 @@ namespace RTC
 		  this->sendProbationTransmission.GetBitrate(DepLibUV::GetTimeMs()));
 	}
 
-	inline void Transport::OnTransportCongestionControlServerSendRtcpPacket(
+	void Transport::OnTransportCongestionControlServerSendRtcpPacket(
 	  RTC::TransportCongestionControlServer* /*tccServer*/, RTC::RTCP::Packet* packet)
 	{
 		MS_TRACE();
@@ -3115,7 +3194,7 @@ namespace RTC
 	}
 
 #ifdef ENABLE_RTC_SENDER_BANDWIDTH_ESTIMATOR
-	inline void Transport::OnSenderBandwidthEstimatorAvailableBitrate(
+	void Transport::OnSenderBandwidthEstimatorAvailableBitrate(
 	  RTC::SenderBandwidthEstimator* /*senderBwe*/,
 	  uint32_t availableBitrate,
 	  uint32_t previousAvailableBitrate)
@@ -3133,7 +3212,7 @@ namespace RTC
 	}
 #endif
 
-	inline void Transport::OnTimer(TimerHandle* timer)
+	void Transport::OnTimer(TimerHandle* timer)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1791,10 +1791,10 @@ namespace RTC
 			return;
 		}
 
-#ifdef MS_SCTP_STACK
-		// TODO: SCTP
-#else
 		// Pass it to the SctpAssociation.
+#ifdef MS_SCTP_STACK
+		this->sctpAssociation->ReceiveSctpData(data, len);
+#else
 		this->sctpAssociation->ProcessSctpData(data, len);
 #endif
 	}

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1,3 +1,4 @@
+#include "RTC/SCTP/public/SctpTypes.hpp"
 #define MS_CLASS "RTC::Transport"
 // #define MS_LOG_DEV_LEVEL 3
 
@@ -112,16 +113,17 @@ namespace RTC
 			}
 
 #ifdef MS_SCTP_STACK
-			// TODO: Many interesting options missing.
-			const SctpOptions sctpOptions = { .sourcePort         = 5000,
-				                                .destinationPort    = 5000,
-				                                .maxOutboundStreams = 65535,
-				                                .maxInboundStreams  = options->numSctpStreams()->mis(),
-				                                // TODO: Sure?
-				                                .maxSendMessageSize = this->maxMessageSize,
-				                                .maxSendBufferSize  = sctpSendBufferSize };
+			// TODO: SCTP: Many interesting options missing.
+			const RTC::SCTP::SctpOptions sctpOptions = { .sourcePort         = 5000,
+				                                           .destinationPort    = 5000,
+				                                           .maxOutboundStreams = 65535,
+				                                           .maxInboundStreams =
+				                                             options->numSctpStreams()->mis(),
+				                                           // TODO: SCTP: Sure?
+				                                           .maxSendMessageSize = this->maxMessageSize,
+				                                           .maxSendBufferSize  = sctpSendBufferSize };
 
-			this->sctpAssociation = std::make_unique<RTC::STCP::Association>(sctpOptions, this);
+			this->sctpAssociation = std::make_unique<RTC::SCTP::Association>(sctpOptions, this);
 #else
 			// This may throw.
 			this->sctpAssociation = new RTC::SctpAssociation(
@@ -182,9 +184,11 @@ namespace RTC
 		}
 		this->mapDataConsumers.clear();
 
+#ifndef MS_SCTP_STACK
 		// Delete SCTP association.
 		delete this->sctpAssociation;
 		this->sctpAssociation = nullptr;
+#endif
 
 		// Delete the RTCP timer.
 		delete this->rtcpTimer;
@@ -359,6 +363,9 @@ namespace RTC
 
 		if (this->sctpAssociation)
 		{
+#ifdef MS_SCTP_STACK
+			// TODO: SCTP
+#else
 			// Add sctpParameters.
 			sctpParameters = this->sctpAssociation->FillBuffer(builder);
 
@@ -396,6 +403,7 @@ namespace RTC
 			}
 
 			sctpListener = this->sctpListener.FillBuffer(builder);
+#endif
 		}
 
 		// Add traceEventTypes.
@@ -443,6 +451,42 @@ namespace RTC
 		if (this->sctpAssociation)
 		{
 			// Add sctpState.
+#ifdef MS_SCTP_STACK
+			// TODO: SCTP: Our RTC::SCTP::Types::AssociationState values don't match
+			// existing values in FBS.
+			// switch (this->sctpAssociation->GetAssociationState())
+			// {
+			// 	case RTC::SCTP::Types::AssociationState::NEW:
+			// 	{
+			// 		sctpState = FBS::SctpAssociation::SctpState::NEW;
+			// 		break;
+			// 	}
+
+			// 	case RTC::SCTP::Types::AssociationState::CONNECTING:
+			// 	{
+			// 		sctpState = FBS::SctpAssociation::SctpState::CONNECTING;
+			// 		break;
+			// 	}
+
+			// 	case RTC::SCTP::Types::AssociationState::CONNECTED:
+			// 	{
+			// 		sctpState = FBS::SctpAssociation::SctpState::CONNECTED;
+			// 		break;
+			// 	}
+
+			// 	case RTC::SCTP::Types::AssociationState::FAILED:
+			// 	{
+			// 		sctpState = FBS::SctpAssociation::SctpState::FAILED;
+			// 		break;
+			// 	}
+
+			// 	case RTC::SCTP::Types::AssociationState::CLOSED:
+			// 	{
+			// 		sctpState = FBS::SctpAssociation::SctpState::CLOSED;
+			// 		break;
+			// 	}
+			// }
+#else
 			switch (this->sctpAssociation->GetState())
 			{
 				case RTC::SctpAssociation::SctpState::NEW:
@@ -475,6 +519,7 @@ namespace RTC
 					break;
 				}
 			}
+#endif
 		}
 
 		return FBS::Transport::CreateStatsDirect(
@@ -1160,8 +1205,12 @@ namespace RTC
 
 				if (dataProducer->GetType() == RTC::DataProducer::Type::SCTP)
 				{
+#ifdef MS_SCTP_STACK
+					// TODO: SCTP
+#else
 					// Tell to the SCTP association.
 					this->sctpAssociation->HandleDataProducer(dataProducer);
+#endif
 				}
 
 				break;
@@ -1188,7 +1237,9 @@ namespace RTC
 				  this->shared,
 				  dataConsumerId,
 				  dataProducerId,
+#ifndef MS_SCTP_STACK
 				  this->sctpAssociation,
+#endif
 				  this,
 				  body,
 				  this->maxMessageSize);
@@ -1257,13 +1308,21 @@ namespace RTC
 
 				if (dataConsumer->GetType() == RTC::DataConsumer::Type::SCTP)
 				{
+#ifdef MS_SCTP_STACK
+					if (this->sctpAssociation->GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED)
+#else
 					if (this->sctpAssociation->GetState() == RTC::SctpAssociation::SctpState::CONNECTED)
+#endif
 					{
 						dataConsumer->SctpAssociationConnected();
 					}
 
+#ifdef MS_SCTP_STACK
+					// TODO: SCTP
+#else
 					// Tell to the SCTP association.
 					this->sctpAssociation->HandleDataConsumer(dataConsumer);
+#endif
 				}
 
 				break;
@@ -1411,8 +1470,12 @@ namespace RTC
 
 				if (dataProducer->GetType() == RTC::DataProducer::Type::SCTP)
 				{
+#ifdef MS_SCTP_STACK
+					// TODO: SCTP
+#else
 					// Tell the SctpAssociation so it can reset the SCTP stream.
 					this->sctpAssociation->DataProducerClosed(dataProducer);
+#endif
 				}
 
 				// Delete it.
@@ -1440,8 +1503,12 @@ namespace RTC
 
 				if (dataConsumer->GetType() == RTC::DataConsumer::Type::SCTP)
 				{
+#ifdef MS_SCTP_STACK
+					// TODO: SCTP
+#else
 					// Tell the SctpAssociation so it can reset the SCTP stream.
 					this->sctpAssociation->DataConsumerClosed(dataConsumer);
+#endif
 				}
 
 				// Delete it.
@@ -1512,7 +1579,11 @@ namespace RTC
 		// Tell the SctpAssociation.
 		if (this->sctpAssociation)
 		{
+#ifdef MS_SCTP_STACK
+			// TODO: SCTP
+#else
 			this->sctpAssociation->TransportConnected();
+#endif
 		}
 
 		// Start the RTCP timer.
@@ -1562,7 +1633,11 @@ namespace RTC
 		// Tell the SctpAssociation.
 		if (this->sctpAssociation)
 		{
+#ifdef MS_SCTP_STACK
+			// TODO: SCTP
+#else
 			this->sctpAssociation->TransportDisconnected();
+#endif
 		}
 
 		// Stop the RTCP timer.
@@ -1696,8 +1771,12 @@ namespace RTC
 			return;
 		}
 
+#ifdef MS_SCTP_STACK
+		// TODO: SCTP
+#else
 		// Pass it to the SctpAssociation.
 		this->sctpAssociation->ProcessSctpData(data, len);
+#endif
 	}
 
 	void Transport::CheckNoDataProducer(const std::string& dataProducerId) const
@@ -2790,8 +2869,12 @@ namespace RTC
 
 		if (dataConsumer->GetType() == RTC::DataConsumer::Type::SCTP)
 		{
+#ifdef MS_SCTP_STACK
+			// TODO: SCTP
+#else
 			// Tell the SctpAssociation so it can reset the SCTP stream.
 			this->sctpAssociation->DataConsumerClosed(dataConsumer);
+#endif
 		}
 
 		// Delete it.
@@ -2810,12 +2893,16 @@ namespace RTC
 		// and we would end here calling SendSctpData() which is an abstract method.
 		if (this->destroying)
 		{
-			return;
+			return false;
 		}
 
 		if (this->sctpAssociation)
 		{
-			SendSctpData(data, len);
+			return SendSctpData(data, len);
+		}
+		else
+		{
+			return false;
 		}
 	}
 
@@ -2823,81 +2910,81 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// TODO
+		// TODO: SCTP
 	}
 
 	void Transport::OnAssociationClosed()
 	{
 		MS_TRACE();
 
-		// TODO
+		// TODO: SCTP
 	}
 
 	void Transport::OnAssociationConnectionRestarted()
 	{
 		MS_TRACE();
 
-		// TODO
+		// TODO: SCTP
 	}
 
 	void Transport::OnAssociationError(RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage)
 	{
 		MS_TRACE();
 
-		// TODO
+		// TODO: SCTP
 	}
 
 	void Transport::OnAssociationAborted(RTC::SCTP::Types::ErrorKind errorKind, std::string_view errorMessage)
 	{
 		MS_TRACE();
 
-		// TODO
+		// TODO: SCTP
 	}
 
 	void Transport::OnAssociationMessageReceived(RTC::SCTP::Message message)
 	{
 		MS_TRACE();
 
-		// TODO
+		// TODO: SCTP
 	}
 
 	void Transport::OnAssociationStreamsResetPerformed(std::span<const uint16_t> outboundStreamIds)
 	{
 		MS_TRACE();
 
-		// TODO
+		// TODO: SCTP
 	}
 
 	void Transport::OnAssociationStreamsResetFailed(
-	  std::span<const uint16_t> outboundStreamIds, std::string_view errorMessage
-	  {
+	  std::span<const uint16_t> outboundStreamIds, std::string_view errorMessage)
+	{
 		MS_TRACE();
 
-		// TODO
-	  }
+		// TODO: SCTP
+	}
 
 	void Transport::OnAssociationInboundStreamsReset(std::span<const uint16_t> inboundStreamIds)
 	{
 		MS_TRACE();
 
-		// TODO
+		// TODO: SCTP
 	}
 
 	void Transport::OnAssociationStreamBufferedAmountLow(uint16_t streamId)
 	{
 		MS_TRACE();
 
-		// TODO
+		// TODO: SCTP
 	}
 
 	void Transport::OnAssociationTotalBufferedAmountLow()
 	{
 		MS_TRACE();
 
-		// TODO
+		// TODO: SCTP
 	}
 
-	// TODO: Add OnAssociationLifecycleMessageXxxxxx() methods.
+	// TODO: SCTP: Add OnAssociationLifecycleMessageXxxxxx() methods.
 #else
 	void Transport::OnSctpAssociationConnecting(RTC::SctpAssociation* /*sctpAssociation*/)
 	{

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -856,10 +856,14 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifdef MS_SCTP_STACK
+		// TODO: SCTP
+#else
 		this->sctpAssociation->SendSctpMessage(dataConsumer, msg, len, ppid, cb);
+#endif
 	}
 
-	void WebRtcTransport::SendSctpData(const uint8_t* data, size_t len)
+	bool WebRtcTransport::SendSctpData(const uint8_t* data, size_t len)
 	{
 		MS_TRACE();
 
@@ -867,10 +871,10 @@ namespace RTC
 		{
 			MS_WARN_TAG(sctp, "DTLS not connected, cannot send SCTP data");
 
-			return;
+			return false;
 		}
 
-		this->dtlsTransport->SendApplicationData(data, len);
+		return this->dtlsTransport->SendApplicationData(data, len);
 	}
 
 	void WebRtcTransport::RecvStreamClosed(uint32_t ssrc)

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -7,10 +7,6 @@
 #include "Settings.hpp"
 #include "Utils.hpp"
 #include "FBS/webRtcTransport.h"
-// TODO: For testing purposes. Must be removed.
-#ifdef MS_SCTP_STACK
-#include "RTC/SCTP/packet/Packet.hpp"
-#endif
 #include <cmath> // std::pow()
 
 namespace RTC
@@ -874,24 +870,6 @@ namespace RTC
 			return;
 		}
 
-// TODO: For testing purposes. Must be removed.
-#ifdef MS_SCTP_STACK
-		MS_DUMP(">>> sending SCTP packet...");
-
-		const auto* packet = RTC::SCTP::Packet::Parse(data, len);
-
-		if (packet)
-		{
-			packet->Dump();
-
-			delete packet;
-		}
-		else
-		{
-			MS_ABORT("RTC::SCTP::Packet::Parse() failed to parse sent SCTP data");
-		}
-#endif
-
 		this->dtlsTransport->SendApplicationData(data, len);
 	}
 
@@ -1458,24 +1436,6 @@ namespace RTC
 	  const RTC::DtlsTransport* /*dtlsTransport*/, const uint8_t* data, size_t len)
 	{
 		MS_TRACE();
-
-// TODO: For testing purposes. Must be removed.
-#ifdef MS_SCTP_STACK
-		MS_DUMP("<<< received SCTP packet...");
-
-		const auto* packet = RTC::SCTP::Packet::Parse(data, len);
-
-		if (packet)
-		{
-			packet->Dump();
-
-			delete packet;
-		}
-		else
-		{
-			MS_ABORT("RTC::SCTP::Packet::Parse() failed to parse received SCTP data");
-		}
-#endif
 
 		// Pass it to the parent transport.
 		RTC::Transport::ReceiveSctpData(data, len);

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -7,7 +7,9 @@
 #include "DepLibUring.hpp"
 #endif
 #include "DepLibUV.hpp"
+#ifndef MS_SCTP_STACK
 #include "DepUsrSCTP.hpp"
+#endif
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include "Settings.hpp"
@@ -40,8 +42,10 @@ Worker::Worker(::Channel::ChannelSocket* channel) : channel(channel)
 	}
 #endif
 
+#ifndef MS_SCTP_STACK
 	// Create the Checker instance in DepUsrSCTP.
 	DepUsrSCTP::CreateChecker();
+#endif
 
 #ifdef MS_LIBURING_SUPPORTED
 	if (DepLibUring::IsEnabled())
@@ -105,8 +109,10 @@ void Worker::Close()
 	// Delete the RTC::Shared singleton.
 	delete this->shared;
 
+#ifndef MS_SCTP_STACK
 	// Close the Checker instance in DepUsrSCTP.
 	DepUsrSCTP::CloseChecker();
+#endif
 
 #ifdef MS_LIBURING_SUPPORTED
 	if (DepLibUring::IsEnabled())

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -9,7 +9,9 @@
 #include "DepLibUV.hpp"
 #include "DepLibWebRTC.hpp"
 #include "DepOpenSSL.hpp"
+#ifndef MS_SCTP_STACK
 #include "DepUsrSCTP.hpp"
+#endif
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include "Settings.hpp"
@@ -146,7 +148,9 @@ extern "C" int mediasoup_worker_run(
 		// Initialize static stuff.
 		DepOpenSSL::ClassInit();
 		DepLibSRTP::ClassInit();
+#ifndef MS_SCTP_STACK
 		DepUsrSCTP::ClassInit();
+#endif
 #ifdef MS_LIBURING_SUPPORTED
 		DepLibUring::ClassInit();
 #endif
@@ -169,7 +173,9 @@ extern "C" int mediasoup_worker_run(
 		DepLibUring::ClassDestroy();
 #endif
 		RTC::DtlsTransport::ClassDestroy();
+#ifndef MS_SCTP_STACK
 		DepUsrSCTP::ClassDestroy();
+#endif
 		DepLibUV::ClassDestroy();
 
 		return 0;

--- a/worker/test/include/RTC/SCTP/sctpCommon.hpp
+++ b/worker/test/include/RTC/SCTP/sctpCommon.hpp
@@ -41,6 +41,7 @@ namespace sctpCommon
   /*size_t*/ chunksCount)                                                                          \
 	do                                                                                               \
 	{                                                                                                \
+		REQUIRE(RTC::SCTP::Packet::IsSctp(buffer, length) == true);                                    \
 		REQUIRE(packet);                                                                               \
 		REQUIRE(packet->GetBuffer() != nullptr);                                                       \
 		REQUIRE(packet->GetBuffer() == buffer);                                                        \

--- a/worker/test/src/RTC/SCTP/packet/TestChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestChunk.cpp
@@ -1,0 +1,111 @@
+#include "common.hpp"
+#include "MediaSoupErrors.hpp"
+#include "RTC/SCTP/packet/chunks/AbortAssociationChunk.hpp"
+#include "RTC/SCTP/packet/chunks/InitChunk.hpp"
+#include "RTC/SCTP/packet/errorCauses/OutOfResourceErrorCause.hpp"
+#include "RTC/SCTP/packet/errorCauses/ProtocolViolationErrorCause.hpp"
+#include "RTC/SCTP/packet/parameters/ForwardTsnSupportedParameter.hpp"
+#include "RTC/SCTP/packet/parameters/ZeroChecksumAcceptableParameter.hpp"
+#include "RTC/SCTP/sctpCommon.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+SCENARIO("SCTP Packet", "[serializable][sctp][chunk]")
+{
+	sctpCommon::ResetBuffers();
+
+	SECTION("BuildParameterInPlace() and AddParameter() throw if the Chunk needs consolidation")
+	{
+		std::unique_ptr<RTC::SCTP::InitChunk> chunk{ RTC::SCTP::InitChunk::Factory(
+			sctpCommon::FactoryBuffer, 1000) };
+
+		REQUIRE(chunk->NeedsConsolidation() == false);
+
+		const auto* parameter1 = chunk->BuildParameterInPlace<RTC::SCTP::ForwardTsnSupportedParameter>();
+
+		REQUIRE(chunk->NeedsConsolidation() == true);
+
+		// We didn't call parameter1->Consolidate() yet so this must throw.
+		REQUIRE_THROWS_AS(
+		  chunk->BuildParameterInPlace<RTC::SCTP::ZeroChecksumAcceptableParameter>(), MediaSoupError);
+
+		const auto* parameter2 = RTC::SCTP::ZeroChecksumAcceptableParameter::Factory(
+		  sctpCommon::FactoryBuffer + 1000, sizeof(sctpCommon::FactoryBuffer));
+
+		// We didn't call parameter1->Consolidate() yet so this must throw.
+		REQUIRE_THROWS_AS(chunk->AddParameter(parameter2), MediaSoupError);
+
+		delete parameter2;
+
+		parameter1->Consolidate();
+
+		REQUIRE(chunk->NeedsConsolidation() == false);
+
+		// This shouldn't throw now.
+		const auto* parameter3 =
+		  chunk->BuildParameterInPlace<RTC::SCTP::ZeroChecksumAcceptableParameter>();
+
+		REQUIRE(chunk->NeedsConsolidation() == true);
+
+		parameter3->Consolidate();
+
+		REQUIRE(chunk->NeedsConsolidation() == false);
+
+		const auto* parameter4 = RTC::SCTP::ZeroChecksumAcceptableParameter::Factory(
+		  sctpCommon::FactoryBuffer + 1000, sizeof(sctpCommon::FactoryBuffer));
+
+		// This shouldn't throw now.
+		chunk->AddParameter(parameter4);
+
+		REQUIRE(chunk->NeedsConsolidation() == false);
+
+		delete parameter4;
+	}
+
+	SECTION("BuildErrorCauseInPlace() and AddErrorCause() throw if the Chunk needs consolidation")
+	{
+		std::unique_ptr<RTC::SCTP::AbortAssociationChunk> chunk{
+			RTC::SCTP::AbortAssociationChunk::Factory(sctpCommon::FactoryBuffer, 1000)
+		};
+
+		REQUIRE(chunk->NeedsConsolidation() == false);
+
+		const auto* errorCause1 = chunk->BuildErrorCauseInPlace<RTC::SCTP::OutOfResourceErrorCause>();
+
+		REQUIRE(chunk->NeedsConsolidation() == true);
+
+		// We didn't call errorCause1->Consolidate() yet so this must throw.
+		REQUIRE_THROWS_AS(
+		  chunk->BuildErrorCauseInPlace<RTC::SCTP::ProtocolViolationErrorCause>(), MediaSoupError);
+
+		const auto* errorCause2 = RTC::SCTP::ProtocolViolationErrorCause::Factory(
+		  sctpCommon::FactoryBuffer + 1000, sizeof(sctpCommon::FactoryBuffer));
+
+		// We didn't call errorCause1->Consolidate() yet so this must throw.
+		REQUIRE_THROWS_AS(chunk->AddErrorCause(errorCause2), MediaSoupError);
+
+		delete errorCause2;
+
+		errorCause1->Consolidate();
+
+		REQUIRE(chunk->NeedsConsolidation() == false);
+
+		// This shouldn't throw now.
+		const auto* errorCause3 = chunk->BuildErrorCauseInPlace<RTC::SCTP::ProtocolViolationErrorCause>();
+
+		REQUIRE(chunk->NeedsConsolidation() == true);
+
+		errorCause3->Consolidate();
+
+		REQUIRE(chunk->NeedsConsolidation() == false);
+
+		const auto* errorCause4 = RTC::SCTP::ProtocolViolationErrorCause::Factory(
+		  sctpCommon::FactoryBuffer + 1000, sizeof(sctpCommon::FactoryBuffer));
+
+		// This shouldn't throw now.
+		chunk->AddErrorCause(errorCause4);
+
+		REQUIRE(chunk->NeedsConsolidation() == false);
+
+		delete errorCause4;
+	}
+}

--- a/worker/test/src/RTC/SCTP/packet/TestPacket.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestPacket.cpp
@@ -744,7 +744,7 @@ SCENARIO("SCTP Packet", "[serializable][sctp][packet]")
 	SECTION("Factory() using AddChunk() succeeds")
 	{
 		std::unique_ptr<RTC::SCTP::Packet> packet{ RTC::SCTP::Packet::Factory(
-			sctpCommon::FactoryBuffer, sizeof(sctpCommon::FactoryBuffer)) };
+			sctpCommon::FactoryBuffer, 1000) };
 
 		packet->SetSourcePort(1);
 		packet->SetDestinationPort(2);
@@ -752,8 +752,7 @@ SCENARIO("SCTP Packet", "[serializable][sctp][packet]")
 		packet->SetChecksum(4);
 
 		// 4 bytes Chunk.
-		auto* chunk1 = RTC::SCTP::ShutdownCompleteChunk::Factory(
-		  sctpCommon::FactoryBuffer + 1000, sizeof(sctpCommon::FactoryBuffer));
+		auto* chunk1 = RTC::SCTP::ShutdownCompleteChunk::Factory(sctpCommon::FactoryBuffer + 1000, 1000);
 
 		chunk1->SetT(true);
 
@@ -775,7 +774,7 @@ SCENARIO("SCTP Packet", "[serializable][sctp][packet]")
 		CHECK_SCTP_PACKET(
 		  /*packet*/ packet.get(),
 		  /*buffer*/ sctpCommon::FactoryBuffer,
-		  /*bufferLength*/ sizeof(sctpCommon::FactoryBuffer),
+		  /*bufferLength*/ 1000,
 		  /*length*/ 16,
 		  /*sourcePort*/ 1,
 		  /*destinationPort*/ 2,
@@ -845,5 +844,51 @@ SCENARIO("SCTP Packet", "[serializable][sctp][packet]")
 		  /*checksum*/ 0,
 		  /*hasValidCrc32cChecksum*/ false,
 		  /*chunksCount*/ 0);
+	}
+
+	SECTION("BuildChunkInPlace() and AddChunk() throw if the Packet needs consolidation")
+	{
+		std::unique_ptr<RTC::SCTP::Packet> packet{ RTC::SCTP::Packet::Factory(
+			sctpCommon::FactoryBuffer, 1000) };
+
+		REQUIRE(packet->NeedsConsolidation() == false);
+
+		const auto* chunk1 = packet->BuildChunkInPlace<RTC::SCTP::InitChunk>();
+
+		REQUIRE(packet->NeedsConsolidation() == true);
+
+		// We didn't call chunk1->Consolidate() yet so this must throw.
+		REQUIRE_THROWS_AS(packet->BuildChunkInPlace<RTC::SCTP::ShutdownCompleteChunk>(), MediaSoupError);
+
+		const auto* chunk2 = RTC::SCTP::ShutdownCompleteChunk::Factory(
+		  sctpCommon::FactoryBuffer + 1000, sizeof(sctpCommon::FactoryBuffer));
+
+		// We didn't call chunk1->Consolidate() yet so this must throw.
+		REQUIRE_THROWS_AS(packet->AddChunk(chunk2), MediaSoupError);
+
+		delete chunk2;
+
+		chunk1->Consolidate();
+
+		REQUIRE(packet->NeedsConsolidation() == false);
+
+		// This shouldn't throw now.
+		const auto* chunk3 = packet->BuildChunkInPlace<RTC::SCTP::ShutdownCompleteChunk>();
+
+		REQUIRE(packet->NeedsConsolidation() == true);
+
+		chunk3->Consolidate();
+
+		REQUIRE(packet->NeedsConsolidation() == false);
+
+		const auto* chunk4 = RTC::SCTP::ShutdownCompleteChunk::Factory(
+		  sctpCommon::FactoryBuffer + 1000, sizeof(sctpCommon::FactoryBuffer));
+
+		// This shouldn't throw now.
+		packet->AddChunk(chunk4);
+
+		REQUIRE(packet->NeedsConsolidation() == false);
+
+		delete chunk4;
 	}
 }

--- a/worker/test/src/tests.cpp
+++ b/worker/test/src/tests.cpp
@@ -3,7 +3,9 @@
 #include "DepLibUV.hpp"
 #include "DepLibWebRTC.hpp"
 #include "DepOpenSSL.hpp"
+#ifndef MS_SCTP_STACK
 #include "DepUsrSCTP.hpp"
+#endif
 #include "Settings.hpp"
 #include "Utils.hpp"
 #include <catch2/catch_session.hpp>
@@ -47,7 +49,9 @@ int main(int argc, char* argv[])
 	DepLibUV::ClassInit();
 	DepOpenSSL::ClassInit();
 	DepLibSRTP::ClassInit();
+#ifndef MS_SCTP_STACK
 	DepUsrSCTP::ClassInit();
+#endif
 	DepLibWebRTC::ClassInit();
 	Utils::Crypto::ClassInit();
 
@@ -59,7 +63,9 @@ int main(int argc, char* argv[])
 	DepLibSRTP::ClassDestroy();
 	Utils::Crypto::ClassDestroy();
 	DepLibWebRTC::ClassDestroy();
+#ifndef MS_SCTP_STACK
 	DepUsrSCTP::ClassDestroy();
+#endif
 	DepLibUV::ClassDestroy();
 
 	return status;


### PR DESCRIPTION
# Details

- Start integrating the new SCTP stack in the code. Not functional yet (more PRs coming after this one) but at least SCTP establishment already works (but mediasoup does not yet send SCTP INIT so it only works because peers also send SCTP INIT).
- Do not `#include "RTC/SctpAssociation.hpp"` or `#include "DepUsrSctp.hpp"` when `MS_SCTP_STACK` define is set.
- Some improvements in SCTP `Packet`, `Chunk`, `Parameter` and `ErrorCause` classes.
- Also make some C++ `SendXxxx()` methods return a boolean instead of `void`. This will be useful in the future.

## Bonus tracks

- CI: Remove `macos-14` host because it has `clang` v15 which is too old and its `libc++` doesn't implement some C++20 features such as `std::ranges::short()`. And because nobody uses macOS 14 anymore.
- CI: make jobs run on changes in `package.json`, `Cargo.toml`, etc. Why? Because otherwise when GH dependantbot creates a PR updating NPM or Cargo dependencies, our `mediasoup-node` and `mediasoup-rust` CI jobs don't run. See for example this [PR](https://github.com/versatica/mediasoup/pull/1754).