### PR TITLE
Node: Avoid "worker died" event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Node: Avoid "worker died" event when the Node application is closed via signal without calling `worker.close()` ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 3.19.21
 
 - Worker: Fix regression in `DirectTransport` when closing a `DataProducer` or `DataConsumer` ([PR #1780](https://github.com/versatica/mediasoup/pull/1780)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Node: Avoid "worker died" event when the Node application is closed via signal without calling `worker.close()` ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Node: Avoid "worker died" event when the Node application is closed via signal without calling `worker.close()` ([PR #1788](https://github.com/versatica/mediasoup/pull/1788)).
 
 ### 3.19.21
 

--- a/node/src/Worker.ts
+++ b/node/src/Worker.ts
@@ -293,6 +293,16 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 			}
 		});
 
+		// NOTE: Avoid "Possible EventEmitter memory leak detected" Node warning.
+		const processListenerCount = process.getMaxListeners();
+
+		if (processListenerCount >= 10) {
+			process.setMaxListeners(processListenerCount + 2);
+		}
+
+		process.once('SIGINT', this.onSignal);
+		process.once('SIGTERM', this.onSignal);
+
 		this.handleListenerError();
 	}
 
@@ -346,6 +356,9 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 		logger.debug('close()');
 
 		this.#closed = true;
+
+		process.removeListener('SIGINT', this.onSignal);
+		process.removeListener('SIGTERM', this.onSignal);
 
 		// Close every Router.
 		for (const router of this.#routers) {
@@ -593,6 +606,15 @@ export class WorkerImpl<WorkerAppData extends AppData = AppData>
 			);
 		});
 	}
+
+	// NOTE: Arrow method on purpose.
+	private onSignal = (signal: 'SIGINT' | 'SIGTERM'): void => {
+		logger.debug(
+			`signal received, closing the worker process [pid:${this.#pid}, signal:${signal}]`
+		);
+
+		this.close();
+	};
 }
 
 function parseWorkerDumpResponse(binary: FbsWorker.DumpResponse): WorkerDump {

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -504,7 +504,8 @@ void Worker::OnChannelClosed(Channel::ChannelSocket* /*socket*/)
 {
 	MS_TRACE_STD();
 
-	// Only needed for executable, library user can close channel earlier and it is fine.
+	// Only needed for executable, library user can close channel earlier and it
+	// is fine.
 #ifdef MS_EXECUTABLE
 	// If the pipe is remotely closed it may mean that mediasoup Node process
 	// abruptly died (SIGKILL?) so we must die.
@@ -528,11 +529,6 @@ void Worker::OnSignal(SignalHandle* /*signalHandle*/, int signum)
 		case SIGINT:
 		case SIGTERM:
 		{
-			if (this->closed)
-			{
-				return;
-			}
-
 			MS_DEBUG_DEV("%s signal received, closing myself", signum == SIGINT ? "INT" : "TERM");
 
 			Close();
@@ -542,7 +538,7 @@ void Worker::OnSignal(SignalHandle* /*signalHandle*/, int signum)
 
 		default:
 		{
-			MS_WARN_DEV("received a non handled signal [signum:%d]", signum);
+			MS_WARN_DEV("ignoring received non handled signal [signum:%d]", signum);
 		}
 	}
 }

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -172,8 +172,12 @@ extern "C" int mediasoup_worker_run(
 		// Ignore some signals.
 		ignoreSignals();
 
+		MS_DEBUG_TAG(info, "creating Worker instance");
+
 		// Run the Worker.
 		const Worker worker(channel.get(), shared.get());
+
+		MS_DEBUG_TAG(info, "Worker instance terminated");
 
 		// Free static stuff.
 		DepLibSRTP::ClassDestroy();


### PR DESCRIPTION
# Details

- Avoid "worker died" event when the Node application is closed via signal without calling `worker.close()`.
- The problem was that `Worker.ts` creates the worker `Child` in `detached: false` mode so all worker subprocesses are part of the same process group and hence a signal sent to the main Node app is also sent to the worker subprocesses. So the worker receives it, auto-closes and hence Node process gets `child.on('exit')` and assumes that the worker died.
- Solution is basically to subscribe to SIGINT and SIGTERM signals in `Worker.ts` and immediately invoke `this.close()`.
- There is still room for race conditions since any process (the parent Node process or any worker subprocess) could receive the signal first, however in most of the cases it will take longer for the worker process to exit since it properly cleans up routers, transports, etc, so by the time the worker process auto-terminates, the Node process has already received the singal (most probably).
- By using the mediasoup-app, effects of this PR can be seen. Just comment the `worker.close()` inne in `Server.ts` and try killing the app in "v3" branch and in this branch. In this one there is no "worker died" events. In "v3" there are a lot.