### PR TITLE
Fix `thread local` usages (linking error)

### DIFF
--- a/worker/fuzzer/src/RTC/FuzzerRateCalculator.cpp
+++ b/worker/fuzzer/src/RTC/FuzzerRateCalculator.cpp
@@ -23,7 +23,7 @@ void FuzzerRtcRateCalculator::Fuzz(const uint8_t* data, size_t len)
 {
 	// Trick to initialize our stuff just once.
 	// NOLINTNEXTLINE(readability-identifier-naming)
-	thread_local const int unused = init();
+	static thread_local const int unused = init();
 
 	// Avoid [-Wunused-variable].
 	(void)unused;

--- a/worker/fuzzer/src/RTC/ICE/FuzzerStunPacket.cpp
+++ b/worker/fuzzer/src/RTC/ICE/FuzzerStunPacket.cpp
@@ -2,12 +2,15 @@
 #include "RTC/ICE/StunPacket.hpp"
 #include <string_view>
 
-static constexpr size_t ResponseFactoryBufferLength{ 65536 };
-alignas(4) thread_local uint8_t ResponseFactoryBuffer[ResponseFactoryBufferLength];
-static constexpr size_t SerializeBufferLength{ 65536 };
-alignas(4) thread_local uint8_t SerializeBuffer[SerializeBufferLength];
-static constexpr size_t CloneBufferLength{ 65536 };
-alignas(4) thread_local uint8_t CloneBuffer[CloneBufferLength];
+namespace
+{
+	constexpr size_t ResponseFactoryBufferLength{ 65536 };
+	alignas(4) thread_local uint8_t ResponseFactoryBuffer[ResponseFactoryBufferLength];
+	constexpr size_t SerializeBufferLength{ 65536 };
+	alignas(4) thread_local uint8_t SerializeBuffer[SerializeBufferLength];
+	constexpr size_t CloneBufferLength{ 65536 };
+	alignas(4) thread_local uint8_t CloneBuffer[CloneBufferLength];
+} // namespace
 
 void FuzzerRtcIceStunPacket::Fuzz(const uint8_t* data, size_t len)
 {

--- a/worker/fuzzer/src/RTC/SCTP/packet/FuzzerPacket.cpp
+++ b/worker/fuzzer/src/RTC/SCTP/packet/FuzzerPacket.cpp
@@ -1,8 +1,11 @@
 #include "RTC/SCTP/packet/FuzzerPacket.hpp"
 #include "RTC/SCTP/packet/Packet.hpp"
 
-thread_local uint8_t PacketSerializeBuffer[65536];
-thread_local uint8_t PacketCloneBuffer[65536];
+namespace
+{
+	thread_local uint8_t PacketSerializeBuffer[65536];
+	thread_local uint8_t PacketCloneBuffer[65536];
+} // namespace
 
 void FuzzerRtcSctpPacket::Fuzz(const uint8_t* data, size_t len)
 {

--- a/worker/fuzzer/src/fuzzer.cpp
+++ b/worker/fuzzer/src/fuzzer.cpp
@@ -163,7 +163,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t* data, size_t len)
 {
 	// Trick to initialize our stuff just once.
 	// NOLINTNEXTLINE(readability-identifier-naming)
-	thread_local const int unused = init();
+	static thread_local const int unused = init();
 
 	// Avoid [-Wunused-variable].
 	(void)unused;

--- a/worker/include/Channel/ChannelRequest.hpp
+++ b/worker/include/Channel/ChannelRequest.hpp
@@ -21,7 +21,7 @@ namespace Channel
 		using Method = FBS::Request::Method;
 
 	public:
-		thread_local static flatbuffers::FlatBufferBuilder bufferBuilder;
+		static thread_local flatbuffers::FlatBufferBuilder bufferBuilder;
 		static const absl::flat_hash_map<FBS::Request::Method, const char*> Method2String;
 
 	public:

--- a/worker/include/DepLibUV.hpp
+++ b/worker/include/DepLibUV.hpp
@@ -41,7 +41,7 @@ public:
 	}
 
 private:
-	thread_local static uv_loop_t* loop;
+	static thread_local uv_loop_t* loop;
 };
 
 #endif

--- a/worker/include/DepLibUring.hpp
+++ b/worker/include/DepLibUring.hpp
@@ -52,8 +52,8 @@ public:
 	class LibUring;
 
 	// Whether liburing is enabled or not after runtime checks.
-	thread_local static bool enabled;
-	thread_local static LibUring* liburing;
+	static thread_local bool enabled;
+	static thread_local LibUring* liburing;
 
 public:
 	// Singleton.

--- a/worker/include/DepUsrSCTP.hpp
+++ b/worker/include/DepUsrSCTP.hpp
@@ -40,7 +40,7 @@ public:
 	static RTC::SctpAssociation* RetrieveSctpAssociation(uintptr_t id);
 
 private:
-	thread_local static Checker* checker;
+	static thread_local Checker* checker;
 	static uint64_t numSctpAssociations;
 	static uintptr_t nextSctpAssociationId;
 	static absl::flat_hash_map<uintptr_t, RTC::SctpAssociation*> mapIdSctpAssociation;

--- a/worker/include/DepUsrSCTP.hpp
+++ b/worker/include/DepUsrSCTP.hpp
@@ -13,7 +13,7 @@ private:
 	class Checker : public TimerHandleInterface::Listener
 	{
 	public:
-		Checker(SharedInterface* shared);
+		explicit Checker(SharedInterface* shared);
 		~Checker() override;
 
 	public:

--- a/worker/include/Logger.hpp
+++ b/worker/include/Logger.hpp
@@ -156,7 +156,7 @@ public:
 	static void ClassInit(Channel::ChannelSocket* channel);
 
 public:
-	static const uint64_t pid;
+	static const uint64_t Pid;
 	static thread_local Channel::ChannelSocket* channel;
 	static const size_t BufferSize {50000};
 	static thread_local char buffer[];

--- a/worker/include/Logger.hpp
+++ b/worker/include/Logger.hpp
@@ -157,9 +157,9 @@ public:
 
 public:
 	static const uint64_t pid;
-	thread_local static Channel::ChannelSocket* channel;
+	static thread_local Channel::ChannelSocket* channel;
 	static const size_t BufferSize {50000};
-	thread_local static char buffer[];
+	static thread_local char buffer[];
 };
 
 /* Logging macros. */

--- a/worker/include/MediaSoupErrors.hpp
+++ b/worker/include/MediaSoupErrors.hpp
@@ -14,7 +14,7 @@ public:
 
 public:
 	static const size_t BufferSize{ 2000 };
-	thread_local static char buffer[];
+	static thread_local char buffer[];
 };
 
 class MediaSoupTypeError : public MediaSoupError

