### PR TITLE
Worker tests: check `alignof()` structs

### DIFF
--- a/worker/include/RTC/ICE/StunPacket.hpp
+++ b/worker/include/RTC/ICE/StunPacket.hpp
@@ -125,6 +125,12 @@ namespace RTC
 			};
 
 		private:
+			/**
+			 * @remarks
+			 * - This struct is NOT guaranteed to be aligned to any fixed number of
+			 *   bytes because it contains a `size_t`, which is 4 or 8 bytes depending
+			 *   on the architecture. Anyway we never cast any buffer to this struct.
+			 */
 			struct Attribute
 			{
 				Attribute(AttributeType type, uint16_t len, size_t offset)

--- a/worker/include/RTC/RTCP/Feedback.hpp
+++ b/worker/include/RTC/RTCP/Feedback.hpp
@@ -17,7 +17,7 @@ namespace RTC
 			 * Struct for RTP Feedback message.
 			 *
 			 * @remarks
-			 * - This struct is guaranteed to be aligned to 8 bytes.
+			 * - This struct is guaranteed to be aligned to 4 bytes.
 			 */
 			struct Header
 			{

--- a/worker/include/RTC/RTCP/Feedback.hpp
+++ b/worker/include/RTC/RTCP/Feedback.hpp
@@ -13,7 +13,12 @@ namespace RTC
 		class FeedbackPacket : public Packet
 		{
 		public:
-			/* Struct for RTP Feedback message. */
+			/**
+			 * Struct for RTP Feedback message.
+			 *
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 8 bytes.
+			 */
 			struct Header
 			{
 				uint32_t senderSsrc;

--- a/worker/include/RTC/RTCP/FeedbackPsFir.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsFir.hpp
@@ -23,6 +23,10 @@ namespace RTC
 		class FeedbackPsFirItem : public FeedbackItem
 		{
 		public:
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 4 bytes.
+			 */
 			struct Header
 			{
 				uint32_t ssrc;

--- a/worker/include/RTC/RTCP/FeedbackPsLei.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsLei.hpp
@@ -20,6 +20,10 @@ namespace RTC
 		class FeedbackPsLeiItem : public FeedbackItem
 		{
 		public:
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 4 bytes.
+			 */
 			struct Header
 			{
 				uint32_t ssrc;

--- a/worker/include/RTC/RTCP/FeedbackPsRpsi.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsRpsi.hpp
@@ -25,6 +25,10 @@ namespace RTC
 			static const size_t MaxBitStringSize{ 6 };
 
 		public:
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 1 byte.
+			 */
 			struct Header
 			{
 				uint8_t paddingBits;

--- a/worker/include/RTC/RTCP/FeedbackPsSli.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsSli.hpp
@@ -20,6 +20,10 @@ namespace RTC
 		class FeedbackPsSliItem : public FeedbackItem
 		{
 		public:
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 4 bytes.
+			 */
 			struct Header
 			{
 				uint32_t compact;

--- a/worker/include/RTC/RTCP/FeedbackPsTst.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsTst.hpp
@@ -30,6 +30,11 @@ namespace RTC
 #else
 #define MEDIASOUP_PACKED __attribute__((packed))
 #endif
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 1 byte due to the usage
+			 *   of `pack()` and `packed` macros.
+			 */
 			struct Header
 			{
 				uint32_t ssrc;

--- a/worker/include/RTC/RTCP/FeedbackPsVbcm.hpp
+++ b/worker/include/RTC/RTCP/FeedbackPsVbcm.hpp
@@ -26,6 +26,10 @@ namespace RTC
 		class FeedbackPsVbcmItem : public FeedbackItem
 		{
 		public:
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 4 bytes.
+			 */
 			struct Header
 			{
 				uint32_t ssrc;

--- a/worker/include/RTC/RTCP/FeedbackRtpEcn.hpp
+++ b/worker/include/RTC/RTCP/FeedbackRtpEcn.hpp
@@ -30,6 +30,10 @@ namespace RTC
 		class FeedbackRtpEcnItem : public FeedbackItem
 		{
 		public:
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 4 bytes.
+			 */
 			struct Header
 			{
 				uint32_t sequenceNumber;

--- a/worker/include/RTC/RTCP/FeedbackRtpNack.hpp
+++ b/worker/include/RTC/RTCP/FeedbackRtpNack.hpp
@@ -21,6 +21,10 @@ namespace RTC
 		class FeedbackRtpNackItem : public FeedbackItem
 		{
 		public:
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 2 bytes.
+			 */
 			struct Header
 			{
 				uint16_t packetId;

--- a/worker/include/RTC/RTCP/FeedbackRtpTllei.hpp
+++ b/worker/include/RTC/RTCP/FeedbackRtpTllei.hpp
@@ -20,6 +20,10 @@ namespace RTC
 		class FeedbackRtpTlleiItem : public FeedbackItem
 		{
 		public:
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 2 bytes.
+			 */
 			struct Header
 			{
 				uint16_t packetId;

--- a/worker/include/RTC/RTCP/FeedbackRtpTmmb.hpp
+++ b/worker/include/RTC/RTCP/FeedbackRtpTmmb.hpp
@@ -24,6 +24,10 @@ namespace RTC
 		class FeedbackRtpTmmbItem : public FeedbackItem
 		{
 		public:
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 4 bytes.
+			 */
 			struct Header
 			{
 				uint32_t ssrc;

--- a/worker/include/RTC/RTCP/Packet.hpp
+++ b/worker/include/RTC/RTCP/Packet.hpp
@@ -32,7 +32,12 @@ namespace RTC
 		class Packet
 		{
 		public:
-			/* Struct for RTCP common header. */
+			/**
+			 * Struct for RTCP common header.
+			 *
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 2 bytes.
+			 */
 			struct CommonHeader
 			{
 #if defined(MS_LITTLE_ENDIAN)

--- a/worker/include/RTC/RTCP/ReceiverReport.hpp
+++ b/worker/include/RTC/RTCP/ReceiverReport.hpp
@@ -13,7 +13,12 @@ namespace RTC
 		class ReceiverReport
 		{
 		public:
-			/* Struct for RTCP receiver report. */
+			/**
+			 * Struct for RTCP receiver report.
+			 *
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 4 bytes.
+			 */
 			struct Header
 			{
 				uint32_t ssrc;

--- a/worker/include/RTC/RTCP/Sdes.hpp
+++ b/worker/include/RTC/RTCP/Sdes.hpp
@@ -27,7 +27,15 @@ namespace RTC
 				PRIV
 			};
 
+#ifdef MS_TEST
+		public:
+#else
 		private:
+#endif
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 1 byte.
+			 */
 			struct Header
 			{
 				SdesItem::Type type;

--- a/worker/include/RTC/RTCP/SenderReport.hpp
+++ b/worker/include/RTC/RTCP/SenderReport.hpp
@@ -12,7 +12,12 @@ namespace RTC
 		class SenderReport
 		{
 		public:
-			/* Struct for RTCP sender report. */
+			/**
+			 * Struct for RTCP sender report.
+			 *
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 4 bytes.
+			 */
 			struct Header
 			{
 				uint32_t ssrc;

--- a/worker/include/RTC/RTCP/XR.hpp
+++ b/worker/include/RTC/RTCP/XR.hpp
@@ -37,12 +37,17 @@ namespace RTC
 			};
 
 		public:
-			/* Struct for Extended Report Block common header. */
+			/**
+			 * Struct for Extended Report Block common header.
+			 *
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 2 bytes.
+			 */
 			struct CommonHeader
 			{
-				uint8_t blockType : 8;
-				uint8_t reserved : 8;
-				uint16_t length : 16;
+				uint8_t blockType;
+				uint8_t reserved;
+				uint16_t length;
 			};
 
 		public:

--- a/worker/include/RTC/RTCP/XrDelaySinceLastRr.hpp
+++ b/worker/include/RTC/RTCP/XrDelaySinceLastRr.hpp
@@ -40,6 +40,10 @@ namespace RTC
 				static SsrcInfo* Parse(const uint8_t* data, size_t len);
 
 			public:
+				/**
+				 * @remarks
+				 * - This struct is guaranteed to be aligned to 4 bytes.
+				 */
 				struct Body
 				{
 					uint32_t ssrc;

--- a/worker/include/RTC/RTCP/XrReceiverReferenceTime.hpp
+++ b/worker/include/RTC/RTCP/XrReceiverReferenceTime.hpp
@@ -24,6 +24,10 @@ namespace RTC
 		class ReceiverReferenceTime : public ExtendedReportBlock
 		{
 		public:
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 4 bytes.
+			 */
 			struct Body
 			{
 				uint32_t ntpSec;

--- a/worker/include/RTC/RTP/Packet.hpp
+++ b/worker/include/RTC/RTP/Packet.hpp
@@ -47,6 +47,9 @@ namespace RTC
 			 * |            contributing source (CSRC) identifiers             |
 			 * |                             ....                              |
 			 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+			 *
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 4 bytes.
 			 */
 			struct FixedHeader
 			{
@@ -70,7 +73,11 @@ namespace RTC
 				uint32_t ssrc;
 			};
 
+#ifdef MS_TEST
+		public:
+#else
 		private:
+#endif
 			/**
 			 * RTP Header Extension.
 			 *
@@ -83,6 +90,9 @@ namespace RTC
 			 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 			 * |                        header extension                       |
 			 * |                             ....                              |
+			 *
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 2 bytes.
 			 */
 			struct HeaderExtension
 			{
@@ -115,7 +125,15 @@ namespace RTC
 				TwoBytes = 2
 			};
 
+#ifdef MS_TEST
+		public:
+#else
 		private:
+#endif
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 1 byte.
+			 */
 			struct OneByteExtension
 			{
 #if defined(MS_LITTLE_ENDIAN)
@@ -128,7 +146,15 @@ namespace RTC
 				uint8_t value[];
 			};
 
+#ifdef MS_TEST
+		public:
+#else
 		private:
+#endif
+			/**
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 1 byte.
+			 */
 			struct TwoBytesExtension
 			{
 				uint8_t id;
@@ -139,6 +165,11 @@ namespace RTC
 		public:
 			/**
 			 * Struct for setting and replacing Extensions.
+			 *
+			 * @remarks
+			 * - This struct is NOT guaranteed to be aligned to any fixed number of
+			 *   bytes because it contains a pointer, which is 4 or 8 bytes depending
+			 *   on the architecture. Anyway we never cast any buffer to this struct.
 			 */
 			struct Extension
 			{

--- a/worker/include/RTC/SCTP/packet/Chunk.hpp
+++ b/worker/include/RTC/SCTP/packet/Chunk.hpp
@@ -91,6 +91,9 @@ namespace RTC
 
 			/**
 			 * Struct of an SCTP Chunk Header.
+			 *
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 2 bytes.
 			 */
 			struct ChunkHeader
 			{
@@ -106,10 +109,17 @@ namespace RTC
 				uint16_t length;
 			};
 
+#ifdef MS_TEST
+		public:
+#else
 		private:
+#endif
 			/**
 			 * Access to individual bit in the Chunk Flags field. bit0 corresponds
 			 * to the least significant bit.
+			 *
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 1 byte.
 			 */
 			struct ChunkFlags
 			{

--- a/worker/include/RTC/SCTP/packet/ErrorCause.hpp
+++ b/worker/include/RTC/SCTP/packet/ErrorCause.hpp
@@ -67,6 +67,9 @@ namespace RTC
 
 			/**
 			 * Struct of an SCTP Error Cause Header.
+			 *
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 2 bytes.
 			 */
 			struct ErrorCauseHeader
 			{

--- a/worker/include/RTC/SCTP/packet/Packet.hpp
+++ b/worker/include/RTC/SCTP/packet/Packet.hpp
@@ -57,6 +57,9 @@ namespace RTC
 		public:
 			/**
 			 * Struct of an SCTP Packet Common Header.
+			 *
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 4 bytes.
 			 */
 			struct CommonHeader
 			{

--- a/worker/include/RTC/SCTP/packet/Parameter.hpp
+++ b/worker/include/RTC/SCTP/packet/Parameter.hpp
@@ -81,6 +81,9 @@ namespace RTC
 
 			/**
 			 * Struct of an SCTP Parameter Header.
+			 *
+			 * @remarks
+			 * - This struct is guaranteed to be aligned to 2 bytes.
 			 */
 			struct ParameterHeader
 			{

--- a/worker/include/RTC/SCTP/public/SctpTypes.hpp
+++ b/worker/include/RTC/SCTP/public/SctpTypes.hpp
@@ -176,6 +176,8 @@ namespace RTC
 					{
 						return "UNSUPPORTED_OPERATION";
 					}
+
+						NO_DEFAULT_GCC();
 				}
 			}
 

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -463,6 +463,8 @@ test_sources = [
   'test/src/RTC/SCTP/tx/TestRetransmissionTimeout.cpp',
   'test/src/RTC/SCTP/packet/TestPacket.cpp',
   'test/src/RTC/SCTP/packet/TestChunk.cpp',
+  'test/src/RTC/SCTP/packet/TestParameter.cpp',
+  'test/src/RTC/SCTP/packet/TestErrorCause.cpp',
   'test/src/RTC/SCTP/packet/chunks/TestDataChunk.cpp',
   'test/src/RTC/SCTP/packet/chunks/TestInitChunk.cpp',
   'test/src/RTC/SCTP/packet/chunks/TestInitAckChunk.cpp',

--- a/worker/src/DepLibUring.cpp
+++ b/worker/src/DepLibUring.cpp
@@ -356,7 +356,7 @@ DepLibUring::LibUring::LibUring()
 			{
 				MS_WARN_TAG(
 				  info,
-				  "io_uring_register_buffers() failed due to low RLIMIT_MEMLOCK (soft:%lu, hard:%lu), disabling zero copy: %s",
+				  "io_uring_register_buffers() failed due to low RLIMIT_MEMLOCK (soft:%llu, hard:%llu), disabling zero copy: %s",
 				  l.rlim_cur,
 				  l.rlim_max,
 				  std::strerror(error));

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsFir.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsFir.cpp
@@ -36,7 +36,7 @@ SCENARIO("RTCP Feedback PS FIR", "[rtcp][feedback-ps][fir]")
 		REQUIRE(item->GetSequenceNumber() == seq);
 	};
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::FeedbackPsFirItem::Header) == 4);
 	}

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsFir.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsFir.cpp
@@ -36,6 +36,11 @@ SCENARIO("RTCP Feedback PS FIR", "[rtcp][feedback-ps][fir]")
 		REQUIRE(item->GetSequenceNumber() == seq);
 	};
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::FeedbackPsFirItem::Header) == 4);
+	}
+
 	SECTION("parse FeedbackPsFirPacket")
 	{
 		std::unique_ptr<RTC::RTCP::FeedbackPsFirPacket> packet{ RTC::RTCP::FeedbackPsFirPacket::Parse(

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsLei.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsLei.cpp
@@ -33,6 +33,11 @@ SCENARIO("RTCP Feedback PS LEI", "[rtcp][feedback-ps][lei]")
 		REQUIRE(item->GetSsrc() == ssrc);
 	};
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::FeedbackPsLeiItem::Header) == 4);
+	}
+
 	SECTION("parse FeedbackPsLeiPacket")
 	{
 		std::unique_ptr<RTC::RTCP::FeedbackPsLeiPacket> packet{ RTC::RTCP::FeedbackPsLeiPacket::Parse(

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsLei.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsLei.cpp
@@ -33,7 +33,7 @@ SCENARIO("RTCP Feedback PS LEI", "[rtcp][feedback-ps][lei]")
 		REQUIRE(item->GetSsrc() == ssrc);
 	};
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::FeedbackPsLeiItem::Header) == 4);
 	}

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp
@@ -41,6 +41,11 @@ SCENARIO("RTCP Feedback PS RPSI", "[rtcp][feedback-ps][rpsi]")
 		REQUIRE((item->GetBitString()[item->GetLength() - 1] & 1) == payloadMask);
 	};
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::FeedbackPsRpsiItem::Header) == 1);
+	}
+
 	SECTION("parse FeedbackPsRpsiPacket")
 	{
 		std::unique_ptr<RTC::RTCP::FeedbackPsRpsiPacket> packet{ RTC::RTCP::FeedbackPsRpsiPacket::Parse(

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsRpsi.cpp
@@ -41,7 +41,7 @@ SCENARIO("RTCP Feedback PS RPSI", "[rtcp][feedback-ps][rpsi]")
 		REQUIRE((item->GetBitString()[item->GetLength() - 1] & 1) == payloadMask);
 	};
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::FeedbackPsRpsiItem::Header) == 1);
 	}

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsTst.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsTst.cpp
@@ -38,6 +38,12 @@ SCENARIO("RTCP Feedback PS TSTN", "[rtcp][feedback-ps][tstn]")
 		REQUIRE(item->GetSequenceNumber() == seq);
 	};
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::FeedbackPsTstrItem::Header) == 1);
+		REQUIRE(alignof(RTC::RTCP::FeedbackPsTstnItem::Header) == 1);
+	}
+
 	SECTION("parse FeedbackPsTstnPacket")
 	{
 		std::unique_ptr<RTC::RTCP::FeedbackPsTstnPacket> packet{ RTC::RTCP::FeedbackPsTstnPacket::Parse(

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsTst.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsTst.cpp
@@ -38,7 +38,7 @@ SCENARIO("RTCP Feedback PS TSTN", "[rtcp][feedback-ps][tstn]")
 		REQUIRE(item->GetSequenceNumber() == seq);
 	};
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::FeedbackPsTstrItem::Header) == 1);
 		REQUIRE(alignof(RTC::RTCP::FeedbackPsTstnItem::Header) == 1);

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp
@@ -47,6 +47,11 @@ SCENARIO("RTCP Feedback PS VBCM", "[rtcp][feedback-ps][vbcm]")
 		REQUIRE((item->GetValue()[item->GetLength() - 1] & 1) == valueMask);
 	};
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::FeedbackPsVbcmItem::Header) == 4);
+	}
+
 	SECTION("parse FeedbackPsVbcmPacket")
 	{
 		std::unique_ptr<RTC::RTCP::FeedbackPsVbcmPacket> packet{ RTC::RTCP::FeedbackPsVbcmPacket::Parse(

--- a/worker/test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackPsVbcm.cpp
@@ -47,7 +47,7 @@ SCENARIO("RTCP Feedback PS VBCM", "[rtcp][feedback-ps][vbcm]")
 		REQUIRE((item->GetValue()[item->GetLength() - 1] & 1) == valueMask);
 	};
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::FeedbackPsVbcmItem::Header) == 4);
 	}

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp
@@ -51,6 +51,11 @@ SCENARIO("RTCP Feedback RTP ECN", "[rtcp][feedback-rtp][ecn]")
 		REQUIRE(item->GetDuplicatedPackets() == duplicatedPackets);
 	};
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::FeedbackRtpEcnItem::Header) == 4);
+	}
+
 	SECTION("parse FeedbackRtpEcnPacket")
 	{
 		std::unique_ptr<RTC::RTCP::FeedbackRtpEcnPacket> packet{ RTC::RTCP::FeedbackRtpEcnPacket::Parse(

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpEcn.cpp
@@ -51,7 +51,7 @@ SCENARIO("RTCP Feedback RTP ECN", "[rtcp][feedback-rtp][ecn]")
 		REQUIRE(item->GetDuplicatedPackets() == duplicatedPackets);
 	};
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::FeedbackRtpEcnItem::Header) == 4);
 	}

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpNack.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpNack.cpp
@@ -37,6 +37,11 @@ SCENARIO("RTCP Feedback RTP NACK", "[rtcp][feedback-rtp][nack]")
 		REQUIRE(item->CountRequestedPackets() == 3);
 	};
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::FeedbackRtpNackItem::Header) == 2);
+	}
+
 	SECTION("parse FeedbackRtpNackItem")
 	{
 		std::unique_ptr<RTC::RTCP::FeedbackRtpNackPacket> packet{ RTC::RTCP::FeedbackRtpNackPacket::Parse(

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpNack.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpNack.cpp
@@ -37,7 +37,7 @@ SCENARIO("RTCP Feedback RTP NACK", "[rtcp][feedback-rtp][nack]")
 		REQUIRE(item->CountRequestedPackets() == 3);
 	};
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::FeedbackRtpNackItem::Header) == 2);
 	}

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp
@@ -37,6 +37,11 @@ SCENARIO("RTCP Feedback RTP TLLEI", "[rtcp][feedback-rtp][tllei]")
 		REQUIRE(item->GetLostPacketBitmask() == lostPacketBitmask);
 	};
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::FeedbackRtpTlleiItem::Header) == 2);
+	}
+
 	SECTION("parse RTC::RTCP::FeedbackRtpTlleiPacket")
 	{
 		std::unique_ptr<RTC::RTCP::FeedbackRtpTlleiPacket> packet{

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTllei.cpp
@@ -37,7 +37,7 @@ SCENARIO("RTCP Feedback RTP TLLEI", "[rtcp][feedback-rtp][tllei]")
 		REQUIRE(item->GetLostPacketBitmask() == lostPacketBitmask);
 	};
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::FeedbackRtpTlleiItem::Header) == 2);
 	}

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp
@@ -40,7 +40,7 @@ SCENARIO("RTCP Feedback RTP TMMBR", "[rtcp][feedback-rtp][tmmb]")
 		REQUIRE(item->GetOverhead() == overhead);
 	};
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::FeedbackRtpTmmbrItem::Header) == 4);
 		REQUIRE(alignof(RTC::RTCP::FeedbackRtpTmmbnItem::Header) == 4);

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTmmb.cpp
@@ -40,6 +40,12 @@ SCENARIO("RTCP Feedback RTP TMMBR", "[rtcp][feedback-rtp][tmmb]")
 		REQUIRE(item->GetOverhead() == overhead);
 	};
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::FeedbackRtpTmmbrItem::Header) == 4);
+		REQUIRE(alignof(RTC::RTCP::FeedbackRtpTmmbnItem::Header) == 4);
+	}
+
 	SECTION("parse FeedbackRtpTmmbrPacket")
 	{
 		std::unique_ptr<RTC::RTCP::FeedbackRtpTmmbrPacket> packet{

--- a/worker/test/src/RTC/RTCP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTCP/TestPacket.cpp
@@ -1,4 +1,6 @@
 #include "common.hpp"
+#include "RTC/RTCP/FeedbackPs.hpp"
+#include "RTC/RTCP/FeedbackRtp.hpp"
 #include "RTC/RTCP/Packet.hpp"
 #include <catch2/catch_test_macros.hpp>
 
@@ -13,6 +15,13 @@ SCENARIO("RTCP Packet", "[rtcp][packet]")
 		0x80, 0xc8, 0x00, 0x00
 	};
 	// clang-format on
+
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::Packet::CommonHeader) == 2);
+		REQUIRE(alignof(RTC::RTCP::FeedbackRtpPacket::Header) == 4);
+		REQUIRE(alignof(RTC::RTCP::FeedbackPsPacket::Header) == 4);
+	}
 
 	SECTION("a RTCP packet may only contain the RTCP common header")
 	{

--- a/worker/test/src/RTC/RTCP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTCP/TestPacket.cpp
@@ -16,7 +16,7 @@ SCENARIO("RTCP Packet", "[rtcp][packet]")
 	};
 	// clang-format on
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::Packet::CommonHeader) == 2);
 		REQUIRE(alignof(RTC::RTCP::FeedbackRtpPacket::Header) == 4);

