### PR TITLE
Only fetch Catch2 when building worker tests

### DIFF
--- a/worker/meson.build
+++ b/worker/meson.build
@@ -547,6 +547,7 @@ mediasoup_worker_test = executable(
     'include',
     'test/include',
   ),
+  cpp_args: cpp_args,
 )
 
 test(

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -62,6 +62,13 @@ if get_option('ms_sctp_stack')
   ]
 endif
 
+if get_option('ms_build_tests')
+  cpp_args += [
+    '-DMS_TEST',
+    '-DMS_LOG_STD'
+  ]
+endif
+
 cpp = meson.get_compiler('cpp')
 
 # This is a workaround to define FLATBUFFERS_LOCALE_INDEPENDENT=0 outside
@@ -312,13 +319,6 @@ flatbuffers_proj = subproject(
   ],
 )
 
-catch2_proj = subproject(
-  'catch2',
-  default_options: [
-    'warning_level=0',
-  ],
-)
-
 # flatbuffers schemas subdirectory.
 subdir('fbs')
 
@@ -384,6 +384,19 @@ if host_machine.system() == 'linux' and not get_option('ms_disable_liburing')
       '-DMS_LIBURING_SUPPORTED',
     ]
   endif
+endif
+
+if get_option('ms_build_tests')
+  catch2_proj = subproject(
+    'catch2',
+    default_options: [
+      'warning_level=0',
+    ],
+  )
+
+  dependencies += [
+    catch2_proj.get_variable('catch2_dep'),
+  ]
 endif
 
 libmediasoup_worker = library(
@@ -528,18 +541,12 @@ mediasoup_worker_test = executable(
   build_by_default: false,
   install: true,
   install_tag: 'mediasoup-worker-test',
-  dependencies: dependencies + [
-    catch2_proj.get_variable('catch2_dep'),
-  ],
+  dependencies: dependencies,
   sources: common_sources + test_sources,
   include_directories: include_directories(
     'include',
     'test/include',
   ),
-  cpp_args: cpp_args + [
-    '-DMS_LOG_STD',
-    '-DMS_TEST',
-  ],
 )
 
 test(
@@ -553,17 +560,13 @@ mediasoup_worker_test_asan_address = executable(
   build_by_default: false,
   install: true,
   install_tag: 'mediasoup-worker-test-asan-address',
-  dependencies: dependencies + [
-    catch2_proj.get_variable('catch2_dep'),
-  ],
+  dependencies: dependencies,
   sources: common_sources + test_sources,
   include_directories: include_directories(
     'include',
     'test/include',
   ),
   cpp_args: cpp_args + [
-    '-DMS_LOG_STD',
-    '-DMS_TEST',
     '-g',
     '-O3',
     '-fno-omit-frame-pointer',
@@ -585,17 +588,13 @@ mediasoup_worker_test_asan_undefined = executable(
   build_by_default: false,
   install: true,
   install_tag: 'mediasoup-worker-test-asan-undefined',
-  dependencies: dependencies + [
-    catch2_proj.get_variable('catch2_dep'),
-  ],
+  dependencies: dependencies,
   sources: common_sources + test_sources,
   include_directories: include_directories(
     'include',
     'test/include',
   ),
   cpp_args: cpp_args + [
-    '-DMS_LOG_STD',
-    '-DMS_TEST',
     '-g',
     '-O3',
     '-fno-omit-frame-pointer',
@@ -617,17 +616,13 @@ mediasoup_worker_test_asan_thread = executable(
   build_by_default: false,
   install: true,
   install_tag: 'mediasoup-worker-test-asan-thread',
-  dependencies: dependencies + [
-    catch2_proj.get_variable('catch2_dep'),
-  ],
+  dependencies: dependencies,
   sources: common_sources + test_sources,
   include_directories: include_directories(
     'include',
     'test/include',
   ),
   cpp_args: cpp_args + [
-    '-DMS_LOG_STD',
-    '-DMS_TEST',
     '-g',
     '-O3',
     '-fno-omit-frame-pointer',

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -26,6 +26,13 @@ if host_machine.system() == 'windows'
   ]
 endif
 
+if get_option('ms_build_tests')
+  cpp_args += [
+    '-DMS_TEST',
+    '-DMS_LOG_STD'
+  ]
+endif
+
 if get_option('ms_log_trace')
   cpp_args += [
     '-DMS_LOG_TRACE',
@@ -59,13 +66,6 @@ endif
 if get_option('ms_sctp_stack')
   cpp_args += [
     '-DMS_SCTP_STACK',
-  ]
-endif
-
-if get_option('ms_build_tests')
-  cpp_args += [
-    '-DMS_TEST',
-    '-DMS_LOG_STD'
   ]
 endif
 

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -62,13 +62,6 @@ if get_option('ms_sctp_stack')
   ]
 endif
 
-if get_option('ms_build_tests')
-  cpp_args += [
-    '-DMS_TEST',
-    '-DMS_LOG_STD'
-  ]
-endif
-
 cpp = meson.get_compiler('cpp')
 
 # This is a workaround to define FLATBUFFERS_LOCALE_INDEPENDENT=0 outside
@@ -319,6 +312,13 @@ flatbuffers_proj = subproject(
   ],
 )
 
+catch2_proj = subproject(
+  'catch2',
+  default_options: [
+    'warning_level=0',
+  ],
+)
+
 # flatbuffers schemas subdirectory.
 subdir('fbs')
 
@@ -384,19 +384,6 @@ if host_machine.system() == 'linux' and not get_option('ms_disable_liburing')
       '-DMS_LIBURING_SUPPORTED',
     ]
   endif
-endif
-
-if get_option('ms_build_tests')
-  catch2_proj = subproject(
-    'catch2',
-    default_options: [
-      'warning_level=0',
-    ],
-  )
-
-  dependencies += [
-    catch2_proj.get_variable('catch2_dep'),
-  ]
 endif
 
 libmediasoup_worker = library(
@@ -541,11 +528,18 @@ mediasoup_worker_test = executable(
   build_by_default: false,
   install: true,
   install_tag: 'mediasoup-worker-test',
+  dependencies: dependencies + [
+    catch2_proj.get_variable('catch2_dep'),
+  ],
   sources: common_sources + test_sources,
   include_directories: include_directories(
     'include',
     'test/include',
   ),
+  cpp_args: cpp_args + [
+    '-DMS_LOG_STD',
+    '-DMS_TEST',
+  ],
 )
 
 test(
@@ -559,12 +553,17 @@ mediasoup_worker_test_asan_address = executable(
   build_by_default: false,
   install: true,
   install_tag: 'mediasoup-worker-test-asan-address',
+  dependencies: dependencies + [
+    catch2_proj.get_variable('catch2_dep'),
+  ],
   sources: common_sources + test_sources,
   include_directories: include_directories(
     'include',
     'test/include',
   ),
   cpp_args: cpp_args + [
+    '-DMS_LOG_STD',
+    '-DMS_TEST',
     '-g',
     '-O3',
     '-fno-omit-frame-pointer',
@@ -586,12 +585,17 @@ mediasoup_worker_test_asan_undefined = executable(
   build_by_default: false,
   install: true,
   install_tag: 'mediasoup-worker-test-asan-undefined',
+  dependencies: dependencies + [
+    catch2_proj.get_variable('catch2_dep'),
+  ],
   sources: common_sources + test_sources,
   include_directories: include_directories(
     'include',
     'test/include',
   ),
   cpp_args: cpp_args + [
+    '-DMS_LOG_STD',
+    '-DMS_TEST',
     '-g',
     '-O3',
     '-fno-omit-frame-pointer',
@@ -613,12 +617,17 @@ mediasoup_worker_test_asan_thread = executable(
   build_by_default: false,
   install: true,
   install_tag: 'mediasoup-worker-test-asan-thread',
+  dependencies: dependencies + [
+    catch2_proj.get_variable('catch2_dep'),
+  ],
   sources: common_sources + test_sources,
   include_directories: include_directories(
     'include',
     'test/include',
   ),
   cpp_args: cpp_args + [
+    '-DMS_LOG_STD',
+    '-DMS_TEST',
     '-g',
     '-O3',
     '-fno-omit-frame-pointer',

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -62,6 +62,13 @@ if get_option('ms_sctp_stack')
   ]
 endif
 
+if get_option('ms_build_tests')
+  cpp_args += [
+    '-DMS_TEST',
+    '-DMS_LOG_STD'
+  ]
+endif
+
 cpp = meson.get_compiler('cpp')
 
 # This is a workaround to define FLATBUFFERS_LOCALE_INDEPENDENT=0 outside
@@ -312,13 +319,6 @@ flatbuffers_proj = subproject(
   ],
 )
 
-catch2_proj = subproject(
-  'catch2',
-  default_options: [
-    'warning_level=0',
-  ],
-)
-
 # flatbuffers schemas subdirectory.
 subdir('fbs')
 
@@ -384,6 +384,19 @@ if host_machine.system() == 'linux' and not get_option('ms_disable_liburing')
       '-DMS_LIBURING_SUPPORTED',
     ]
   endif
+endif
+
+if get_option('ms_build_tests')
+  catch2_proj = subproject(
+    'catch2',
+    default_options: [
+      'warning_level=0',
+    ],
+  )
+
+  dependencies += [
+    catch2_proj.get_variable('catch2_dep'),
+  ]
 endif
 
 libmediasoup_worker = library(
@@ -528,18 +541,11 @@ mediasoup_worker_test = executable(
   build_by_default: false,
   install: true,
   install_tag: 'mediasoup-worker-test',
-  dependencies: dependencies + [
-    catch2_proj.get_variable('catch2_dep'),
-  ],
   sources: common_sources + test_sources,
   include_directories: include_directories(
     'include',
     'test/include',
   ),
-  cpp_args: cpp_args + [
-    '-DMS_LOG_STD',
-    '-DMS_TEST',
-  ],
 )
 
 test(
@@ -553,17 +559,12 @@ mediasoup_worker_test_asan_address = executable(
   build_by_default: false,
   install: true,
   install_tag: 'mediasoup-worker-test-asan-address',
-  dependencies: dependencies + [
-    catch2_proj.get_variable('catch2_dep'),
-  ],
   sources: common_sources + test_sources,
   include_directories: include_directories(
     'include',
     'test/include',
   ),
   cpp_args: cpp_args + [
-    '-DMS_LOG_STD',
-    '-DMS_TEST',
     '-g',
     '-O3',
     '-fno-omit-frame-pointer',
@@ -585,17 +586,12 @@ mediasoup_worker_test_asan_undefined = executable(
   build_by_default: false,
   install: true,
   install_tag: 'mediasoup-worker-test-asan-undefined',
-  dependencies: dependencies + [
-    catch2_proj.get_variable('catch2_dep'),
-  ],
   sources: common_sources + test_sources,
   include_directories: include_directories(
     'include',
     'test/include',
   ),
   cpp_args: cpp_args + [
-    '-DMS_LOG_STD',
-    '-DMS_TEST',
     '-g',
     '-O3',
     '-fno-omit-frame-pointer',
@@ -617,17 +613,12 @@ mediasoup_worker_test_asan_thread = executable(
   build_by_default: false,
   install: true,
   install_tag: 'mediasoup-worker-test-asan-thread',
-  dependencies: dependencies + [
-    catch2_proj.get_variable('catch2_dep'),
-  ],
   sources: common_sources + test_sources,
   include_directories: include_directories(
     'include',
     'test/include',
   ),
   cpp_args: cpp_args + [
-    '-DMS_LOG_STD',
-    '-DMS_TEST',
     '-g',
     '-O3',
     '-fno-omit-frame-pointer',

--- a/worker/meson_options.txt
+++ b/worker/meson_options.txt
@@ -1,3 +1,4 @@
+option('ms_build_tests', type: 'boolean', value: false, description: 'Whether to build mediasoup worker tests')
 option('ms_log_trace', type: 'boolean', value: false, description: 'Logs the current method/function if current log level is "debug"')
 option('ms_log_file_line', type: 'boolean', value: false, description: 'Logging macros print more verbose information, including current file and line')
 option('ms_rtc_logger_rtp', type: 'boolean', value: false, description: 'Prints a line with information for each processed RTP packet')

--- a/worker/subprojects/catch2.wrap
+++ b/worker/subprojects/catch2.wrap
@@ -1,10 +1,10 @@
 [wrap-file]
-directory = Catch2-3.12.0
-source_url = https://github.com/catchorg/Catch2/archive/v3.12.0.tar.gz
-source_filename = Catch2-3.12.0.tar.gz
-source_hash = e077079f214afc99fee940d91c14cf1a8c1d378212226bb9f50efff75fe07b23
-source_fallback_url = https://wrapdb.mesonbuild.com/v2/catch2_3.12.0-1/get_source/Catch2-3.12.0.tar.gz
-wrapdb_version = 3.12.0-1
+directory = Catch2-3.13.0
+source_url = https://github.com/catchorg/Catch2/archive/v3.13.0.tar.gz
+source_filename = Catch2-3.13.0.tar.gz
+source_hash = 650795f6501af514f806e78c554729847b98db6935e69076f36bb03ed2e985ef
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/catch2_3.13.0-1/get_source/Catch2-3.13.0.tar.gz
+wrapdb_version = 3.13.0-1
 
 [provide]
 catch2 = catch2_dep

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -398,6 +398,7 @@ def tidy_fix(ctx):
         );
 
 
+@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Dms_build_tests=true -Db_lundef=false'), flatc])
 @task(pre=[setup, flatc])
 def test(ctx):
     """
@@ -430,7 +431,7 @@ def test(ctx):
         );
 
 
-@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Db_sanitize=address -Db_lundef=false'), flatc])
+@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Dms_build_tests=true -Db_sanitize=address -Db_lundef=false'), flatc])
 def test_asan_address(ctx):
     """
     Run worker test with Address Sanitizer with '-fsanitize=address'
@@ -462,7 +463,7 @@ def test_asan_address(ctx):
         );
 
 
-@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Db_sanitize=undefined -Db_lundef=false'), flatc])
+@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Dms_build_tests=true -Db_sanitize=undefined -Db_lundef=false'), flatc])
 def test_asan_undefined(ctx):
     """
     Run worker test with undefined Sanitizer with -fsanitize=undefined
@@ -496,7 +497,7 @@ def test_asan_undefined(ctx):
         );
 
 
-@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Db_sanitize=thread -Db_lundef=false'), flatc])
+@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Dms_build_tests=true -Db_sanitize=thread -Db_lundef=false'), flatc])
 def test_asan_thread(ctx):
     """
     Run worker test with thread Sanitizer with -fsanitize=thread

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -398,8 +398,7 @@ def tidy_fix(ctx):
         );
 
 
-@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Dms_build_tests=true -Db_lundef=false'), flatc])
-@task(pre=[setup, flatc])
+@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Dms_build_tests=true'), flatc])
 def test(ctx):
     """
     Run worker tests


### PR DESCRIPTION
# Details

- Only fetch Catch2 when building worker tests.
- Update Catch2 from 3.12.0-1 to 3.13.0-1.