--- a/worker/include/RTC/DtlsTransport.hpp
+++ b/worker/include/RTC/DtlsTransport.hpp
@@ -125,14 +125,14 @@ namespace RTC
 		static void GenerateFingerprints();
 
 	private:
-		thread_local static X509* certificate;
-		thread_local static EVP_PKEY* privateKey;
-		thread_local static SSL_CTX* sslCtx;
-		thread_local static uint8_t sslReadBuffer[];
+		static thread_local X509* certificate;
+		static thread_local EVP_PKEY* privateKey;
+		static thread_local SSL_CTX* sslCtx;
+		static thread_local uint8_t sslReadBuffer[];
 		static const absl::flat_hash_map<std::string, Role> String2Role;
 		static const absl::flat_hash_map<std::string, FingerprintAlgorithm> String2FingerprintAlgorithm;
 		static const absl::flat_hash_map<FingerprintAlgorithm, std::string> FingerprintAlgorithm2String;
-		thread_local static std::vector<Fingerprint> localFingerprints;
+		static thread_local std::vector<Fingerprint> localFingerprints;
 		static const std::vector<SrtpCryptoSuiteMapEntry> SrtpCryptoSuites;
 
 	public:

--- a/worker/include/RTC/PortManager.hpp
+++ b/worker/include/RTC/PortManager.hpp
@@ -78,7 +78,7 @@ namespace RTC
 		static uint8_t ConvertSocketFlags(RTC::Transport::SocketFlags& flags, Protocol protocol, int family);
 
 	private:
