### PR TITLE
Remove worker `test-asan-thread`

### DIFF
--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -37,7 +37,6 @@ jobs:
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
-            run-test-asan-thread: false
           - os: ubuntu-22.04
             cc: clang
             cxx: clang++
@@ -46,7 +45,6 @@ jobs:
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
-            run-test-asan-thread: false
           - os: ubuntu-22.04-arm
             cc: gcc
             cxx: g++
@@ -56,7 +54,6 @@ jobs:
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
-            run-test-asan-thread: false
           - os: ubuntu-24.04
             cc: gcc
             cxx: g++
@@ -66,7 +63,6 @@ jobs:
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
-            run-test-asan-thread: false
             # Compile with all Meson option flags enabled once with gcc in
             # Release mode.
             meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_sctp_stack=true'
@@ -79,7 +75,6 @@ jobs:
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
-            run-test-asan-thread: false
             # Compile with all Meson option flags enabled once with gcc in
             # Debug mode.
             meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_disable_liburing=true -Dms_sctp_stack=true'
@@ -92,7 +87,6 @@ jobs:
             run-test: true
             run-test-asan-address: true
             run-test-asan-undefined: true
-            run-test-asan-thread: true
             # Let's just compile with all Meson option flags enabled once with
             # clang.
             meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_sctp_stack=true'
@@ -106,7 +100,6 @@ jobs:
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
-            run-test-asan-thread: false
           - os: ubuntu-24.04-arm
             cc: clang
             cxx: clang++
@@ -117,7 +110,6 @@ jobs:
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
-            run-test-asan-thread: false
           - os: macos-15
             cc: clang
             cxx: clang++
@@ -128,7 +120,6 @@ jobs:
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
-            run-test-asan-thread: false
           - os: windows-2022
             cc: cl
             cxx: cl
@@ -140,7 +131,6 @@ jobs:
             # Address Sanitizer does not work on Windows.
             run-test-asan-address: false
             run-test-asan-undefined: false
-            run-test-asan-thread: false
           - os: windows-2025
             cc: cl
             cxx: cl
@@ -152,7 +142,6 @@ jobs:
             # Address Sanitizer does not work on Windows.
             run-test-asan-address: false
             run-test-asan-undefined: false
-            run-test-asan-thread: false
         # A single Node.js version should be fine for C++.
         node:
           - 24
@@ -233,8 +222,3 @@ jobs:
       - if: ${{ matrix.build.run-test-asan-undefined }}
         name: invoke -r worker test-asan-undefined
         run: invoke -r worker clean-all && invoke -r worker test-asan-undefined
-
-      # Let's clean everything before rebuilding worker tests with ASAN.
-      - if: ${{ matrix.build.run-test-asan-thread }}
-        name: invoke -r worker test-asan-thread
-        run: invoke -r worker clean-all && invoke -r worker test-asan-thread

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -269,10 +269,6 @@ Run test with Address Sanitizer with `-fsanitize=address`.
 
 Run test with Address Sanitizer with `-fsanitize=undefined`.
 
