### PR TITLE
[Rust] mediasoup crate 0.21.0 and mediasoup-sys crate 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1354,7 +1354,7 @@ checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 
 [[package]]
 name = "mediasoup"
-version = "0.20.0"
+version = "0.21.0"
 dependencies = [
  "actix",
  "actix-web",
@@ -1392,7 +1392,7 @@ dependencies = [
 
 [[package]]
 name = "mediasoup-sys"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "planus",
  "planus-codegen",

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 # NEXT
 
+# 0.21.0
+
 - `router.pipe_producer_to_router()` and `router.pipe_data_producer_to_router()` can now connect two `Routers` in the same `Worker` if `keep_id` is set to `false` (PR #1604).
 - Updates from mediasoup TypeScript `3.18.1.=3.19.0`.
 - Ensure that the order of acquiring the `paused` and `producer_paused` locks in `consumer.rs` is consistent at all times to avoid deadlock (PR #1605).

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup"
-version = "0.20.0"
+version = "0.21.0"
 description = "Cutting Edge WebRTC Video Conferencing in Rust"
 categories = ["api-bindings", "multimedia", "network-programming"]
 authors = [
@@ -46,7 +46,7 @@ version = "0.8.1"
 
 [dependencies.mediasoup-sys]
 path = "../worker"
-version = "0.10.0"
+version = "0.11.0"
 
 [dependencies.mediasoup-types]
 path = "./types"

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup-sys"
-version = "0.10.0"
+version = "0.11.0"
 description = "FFI bindings to C++ libmediasoup-worker"
 authors = [
     "Nazar Mokrynskyi <nazar@mokrynskyi.com>",


### PR DESCRIPTION
- mediasoup-sys does not have the mediasoup-packet-id RTP header extension.
- WORKER_CLOSE was moved into a notification.