-		thread_local static absl::flat_hash_map<uint64_t, PortRange> mapPortRanges;
+		static thread_local absl::flat_hash_map<uint64_t, PortRange> mapPortRanges;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/RTP/Packet.hpp
+++ b/worker/include/RTC/RTP/Packet.hpp
@@ -229,7 +229,7 @@ namespace RTC
 			static uint32_t GetNextMediasoupPacketId();
 
 		private:
-			thread_local static uint32_t nextMediasoupPacketId;
+			static thread_local uint32_t nextMediasoupPacketId;
 
 		private:
 			/**

--- a/worker/include/RTC/RTP/SharedPacket.hpp
+++ b/worker/include/RTC/RTP/SharedPacket.hpp
@@ -12,7 +12,7 @@ namespace RTC
 		{
 		public:
 #ifdef MS_DUMP_RTP_SHARED_PACKET_MEMORY_USAGE
-			thread_local static uint64_t allocatedMemory;
+			static thread_local uint64_t allocatedMemory;
 #endif
 
 		public:

--- a/worker/include/Settings.hpp
+++ b/worker/include/Settings.hpp
@@ -54,7 +54,7 @@ private:
 	static void SetDtlsCertificateAndPrivateKeyFiles();
 
 public:
-	thread_local static struct Configuration configuration;
+	static thread_local struct Configuration configuration;
 
 private:
 	static const absl::flat_hash_map<std::string, LogLevel> String2LogLevel;

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -265,10 +265,10 @@ namespace Utils
 		static void WriteRandomBytes(uint8_t* buffer, size_t len);
 
 	private:
-		thread_local static std::mt19937_64 rng;
-		thread_local static EVP_MAC* mac;
-		thread_local static EVP_MAC_CTX* hmacSha1Ctx;
-		thread_local static uint8_t hmacSha1Buffer[];
+		static thread_local std::mt19937_64 rng;
+		static thread_local EVP_MAC* mac;
+		static thread_local EVP_MAC_CTX* hmacSha1Ctx;
+		static thread_local uint8_t hmacSha1Buffer[];
 		static const uint32_t Crc32Table[256];
 		static const uint32_t Crc32cTable[256];
 	};

--- a/worker/mocks/src/RTC/SCTP/association/MockTransmissionControlBlockContext.cpp
+++ b/worker/mocks/src/RTC/SCTP/association/MockTransmissionControlBlockContext.cpp
@@ -4,7 +4,7 @@
 #include "mocks/include/RTC/SCTP/association/MockTransmissionControlBlockContext.hpp"
 #include "Logger.hpp"
 
-alignas(4) thread_local uint8_t FactoryBuffer[65536];
+alignas(4) static thread_local uint8_t FactoryBuffer[65536];
 
 namespace mocks
 {

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -4,7 +4,7 @@
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
 
-/* Static variables. */
+/* Class variables. */
 
 thread_local uv_loop_t* DepLibUV::loop{ nullptr };
 

--- a/worker/src/DepLibUring.cpp
+++ b/worker/src/DepLibUring.cpp
@@ -12,7 +12,8 @@
 #include <sys/resource.h>
 #include <sys/utsname.h>
 
-/* Static variables. */
+/* Class variables. */
+
 thread_local bool DepLibUring::enabled{ false };
 // liburing instance per thread.
 thread_local DepLibUring::LibUring* DepLibUring::liburing{ nullptr };

--- a/worker/src/DepUsrSCTP.cpp
+++ b/worker/src/DepUsrSCTP.cpp
@@ -54,7 +54,7 @@ inline static void sctpDebug(const char* format, ...)
 	va_end(ap);
 }
 
-/* Static variables. */
+/* Class variables. */
 
 thread_local DepUsrSCTP::Checker* DepUsrSCTP::checker{ nullptr };
 uint64_t DepUsrSCTP::numSctpAssociations{ 0u };

