### PR TITLE
Add `Dockerfile.386` to test Linux 386 (32 bits architecture)

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -295,7 +295,7 @@ Builds a Linux Ubuntu Docker image with fuzzer capable clang++ and all dependenc
 
 ### `invoke docker-run`
 
-Runs a container of the Ubuntu Docker image created with `invoke docker`. It automatically executes a `bash` session in the `/mediasoup` directory, which is a Docker volume that points to the mediasoup root folder.
+Runs a container of the Ubuntu Docker image created with `invoke docker`. It automatically executes a `bash` session in the mediasoup directory, which is a Docker volume that points to the mediasoup root folder.
 
 **NOTE:** To install and run mediasoup in the container, previous installation (if any) must be properly cleaned by entering the `worker` directory and running `invoke clean-all`.
 
@@ -305,9 +305,20 @@ Builds a Linux Alpine Docker image with all dependencies to run mediasoup.
 
 ### `invoke docker-alpine-run`
 
-Runs a container of the Alpine Docker image created with `invoke docker-alpine`. It automatically executes an `ash` session in the `/mediasoup` directory, which is a Docker volume that points to the mediasoup root folder.
+Runs a container of the Alpine Docker image created with `invoke docker-alpine`. It automatically executes an `ash` session in the mediasoup directory, which is a Docker volume that points to the mediasoup root folder.
 
 **NOTE:** To install and run mediasoup in the container, previous installation (if any) must be properly cleaned by entering the `worker` directory and running `invoke clean-all`.
+
+### `invoke docker-386`
+
+Builds a 386 Linux Debian (32 bits arch) Docker image with all dependencies to run mediasoup.
+
+### `invoke docker-alpine-386`
+
+Runs a container of the 386 Linux Debian (32 bits arch) Docker image created with `invoke docker-386`. It automatically executes an `ash` session in the mediasoup directory, which is a Docker volume that points to the mediasoup root folder.
+
+**NOTE:** To install and run mediasoup in the container, previous installation (if any) must be properly cleaned by entering the `worker` directory and running `invoke clean-all`.
+**NOTE:** Due to the very old Node v18 in this image, in order to run mediasoup Node tests, `npm ci` must be executed with `--ignore-scripts --engine-strict=false` arguments.
 
 ## Makefile
 

--- a/worker/Dockerfile.386
+++ b/worker/Dockerfile.386
@@ -1,0 +1,25 @@
+#
+# This container installs a 32-bits Linux Debian.
+#
+
+FROM --platform=linux/386 debian:bookworm
+
+# Install dependencies.
+RUN set -x \
+	&& apt-get update \
+	&& apt-get install --yes \
+		make pkg-config bash-completion wget curl git screen python3-pip python3-yaml \
+		zlib1g-dev libgss-dev libssl-dev libxml2-dev gdb nodejs npm
+
+# Enable core dumps.
+RUN set -x \
+	&& echo "mkdir -p /tmp/cores && chmod 777 /tmp/cores && echo \"/tmp/cores/core.%e.sig%s.%p\" > /proc/sys/kernel/core_pattern && ulimit -c unlimited" >> ~/.bashrc
+
+ENV LANG="C.UTF-8"
+
+ENV MEDIASOUP_LOCAL_DEV="true"
+ENV KEEP_BUILD_ARTIFACTS="1"
+
+WORKDIR "/foo bar/mediasoup"
+
+CMD ["bash"]

--- a/worker/Dockerfile.386
+++ b/worker/Dockerfile.386
@@ -2,7 +2,7 @@
 # This container installs a 32-bits Linux Debian.
 #
 
-FROM --platform=linux/386 debian:bookworm
+FROM debian:bookworm
 
 # Install dependencies.
 RUN set -x \

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -42,7 +42,9 @@ endif
 	docker \
 	docker-run \
 	docker-alpine \
-	docker-alpine-run
+	docker-alpine-run \
+	docker-386 \
+	docker-386-run
 
 default: mediasoup-worker
 
@@ -131,3 +133,9 @@ docker-alpine: invoke
 
 docker-alpine-run: invoke
 	"$(PYTHON)" -m invoke docker-alpine-run
+
+docker-386: invoke
+	"$(PYTHON)" -m invoke docker-386
+
+docker-386-run: invoke
+	"$(PYTHON)" -m invoke docker-386-run

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -650,7 +650,7 @@ def docker_386(ctx):
     if os.getenv('DOCKER_NO_CACHE') == 'true':
         with cd_worker():
             ctx.run(
-                f'"{DOCKER}" build -f Dockerfile.386 --no-cache --tag mediasoup/docker-386:latest .',
+                f'"{DOCKER}" build --platform linux/386 -f Dockerfile.386 --no-cache --tag mediasoup/docker-386:latest .',
                 echo=True,
                 pty=PTY_SUPPORTED,
                 shell=SHELL
@@ -658,7 +658,7 @@ def docker_386(ctx):
     else:
         with cd_worker():
             ctx.run(
-                f'"{DOCKER}" build -f Dockerfile.386 --tag mediasoup/docker-386:latest .',
+                f'"{DOCKER}" build --platform linux/386 -f Dockerfile.386 --tag mediasoup/docker-386:latest .',
                 echo=True,
                 pty=PTY_SUPPORTED,
                 shell=SHELL

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -640,3 +640,41 @@ def docker_alpine_run(ctx):
             pty=True, # NOTE: Needed to enter the terminal of the Docker image.
             shell=SHELL
         );
+
+
+@task
+def docker_386(ctx):
+    """
+    Build a 386 Linux Debian (32 bits arch) Docker image
+    """
+    if os.getenv('DOCKER_NO_CACHE') == 'true':
+        with cd_worker():
+            ctx.run(
+                f'"{DOCKER}" build -f Dockerfile.386 --no-cache --tag mediasoup/docker-386:latest .',
+                echo=True,
+                pty=PTY_SUPPORTED,
+                shell=SHELL
+            );
+    else:
+        with cd_worker():
+            ctx.run(
+                f'"{DOCKER}" build -f Dockerfile.386 --tag mediasoup/docker-386:latest .',
+                echo=True,
+                pty=PTY_SUPPORTED,
+                shell=SHELL
+            );
+
+
+@task
+def docker_386_run(ctx):
+    """
+    Run a container of the 386 Linux Debian (32 bits arch) Docker image created
+    in the docker_386 task
+    """
+    with cd_worker():
+        ctx.run(
+            f'"{DOCKER}" run --name=mediasoupDocker386 -it --rm --privileged --cap-add SYS_PTRACE -v "{WORKER_DIR}/../:/foo bar/mediasoup" mediasoup/docker-386:latest',
+            echo=True,
+            pty=True, # NOTE: Needed to enter the terminal of the Docker image.
+            shell=SHELL
+        );


### PR DESCRIPTION
# Details

- Add `make/invoke docker-386` and `make/invoke docker-386-run`.
- I've run Node and Worker tests within this 32 bits Linux image and they pass.
- _NOTE:_ Ideally we should test this in GitHub CI but it would require too many changes in our CI jobs since there are no 32 bits arch hosts in CI.
- _NOTE:_ Purpose is not really to support super old 32 bits architecture but just to be sure that our code is fully ready for it (so we know that all our design and assumptions regarding C++ `structs` and alignments and so on are correct).