-### `invoke test-asan-thread`
-
-Run test with Address Sanitizer with `-fsanitize=thread`.
-
 ### `invoke fuzzer`
 
 Builds the `mediasoup-worker-fuzzer` binary (which uses [libFuzzer](http://llvm.org/docs/LibFuzzer.html)) at `worker/out/Release` (or at `worker/out/Debug/` if the "MEDIASOUP_BUILDTYPE" environment variable is set to "Debug").

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -36,7 +36,6 @@ endif
 	test \
 	test-asan-address \
 	test-asan-undefined \
-	test-asan-thread \
 	fuzzer \
 	fuzzer-run-all \
 	docker \
@@ -112,9 +111,6 @@ test-asan-address: invoke
 
 test-asan-undefined: invoke
 	"$(PYTHON)" -m invoke test-asan-undefined
-
-test-asan-thread: invoke
-	"$(PYTHON)" -m invoke test-asan-thread
 
 fuzzer: invoke
 	"$(PYTHON)" -m invoke fuzzer

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -375,10 +375,10 @@ if host_machine.system() == 'linux' and not get_option('ms_disable_liburing')
       default_options: [
         'default_library=static',
         # NOTE: We need to add this to disable ASAN in liburing, otherwise when
-        # building `mediasoup-test-asan-undefined & -thread` binaries, liburing
-        # receives `use_ubsan: true` and tries to compile its `sanitize.c` file
+        # building `mediasoup-test-asan-undefined` binary, liburing receives
+        # `use_ubsan: true` and tries to compile its `sanitize.c` file
         # that contains references to `__asan_*` functions, but we don't enable
-        # ASAN (`-fsanitize=address) in those binaries so liburing fails to
+        # ASAN (`-fsanitize=address) in that binaries so liburing fails to
         # compile.
         'b_sanitize=none',
       ],
@@ -622,34 +622,6 @@ mediasoup_worker_test_asan_undefined = executable(
 test(
   'mediasoup-worker-test-asan-undefined',
   mediasoup_worker_test_asan_undefined,
-  workdir: meson.project_source_root(),
-)
-
-mediasoup_worker_test_asan_thread = executable(
-  'mediasoup-worker-test-asan-thread',
-  build_by_default: false,
-  install: true,
-  install_tag: 'mediasoup-worker-test-asan-thread',
-  dependencies: dependencies,
-  sources: common_sources + test_sources,
-  include_directories: include_directories(
-    'include',
-    'test/include',
-  ),
-  cpp_args: cpp_args + [
-    '-g',
-    '-O3',
-    '-fno-omit-frame-pointer',
-    '-fsanitize=thread',
-  ],
-  link_args: [
-    '-fsanitize=thread',
-  ],
-)
-
-test(
-  'mediasoup-worker-test-asan-thread',
-  mediasoup_worker_test_asan_thread,
   workdir: meson.project_source_root(),
 )
 

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -496,39 +496,6 @@ def test_asan_undefined(ctx):
         );
 
 
-@task(pre=[call(setup, meson_args=MESON_ARGS + ' -Dms_build_tests=true -Db_sanitize=thread -Db_lundef=false'), flatc])
-def test_asan_thread(ctx):
-    """
-    Run worker test with thread Sanitizer with -fsanitize=thread
-    """
-    with cd_worker():
-        ctx.run(
-            f'"{MESON}" compile -C "{BUILD_DIR}" -j {NUM_CORES} mediasoup-worker-test-asan-thread',
-            echo=True,
-            pty=PTY_SUPPORTED,
-            shell=SHELL
-        );
-    with cd_worker():
-        ctx.run(
-            f'"{MESON}" install -C "{BUILD_DIR}" --no-rebuild --tags mediasoup-worker-test-asan-thread',
-            echo=True,
-            pty=PTY_SUPPORTED,
-            shell=SHELL
-        );
-
-    mediasoup_test_tags = os.getenv('MEDIASOUP_TEST_TAGS') or '';
-
-    with cd_worker():
-        ctx.run(
-            f'"{BUILD_DIR}/mediasoup-worker-test-asan-thread" --invisibles {mediasoup_test_tags}',
-            echo=True,
-            pty=PTY_SUPPORTED,
-            shell=SHELL,
-            # Exit with error if there are issues.
-            env={**os.environ, 'TSAN_OPTIONS': 'halt_on_error=1:print_stacktrace=1'}
-        );
-
-
 @task(pre=[call(setup, meson_args=MESON_ARGS + ' -Db_sanitize=address -Db_lundef=false'), flatc])
 def fuzzer(ctx):
     """


### PR DESCRIPTION
# Details

- mediasoup worker is mono thread, so testing `sanitize=thread` on it doesn't make any sense.
- Yes, usrsctp creates a separate thread for timers purpose, but it will go away when we complete and enable our SCTP stack.