--- a/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
@@ -45,7 +45,7 @@ SCENARIO("RTCP ReceiverReport", "[rtcp][receiver-report]")
 		REQUIRE(report->GetDelaySinceLastSenderReport() == delaySinceLastSenderReport);
 	};
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::ReceiverReport::Header) == 4);
 	}

--- a/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestReceiverReport.cpp
@@ -45,6 +45,11 @@ SCENARIO("RTCP ReceiverReport", "[rtcp][receiver-report]")
 		REQUIRE(report->GetDelaySinceLastSenderReport() == delaySinceLastSenderReport);
 	};
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::ReceiverReport::Header) == 4);
+	}
+
 	SECTION("parse RR packet with a single report")
 	{
 		std::unique_ptr<RTC::RTCP::ReceiverReportPacket> packet{ RTC::RTCP::ReceiverReportPacket::Parse(

--- a/worker/test/src/RTC/RTCP/TestSdes.cpp
+++ b/worker/test/src/RTC/RTCP/TestSdes.cpp
@@ -88,7 +88,7 @@ SCENARIO("RTCP SDES", "[rtcp][sdes]")
 	const std::string item5Value{ "ab" };
 	const size_t item5Length{ 2u };
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::SdesItem::Header) == 1);
 	}

--- a/worker/test/src/RTC/RTCP/TestSdes.cpp
+++ b/worker/test/src/RTC/RTCP/TestSdes.cpp
@@ -88,6 +88,11 @@ SCENARIO("RTCP SDES", "[rtcp][sdes]")
 	const std::string item5Value{ "ab" };
 	const size_t item5Length{ 2u };
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::SdesItem::Header) == 1);
+	}
+
 	SECTION("parse packet 1")
 	{
 		std::unique_ptr<RTC::RTCP::SdesPacket> packet{ RTC::RTCP::SdesPacket::Parse(

--- a/worker/test/src/RTC/RTCP/TestSenderReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestSenderReport.cpp
@@ -42,6 +42,11 @@ SCENARIO("RTCP SenderReport", "[rtcp][sender-report]")
 		REQUIRE(report->GetOctetCount() == octetCount);
 	};
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::SenderReport::Header) == 4);
+	}
+
 	SECTION("parse SR packet")
 	{
 		std::unique_ptr<RTC::RTCP::SenderReportPacket> packet{ RTC::RTCP::SenderReportPacket::Parse(

--- a/worker/test/src/RTC/RTCP/TestSenderReport.cpp
+++ b/worker/test/src/RTC/RTCP/TestSenderReport.cpp
@@ -42,7 +42,7 @@ SCENARIO("RTCP SenderReport", "[rtcp][sender-report]")
 		REQUIRE(report->GetOctetCount() == octetCount);
 	};
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::SenderReport::Header) == 4);
 	}

