### PR TITLE
Worker: Add interfaces for Timer classes

### DIFF
--- a/worker/include/DepUsrSCTP.hpp
+++ b/worker/include/DepUsrSCTP.hpp
@@ -3,13 +3,13 @@
 
 #include "common.hpp"
 #include "RTC/SctpAssociation.hpp"
-#include "handles/TimerHandle.hpp"
+#include "handles/TimerHandleInterface.hpp"
 #include <absl/container/flat_hash_map.h>
 
 class DepUsrSCTP
 {
 private:
-	class Checker : public TimerHandle::Listener
+	class Checker : public TimerHandleInterface::Listener
 	{
 	public:
 		Checker();
@@ -19,12 +19,12 @@ private:
 		void Start();
 		void Stop();
 
-		/* Pure virtual methods inherited from TimerHandle::Listener. */
+		/* Pure virtual methods inherited from TimerHandleInterface::Listener. */
 	public:
-		void OnTimer(TimerHandle* timer) override;
+		void OnTimer(TimerHandleInterface* timer) override;
 
 	private:
-		TimerHandle* timer{ nullptr };
+		TimerHandleInterface* timer{ nullptr };
 		uint64_t lastCalledAtMs{ 0u };
 	};
 

--- a/worker/include/RTC/ActiveSpeakerObserver.hpp
+++ b/worker/include/RTC/ActiveSpeakerObserver.hpp
@@ -3,7 +3,7 @@
 
 #include "RTC/RtpObserver.hpp"
 #include "RTC/Shared.hpp"
-#include "handles/TimerHandle.hpp"
+#include "handles/TimerHandleInterface.hpp"
 #include <absl/container/flat_hash_map.h>
 #include <vector>
 
@@ -14,7 +14,7 @@
 // https://github.com/jitsi/jitsi-utils/blob/master/src/main/java/org/jitsi/utils/dsi/DominantSpeakerIdentification.java
 namespace RTC
 {
-	class ActiveSpeakerObserver : public RTC::RtpObserver, public TimerHandle::Listener
+	class ActiveSpeakerObserver : public RTC::RtpObserver, public TimerHandleInterface::Listener
 	{
 	private:
 		class Speaker
@@ -89,14 +89,14 @@ namespace RTC
 		bool CalculateActiveSpeaker();
 		void TimeoutIdleLevels(uint64_t now);
 
-		/* Pure virtual methods inherited from TimerHandle. */
+		/* Pure virtual methods inherited from TimerHandleInterface. */
 	protected:
-		void OnTimer(TimerHandle* timer) override;
+		void OnTimer(TimerHandleInterface* timer) override;
 
 	private:
 		double relativeSpeachActivities[RelativeSpeachActivitiesLen]{};
 		std::string dominantId;
-		TimerHandle* periodicTimer{ nullptr };
+		TimerHandleInterface* periodicTimer{ nullptr };
 		uint16_t interval{ 300u };
 		// Map of ProducerSpeakers indexed by Producer id.
 		absl::flat_hash_map<std::string, ProducerSpeaker*> mapProducerSpeakers;

--- a/worker/include/RTC/AudioLevelObserver.hpp
+++ b/worker/include/RTC/AudioLevelObserver.hpp
@@ -3,12 +3,12 @@
 
 #include "RTC/RtpObserver.hpp"
 #include "RTC/Shared.hpp"
-#include "handles/TimerHandle.hpp"
+#include "handles/TimerHandleInterface.hpp"
 #include <absl/container/flat_hash_map.h>
 
 namespace RTC
 {
-	class AudioLevelObserver : public RTC::RtpObserver, public TimerHandle::Listener
+	class AudioLevelObserver : public RTC::RtpObserver, public TimerHandleInterface::Listener
 	{
 	private:
 		struct DBovs
@@ -38,9 +38,9 @@ namespace RTC
 		void Update();
 		void ResetMapProducerDBovs();
 
-		/* Pure virtual methods inherited from TimerHandle. */
+		/* Pure virtual methods inherited from TimerHandleInterface. */
 	protected:
-		void OnTimer(TimerHandle* timer) override;
+		void OnTimer(TimerHandleInterface* timer) override;
 
 	private:
 		// Passed by argument.
@@ -48,7 +48,7 @@ namespace RTC
 		int8_t threshold{ -80 };
 		uint16_t interval{ 1000u };
 		// Allocated by this.
-		TimerHandle* periodicTimer{ nullptr };
+		TimerHandleInterface* periodicTimer{ nullptr };
 		// Others.
 		absl::flat_hash_map<RTC::Producer*, DBovs> mapProducerDBovs;
 		bool silence{ true };

--- a/worker/include/RTC/DtlsTransport.hpp
+++ b/worker/include/RTC/DtlsTransport.hpp
@@ -4,7 +4,7 @@
 #include "common.hpp"
 #include "FBS/webRtcTransport.h"
 #include "RTC/SrtpSession.hpp"
-#include "handles/TimerHandle.hpp"
+#include "handles/TimerHandleInterface.hpp"
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
@@ -14,7 +14,7 @@
 
 namespace RTC
 {
-	class DtlsTransport : public TimerHandle::Listener
+	class DtlsTransport : public TimerHandleInterface::Listener
 	{
 	public:
 		enum class DtlsState : uint8_t
@@ -195,9 +195,9 @@ namespace RTC
 	public:
 		void OnSslInfo(int where, int ret);
 
-		/* Pure virtual methods inherited from TimerHandle::Listener. */
+		/* Pure virtual methods inherited from TimerHandleInterface::Listener. */
 	public:
-		void OnTimer(TimerHandle* timer) override;
+		void OnTimer(TimerHandleInterface* timer) override;
 
 	private:
 		// Passed by argument.
@@ -206,7 +206,7 @@ namespace RTC
 		SSL* ssl{ nullptr };
 		BIO* sslBioFromNetwork{ nullptr }; // The BIO from which ssl reads.
 		BIO* sslBioToNetwork{ nullptr };   // The BIO in which ssl writes.
-		TimerHandle* timer{ nullptr };
+		TimerHandleInterface* timer{ nullptr };
 		// Others.
 		DtlsState state{ DtlsState::NEW };
 		std::optional<Role> localRole;

--- a/worker/include/RTC/ICE/IceServer.hpp
+++ b/worker/include/RTC/ICE/IceServer.hpp
@@ -5,7 +5,7 @@
 #include "FBS/webRtcTransport.h"
 #include "RTC/ICE/StunPacket.hpp"
 #include "RTC/TransportTuple.hpp"
-#include "handles/TimerHandle.hpp"
+#include "handles/TimerHandleInterface.hpp"
 #include <list>
 #include <string>
 #include <unordered_map>
@@ -14,7 +14,7 @@ namespace RTC
 {
 	namespace ICE
 	{
-		class IceServer : public TimerHandle::Listener
+		class IceServer : public TimerHandleInterface::Listener
 		{
 		public:
 			enum class IceState : uint8_t
@@ -129,9 +129,9 @@ namespace RTC
 			void RestartConsentCheck();
 			void StopConsentCheck();
 
-			/* Pure virtual methods inherited from TimerHandle::Listener. */
+			/* Pure virtual methods inherited from TimerHandleInterface::Listener. */
 		public:
-			void OnTimer(TimerHandle* timer) override;
+			void OnTimer(TimerHandleInterface* timer) override;
 
 		private:
 			// Passed by argument.
@@ -146,7 +146,7 @@ namespace RTC
 			uint32_t remoteNomination{ 0u };
 			std::list<RTC::TransportTuple> tuples;
 			RTC::TransportTuple* selectedTuple{ nullptr };
-			TimerHandle* consentCheckTimer{ nullptr };
+			TimerHandleInterface* consentCheckTimer{ nullptr };
 			bool isRemovingTuples{ false };
 		};
 	} // namespace ICE

--- a/worker/include/RTC/KeyFrameRequestManager.hpp
+++ b/worker/include/RTC/KeyFrameRequestManager.hpp
@@ -1,12 +1,12 @@
 #ifndef MS_KEY_FRAME_REQUEST_MANAGER_HPP
 #define MS_KEY_FRAME_REQUEST_MANAGER_HPP
 
-#include "handles/TimerHandle.hpp"
+#include "handles/TimerHandleInterface.hpp"
 #include <absl/container/flat_hash_map.h>
 
 namespace RTC
 {
-	class PendingKeyFrameInfo : public TimerHandle::Listener
+	class PendingKeyFrameInfo : public TimerHandleInterface::Listener
 	{
 	public:
 		class Listener
@@ -39,18 +39,18 @@ namespace RTC
 			this->timer->Restart();
 		}
 
-		/* Pure virtual methods inherited from TimerHandle::Listener. */
+		/* Pure virtual methods inherited from TimerHandleInterface::Listener. */
 	public:
-		void OnTimer(TimerHandle* timer) override;
+		void OnTimer(TimerHandleInterface* timer) override;
 
 	private:
 		Listener* listener{ nullptr };
 		uint32_t ssrc;
-		TimerHandle* timer{ nullptr };
+		TimerHandleInterface* timer{ nullptr };
 		bool retryOnTimeout{ true };
 	};
 
-	class KeyFrameRequestDelayer : public TimerHandle::Listener
+	class KeyFrameRequestDelayer : public TimerHandleInterface::Listener
 	{
 	public:
 		class Listener
@@ -79,14 +79,14 @@ namespace RTC
 			this->keyFrameRequested = flag;
 		}
 
-		/* Pure virtual methods inherited from TimerHandle::Listener. */
+		/* Pure virtual methods inherited from TimerHandleInterface::Listener. */
 	public:
-		void OnTimer(TimerHandle* timer) override;
+		void OnTimer(TimerHandleInterface* timer) override;
 
 	private:
 		Listener* listener{ nullptr };
 		uint32_t ssrc;
-		TimerHandle* timer{ nullptr };
+		TimerHandleInterface* timer{ nullptr };
 		bool keyFrameRequested{ false };
 	};
 

--- a/worker/include/RTC/NackGenerator.hpp
+++ b/worker/include/RTC/NackGenerator.hpp
@@ -4,14 +4,14 @@
 #include "common.hpp"
 #include "RTC/RTP/Packet.hpp"
 #include "RTC/SeqManager.hpp"
-#include "handles/TimerHandle.hpp"
+#include "handles/TimerHandleInterface.hpp"
 #include <map>
 #include <set>
 #include <vector>
 
 namespace RTC
 {
-	class NackGenerator : public TimerHandle::Listener
+	class NackGenerator : public TimerHandleInterface::Listener
 	{
 	public:
 		class Listener
@@ -67,16 +67,16 @@ namespace RTC
 		std::vector<uint16_t> GetNackBatch(NackFilter filter);
 		void MayRunTimer() const;
 
-		/* Pure virtual methods inherited from TimerHandle::Listener. */
+		/* Pure virtual methods inherited from TimerHandleInterface::Listener. */
 	public:
-		void OnTimer(TimerHandle* timer) override;
+		void OnTimer(TimerHandleInterface* timer) override;
 
 	private:
 		// Passed by argument.
 		Listener* listener{ nullptr };
 		unsigned int sendNackDelayMs{ 0u };
 		// Allocated by this.
-		TimerHandle* timer{ nullptr };
+		TimerHandleInterface* timer{ nullptr };
 		// Others.
 		std::map<uint16_t, NackInfo, RTC::SeqManager<uint16_t>::SeqLowerThan> nackList;
 		std::set<uint16_t, RTC::SeqManager<uint16_t>::SeqLowerThan> keyFrameList;

--- a/worker/include/RTC/RTP/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RTP/RtpStreamRecv.hpp
@@ -5,7 +5,7 @@
 #include "RTC/RTCP/XrDelaySinceLastRr.hpp"
 #include "RTC/RTP/RtpStream.hpp"
 #include "RTC/RateCalculator.hpp"
-#include "handles/TimerHandle.hpp"
+#include "handles/TimerHandleInterface.hpp"
 #include <vector>
 
 namespace RTC
@@ -14,7 +14,7 @@ namespace RTC
 	{
 		class RtpStreamRecv : public RTP::RtpStream,
 		                      public RTC::NackGenerator::Listener,
-		                      public TimerHandle::Listener
+		                      public TimerHandleInterface::Listener
 		{
 		public:
 			class Listener : public RTP::RtpStream::Listener
@@ -92,9 +92,9 @@ namespace RTC
 		public:
 			void UserOnSequenceNumberReset() override;
 
-			/* Pure virtual methods inherited from TimerHandle. */
+			/* Pure virtual methods inherited from TimerHandleInterface. */
 		protected:
-			void OnTimer(TimerHandle* timer) override;
+			void OnTimer(TimerHandleInterface* timer) override;
 
 			/* Pure virtual methods inherited from RTC::NackGenerator. */
 		protected:
@@ -124,7 +124,7 @@ namespace RTC
 			uint8_t firSeqNumber{ 0u };
 			int32_t reportedPacketsLost{ 0 };
 			std::unique_ptr<RTC::NackGenerator> nackGenerator;
-			TimerHandle* inactivityCheckPeriodicTimer{ nullptr };
+			TimerHandleInterface* inactivityCheckPeriodicTimer{ nullptr };
 			bool inactive{ false };
 			// Valid media + valid RTX.
 			TransmissionCounter transmissionCounter;

--- a/worker/include/RTC/SCTP/TODO_SCTP.md
+++ b/worker/include/RTC/SCTP/TODO_SCTP.md
@@ -46,9 +46,13 @@
 
 - Look for "TODO: SCTP" everywhere.
 
-- Test Chrome with I-DATA (message interleaving):
-
+- Test Chrome/Canary with I-DATA (message interleaving):
+  ```bash
+  open -a "Google Chrome" \
+    --args \
+    --force-fieldtrials="WebRTC-DataChannelMessageInterleaving/Enabled/"
   ```
+  ```bash
   open -a "Google Chrome Canary" \
     --args \
     --force-fieldtrials="WebRTC-DataChannelMessageInterleaving/Enabled/"

--- a/worker/include/RTC/SCTP/association/Association.hpp
+++ b/worker/include/RTC/SCTP/association/Association.hpp
@@ -36,7 +36,7 @@
 #include "RTC/SCTP/public/Message.hpp"
 #include "RTC/SCTP/public/SctpOptions.hpp"
 #include "RTC/SCTP/public/SctpTypes.hpp"
-#include "handles/BackoffTimerHandle.hpp"
+#include "handles/BackoffTimerHandleInterface.hpp"
 #include <FBS/sctpParameters.h>
 #include <span>
 #include <string_view>
@@ -51,7 +51,7 @@ namespace RTC
 		 */
 		class Association : public AssociationInterface,
 		                    public PacketSender::Listener,
-		                    public BackoffTimerHandle::Listener
+		                    public BackoffTimerHandleInterface::Listener
 		{
 		public:
 			/**
@@ -460,9 +460,9 @@ namespace RTC
 		public:
 			void OnPacketSenderPacketSent(PacketSender* packetSender, const Packet* packet, bool sent) override;
 
-			/* Pure virtual methods inherited from BackoffTimerHandle::Listener. */
+			/* Pure virtual methods inherited from BackoffTimerHandleInterface::Listener. */
 		public:
-			void OnTimer(BackoffTimerHandle* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
+			void OnTimer(BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
 
 		private:
 			// SCTP options given in the constructor.
@@ -487,11 +487,11 @@ namespace RTC
 			// Private metrics.
 			AssociationPrivateMetrics privateMetrics{};
 			// T1-init timer.
-			const std::unique_ptr<BackoffTimerHandle> t1InitTimer;
+			const std::unique_ptr<BackoffTimerHandleInterface> t1InitTimer;
 			// T1-cookie timer.
-			const std::unique_ptr<BackoffTimerHandle> t1CookieTimer;
+			const std::unique_ptr<BackoffTimerHandleInterface> t1CookieTimer;
 			// T2-shutdown timer.
-			const std::unique_ptr<BackoffTimerHandle> t2ShutdownTimer;
+			const std::unique_ptr<BackoffTimerHandleInterface> t2ShutdownTimer;
 		};
 	} // namespace SCTP
 } // namespace RTC

--- a/worker/include/RTC/SCTP/association/HeartbeatHandler.hpp
+++ b/worker/include/RTC/SCTP/association/HeartbeatHandler.hpp
@@ -7,7 +7,7 @@
 #include "RTC/SCTP/packet/chunks/HeartbeatRequestChunk.hpp"
 #include "RTC/SCTP/public/AssociationListener.hpp"
 #include "RTC/SCTP/public/SctpOptions.hpp"
-#include "handles/BackoffTimerHandle.hpp"
+#include "handles/BackoffTimerHandleInterface.hpp"
 
 namespace RTC
 {
@@ -21,7 +21,7 @@ namespace RTC
 		 * still healthy and to measure the RTT. If a number of heartbeats time out,
 		 * the connection will eventually be closed.
 		 */
-		class HeartbeatHandler : public BackoffTimerHandle::Listener
+		class HeartbeatHandler : public BackoffTimerHandleInterface::Listener
 		{
 		public:
 			HeartbeatHandler(
@@ -55,9 +55,9 @@ namespace RTC
 
 			void OnTimeoutTimer(uint64_t& baseTimeoutMs, bool& stop);
 
-			/* Pure virtual methods inherited from BackoffTimerHandle::Listener. */
+			/* Pure virtual methods inherited from BackoffTimerHandleInterface::Listener. */
 		public:
-			void OnTimer(BackoffTimerHandle* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
+			void OnTimer(BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
 
 		private:
 			AssociationListener& associationListener;
@@ -68,8 +68,8 @@ namespace RTC
 			// Adding RTT to the duration will add some jitter, which is good in
 			// production, but less good in unit tests, which is why it can be disabled.
 			const bool intervalDurationShouldIncludeRtt{ false };
-			const std::unique_ptr<BackoffTimerHandle> intervalTimer;
-			const std::unique_ptr<BackoffTimerHandle> timeoutTimer;
+			const std::unique_ptr<BackoffTimerHandleInterface> intervalTimer;
+			const std::unique_ptr<BackoffTimerHandleInterface> timeoutTimer;
 		};
 	} // namespace SCTP
 } // namespace RTC

--- a/worker/include/RTC/SCTP/association/StreamResetHandler.hpp
+++ b/worker/include/RTC/SCTP/association/StreamResetHandler.hpp
@@ -11,7 +11,7 @@
 #include "RTC/SCTP/packet/parameters/ReconfigurationResponseParameter.hpp"
 #include "RTC/SCTP/public/AssociationListener.hpp"
 #include "RTC/SCTP/tx/RetransmissionQueue.hpp"
-#include "handles/BackoffTimerHandle.hpp"
+#include "handles/BackoffTimerHandleInterface.hpp"
 #include <span>
 #include <vector>
 
@@ -50,7 +50,7 @@ namespace RTC
 		 * not-yet-sent messages will be discarded, but that may change in the future.
 		 * RFC8831 allows both behaviors.
 		 */
-		class StreamResetHandler : public BackoffTimerHandle::Listener
+		class StreamResetHandler : public BackoffTimerHandleInterface::Listener
 		{
 		private:
 			enum class ReqSeqNbrValidationResult : uint8_t
@@ -254,9 +254,9 @@ namespace RTC
 
 			void OnReConfigTimer(uint64_t& baseTimeoutMs, bool& stop);
 
-			/* Pure virtual methods inherited from BackoffTimerHandle::Listener. */
+			/* Pure virtual methods inherited from BackoffTimerHandleInterface::Listener. */
 		public:
-			void OnTimer(BackoffTimerHandle* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
+			void OnTimer(BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
 
 		private:
 			AssociationListener& associationListener;
@@ -267,7 +267,7 @@ namespace RTC
 			// ReassemblyQueue* reassemblyQueue;,
 			RetransmissionQueue* retransmissionQueue;
 			UnwrappedReConfigRequestSn::Unwrapper incomingReConfigRequestSnUnwrapper;
-			const std::unique_ptr<BackoffTimerHandle> reConfigTimer;
+			const std::unique_ptr<BackoffTimerHandleInterface> reConfigTimer;
 			// The next sequence number for outgoing stream requests.
 			uint32_t nextOutgoingReqSeqNbr{ 0 };
 			// The current stream request operation.

--- a/worker/include/RTC/SCTP/association/TransmissionControlBlock.hpp
+++ b/worker/include/RTC/SCTP/association/TransmissionControlBlock.hpp
@@ -13,7 +13,7 @@
 #include "RTC/SCTP/tx/RetransmissionErrorCounter.hpp"
 #include "RTC/SCTP/tx/RetransmissionQueue.hpp"
 #include "RTC/SCTP/tx/RetransmissionTimeout.hpp"
-#include "handles/BackoffTimerHandle.hpp"
+#include "handles/BackoffTimerHandleInterface.hpp"
 #include <string_view>
 #include <vector>
 
@@ -29,7 +29,7 @@ namespace RTC
 		 */
 		class TransmissionControlBlock : public TCBContext,
 		                                 public RetransmissionQueue::Listener,
-		                                 public BackoffTimerHandle::Listener
+		                                 public BackoffTimerHandleInterface::Listener
 		{
 		public:
 			TransmissionControlBlock(
@@ -269,9 +269,9 @@ namespace RTC
 			void OnRetransmissionQueueClearRetransmissionCounter() override;
 			;
 
-			/* Pure virtual methods inherited from BackoffTimerHandle::Listener. */
+			/* Pure virtual methods inherited from BackoffTimerHandleInterface::Listener. */
 		public:
-			void OnTimer(BackoffTimerHandle* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
+			void OnTimer(BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
 
 		private:
 			AssociationListener& associationListener;
@@ -287,10 +287,10 @@ namespace RTC
 			NegotiatedCapabilities negotiatedCapabilities;
 			std::function<bool()> isAssociationEstablished;
 			// The data retransmission timer.
-			const std::unique_ptr<BackoffTimerHandle> t3RtxTimer;
+			const std::unique_ptr<BackoffTimerHandleInterface> t3RtxTimer;
 			// Delayed ack timer, which triggers when acks should be sent (when
 			// delayed).
-			const std::unique_ptr<BackoffTimerHandle> delayedAckTimer;
+			const std::unique_ptr<BackoffTimerHandleInterface> delayedAckTimer;
 			RetransmissionTimeout rto;
 			RetransmissionErrorCounter txErrorCounter;
 			// TODO: SCTP: Implement.

--- a/worker/include/RTC/SCTP/tx/RetransmissionQueue.hpp
+++ b/worker/include/RTC/SCTP/tx/RetransmissionQueue.hpp
@@ -11,7 +11,7 @@
 #include "RTC/SCTP/public/AssociationListener.hpp"
 #include "RTC/SCTP/public/SctpOptions.hpp"
 #include "RTC/SCTP/tx/OutstandingData.hpp"
-#include "handles/BackoffTimerHandle.hpp"
+#include "handles/BackoffTimerHandleInterface.hpp"
 #include <vector>
 
 namespace RTC
@@ -69,7 +69,7 @@ namespace RTC
 			  uint32_t remoteAdvertisedReceiverWindowCredit,
 			  // TODO: SCTP: Implement
 			  // SendQueue& sendQueue,
-			  BackoffTimerHandle* t3RtxTimer,
+			  BackoffTimerHandleInterface* t3RtxTimer,
 			  const SctpOptions& sctpOptions,
 			  // TODO: SCTP: I don't like these defaults (true and false), let's be explicit.
 			  bool supportsPartialReliability,
@@ -303,7 +303,7 @@ namespace RTC
 			// The length of the data chunk (DATA/I-DATA) header that is used.
 			const size_t dataChunkHeaderLength;
 			// The retransmission timer.
-			BackoffTimerHandle* t3RtxTimer;
+			BackoffTimerHandleInterface* t3RtxTimer;
 			// Unwraps TSNs.
 			UnwrappedTsn::Unwrapper tsnUnwrapper;
 			// Congestion Window. Number of bytes that may be in-flight (sent, not

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -31,7 +31,7 @@
 #endif
 #include "RTC/TransportCongestionControlClient.hpp"
 #include "RTC/TransportCongestionControlServer.hpp"
-#include "handles/TimerHandle.hpp"
+#include "handles/TimerHandleInterface.hpp"
 #include <absl/container/flat_hash_map.h>
 #include <string>
 #include <vector>
@@ -52,7 +52,7 @@ namespace RTC
 #ifdef ENABLE_RTC_SENDER_BANDWIDTH_ESTIMATOR
 	                  public RTC::SenderBandwidthEstimator::Listener,
 #endif
-	                  public TimerHandle::Listener
+	                  public TimerHandleInterface::Listener
 	{
 	protected:
 		using onSendCallback   = const std::function<void(bool sent)>;
@@ -350,9 +350,9 @@ namespace RTC
 		  uint32_t previousAvailableBitrate) override;
 #endif
 
-		/* Pure virtual methods inherited from TimerHandle::Listener. */
+		/* Pure virtual methods inherited from TimerHandleInterface::Listener. */
 	public:
-		void OnTimer(TimerHandle* timer) override;
+		void OnTimer(TimerHandleInterface* timer) override;
 
 	public:
 		// Passed by argument.
@@ -376,7 +376,7 @@ namespace RTC
 		absl::flat_hash_map<std::string, RTC::DataConsumer*> mapDataConsumers;
 		absl::flat_hash_map<uint32_t, RTC::Consumer*> mapSsrcConsumer;
 		absl::flat_hash_map<uint32_t, RTC::Consumer*> mapRtxSsrcConsumer;
-		TimerHandle* rtcpTimer{ nullptr };
+		TimerHandleInterface* rtcpTimer{ nullptr };
 		std::shared_ptr<RTC::TransportCongestionControlClient> tccClient{ nullptr };
 		std::shared_ptr<RTC::TransportCongestionControlServer> tccServer{ nullptr };
 #ifdef ENABLE_RTC_SENDER_BANDWIDTH_ESTIMATOR

--- a/worker/include/RTC/TransportCongestionControlClient.hpp
+++ b/worker/include/RTC/TransportCongestionControlClient.hpp
@@ -8,7 +8,7 @@
 #include "RTC/RTP/Packet.hpp"
 #include "RTC/RTP/ProbationGenerator.hpp"
 #include "RTC/TrendCalculator.hpp"
-#include "handles/TimerHandle.hpp"
+#include "handles/TimerHandleInterface.hpp"
 #include <libwebrtc/api/transport/goog_cc_factory.h>
 #include <libwebrtc/api/transport/network_types.h>
 #include <libwebrtc/call/rtp_transport_controller_send.h>
@@ -21,7 +21,7 @@ namespace RTC
 
 	class TransportCongestionControlClient : public webrtc::PacketRouter,
 	                                         public webrtc::TargetTransferRateObserver,
-	                                         public TimerHandle::Listener
+	                                         public TimerHandleInterface::Listener
 	{
 	public:
 		struct Bitrates
@@ -104,9 +104,9 @@ namespace RTC
 		void SendPacket(RTC::RTP::Packet* packet, const webrtc::PacedPacketInfo& pacingInfo) override;
 		RTC::RTP::Packet* GeneratePadding(size_t size) override;
 
-		/* Pure virtual methods inherited from RTC::TimerHandle. */
+		/* Pure virtual methods inherited from RTC::TimerHandleInterface. */
 	public:
-		void OnTimer(TimerHandle* timer) override;
+		void OnTimer(TimerHandleInterface* timer) override;
 
 	private:
 		// Passed by argument.
@@ -115,7 +115,7 @@ namespace RTC
 		webrtc::NetworkControllerFactoryInterface* controllerFactory{ nullptr };
 		webrtc::RtpTransportControllerSend* rtpTransportControllerSend{ nullptr };
 		RTC::RTP::ProbationGenerator* probationGenerator{ nullptr };
-		TimerHandle* processTimer{ nullptr };
+		TimerHandleInterface* processTimer{ nullptr };
 		// Others.
 		RTC::BweType bweType;
 		uint32_t initialAvailableBitrate{ 0u };

--- a/worker/include/RTC/TransportCongestionControlServer.hpp
+++ b/worker/include/RTC/TransportCongestionControlServer.hpp
@@ -7,14 +7,14 @@
 #include "RTC/RTCP/Packet.hpp"
 #include "RTC/RTP/Packet.hpp"
 #include "RTC/SeqManager.hpp"
-#include "handles/TimerHandle.hpp"
+#include "handles/TimerHandleInterface.hpp"
 #include <libwebrtc/modules/remote_bitrate_estimator/remote_bitrate_estimator_abs_send_time.h>
 #include <deque>
 
 namespace RTC
 {
 	class TransportCongestionControlServer : public webrtc::RemoteBitrateEstimator::Listener,
-	                                         public TimerHandle::Listener
+	                                         public TimerHandleInterface::Listener
 	{
 	public:
 		class Listener
@@ -72,15 +72,15 @@ namespace RTC
 		  const std::vector<uint32_t>& ssrcs,
 		  uint32_t availableBitrate) override;
 
-		/* Pure virtual methods inherited from TimerHandle::Listener. */
+		/* Pure virtual methods inherited from TimerHandleInterface::Listener. */
 	public:
-		void OnTimer(TimerHandle* timer) override;
+		void OnTimer(TimerHandleInterface* timer) override;
 
 	private:
 		// Passed by argument.
 		Listener* listener{ nullptr };
 		// Allocated by this.
-		TimerHandle* transportCcFeedbackSendPeriodicTimer{ nullptr };
+		TimerHandleInterface* transportCcFeedbackSendPeriodicTimer{ nullptr };
 		std::unique_ptr<RTC::RTCP::FeedbackRtpTransportPacket> transportCcFeedbackPacket;
 		webrtc::RemoteBitrateEstimatorAbsSendTime* rembServer{ nullptr };
 		// Others.

--- a/worker/include/handles/BackoffTimerHandle.hpp
+++ b/worker/include/handles/BackoffTimerHandle.hpp
@@ -2,49 +2,18 @@
 #define MS_BACKOFF_TIMER_HANDLE_HPP
 
 #include "common.hpp"
+#include "handles/BackoffTimerHandleInterface.hpp"
 #include "handles/TimerHandle.hpp"
-#include <limits> // std::numeric_limits()
+#include "handles/TimerHandleInterface.hpp"
 
-class BackoffTimerHandle : public TimerHandle::Listener
+class BackoffTimerHandle : public BackoffTimerHandleInterface, public TimerHandleInterface::Listener
 {
-public:
-	class Listener
-	{
-	public:
-		virtual ~Listener() = default;
-
-	public:
-		/**
-		 * Invoked on timeout expiration. The parent can modify the base
-		 * timeout given as reference and affect the next timeout duration.
-		 *
-		 * @remarks
-		 * - If the caller deletes this BackoffTimer instance within the callback
-		 *   it must signal it be setting `stop` to true.
-		 */
-		virtual void OnTimer(BackoffTimerHandle* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) = 0;
-	};
-
-public:
-	enum class BackoffAlgorithm : uint8_t
-	{
-		// The base duration will be used for any restart.
-		FIXED,
-		// An exponential backoff is used for restarts, with a 2x multiplier,
-		// meaning that every restart will use a duration that is twice as long as
-		// the previous.
-		EXPONENTIAL,
-	};
-
-public:
-	static constexpr uint64_t MaxTimeoutMs{ std::numeric_limits<uint64_t>::max() / 2 };
-
 public:
 	explicit BackoffTimerHandle(
 	  /**
 	   * Listener on which OnTimer() callback will be invoked.
 	   */
-	  Listener* listener,
+	  BackoffTimerHandleInterface::Listener* listener,
 	  /**
 	   * Base timeout duration (ms).
 	   */
@@ -75,24 +44,24 @@ public:
 	 * Start the BackoffTimer (if it's stopped) or restart it (if already
 	 * running). It will reset the timeout count.
 	 */
-	void Start();
+	void Start() override;
 
 	/**
 	 * Stop the BackoffTimer. It will reset the timeout count.
 	 */
-	void Stop();
+	void Stop() override;
 
 	/**
 	 * Set the base timeout duration. It will be applied after the next timeout
 	 * and effective duration can be larger if backoff algorithm is exponential.
 	 */
-	void SetBaseTimeoutMs(uint64_t baseTimeoutMs);
+	void SetBaseTimeoutMs(uint64_t baseTimeoutMs) override;
 
 	/**
 	 * Whether the BackoffTimer is running. Useful to check if this BackoffTimer
 	 * will timeout again within the OnTimer() callback.
 	 */
-	bool IsRunning() const
+	bool IsRunning() const override
 	{
 		return this->running;
 	}
@@ -101,9 +70,10 @@ public:
 	 * Maximum number of restarts.
 	 *
 	 * @remarks
-	 * - If `maxRestarts` was not given in the constructor, this method returns 0.
+	 * - If `maxRestarts` was not given in the constructor, this method returns
+	 *   `std::nullopt`.
 	 */
-	std::optional<size_t> GetMaxRestarts() const
+	std::optional<size_t> GetMaxRestarts() const override
 	{
 		return this->maxRestarts;
 	}
@@ -111,7 +81,7 @@ public:
 	/**
 	 * Number of times the timer has expired.
 	 */
-	size_t GetExpirationCount() const
+	size_t GetExpirationCount() const override
 	{
 		return this->expirationCount;
 	}
@@ -119,13 +89,13 @@ public:
 private:
 	uint64_t ComputeNextTimeoutMs() const;
 
-	/* Pure virtual methods inherited from TimerHandle::Listener. */
+	/* Pure virtual methods inherited from TimerHandleInterface::Listener. */
 public:
-	void OnTimer(TimerHandle* timer) override;
+	void OnTimer(TimerHandleInterface* timer) override;
 
 private:
 	// Passed by argument.
-	Listener* listener{ nullptr };
+	BackoffTimerHandleInterface::Listener* listener{ nullptr };
 	uint64_t baseTimeoutMs{ 0 };
 	BackoffAlgorithm backoffAlgorithm;
 	std::optional<uint64_t> maxBackoffTimeoutMs;

--- a/worker/include/handles/BackoffTimerHandleInterface.hpp
+++ b/worker/include/handles/BackoffTimerHandleInterface.hpp
@@ -1,0 +1,89 @@
+#ifndef MS_BACKOFF_TIMER_HANDLE_INTERFACE_HPP
+#define MS_BACKOFF_TIMER_HANDLE_INTERFACE_HPP
+
+#include "common.hpp"
+#include <limits> // std::numeric_limits()
+
+class BackoffTimerHandleInterface
+{
+public:
+	class Listener
+	{
+	public:
+		virtual ~Listener() = default;
+
+	public:
+		/**
+		 * Invoked on timeout expiration. The parent can modify the base
+		 * timeout given as reference and affect the next timeout duration.
+		 *
+		 * @remarks
+		 * - If the caller deletes this BackoffTimer instance within the callback
+		 *   it must signal it be setting `stop` to true.
+		 */
+		virtual void OnTimer(
+		  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) = 0;
+	};
+
+public:
+	enum class BackoffAlgorithm : uint8_t
+	{
+		// The base duration will be used for any restart.
+		FIXED,
+		// An exponential backoff is used for restarts, with a 2x multiplier,
+		// meaning that every restart will use a duration that is twice as long as
+		// the previous.
+		EXPONENTIAL,
+	};
+
+public:
+	static constexpr uint64_t MaxTimeoutMs{ std::numeric_limits<uint64_t>::max() / 2 };
+
+public:
+	BackoffTimerHandleInterface() = default;
+
+	BackoffTimerHandleInterface& operator=(const BackoffTimerHandleInterface&) = delete;
+
+	BackoffTimerHandleInterface(const BackoffTimerHandleInterface&) = delete;
+
+	virtual ~BackoffTimerHandleInterface() = default;
+
+public:
+	/**
+	 * Start the BackoffTimer (if it's stopped) or restart it (if already
+	 * running). It will reset the timeout count.
+	 */
+	virtual void Start() = 0;
+
+	/**
+	 * Stop the BackoffTimer. It will reset the timeout count.
+	 */
+	virtual void Stop() = 0;
+
+	/**
+	 * Set the base timeout duration. It will be applied after the next timeout
+	 * and effective duration can be larger if backoff algorithm is exponential.
+	 */
+	virtual void SetBaseTimeoutMs(uint64_t baseTimeoutMs) = 0;
+
+	/**
+	 * Whether the BackoffTimer is running. Useful to check if this BackoffTimer
+	 * will timeout again within the OnTimer() callback.
+	 */
+	virtual bool IsRunning() const = 0;
+
+	/**
+	 * Maximum number of restarts.
+	 *
+	 * @remarks
+	 * - If `maxRestarts` was not given in the constructor, this method returns 0.
+	 */
+	virtual std::optional<size_t> GetMaxRestarts() const = 0;
+
+	/**
+	 * Number of times the timer has expired.
+	 */
+	virtual size_t GetExpirationCount() const = 0;
+};
+
+#endif

--- a/worker/include/handles/TimerHandle.hpp
+++ b/worker/include/handles/TimerHandle.hpp
@@ -2,40 +2,40 @@
 #define MS_TIMER_HANDLE_HPP
 
 #include "common.hpp"
+#include "handles/TimerHandleInterface.hpp"
 #include <uv.h>
 
-class TimerHandle
+class TimerHandle : public TimerHandleInterface
 {
 public:
-	class Listener
-	{
-	public:
-		virtual ~Listener() = default;
+	explicit TimerHandle(TimerHandleInterface::Listener* listener);
 
-	public:
-		virtual void OnTimer(TimerHandle* timer) = 0;
-	};
-
-public:
-	explicit TimerHandle(Listener* listener);
 	TimerHandle& operator=(const TimerHandle&) = delete;
-	TimerHandle(const TimerHandle&)            = delete;
-	~TimerHandle();
+
+	TimerHandle(const TimerHandle&) = delete;
+
+	~TimerHandle() override;
 
 public:
-	void Start(uint64_t timeout, uint64_t repeat = 0);
-	void Stop();
-	void Restart();
-	void Restart(uint64_t timeout, uint64_t repeat = 0);
-	uint64_t GetTimeout() const
+	void Start(uint64_t timeout, uint64_t repeat = 0) override;
+
+	void Stop() override;
+
+	void Restart() override;
+
+	void Restart(uint64_t timeout, uint64_t repeat = 0) override;
+
+	uint64_t GetTimeout() const override
 	{
 		return this->timeout;
 	}
-	uint64_t GetRepeat() const
+
+	uint64_t GetRepeat() const override
 	{
 		return this->repeat;
 	}
-	bool IsActive() const
+
+	bool IsActive() const override
 	{
 		return uv_is_active(reinterpret_cast<uv_handle_t*>(this->uvHandle)) != 0;
 	}
@@ -49,7 +49,7 @@ public:
 
 private:
 	// Passed by argument.
-	Listener* listener{ nullptr };
+	TimerHandleInterface::Listener* listener{ nullptr };
 	// Allocated by this.
 	uv_timer_t* uvHandle{ nullptr };
 	// Others.

--- a/worker/include/handles/TimerHandleInterface.hpp
+++ b/worker/include/handles/TimerHandleInterface.hpp
@@ -1,0 +1,43 @@
+#ifndef MS_TIMER_HANDLE_INTERFACE_HPP
+#define MS_TIMER_HANDLE_INTERFACE_HPP
+
+#include "common.hpp"
+
+class TimerHandleInterface
+{
+public:
+	class Listener
+	{
+	public:
+		virtual ~Listener() = default;
+
+	public:
+		virtual void OnTimer(TimerHandleInterface* timer) = 0;
+	};
+
+public:
+	TimerHandleInterface() = default;
+
+	TimerHandleInterface& operator=(const TimerHandleInterface&) = delete;
+
+	TimerHandleInterface(const TimerHandleInterface&) = delete;
+
+	virtual ~TimerHandleInterface() = default;
+
+public:
+	virtual void Start(uint64_t timeout, uint64_t repeat = 0) = 0;
+
+	virtual void Stop() = 0;
+
+	virtual void Restart() = 0;
+
+	virtual void Restart(uint64_t timeout, uint64_t repeat = 0) = 0;
+
+	virtual uint64_t GetTimeout() const = 0;
+
+	virtual uint64_t GetRepeat() const = 0;
+
+	virtual bool IsActive() const = 0;
+};
+
+#endif

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -7,6 +7,7 @@
 #endif
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
+#include "handles/TimerHandle.hpp"
 #include <usrsctp.h>
 #include <cstdio> // std::vsnprintf()
 #include <mutex>
@@ -244,7 +245,7 @@ void DepUsrSCTP::Checker::Stop()
 	this->timer->Stop();
 }
 
-void DepUsrSCTP::Checker::OnTimer(TimerHandle* /*timer*/)
+void DepUsrSCTP::Checker::OnTimer(TimerHandleInterface* /*timer*/)
 {
 	MS_TRACE();
 

--- a/worker/src/RTC/ActiveSpeakerObserver.cpp
+++ b/worker/src/RTC/ActiveSpeakerObserver.cpp
@@ -4,6 +4,7 @@
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include "RTC/RtpDictionaries.hpp"
+#include "handles/TimerHandle.hpp"
 
 namespace RTC
 {
@@ -249,7 +250,7 @@ namespace RTC
 		this->periodicTimer->Restart();
 	}
 
-	void ActiveSpeakerObserver::OnTimer(TimerHandle* /*timer*/)
+	void ActiveSpeakerObserver::OnTimer(TimerHandleInterface* /*timer*/)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/AudioLevelObserver.cpp
+++ b/worker/src/RTC/AudioLevelObserver.cpp
@@ -5,6 +5,7 @@
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include "RTC/RtpDictionaries.hpp"
+#include "handles/TimerHandle.hpp"
 #include <absl/container/btree_map.h>
 #include <cmath> // std::lround()
 
@@ -213,7 +214,7 @@ namespace RTC
 		}
 	}
 
-	inline void AudioLevelObserver::OnTimer(TimerHandle* /*timer*/)
+	inline void AudioLevelObserver::OnTimer(TimerHandleInterface* /*timer*/)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -6,6 +6,7 @@
 #include "MediaSoupErrors.hpp"
 #include "Settings.hpp"
 #include "Utils.hpp"
+#include "handles/TimerHandle.hpp"
 #include <openssl/err.h>
 #include <openssl/evp.h>
 #include <uv.h>
@@ -1699,7 +1700,7 @@ namespace RTC
 	}
 
 	// NOLINTNEXTLINE(misc-no-recursion)
-	void DtlsTransport::OnTimer(TimerHandle* /*timer*/)
+	void DtlsTransport::OnTimer(TimerHandleInterface* /*timer*/)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/ICE/IceServer.cpp
+++ b/worker/src/RTC/ICE/IceServer.cpp
@@ -3,6 +3,7 @@
 
 #include "RTC/ICE/IceServer.hpp"
 #include "Logger.hpp"
+#include "handles/TimerHandle.hpp"
 #include <string_view>
 
 namespace RTC
@@ -962,7 +963,7 @@ namespace RTC
 			this->consentCheckTimer->Stop();
 		}
 
-		inline void IceServer::OnTimer(TimerHandle* timer)
+		inline void IceServer::OnTimer(TimerHandleInterface* timer)
 		{
 			MS_TRACE();
 

--- a/worker/src/RTC/KeyFrameRequestManager.cpp
+++ b/worker/src/RTC/KeyFrameRequestManager.cpp
@@ -3,6 +3,7 @@
 
 #include "RTC/KeyFrameRequestManager.hpp"
 #include "Logger.hpp"
+#include "handles/TimerHandle.hpp"
 
 static constexpr uint32_t KeyFrameRetransmissionWaitTime{ 1000u };
 
@@ -24,7 +25,7 @@ RTC::PendingKeyFrameInfo::~PendingKeyFrameInfo()
 	delete this->timer;
 }
 
-inline void RTC::PendingKeyFrameInfo::OnTimer(TimerHandle* timer)
+void RTC::PendingKeyFrameInfo::OnTimer(TimerHandleInterface* timer)
 {
 	MS_TRACE();
 
@@ -53,7 +54,7 @@ RTC::KeyFrameRequestDelayer::~KeyFrameRequestDelayer()
 	delete this->timer;
 }
 
-inline void RTC::KeyFrameRequestDelayer::OnTimer(TimerHandle* timer)
+void RTC::KeyFrameRequestDelayer::OnTimer(TimerHandleInterface* timer)
 {
 	MS_TRACE();
 
@@ -198,7 +199,7 @@ void RTC::KeyFrameRequestManager::KeyFrameReceived(uint32_t ssrc)
 	this->mapSsrcPendingKeyFrameInfo.erase(it);
 }
 
-inline void RTC::KeyFrameRequestManager::OnKeyFrameRequestTimeout(PendingKeyFrameInfo* pendingKeyFrameInfo)
+void RTC::KeyFrameRequestManager::OnKeyFrameRequestTimeout(PendingKeyFrameInfo* pendingKeyFrameInfo)
 {
 	MS_TRACE();
 
@@ -225,8 +226,7 @@ inline void RTC::KeyFrameRequestManager::OnKeyFrameRequestTimeout(PendingKeyFram
 	this->listener->OnKeyFrameNeeded(this, pendingKeyFrameInfo->GetSsrc());
 }
 
-inline void RTC::KeyFrameRequestManager::OnKeyFrameDelayTimeout(
-  KeyFrameRequestDelayer* keyFrameRequestDelayer)
+void RTC::KeyFrameRequestManager::OnKeyFrameDelayTimeout(KeyFrameRequestDelayer* keyFrameRequestDelayer)
 {
 	MS_TRACE();
 

--- a/worker/src/RTC/NackGenerator.cpp
+++ b/worker/src/RTC/NackGenerator.cpp
@@ -4,6 +4,7 @@
 #include "RTC/NackGenerator.hpp"
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
+#include "handles/TimerHandle.hpp"
 
 namespace RTC
 {
@@ -365,7 +366,7 @@ namespace RTC
 		}
 	}
 
-	inline void NackGenerator::OnTimer(TimerHandle* /*timer*/)
+	inline void NackGenerator::OnTimer(TimerHandleInterface* /*timer*/)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/RTP/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RTP/RtpStreamRecv.cpp
@@ -5,6 +5,7 @@
 #include "Logger.hpp"
 #include "Utils.hpp"
 #include "RTC/RTP/Codecs/Tools.hpp"
+#include "handles/TimerHandle.hpp"
 
 namespace RTC
 {
@@ -858,7 +859,7 @@ namespace RTC
 			// Nothing to do.
 		}
 
-		inline void RtpStreamRecv::OnTimer(TimerHandle* timer)
+		inline void RtpStreamRecv::OnTimer(TimerHandleInterface* timer)
 		{
 			MS_TRACE();
 

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -17,6 +17,7 @@
 #include "RTC/SCTP/packet/parameters/StateCookieParameter.hpp"
 #include "RTC/SCTP/packet/parameters/SupportedExtensionsParameter.hpp"
 #include "RTC/SCTP/packet/parameters/ZeroChecksumAcceptableParameter.hpp"
+#include "handles/BackoffTimerHandle.hpp"
 #include <limits>  // std::numeric_limits()
 #include <sstream> // std::ostringstream
 #include <string>
@@ -49,21 +50,21 @@ namespace RTC
 		      std::make_unique<BackoffTimerHandle>(
 		        /*listener*/ this,
 		        /*baseTimeoutMs*/ sctpOptions.t1InitTimeoutMs,
-		        /*backoffAlgorithm*/ BackoffTimerHandle::BackoffAlgorithm::EXPONENTIAL,
+		        /*backoffAlgorithm*/ BackoffTimerHandleInterface::BackoffAlgorithm::EXPONENTIAL,
 		        /*maxBackoffTimeoutMs*/ sctpOptions.timerMaxBackoffTimeoutMs,
 		        /*maxRestarts*/ sctpOptions.maxInitRetransmissions)),
 		    t1CookieTimer(
 		      std::make_unique<BackoffTimerHandle>(
 		        /*listener*/ this,
 		        /*baseTimeoutMs*/ sctpOptions.t1CookieTimeoutMs,
-		        /*backoffAlgorithm*/ BackoffTimerHandle::BackoffAlgorithm::EXPONENTIAL,
+		        /*backoffAlgorithm*/ BackoffTimerHandleInterface::BackoffAlgorithm::EXPONENTIAL,
 		        /*maxBackoffTimeoutMs*/ sctpOptions.timerMaxBackoffTimeoutMs,
 		        /*maxRestarts*/ sctpOptions.maxInitRetransmissions)),
 		    t2ShutdownTimer(
 		      std::make_unique<BackoffTimerHandle>(
 		        /*listener*/ this,
 		        /*baseTimeoutMs*/ sctpOptions.t2ShutdownTimeoutMs,
-		        /*backoffAlgorithm*/ BackoffTimerHandle::BackoffAlgorithm::EXPONENTIAL,
+		        /*backoffAlgorithm*/ BackoffTimerHandleInterface::BackoffAlgorithm::EXPONENTIAL,
 		        /*maxBackoffTimeoutMs*/ sctpOptions.timerMaxBackoffTimeoutMs,
 		        /*maxRestarts*/ sctpOptions.maxRetransmissions))
 		{
@@ -2781,7 +2782,8 @@ namespace RTC
 			}
 		}
 
-		void Association::OnTimer(BackoffTimerHandle* backoffTimer, uint64_t& baseTimeoutMs, bool& stop)
+		void Association::OnTimer(
+		  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop)
 		{
 			MS_TRACE();
 

--- a/worker/src/RTC/SCTP/association/HeartbeatHandler.cpp
+++ b/worker/src/RTC/SCTP/association/HeartbeatHandler.cpp
@@ -8,6 +8,7 @@
 #include "Utils.hpp"
 #include "RTC/SCTP/packet/parameters/HeartbeatInfoParameter.hpp"
 #include "RTC/SCTP/public/SctpTypes.hpp"
+#include "handles/BackoffTimerHandle.hpp"
 #include <string>
 
 namespace RTC
@@ -31,14 +32,14 @@ namespace RTC
 		      std::make_unique<BackoffTimerHandle>(
 		        /*listener*/ this,
 		        /*baseTimeoutMs*/ sctpOptions.initialRtoMs,
-		        /*backoffAlgorithm*/ BackoffTimerHandle::BackoffAlgorithm::EXPONENTIAL,
+		        /*backoffAlgorithm*/ BackoffTimerHandleInterface::BackoffAlgorithm::EXPONENTIAL,
 		        /*maxBackoffTimeoutMs*/ sctpOptions.timerMaxBackoffTimeoutMs,
 		        /*maxRestarts*/ std::nullopt)),
 		    timeoutTimer(
 		      std::make_unique<BackoffTimerHandle>(
 		        /*listener*/ this,
 		        /*baseTimeoutMs*/ sctpOptions.initialRtoMs,
-		        /*backoffAlgorithm*/ BackoffTimerHandle::BackoffAlgorithm::FIXED,
+		        /*backoffAlgorithm*/ BackoffTimerHandleInterface::BackoffAlgorithm::FIXED,
 		        /*maxBackoffTimeoutMs*/ std::nullopt,
 		        /*maxRestarts*/ 0))
 		{
@@ -227,7 +228,8 @@ namespace RTC
 			this->tcbContext->IncrementTxErrorCounter("hearbeat timeout");
 		}
 
-		void HeartbeatHandler::OnTimer(BackoffTimerHandle* backoffTimer, uint64_t& baseTimeoutMs, bool& stop)
+		void HeartbeatHandler::OnTimer(
+		  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop)
 		{
 			MS_TRACE();
 

--- a/worker/src/RTC/SCTP/association/StreamResetHandler.cpp
+++ b/worker/src/RTC/SCTP/association/StreamResetHandler.cpp
@@ -6,6 +6,7 @@
 #include "Logger.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/parameters/ReconfigurationResponseParameter.hpp"
+#include "handles/BackoffTimerHandle.hpp"
 
 namespace RTC
 {
@@ -27,7 +28,7 @@ namespace RTC
 		      std::make_unique<BackoffTimerHandle>(
 		        /*listener*/ this,
 		        /*baseTimeoutMs*/ 0,
-		        /*backoffAlgorithm*/ BackoffTimerHandle::BackoffAlgorithm::EXPONENTIAL,
+		        /*backoffAlgorithm*/ BackoffTimerHandleInterface::BackoffAlgorithm::EXPONENTIAL,
 		        /*maxBackoffTimeoutMs*/ std::nullopt,
 		        /*maxRestarts*/ std::nullopt)),
 		    nextOutgoingReqSeqNbr(tcbContext->GetLocalInitialTsn()),
@@ -491,7 +492,8 @@ namespace RTC
 			baseTimeoutMs = this->tcbContext->GetCurrentRtoMs();
 		}
 
-		void StreamResetHandler::OnTimer(BackoffTimerHandle* backoffTimer, uint64_t& baseTimeoutMs, bool& stop)
+		void StreamResetHandler::OnTimer(
+		  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop)
 		{
 			MS_TRACE();
 

--- a/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
+++ b/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
@@ -8,6 +8,7 @@
 #include "RTC/Consts.hpp"
 #include "RTC/SCTP/packet/chunks/DataChunk.hpp"
 #include "RTC/SCTP/packet/chunks/IDataChunk.hpp"
+#include "handles/BackoffTimerHandle.hpp"
 #include <cmath> // std::min()
 #include <string>
 
@@ -52,14 +53,14 @@ namespace RTC
 		      std::make_unique<BackoffTimerHandle>(
 		        /*listener*/ this,
 		        /*baseTimeoutMs*/ sctpOptions.initialRtoMs,
-		        /*backoffAlgorithm*/ BackoffTimerHandle::BackoffAlgorithm::EXPONENTIAL,
+		        /*backoffAlgorithm*/ BackoffTimerHandleInterface::BackoffAlgorithm::EXPONENTIAL,
 		        /*maxBackoffTimeoutMs*/ sctpOptions.timerMaxBackoffTimeoutMs,
 		        /*maxRestarts*/ std::nullopt)),
 		    delayedAckTimer(
 		      std::make_unique<BackoffTimerHandle>(
 		        /*listener*/ this,
 		        /*baseTimeoutMs*/ sctpOptions.delayedAckMaxTimeoutMs,
-		        /*backoffAlgorithm*/ BackoffTimerHandle::BackoffAlgorithm::EXPONENTIAL,
+		        /*backoffAlgorithm*/ BackoffTimerHandleInterface::BackoffAlgorithm::EXPONENTIAL,
 		        /*maxBackoffTimeoutMs*/ std::nullopt,
 		        /*maxRestarts*/ 0)),
 		    rto(sctpOptions),
@@ -335,7 +336,7 @@ namespace RTC
 		}
 
 		void TransmissionControlBlock::OnTimer(
-		  BackoffTimerHandle* backoffTimer, uint64_t& baseTimeoutMs, bool& stop)
+		  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop)
 		{
 			MS_TRACE();
 

--- a/worker/src/RTC/SCTP/tx/RetransmissionQueue.cpp
+++ b/worker/src/RTC/SCTP/tx/RetransmissionQueue.cpp
@@ -25,7 +25,7 @@ namespace RTC
 		  uint32_t remoteAdvertisedReceiverWindowCredit,
 		  // TODO: SCTP: Implement
 		  // SendQueue& sendQueue,
-		  BackoffTimerHandle* t3RtxTimer,
+		  BackoffTimerHandleInterface* t3RtxTimer,
 		  const SctpOptions& sctpOptions,
 		  // NOTE: I don't like default argument values in dcsctp (true and false),
 		  // let's be explicit.

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -6,6 +6,7 @@
 #include "MediaSoupErrors.hpp"
 #include "Settings.hpp"
 #include "Utils.hpp"
+#include "handles/TimerHandle.hpp"
 #ifdef MS_LIBURING_SUPPORTED
 #include "DepLibUring.hpp"
 #endif
@@ -3518,7 +3519,7 @@ namespace RTC
 	}
 #endif
 
-	void Transport::OnTimer(TimerHandle* timer)
+	void Transport::OnTimer(TimerHandleInterface* timer)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -5,6 +5,7 @@
 #include "RTC/TransportCongestionControlClient.hpp"
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
+#include "handles/TimerHandle.hpp"
 #include <libwebrtc/api/transport/network_types.h> // webrtc::TargetRateConstraints
 #include <limits>                                  // std::numeric_limits
 
@@ -552,7 +553,7 @@ namespace RTC
 		return this->probationGenerator->GetNextPacket(size);
 	}
 
-	void TransportCongestionControlClient::OnTimer(TimerHandle* timer)
+	void TransportCongestionControlClient::OnTimer(TimerHandleInterface* timer)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/TransportCongestionControlServer.cpp
+++ b/worker/src/RTC/TransportCongestionControlServer.cpp
@@ -5,6 +5,7 @@
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
 #include "RTC/RTCP/FeedbackPsRemb.hpp"
+#include "handles/TimerHandle.hpp"
 
 namespace RTC
 {
@@ -468,7 +469,7 @@ namespace RTC
 		this->listener->OnTransportCongestionControlServerSendRtcpPacket(this, &packet);
 	}
 
-	void TransportCongestionControlServer::OnTimer(TimerHandle* timer)
+	void TransportCongestionControlServer::OnTimer(TimerHandleInterface* timer)
 	{
 		MS_TRACE();
 

--- a/worker/src/handles/BackoffTimerHandle.cpp
+++ b/worker/src/handles/BackoffTimerHandle.cpp
@@ -9,7 +9,7 @@
 /* Instance methods. */
 
 BackoffTimerHandle::BackoffTimerHandle(
-  Listener* listener,
+  BackoffTimerHandleInterface::Listener* listener,
   uint64_t baseTimeoutMs,
   BackoffAlgorithm backoffAlgorithm,
   std::optional<uint64_t> maxBackoffTimeoutMs,
@@ -60,12 +60,12 @@ void BackoffTimerHandle::SetBaseTimeoutMs(uint64_t baseTimeoutMs)
 {
 	MS_TRACE();
 
-	if (baseTimeoutMs > BackoffTimerHandle::MaxTimeoutMs)
+	if (baseTimeoutMs > BackoffTimerHandleInterface::MaxTimeoutMs)
 	{
 		MS_THROW_ERROR(
 		  "base timeout (%" PRIu64 " ms) cannot be greater than %" PRIu64 " ms",
 		  baseTimeoutMs,
-		  BackoffTimerHandle::MaxTimeoutMs);
+		  BackoffTimerHandleInterface::MaxTimeoutMs);
 	}
 
 	this->baseTimeoutMs = baseTimeoutMs;
@@ -88,7 +88,7 @@ uint64_t BackoffTimerHandle::ComputeNextTimeoutMs() const
 		{
 			auto timeoutMs = this->baseTimeoutMs;
 
-			while (expirationCount > 0 && timeoutMs < BackoffTimerHandle::MaxTimeoutMs)
+			while (expirationCount > 0 && timeoutMs < BackoffTimerHandleInterface::MaxTimeoutMs)
 			{
 				timeoutMs *= 2;
 				--expirationCount;
@@ -99,14 +99,14 @@ uint64_t BackoffTimerHandle::ComputeNextTimeoutMs() const
 				}
 			}
 
-			return std::min<uint64_t>(timeoutMs, BackoffTimerHandle::MaxTimeoutMs);
+			return std::min<uint64_t>(timeoutMs, BackoffTimerHandleInterface::MaxTimeoutMs);
 		}
 
 			NO_DEFAULT_GCC();
 	}
 }
 
-void BackoffTimerHandle::OnTimer(TimerHandle* timer)
+void BackoffTimerHandle::OnTimer(TimerHandleInterface* timer)
 {
 	MS_TRACE();
 

--- a/worker/src/handles/BackoffTimerHandle.cpp
+++ b/worker/src/handles/BackoffTimerHandle.cpp
@@ -106,7 +106,7 @@ uint64_t BackoffTimerHandle::ComputeNextTimeoutMs() const
 	}
 }
 
-void BackoffTimerHandle::OnTimer(TimerHandleInterface*  /*timer*/)
+void BackoffTimerHandle::OnTimer(TimerHandleInterface* /*timer*/)
 {
 	MS_TRACE();
 

--- a/worker/src/handles/BackoffTimerHandle.cpp
+++ b/worker/src/handles/BackoffTimerHandle.cpp
@@ -106,7 +106,7 @@ uint64_t BackoffTimerHandle::ComputeNextTimeoutMs() const
 	}
 }
 
-void BackoffTimerHandle::OnTimer(TimerHandleInterface* timer)
+void BackoffTimerHandle::OnTimer(TimerHandleInterface*  /*timer*/)
 {
 	MS_TRACE();
 

--- a/worker/src/handles/TimerHandle.cpp
+++ b/worker/src/handles/TimerHandle.cpp
@@ -8,19 +8,20 @@
 
 /* Static methods for UV callbacks. */
 
-inline static void onTimer(uv_timer_t* handle)
+static void onTimer(uv_timer_t* handle)
 {
 	static_cast<TimerHandle*>(handle->data)->OnUvTimer();
 }
 
-inline static void onCloseTimer(uv_handle_t* handle)
+static void onCloseTimer(uv_handle_t* handle)
 {
 	delete reinterpret_cast<uv_timer_t*>(handle);
 }
 
 /* Instance methods. */
 
-TimerHandle::TimerHandle(Listener* listener) : listener(listener), uvHandle(new uv_timer_t)
+TimerHandle::TimerHandle(TimerHandleInterface::Listener* listener)
+  : listener(listener), uvHandle(new uv_timer_t)
 {
 	MS_TRACE();
 
@@ -174,7 +175,7 @@ void TimerHandle::InternalClose()
 	uv_close(reinterpret_cast<uv_handle_t*>(this->uvHandle), static_cast<uv_close_cb>(onCloseTimer));
 }
 
-inline void TimerHandle::OnUvTimer()
+void TimerHandle::OnUvTimer()
 {
 	MS_TRACE();
 


### PR DESCRIPTION
# Details

- Add `TimerHandleInterface`.
- Add `BackoffTimerHandleInterface`.

## Notes

This PR replaces https://github.com/versatica/mediasoup/pull/1058 which is too old and we never paid attention, but we should check if we can use things from it. What I don't like is that such a PR uses C macros for the code to behave in one way or another when in production builds or when running tests.

## TODO

- [ ] Pass somehow factory functions to classes that need to create a timer. Otherwise these classes are useless. For example libwebrtc/dcsctp passes a `callbacks` object to all classes and it includes a `createTimeout()` function.
  - _NOTE:_ We have the proper place for this: `RTC::Shared` instance that it's created in each `Worker`. Currently we pass it to many classes but not to all them. We should propagate it to all classes and include on `Shared` functions such as `CreateTimer()`, etc. But this should be part of a separate story.
- [ ] Implement mock timers. Specially useful for adding missing tests in new SCTP classes that require a timer.