--- a/worker/src/Logger.cpp
+++ b/worker/src/Logger.cpp
@@ -6,7 +6,7 @@
 
 /* Class variables. */
 
-const uint64_t Logger::pid{ static_cast<uint64_t>(uv_os_getpid()) };
+const uint64_t Logger::Pid{ static_cast<uint64_t>(uv_os_getpid()) };
 thread_local Channel::ChannelSocket* Logger::channel{ nullptr };
 thread_local char Logger::buffer[Logger::BufferSize];
 

--- a/worker/src/MediaSoupErrors.cpp
+++ b/worker/src/MediaSoupErrors.cpp
@@ -2,4 +2,6 @@
 
 #include "MediaSoupErrors.hpp"
 
+/* Class variables. */
+
 thread_local char MediaSoupError::buffer[MediaSoupError::BufferSize];

--- a/worker/src/RTC/ICE/IceServer.cpp
+++ b/worker/src/RTC/ICE/IceServer.cpp
@@ -12,7 +12,7 @@ namespace RTC
 		/* Static. */
 
 		static constexpr size_t StunResponseFactoryBufferLength{ 65536 };
-		thread_local uint8_t StunResponseFactoryBuffer[StunResponseFactoryBufferLength];
+		static thread_local uint8_t StunResponseFactoryBuffer[StunResponseFactoryBufferLength];
 		static constexpr size_t MaxTuples{ 8 };
 		static constexpr uint8_t ConsentCheckMinTimeoutSec{ 10u };
 		static constexpr uint8_t ConsentCheckMaxTimeoutSec{ 60u };