--- a/worker/test/src/RTC/RTCP/TestXr.cpp
+++ b/worker/test/src/RTC/RTCP/TestXr.cpp
@@ -24,6 +24,13 @@ SCENARIO("RTCP XR", "[rtcp][xr]")
 	};
 	// clang-format on
 
+	SECTION("asignof() RTCP structs")
+	{
+		REQUIRE(alignof(RTC::RTCP::ExtendedReportBlock::CommonHeader) == 2);
+		REQUIRE(alignof(RTC::RTCP::DelaySinceLastRr::SsrcInfo::Body) == 4);
+		REQUIRE(alignof(RTC::RTCP::ReceiverReferenceTime::Body) == 4);
+	}
+
 	SECTION("parse XR packet")
 	{
 		std::unique_ptr<RTC::RTCP::ExtendedReportPacket> packet(

--- a/worker/test/src/RTC/RTCP/TestXr.cpp
+++ b/worker/test/src/RTC/RTCP/TestXr.cpp
@@ -24,7 +24,7 @@ SCENARIO("RTCP XR", "[rtcp][xr]")
 	};
 	// clang-format on
 
-	SECTION("asignof() RTCP structs")
+	SECTION("alignof() RTCP structs")
 	{
 		REQUIRE(alignof(RTC::RTCP::ExtendedReportBlock::CommonHeader) == 2);
 		REQUIRE(alignof(RTC::RTCP::DelaySinceLastRr::SsrcInfo::Body) == 4);

--- a/worker/test/src/RTC/RTP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTP/TestPacket.cpp
@@ -13,7 +13,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 {
 	rtpCommon::ResetBuffers();
 
-	SECTION("asignof() RTP structs")
+	SECTION("alignof() RTP structs")
 	{
 		REQUIRE(alignof(RTC::RTP::Packet::FixedHeader) == 4);
 		REQUIRE(alignof(RTC::RTP::Packet::HeaderExtension) == 2);

--- a/worker/test/src/RTC/RTP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTP/TestPacket.cpp
@@ -13,6 +13,14 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 {
 	rtpCommon::ResetBuffers();
 
+	SECTION("asignof() RTP structs")
+	{
+		REQUIRE(alignof(RTC::RTP::Packet::FixedHeader) == 4);
+		REQUIRE(alignof(RTC::RTP::Packet::HeaderExtension) == 2);
+		REQUIRE(alignof(RTC::RTP::Packet::OneByteExtension) == 1);
+		REQUIRE(alignof(RTC::RTP::Packet::TwoBytesExtension) == 1);
+	}
+
 	SECTION("Packet::Parse() packet1.raw succeeds")
 	{
 		alignas(4) uint8_t buffer[65536];

--- a/worker/test/src/RTC/SCTP/packet/TestChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestChunk.cpp
@@ -9,9 +9,15 @@
 #include "RTC/SCTP/sctpCommon.hpp"
 #include <catch2/catch_test_macros.hpp>
 
-SCENARIO("SCTP Packet", "[serializable][sctp][chunk]")
+SCENARIO("SCTP Chunk", "[serializable][sctp][chunk]")
 {
 	sctpCommon::ResetBuffers();
+
+	SECTION("asignof() SCTP structs")
+	{
+		REQUIRE(alignof(RTC::SCTP::Chunk::ChunkHeader) == 2);
+		REQUIRE(alignof(RTC::SCTP::Chunk::ChunkFlags) == 1);
+	}
 
 	SECTION("BuildParameterInPlace() and AddParameter() throw if the Chunk needs consolidation")
 	{

--- a/worker/test/src/RTC/SCTP/packet/TestChunk.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestChunk.cpp
@@ -13,7 +13,7 @@ SCENARIO("SCTP Chunk", "[serializable][sctp][chunk]")
 {
 	sctpCommon::ResetBuffers();
 
-	SECTION("asignof() SCTP structs")
+	SECTION("alignof() SCTP structs")
 	{
 		REQUIRE(alignof(RTC::SCTP::Chunk::ChunkHeader) == 2);
 		REQUIRE(alignof(RTC::SCTP::Chunk::ChunkFlags) == 1);

--- a/worker/test/src/RTC/SCTP/packet/TestErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestErrorCause.cpp
@@ -1,0 +1,11 @@
+#include "common.hpp"
+#include "RTC/SCTP/packet/ErrorCause.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+SCENARIO("SCTP Error Cause", "[serializable][sctp][errorcause]")
+{
+	SECTION("asignof() SCTP structs")
+	{
+		REQUIRE(alignof(RTC::SCTP::ErrorCause::ErrorCauseHeader) == 2);
+	}
+}

--- a/worker/test/src/RTC/SCTP/packet/TestErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestErrorCause.cpp
@@ -4,7 +4,7 @@
 
 SCENARIO("SCTP Error Cause", "[serializable][sctp][errorcause]")
 {
-	SECTION("asignof() SCTP structs")
+	SECTION("alignof() SCTP structs")
 	{
 		REQUIRE(alignof(RTC::SCTP::ErrorCause::ErrorCauseHeader) == 2);
 	}

--- a/worker/test/src/RTC/SCTP/packet/TestPacket.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestPacket.cpp
@@ -20,6 +20,11 @@ SCENARIO("SCTP Packet", "[serializable][sctp][packet]")
 {
 	sctpCommon::ResetBuffers();
 
+	SECTION("asignof() SCTP structs")
+	{
+		REQUIRE(alignof(RTC::SCTP::Packet::CommonHeader) == 4);
+	}
+
 	SECTION("Parse() without Chunks succeeds")
 	{
 		// clang-format off

--- a/worker/test/src/RTC/SCTP/packet/TestPacket.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestPacket.cpp
@@ -208,6 +208,7 @@ SCENARIO("SCTP Packet", "[serializable][sctp][packet]")
 		  /*buffer*/ nullptr,
 		  /*bufferLength*/ 8,
 		  /*length*/ 8,
+		  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
 		  /*chunkType*/ static_cast<RTC::SCTP::Chunk::ChunkType>(0xEE),
 		  /*unknownType*/ true,
 		  /*actionForUnknownChunkType*/ RTC::SCTP::Chunk::ActionForUnknownChunkType::SKIP_AND_REPORT,
@@ -325,6 +326,7 @@ SCENARIO("SCTP Packet", "[serializable][sctp][packet]")
 		  /*buffer*/ nullptr,
 		  /*bufferLength*/ 8,
 		  /*length*/ 8,
+		  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
 		  /*chunkType*/ static_cast<RTC::SCTP::Chunk::ChunkType>(0xEE),
 		  /*unknownType*/ true,
 		  /*actionForUnknownChunkType*/ RTC::SCTP::Chunk::ActionForUnknownChunkType::SKIP_AND_REPORT,
@@ -443,6 +445,7 @@ SCENARIO("SCTP Packet", "[serializable][sctp][packet]")
 		  /*buffer*/ nullptr,
 		  /*bufferLength*/ 8,
 		  /*length*/ 8,
+		  // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange)
 		  /*chunkType*/ static_cast<RTC::SCTP::Chunk::ChunkType>(0xEE),
 		  /*unknownType*/ true,
 		  /*actionForUnknownChunkType*/ RTC::SCTP::Chunk::ActionForUnknownChunkType::SKIP_AND_REPORT,

--- a/worker/test/src/RTC/SCTP/packet/TestPacket.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestPacket.cpp
@@ -20,7 +20,7 @@ SCENARIO("SCTP Packet", "[serializable][sctp][packet]")
 {
 	sctpCommon::ResetBuffers();
 
-	SECTION("asignof() SCTP structs")
+	SECTION("alignof() SCTP structs")
 	{
 		REQUIRE(alignof(RTC::SCTP::Packet::CommonHeader) == 4);
 	}

--- a/worker/test/src/RTC/SCTP/packet/TestParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestParameter.cpp
@@ -1,0 +1,11 @@
+#include "common.hpp"
+#include "RTC/SCTP/packet/Parameter.hpp"
+#include <catch2/catch_test_macros.hpp>
+
+SCENARIO("SCTP Parameter", "[serializable][sctp][parameter]")
+{
+	SECTION("asignof() SCTP structs")
+	{
+		REQUIRE(alignof(RTC::SCTP::Parameter::ParameterHeader) == 2);
+	}
+}

--- a/worker/test/src/RTC/SCTP/packet/TestParameter.cpp
+++ b/worker/test/src/RTC/SCTP/packet/TestParameter.cpp
@@ -4,7 +4,7 @@
 
 SCENARIO("SCTP Parameter", "[serializable][sctp][parameter]")
 {
-	SECTION("asignof() SCTP structs")
+	SECTION("alignof() SCTP structs")
 	{
 		REQUIRE(alignof(RTC::SCTP::Parameter::ParameterHeader) == 2);
 	}

--- a/worker/test/src/Utils/TestByte.cpp
+++ b/worker/test/src/Utils/TestByte.cpp
@@ -140,13 +140,12 @@ SCENARIO("Utils::Byte", "[utils][byte]")
 		REQUIRE(Utils::Byte::IsPaddedTo4Bytes(size_t{ 4294967292u }) == true);
 		REQUIRE(Utils::Byte::IsPaddedTo4Bytes(size_t{ 4294967295u }) == false);
 
-		// Check if size_t in current host is 64 bits. Otherwise the test would fail.
-		if (sizeof(size_t) == 8)
-		{
-			REQUIRE(Utils::Byte::IsPaddedTo4Bytes(size_t{ 18446744073709551608u }) == true);
-			REQUIRE(Utils::Byte::IsPaddedTo4Bytes(size_t{ 18446744073709551612u }) == true);
-			REQUIRE(Utils::Byte::IsPaddedTo4Bytes(size_t{ 18446744073709551615u }) == false);
-		}
+// Check if size_t in current host is 64 bits. Otherwise the test would fail.
+#if SIZE_MAX == 0xFFFFFFFFFFFFFFFFu
+		REQUIRE(Utils::Byte::IsPaddedTo4Bytes(size_t{ 18446744073709551608u }) == true);
+		REQUIRE(Utils::Byte::IsPaddedTo4Bytes(size_t{ 18446744073709551612u }) == true);
+		REQUIRE(Utils::Byte::IsPaddedTo4Bytes(size_t{ 18446744073709551615u }) == false);
+#endif
 	}
 
 	SECTION("IsPaddedTo8Bytes()")
@@ -230,13 +229,12 @@ SCENARIO("Utils::Byte", "[utils][byte]")
 		REQUIRE(Utils::Byte::IsPaddedTo8Bytes(size_t{ 4294967292u }) == false);
 		REQUIRE(Utils::Byte::IsPaddedTo8Bytes(size_t{ 4294967295u }) == false);
 
-		// Check if size_t in current host is 64 bits. Otherwise the test would fail.
-		if (sizeof(size_t) == 8)
-		{
-			REQUIRE(Utils::Byte::IsPaddedTo8Bytes(size_t{ 18446744073709551608u }) == true);
-			REQUIRE(Utils::Byte::IsPaddedTo8Bytes(size_t{ 18446744073709551612u }) == false);
-			REQUIRE(Utils::Byte::IsPaddedTo8Bytes(size_t{ 18446744073709551615u }) == false);
-		}
+// Check if size_t in current host is 64 bits. Otherwise the test would fail.
+#if SIZE_MAX == 0xFFFFFFFFFFFFFFFFu
+		REQUIRE(Utils::Byte::IsPaddedTo8Bytes(size_t{ 18446744073709551608u }) == true);
+		REQUIRE(Utils::Byte::IsPaddedTo8Bytes(size_t{ 18446744073709551612u }) == false);
+		REQUIRE(Utils::Byte::IsPaddedTo8Bytes(size_t{ 18446744073709551615u }) == false);
+#endif
 	}
 
 	SECTION("PadTo4Bytes()")
@@ -329,13 +327,12 @@ SCENARIO("Utils::Byte", "[utils][byte]")
 		REQUIRE(Utils::Byte::PadTo4Bytes(size_t{ 4294967288u }) == 4294967288u);
 		REQUIRE(Utils::Byte::PadTo4Bytes(size_t{ 4294967292u }) == 4294967292u);
 
-		// Check if size_t in current host is 64 bits. Otherwise the test would fail.
-		if (sizeof(size_t) == 8)
-		{
-			REQUIRE(Utils::Byte::PadTo4Bytes(size_t{ 18446744073709551608u }) == 18446744073709551608u);
-			REQUIRE(Utils::Byte::PadTo4Bytes(size_t{ 18446744073709551612u }) == 18446744073709551612u);
-			REQUIRE(Utils::Byte::PadTo4Bytes(size_t{ 18446744073709551615u }) == 0u);
-		}
+// Check if size_t in current host is 64 bits. Otherwise the test would fail.
+#if SIZE_MAX == 0xFFFFFFFFFFFFFFFFu
+		REQUIRE(Utils::Byte::PadTo4Bytes(size_t{ 18446744073709551608u }) == 18446744073709551608u);
+		REQUIRE(Utils::Byte::PadTo4Bytes(size_t{ 18446744073709551612u }) == 18446744073709551612u);
+		REQUIRE(Utils::Byte::PadTo4Bytes(size_t{ 18446744073709551615u }) == 0u);
+#endif
 	}
 
 	SECTION("PadTo8Bytes()")
@@ -440,14 +437,13 @@ SCENARIO("Utils::Byte", "[utils][byte]")
 		REQUIRE(Utils::Byte::PadTo8Bytes(size_t{ 65532u }) == 65536u);
 		REQUIRE(Utils::Byte::PadTo8Bytes(size_t{ 65535u }) == 65536u);
 		REQUIRE(Utils::Byte::PadTo8Bytes(size_t{ 4294967288u }) == 4294967288u);
-		REQUIRE(Utils::Byte::PadTo8Bytes(size_t{ 4294967292u }) == 4294967296u);
 
-		// Check if size_t in current host is 64 bits. Otherwise the test would fail.
-		if (sizeof(size_t) == 8)
-		{
-			REQUIRE(Utils::Byte::PadTo8Bytes(size_t{ 18446744073709551608u }) == 18446744073709551608u);
-			REQUIRE(Utils::Byte::PadTo8Bytes(size_t{ 18446744073709551612u }) == 0u);
-			REQUIRE(Utils::Byte::PadTo8Bytes(size_t{ 18446744073709551615u }) == 0u);
-		}
+// Check if size_t in current host is 64 bits. Otherwise the test would fail.
+#if SIZE_MAX == 0xFFFFFFFFFFFFFFFFu
+		REQUIRE(Utils::Byte::PadTo8Bytes(size_t{ 4294967292u }) == 4294967296u);
+		REQUIRE(Utils::Byte::PadTo8Bytes(size_t{ 18446744073709551608u }) == 18446744073709551608u);
+		REQUIRE(Utils::Byte::PadTo8Bytes(size_t{ 18446744073709551612u }) == 0u);
+		REQUIRE(Utils::Byte::PadTo8Bytes(size_t{ 18446744073709551615u }) == 0u);
+#endif
 	}
 }


### PR DESCRIPTION
# Details

- Test the `aligof()` value of all `structs` used to cast buffers with network received data into them.
- _NOTE:_ Additionally we should run these tests into 32 bits archs or exotic archs, but maybe in the future.