### PR TITLE
worker: relax log severity for legitimate situations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Worker: Relax log severity for legitimate situations ([PR #1771](https://github.com/versatica/mediasoup/pull/1771).
+
 ### 3.19.19
 
 - Worker: Ensure 4-byte alignment for network packet receive buffers and test buffers to avoid undefined behavior ([PR #1756](https://github.com/versatica/mediasoup/pull/1756).

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -570,7 +570,7 @@ namespace RTC
 
 		if (!rtpStream)
 		{
-			MS_WARN_TAG(rtp, "no stream found for received packet [ssrc:%" PRIu32 "]", packet->GetSsrc());
+			MS_DEBUG_TAG(rtp, "no stream found for received packet [ssrc:%" PRIu32 "]", packet->GetSsrc());
 
 #ifdef MS_RTC_LOGGER_RTP
 			packet->logger.Discarded(RTC::RtcLogger::RtpPacket::DiscardReason::RECV_RTP_STREAM_NOT_FOUND);

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1746,7 +1746,7 @@ namespace RTC
 			packet->logger.Discarded(RTC::RtcLogger::RtpPacket::DiscardReason::PRODUCER_NOT_FOUND);
 #endif
 
-			MS_WARN_TAG(
+			MS_DEBUG_TAG(
 			  rtp,
 			  "no suitable Producer for received RTP packet [ssrc:%" PRIu32 ", payloadType:%" PRIu8 "]",
 			  packet->GetSsrc(),

--- a/worker/src/RTC/WebRtcServer.cpp
+++ b/worker/src/RTC/WebRtcServer.cpp
@@ -468,7 +468,7 @@ namespace RTC
 
 		if (it2 == this->mapLocalIceUsernameFragmentWebRtcTransport.end())
 		{
-			MS_WARN_TAG(ice, "ignoring received STUN packet with unknown remote ICE usernameFragment");
+			MS_DEBUG_TAG(ice, "ignoring received STUN packet with unknown remote ICE usernameFragment");
 
 			delete packet;
 
@@ -491,7 +491,7 @@ namespace RTC
 
 		if (it == this->mapTupleWebRtcTransport.end())
 		{
-			MS_WARN_TAG(ice, "ignoring received non STUN data from unknown tuple");
+			MS_DEBUG_TAG(ice, "ignoring received non STUN data from unknown tuple");
 
 			return;
 		}


### PR DESCRIPTION
Do not use `warn` for legitimate situations.