### PR TITLE
Fix regression in `DirectTransport` when closing a `DataProducer` or `DataConsumer`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Worker: Fix regression in `DirectTransport` when closing a `DataProducer` or `DataConsumer` ([PR #1778](https://github.com/versatica/mediasoup/pull/1778)).
+
 ### 3.19.20
 
 - Worker: Add `useBuiltInSctpStack` setting (defaults to `false`) to enable mediasoup built-in SCTP stack ([PR #1777](https://github.com/versatica/mediasoup/pull/1777)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Worker: Fix regression in `DirectTransport` when closing a `DataProducer` or `DataConsumer` ([PR #1778](https://github.com/versatica/mediasoup/pull/1778)).
+- Worker: Fix regression in `DirectTransport` when closing a `DataProducer` or `DataConsumer` ([PR #1780](https://github.com/versatica/mediasoup/pull/1780)).
 
 ### 3.19.20
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1506,15 +1506,11 @@ namespace RTC
 			case Channel::ChannelRequest::Method::TRANSPORT_CLOSE_DATAPRODUCER:
 			{
 				if (
-				  (Settings::configuration.useBuiltInSctpStack && !this->sctpAssociation) ||
-				  (!Settings::configuration.useBuiltInSctpStack && !this->oldSctpAssociation))
+				  ((Settings::configuration.useBuiltInSctpStack && !this->sctpAssociation) ||
+				   (!Settings::configuration.useBuiltInSctpStack && !this->oldSctpAssociation)) &&
+				  !this->direct)
 				{
-					MS_WARN_TAG(sctp, "cannot close a DataProducer, no SCTP Association");
-					;
-
-					request->Accept();
-
-					break;
+					MS_THROW_ERROR("cannot close DataProducer, SCTP not enabled and not a direct Transport");
 				}
 
 				const auto* body = request->data->body_as<FBS::Transport::CloseDataProducerRequest>();
@@ -1561,14 +1557,11 @@ namespace RTC
 			case Channel::ChannelRequest::Method::TRANSPORT_CLOSE_DATACONSUMER:
 			{
 				if (
-				  (Settings::configuration.useBuiltInSctpStack && !this->sctpAssociation) ||
-				  (!Settings::configuration.useBuiltInSctpStack && !this->oldSctpAssociation))
+				  ((Settings::configuration.useBuiltInSctpStack && !this->sctpAssociation) ||
+				   (!Settings::configuration.useBuiltInSctpStack && !this->oldSctpAssociation)) &&
+				  !this->direct)
 				{
-					MS_WARN_TAG(sctp, "cannot close a DataConsumer, no SCTP Association");
-
-					request->Accept();
-
-					break;
+					MS_THROW_ERROR("cannot close DataConsumer, SCTP not enabled and not a direct Transport");
 				}
 
 				const auto* body = request->data->body_as<FBS::Transport::CloseDataConsumerRequest>();


### PR DESCRIPTION
# Details

- Fix issue reported by @jiyeyuran here: https://github.com/versatica/mediasoup/pull/1777#pullrequestreview-4147392039