@@ -560,7 +560,7 @@ namespace RTC
 			}
 			else
 			{
-				thread_local std::string_view errorReasonPhrase;
+				static thread_local std::string_view errorReasonPhrase;
 
 				response->GetErrorCode(errorReasonPhrase);
 

--- a/worker/src/RTC/ICE/StunPacket.cpp
+++ b/worker/src/RTC/ICE/StunPacket.cpp
@@ -15,7 +15,7 @@ namespace RTC
 		/* Static. */
 
 		static constexpr size_t AttributeFactoryBufferLength{ 65536 };
-		thread_local uint8_t AttributeFactoryBuffer[AttributeFactoryBufferLength];
+		static thread_local uint8_t AttributeFactoryBuffer[AttributeFactoryBufferLength];
 
 		/* Class variables. */
 

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -20,7 +20,7 @@ namespace RTC
 	/* Static */
 
 	static constexpr size_t ProducerSendBufferSize{ 65536 };
-	thread_local uint8_t ProducerSendBuffer[ProducerSendBufferSize];
+	static thread_local uint8_t ProducerSendBuffer[ProducerSendBufferSize];
 	static constexpr unsigned int SendNackDelay{ 10u }; // In ms.
 
 	/* Instance methods. */
@@ -1195,8 +1195,8 @@ namespace RTC
 
 		// Mangle RTP header extensions.
 		{
-			thread_local uint8_t buffer[4096];
-			thread_local std::vector<RTC::RTP::Packet::Extension> extensions;
+			static thread_local uint8_t buffer[4096];
+			static thread_local std::vector<RTC::RTP::Packet::Extension> extensions;
 
 			// This happens just once.
 			if (extensions.capacity() != 24)

--- a/worker/src/RTC/RTP/ProbationGenerator.cpp
+++ b/worker/src/RTC/RTP/ProbationGenerator.cpp
@@ -14,9 +14,9 @@ namespace RTC
 	{
 		/* Static. */
 
-		thread_local uint8_t ProbationPacketBuffer[ProbationGenerator::ProbationPacketMaxLength];
+		static thread_local uint8_t ProbationPacketBuffer[ProbationGenerator::ProbationPacketMaxLength];
 		static constexpr size_t ProbationPacketExtensionsBufferLength{ 200 };
-		alignas(4) thread_local uint8_t
+		alignas(4) static thread_local uint8_t
 		  ProbationPacketExtensionsBuffer[ProbationPacketExtensionsBufferLength];
 		// 8 bytes, same as RTC::Consts::MidRtpExtensionMaxLength.
 		static const std::string MidValue{ "probator" };
@@ -28,7 +28,7 @@ namespace RTC
 			MS_TRACE();
 
 			// Trick to only fill the padding with zeroes once.
-			thread_local bool mustInitializePayload{ true };
+			static thread_local bool mustInitializePayload{ true };
 
 			if (mustInitializePayload)
 			{

--- a/worker/src/RTC/RTP/RtpStreamSend.cpp
+++ b/worker/src/RTC/RTP/RtpStreamSend.cpp
@@ -21,7 +21,7 @@ namespace RTC
 		static constexpr size_t RetransmissionBufferMaxItems{ 2500u };
 		// 17: 16 bit mask + the initial sequence number.
 		static constexpr size_t MaxRequestedPackets{ 17u };
-		thread_local std::vector<RTP::RetransmissionBuffer::Item*> RetransmissionContainer(
+		static thread_local std::vector<RTP::RetransmissionBuffer::Item*> RetransmissionContainer(
 		  MaxRequestedPackets + 1);
 		static constexpr uint32_t DefaultRtt{ 100u };
 

--- a/worker/src/RTC/RTP/SharedPacket.cpp
+++ b/worker/src/RTC/RTP/SharedPacket.cpp
@@ -32,7 +32,7 @@ namespace RTC
 			  "[worker.pid:%" PRIu64
 			  "] [RTC::RTP::SharedPacket] memory deallocated [packet buffer:%zu, total allocated memory:%" PRIu64
 			  "]",
-			  Logger::pid,
+			  Logger::Pid,
 			  packet->GetBufferLength(),
 			  SharedPacket::allocatedMemory);
 #endif
@@ -170,7 +170,7 @@ namespace RTC
 			  "[worker.pid:%" PRIu64
 			  "] [RTC::RTP::SharedPacket] memory allocated [packet buffer:%zu, total allocated memory:%" PRIu64
 			  "]",
-			  Logger::pid,
+			  Logger::Pid,
 			  clonedPacket->GetBufferLength(),
 			  SharedPacket::allocatedMemory);
 #endif

--- a/worker/src/RTC/RTP/SharedPacket.cpp
+++ b/worker/src/RTC/RTP/SharedPacket.cpp
@@ -17,7 +17,7 @@ namespace RTC
 		static constexpr size_t PacketBufferLengthIncrement{ 100 };
 		// Callback to pass to every cloned RTP Packet to deallocate its buffer once
 		// the Packet releases its buffer (for example when the Packet is destroyed).
-		thread_local Serializable::BufferReleasedListener PacketBufferReleasedListener =
+		static thread_local Serializable::BufferReleasedListener PacketBufferReleasedListener =
 		  // NOLINTNEXTLINE(misc-unused-parameters, readability-non-const-parameter)
 		  [](const Serializable* packet, uint8_t* buffer)
 		{

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -26,7 +26,7 @@ namespace RTC
 	{
 		/* Static. */
 
-		alignas(4) thread_local static uint8_t PacketFactoryBuffer[65536];
+		alignas(4) static thread_local uint8_t PacketFactoryBuffer[65536];
 		// @see https://tools.ietf.org/html/rfc9260#section-5.1
 		constexpr uint32_t MinVerificationTag{ 1 };
 		constexpr uint32_t MaxVerificationTag{ std::numeric_limits<uint32_t>::max() };

--- a/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
+++ b/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
@@ -15,7 +15,7 @@ namespace RTC
 	{
 		/* Static. */
 
-		alignas(4) thread_local static uint8_t PacketFactoryBuffer[65536];
+		alignas(4) static thread_local uint8_t PacketFactoryBuffer[65536];
 
 		/* Instance methods. */
 

--- a/worker/src/RTC/SctpAssociation.cpp
+++ b/worker/src/RTC/SctpAssociation.cpp
@@ -863,7 +863,7 @@ namespace RTC
 						if (notification->sn_header.sn_length > 0)
 						{
 							static const size_t BufferSize{ 1024 };
-							thread_local char buffer[BufferSize];
+							static thread_local char buffer[BufferSize];
 
 							const uint32_t len =
 							  notification->sn_assoc_change.sac_length - sizeof(struct sctp_assoc_change);
@@ -940,7 +940,7 @@ namespace RTC
 						if (notification->sn_header.sn_length > 0)
 						{
 							static const size_t BufferSize{ 1024 };
-							thread_local char buffer[BufferSize];
+							static thread_local char buffer[BufferSize];
 
 							const uint32_t len =
 							  notification->sn_assoc_change.sac_length - sizeof(struct sctp_assoc_change);
@@ -984,7 +984,7 @@ namespace RTC
 			case SCTP_REMOTE_ERROR:
 			{
 				static const size_t BufferSize{ 1024 };
-				thread_local char buffer[BufferSize];
+				static thread_local char buffer[BufferSize];
 
 				const uint32_t len =
 				  notification->sn_remote_error.sre_length - sizeof(struct sctp_remote_error);
@@ -1023,7 +1023,7 @@ namespace RTC
 			case SCTP_SEND_FAILED_EVENT:
 			{
 				static const size_t BufferSize{ 1024 };
-				thread_local char buffer[BufferSize];
+				static thread_local char buffer[BufferSize];
 
 				const uint32_t len =
 				  notification->sn_send_failed_event.ssfe_length - sizeof(struct sctp_send_failed_event);

--- a/worker/src/RTC/SrtpSession.cpp
+++ b/worker/src/RTC/SrtpSession.cpp
@@ -15,7 +15,7 @@ namespace RTC
 	/* Static. */
 
 	static constexpr size_t EncryptBufferSize{ 65536 };
-	alignas(4) thread_local uint8_t EncryptBuffer[EncryptBufferSize];
+	alignas(4) static thread_local uint8_t EncryptBuffer[EncryptBufferSize];
 
 	/* Class methods. */
 

--- a/worker/src/RTC/TcpConnection.cpp
+++ b/worker/src/RTC/TcpConnection.cpp
@@ -15,7 +15,7 @@ namespace RTC
 	// it to structs (e.g. RTP::Packet::FixedHeader) that require 4-byte alignment.
 	// Without this, accessing multi-byte fields would be undefined behavior on
 	// strict-alignment architectures.
-	alignas(4) thread_local uint8_t ReadBuffer[ReadBufferSize];
+	alignas(4) static thread_local uint8_t ReadBuffer[ReadBufferSize];
 
 	/* Instance methods. */
 

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -52,16 +52,16 @@ void Settings::SetConfiguration(int argc, char* argv[])
 	// clang-format off
 	struct option options[] =
 	{
-		{ "logLevel",             optional_argument, nullptr, 'l' },
-		{ "logTags",              optional_argument, nullptr, 't' },
-		{ "rtcMinPort",           optional_argument, nullptr, 'm' },
-		{ "rtcMaxPort",           optional_argument, nullptr, 'M' },
-		{ "dtlsCertificateFile",  optional_argument, nullptr, 'c' },
-		{ "dtlsPrivateKeyFile",   optional_argument, nullptr, 'p' },
-		{ "libwebrtcFieldTrials", optional_argument, nullptr, 'W' },
-		{ "disableLiburing",      optional_argument, nullptr, 'd' },
-		{ "useBuiltInSctpStack",  optional_argument, nullptr, 's' },
-		{ nullptr,                0,                 nullptr,  0  }
+		{ .name="logLevel",             .has_arg=optional_argument, .flag=nullptr, .val='l' },
+		{ .name="logTags",              .has_arg=optional_argument, .flag=nullptr, .val='t' },
+		{ .name="rtcMinPort",           .has_arg=optional_argument, .flag=nullptr, .val='m' },
+		{ .name="rtcMaxPort",           .has_arg=optional_argument, .flag=nullptr, .val='M' },
+		{ .name="dtlsCertificateFile",  .has_arg=optional_argument, .flag=nullptr, .val='c' },
+		{ .name="dtlsPrivateKeyFile",   .has_arg=optional_argument, .flag=nullptr, .val='p' },
+		{ .name="libwebrtcFieldTrials", .has_arg=optional_argument, .flag=nullptr, .val='W' },
+		{ .name="disableLiburing",      .has_arg=optional_argument, .flag=nullptr, .val='d' },
+		{ .name="useBuiltInSctpStack",  .has_arg=optional_argument, .flag=nullptr, .val='s' },
+		{ .name=nullptr,                .has_arg=0,                 .flag=nullptr,  .val=0  }
 	};
 	// clang-format on
 	std::string stringValue;

--- a/worker/src/Utils/Crypto.cpp
+++ b/worker/src/Utils/Crypto.cpp
@@ -8,7 +8,7 @@
 
 namespace Utils
 {
-	/* Static variables. */
+	/* Class variables. */
 
 	thread_local std::mt19937_64 Crypto::rng;
 	thread_local EVP_MAC* Crypto::mac{ nullptr };

--- a/worker/src/Utils/String.cpp
+++ b/worker/src/Utils/String.cpp
@@ -19,7 +19,7 @@
 /* Static. */
 
 static constexpr size_t BufferOutSize{ 65536 };
-thread_local uint8_t BufferOut[BufferOutSize];
+static thread_local uint8_t BufferOut[BufferOutSize];
 static const uint8_t Base64Table[65] =
   "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -52,7 +52,7 @@ Worker::Worker(::Channel::ChannelSocket* channel, SharedInterface* shared)
 
 	// Tell the Node process that we are running.
 	this->shared->GetChannelNotifier()->Emit(
-	  std::to_string(Logger::pid), FBS::Notification::Event::WORKER_RUNNING);
+	  std::to_string(Logger::Pid), FBS::Notification::Event::WORKER_RUNNING);
 
 	MS_DEBUG_DEV("starting libuv loop");
 	DepLibUV::RunLoop();
@@ -153,7 +153,7 @@ flatbuffers::Offset<FBS::Worker::DumpResponse> Worker::FillBuffer(
 	{
 		return FBS::Worker::CreateDumpResponseDirect(
 		  builder,
-		  Logger::pid,
+		  Logger::Pid,
 		  &webRtcServerIds,
 		  &routerIds,
 		  channelMessageHandlers,
@@ -162,11 +162,11 @@ flatbuffers::Offset<FBS::Worker::DumpResponse> Worker::FillBuffer(
 	else
 	{
 		return FBS::Worker::CreateDumpResponseDirect(
-		  builder, Logger::pid, &webRtcServerIds, &routerIds, channelMessageHandlers);
+		  builder, Logger::Pid, &webRtcServerIds, &routerIds, channelMessageHandlers);
 	}
 #else
 	return FBS::Worker::CreateDumpResponseDirect(
-	  builder, Logger::pid, &webRtcServerIds, &routerIds, channelMessageHandlers);
+	  builder, Logger::Pid, &webRtcServerIds, &routerIds, channelMessageHandlers);
 #endif
 }
 

--- a/worker/src/handles/UdpSocketHandle.cpp
+++ b/worker/src/handles/UdpSocketHandle.cpp
@@ -17,7 +17,7 @@ static constexpr size_t ReadBufferSize{ 65536 };
 // it to structs (e.g. RTP::Packet::FixedHeader) that require 4-byte alignment.
 // Without this, accessing multi-byte fields would be undefined behavior on
 // strict-alignment architectures.
-alignas(4) thread_local uint8_t ReadBuffer[ReadBufferSize];
+alignas(4) static thread_local uint8_t ReadBuffer[ReadBufferSize];
 
 /* Static methods for UV callbacks. */
 


### PR DESCRIPTION
# Details

- Use always `static thread_local` instead of `thread_local static` (convention).
- Use `static thread_local` instead of just `thread_local` in variables declared in `cpp` files, otherwise they have external linkage and can collide (error in linking time) if two `cpp` files declare the same `local_thread int Foo`