### PR TITLE
Update CI actions

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -39,10 +39,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 24
 

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -98,15 +98,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.build.node }}
 
       - name: Configure cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.npm

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -47,10 +47,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/mediasoup-worker-clang-tidy.yaml
+++ b/.github/workflows/mediasoup-worker-clang-tidy.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: pip3 install --break-system-packages invoke

--- a/.github/workflows/mediasoup-worker-clang-tidy.yaml
+++ b/.github/workflows/mediasoup-worker-clang-tidy.yaml
@@ -38,7 +38,7 @@ jobs:
       - name: Normalize compile_commands.json paths
         run: npm run normalize-compile-commands --prefix worker/scripts --foreground-scripts
 
-      - uses: ZedThree/clang-tidy-review@v0.23.0
+      - uses: ZedThree/clang-tidy-review@v0.23.1
         id: review
         with:
           apt_packages: 'libclang-rt-21-dev'
@@ -51,7 +51,7 @@ jobs:
           include: 'worker/src/**/*.cpp,worker/test/src/**/*.cpp,worker/fuzzer/src/**/*.cpp'
 
       # Uploads an artifact containing clang_fixes.json.
-      - uses: ZedThree/clang-tidy-review/upload@v0.23.0
+      - uses: ZedThree/clang-tidy-review/upload@v0.23.1
         id: upload-review
 
       # If there are any comments, fail the check.

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # We need to install pip invoke manually.
       - if: ${{ !matrix.build.pip-break-system-packages }}

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -64,6 +64,6 @@ jobs:
         run: npm run worker:prebuild
 
       - name: Upload mediasoup-worker prebuilt binary
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           files: worker/prebuild/mediasoup-worker-*.tgz

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -41,10 +41,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -169,15 +169,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ matrix.node }}
 
       - name: Configure cache
-        uses: actions/cache@v3
+        uses: actions/cache@v5
         with:
           path: |
             ~/.npm


### PR DESCRIPTION
# Details

- Update all CI actions to their latest versions.

# Notes

- Iv'e also updated `softprops/action-gh-release@v1` to `softprops/action-gh-release@v2`, however we cannot check how it works until we publish a new mediasoup release.