### PR TITLE
Update liburing and Catch2

### DIFF
--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -82,7 +82,7 @@ jobs:
             run-test-asan-thread: false
             # Compile with all Meson option flags enabled once with gcc in
             # Debug mode.
-            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_disable_liburing=true -Dms_sctp_stack=true'
+            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_sctp_stack=true'
           - os: ubuntu-24.04
             cc: clang
             cxx: clang++
@@ -95,7 +95,7 @@ jobs:
             run-test-asan-thread: true
             # Let's just compile with all Meson option flags enabled once with
             # clang.
-            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_disable_liburing=true -Dms_sctp_stack=true'
+            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_sctp_stack=true'
           - os: ubuntu-24.04-arm
             cc: gcc
             cxx: g++

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -82,7 +82,7 @@ jobs:
             run-test-asan-thread: false
             # Compile with all Meson option flags enabled once with gcc in
             # Debug mode.
-            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_sctp_stack=true'
+            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_disable_liburing=true -Dms_sctp_stack=true'
           - os: ubuntu-24.04
             cc: clang
             cxx: clang++
@@ -95,7 +95,7 @@ jobs:
             run-test-asan-thread: true
             # Let's just compile with all Meson option flags enabled once with
             # clang.
-            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_sctp_stack=true'
+            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_disable_liburing=true -Dms_sctp_stack=true'
           - os: ubuntu-24.04-arm
             cc: gcc
             cxx: g++

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - Worker: Ensure 4-byte alignment for network packet receive buffers and test buffers to avoid undefined behavior ([PR #1756](https://github.com/versatica/mediasoup/pull/1756).
+- Worker: Update liburing liburing from 2.12-1 to 2.14-1 ([PR #1759](https://github.com/versatica/mediasoup/pull/1759).
 
 ### 3.19.18
 

--- a/worker/subprojects/catch2.wrap
+++ b/worker/subprojects/catch2.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = Catch2-3.12.0
-source_url = https://github.com/catchorg/Catch2/archive/v3.12.0.tar.gz
-source_filename = Catch2-3.12.0.tar.gz
-source_hash = e077079f214afc99fee940d91c14cf1a8c1d378212226bb9f50efff75fe07b23
-source_fallback_url = https://wrapdb.mesonbuild.com/v2/catch2_3.12.0-1/get_source/Catch2-3.12.0.tar.gz
-wrapdb_version = 3.12.0-1
+directory = Catch2-3.13.0
+source_url = https://github.com/catchorg/Catch2/archive/v3.13.0.tar.gz
+source_filename = Catch2-3.13.0.tar.gz
+source_hash = 650795f6501af514f806e78c554729847b98db6935e69076f36bb03ed2e985ef
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/catch2_3.13.0-1/get_source/Catch2-3.13.0.tar.gz
+wrapdb_version = 3.13.0-1
 
 [provide]
 catch2 = catch2_dep

--- a/worker/subprojects/liburing.wrap
+++ b/worker/subprojects/liburing.wrap
@@ -1,13 +1,14 @@
 [wrap-file]
-directory = liburing-liburing-2.12
-source_url = https://github.com/axboe/liburing/archive/refs/tags/liburing-2.12.tar.gz
-source_filename = liburing-2.12.tar.gz
-source_hash = f1d10cb058c97c953b4c0c446b11e9177e8c8b32a5a88b309f23fdd389e26370
-patch_filename = liburing_2.12-1_patch.zip
-patch_url = https://wrapdb.mesonbuild.com/v2/liburing_2.12-1/get_patch
-patch_hash = b21f90196008cde9ed242571a71d8302c703272a2f8b91edd589bd8d6abea47a
-source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/liburing_2.12-1/liburing-2.12.tar.gz
-wrapdb_version = 2.12-1
+directory = liburing-liburing-2.14
+source_url = https://github.com/axboe/liburing/archive/refs/tags/liburing-2.14.tar.gz
+source_filename = liburing-2.14.tar.gz
+source_hash = 5f80964108981c6ad979c735f0b4877d5f49914c2a062f8e88282f26bf61de0c
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/liburing_2.14-1/get_source/liburing-2.14.tar.gz
+patch_filename = liburing_2.14-1_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/liburing_2.14-1/get_patch
+patch_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/liburing_2.14-1/liburing_2.14-1_patch.zip
+patch_hash = 4d0ba8f507c25c4fb9a31507a5c06d2a6c253822828084a0101e2bea27dba62a
+wrapdb_version = 2.14-1
 
 [provide]
 dependency_names = liburing


### PR DESCRIPTION
# Details

- Update `liburing` from 2.12-1 to 2.14-1.
- Update `Catch2` from 3.12.0-1 to 3.13.0-1.