### PR TITLE
SCTP - Part 15

### DIFF
--- a/node/src/Channel.ts
+++ b/node/src/Channel.ts
@@ -27,9 +27,8 @@ type Sent = {
 	close: () => void;
 };
 
-// Binary length for a 4194304 bytes payload.
-const MESSAGE_MAX_LEN = 4194308;
-const PAYLOAD_MAX_LEN = 4194304;
+const MESSAGE_MAX_LEN = 8388608;
+const PAYLOAD_MAX_LEN = MESSAGE_MAX_LEN - 4;
 
 export class Channel extends EnhancedEventEmitter {
 	// Closed flag.

--- a/worker/include/RTC/SCTP/TODO_SCTP.md
+++ b/worker/include/RTC/SCTP/TODO_SCTP.md
@@ -16,6 +16,10 @@
 
 - Probably add many more fields in `SctpOptions` given to the `Association` in `Transport.cpp`.
 
+- Must check those `maxSctpMessageSize`, `sctpSendBufferSize` in `Router.createXxxxTransport()` (also in Rust) which have default value of 262144.
+
+- Must consider also an option to set `SctpOptions::perStreamSendQueueLimit` which defaults to 2000000 bytes.
+
 - When running `test-PipeTransport.ts` and `test-werift-sctp.ts` with `useBuiltInSctpStack: true`, tests pass but those errors show up:
 
   ```

--- a/worker/include/RTC/SCTP/public/SctpOptions.hpp
+++ b/worker/include/RTC/SCTP/public/SctpOptions.hpp
@@ -55,11 +55,16 @@ namespace RTC
 			size_t maxSendMessageSize{ 256 * 1024 };
 
 			/**
-			 * The default stream priority, if not overridden by
-			 * `Association::SetStreamPriority()`. The default value is selected to be
-			 * compatible with https://www.w3.org/TR/webrtc-priority/, section 4.2-4.3.
+			 * Send queue total size limit. It will not be possible to queue more data
+			 * if the queue size is larger than this number.
 			 */
-			uint16_t defaultStreamPriority{ 256 };
+			size_t maxSendBufferSize{ 2000000 };
+
+			/**
+			 * Per stream send queue size limit. Similar to `maxSendBufferSize`, but
+			 * limiting the size of individual streams.
+			 */
+			size_t perStreamSendQueueLimit{ 2000000 };
 
 			/**
 			 * Maximum received window buffer size. This should be a bit larger than
@@ -73,22 +78,17 @@ namespace RTC
 			size_t maxReceiverWindowBufferSize{ 5 * 1024 * 1024 };
 
 			/**
-			 * Send queue total size limit. It will not be possible to queue more data
-			 * if the queue size is larger than this number.
-			 */
-			size_t maxSendBufferSize{ 2000000 };
-
-			/**
-			 * Per stream send queue size limit. Similar to `maxSendBufferSize`, but
-			 * limiting the size of individual streams.
-			 */
-			size_t perStreamSendQueueLimit{ 2000000 };
-
-			/**
 			 * A threshold that, when the amount of data in the send buffer goes below
 			 * this value, will trigger `Association::OnAssociationTotalBufferedAmountLow()`.
 			 */
 			size_t totalBufferedAmountLowThreshold{ 1800000 };
+
+			/**
+			 * The default stream priority, if not overridden by
+			 * `Association::SetStreamPriority()`. The default value is selected to be
+			 * compatible with https://www.w3.org/TR/webrtc-priority/, section 4.2-4.3.
+			 */
+			uint16_t defaultStreamPriority{ 256 };
 
 			/**
 			 * Max allowed RTT value. When the RTT is measured and it's found to be
@@ -256,6 +256,8 @@ namespace RTC
 			ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod zeroChecksumAlternateErrorDetectionMethod{
 				ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::NONE
 			};
+
+			void Dump(int indentation = 0) const;
 		};
 
 		/**

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -280,6 +280,7 @@ common_sources = [
   'src/RTC/SCTP/packet/errorCauses/ProtocolViolationErrorCause.cpp',
   'src/RTC/SCTP/packet/errorCauses/UnknownErrorCause.cpp',
   'src/RTC/SCTP/public/AssociationMetrics.cpp',
+  'src/RTC/SCTP/public/SctpOptions.cpp',
   'src/RTC/SCTP/public/Message.cpp',
 ]
 

--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -9,9 +9,8 @@
 
 namespace Channel
 {
-	// Binary length for a 4194304 bytes payload.
-	static constexpr size_t MessageMaxLen{ 4194308 };
-	static constexpr size_t PayloadMaxLen{ 4194304 };
+	static constexpr size_t MessageMaxLen{ 8388608 };
+	static constexpr size_t PayloadMaxLen{ MessageMaxLen - 4 };
 
 	/* Static methods for UV callbacks. */
 

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -101,6 +101,8 @@ namespace RTC
 			  static_cast<int>(stateStringView.size()),
 			  stateStringView.data());
 
+			this->sctpOptions.Dump();
+
 			if (this->tcb)
 			{
 				this->tcb->Dump(indentation + 1);
@@ -1717,7 +1719,6 @@ namespace RTC
 					operationErrorChunk->Consolidate();
 
 					this->packetSender.SendPacket(packet.get());
-
 					this->associationListenerDeferrer.OnAssociationError(
 					  Types::ErrorKind::WRONG_SEQUENCE, "received COOKIE_ECHO while shutting down");
 

--- a/worker/src/RTC/SCTP/public/SctpOptions.cpp
+++ b/worker/src/RTC/SCTP/public/SctpOptions.cpp
@@ -1,0 +1,89 @@
+#define MS_CLASS "RTC::SCTP::SctpOptions"
+// #define MS_LOG_DEV_LEVEL 3
+
+#include "RTC/SCTP/public/SctpOptions.hpp"
+#include "Logger.hpp"
+#include "RTC/SCTP/packet/parameters/ZeroChecksumAcceptableParameter.hpp"
+#include <string>
+
+namespace RTC
+{
+	namespace SCTP
+	{
+		/* Instance methods. */
+
+		void SctpOptions::Dump(int indentation) const
+		{
+			MS_TRACE();
+
+			MS_DUMP_CLEAN(indentation, "<SCTP::SctpOptions>");
+			MS_DUMP_CLEAN(indentation, "  source port: %" PRIu16, this->sourcePort);
+			MS_DUMP_CLEAN(indentation, "  destination port: %" PRIu16, this->destinationPort);
+			MS_DUMP_CLEAN(
+			  indentation, "  announced max outbound streams: %" PRIu16, this->announcedMaxOutboundStreams);
+			MS_DUMP_CLEAN(
+			  indentation, "  announced max inbound streams: %" PRIu16, this->announcedMaxInboundStreams);
+			MS_DUMP_CLEAN(indentation, "  mtu: %zu", this->mtu);
+			MS_DUMP_CLEAN(indentation, "  max send message size: %zu", this->maxSendMessageSize);
+			MS_DUMP_CLEAN(indentation, "  max send buffer size: %zu", this->maxSendBufferSize);
+			MS_DUMP_CLEAN(indentation, "  per stream send queue limit: %zu", this->perStreamSendQueueLimit);
+			MS_DUMP_CLEAN(indentation, "  max receiver window size: %zu", this->maxReceiverWindowBufferSize);
+			MS_DUMP_CLEAN(
+			  indentation,
+			  "  total buffered amount low threshold: %zu",
+			  this->totalBufferedAmountLowThreshold);
+			MS_DUMP_CLEAN(indentation, "  default stream priority: %" PRIu16, this->defaultStreamPriority);
+			MS_DUMP_CLEAN(indentation, "  max rtt (ms): %" PRIu64, this->maxRttMs);
+			MS_DUMP_CLEAN(indentation, "  initial rto (ms): %" PRIu64, this->initialRtoMs);
+			MS_DUMP_CLEAN(indentation, "  min rto (ms): %" PRIu64, this->minRtoMs);
+			MS_DUMP_CLEAN(indentation, "  max rto (ms): %" PRIu64, this->maxRtoMs);
+			MS_DUMP_CLEAN(indentation, "  t1-init timeout (ms): %" PRIu64, this->t1InitTimeoutMs);
+			MS_DUMP_CLEAN(indentation, "  t1-cookie timeout (ms): %" PRIu64, this->t1CookieTimeoutMs);
+			MS_DUMP_CLEAN(indentation, "  t2-shutdown timeout (ms): %" PRIu64, this->t2ShutdownTimeoutMs);
+			MS_DUMP_CLEAN(
+			  indentation,
+			  "  timer max backoff timeout (ms): %s",
+			  this->timerMaxBackoffTimeoutMs
+			    ? std::to_string(this->timerMaxBackoffTimeoutMs.value()).c_str()
+			    : "Infinite");
+			MS_DUMP_CLEAN(indentation, "  heartbeat interval (ms): %" PRIu64, this->heartbeatIntervalMs);
+			MS_DUMP_CLEAN(
+			  indentation, "  delayed ack max timeout (ms): %" PRIu64, this->delayedAckMaxTimeoutMs);
+			MS_DUMP_CLEAN(indentation, "  min rtt variance (ms): %" PRIu64, this->minRttVarianceMs);
+			MS_DUMP_CLEAN(indentation, "  initial cwnd mtus: %zu", this->initialCwndMtus);
+			MS_DUMP_CLEAN(indentation, "  min cwnd mtus: %zu", this->minCwndMtus);
+			MS_DUMP_CLEAN(
+			  indentation, "  avoid fragmentation cwnd mtus: %zu", this->avoidFragmentationCwndMtus);
+			MS_DUMP_CLEAN(
+			  indentation, "  immediate sack under cwnd mtus: %zu", this->immediateSackUnderCwndMtus);
+			MS_DUMP_CLEAN(indentation, "  max burst: %zu", this->maxBurst);
+			MS_DUMP_CLEAN(
+			  indentation,
+			  "  max retransmissions: %s",
+			  this->maxRetransmissions ? std::to_string(this->maxRetransmissions.value()).c_str()
+			                           : "Infinite");
+			MS_DUMP_CLEAN(
+			  indentation,
+			  "  max init retransmissions: %s",
+			  this->maxInitRetransmissions ? std::to_string(this->maxInitRetransmissions.value()).c_str()
+			                               : "Infinite");
+			MS_DUMP_CLEAN(
+			  indentation, "  enable partial reliability: %s", this->enablePartialReliability ? "yes" : "no");
+			MS_DUMP_CLEAN(
+			  indentation,
+			  "  enable message interleaving: %s",
+			  this->enableMessageInterleaving ? "yes" : "no");
+			MS_DUMP_CLEAN(
+			  indentation,
+			  "  heartbeat interval include rtt: %s",
+			  this->heartbeatIntervalIncludeRtt ? "yes" : "no");
+			MS_DUMP_CLEAN(
+			  indentation,
+			  "  zero checksum alternate error detection method: %s",
+			  ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethodToString(
+			    this->zeroChecksumAlternateErrorDetectionMethod)
+			    .c_str());
+			MS_DUMP_CLEAN(indentation, "</SCTP::SctpOptions>");
+		}
+	} // namespace SCTP
+} // namespace RTC

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -115,9 +115,12 @@ namespace RTC
 				// TODO: SCTP: Many interesting options missing.
 				// NOTE: When using the built-in SCTP stack, `numSctpStreams` given to the
 				// transport is ignored.
-				const RTC::SCTP::SctpOptions sctpOptions = { // TODO: SCTP: Sure?
-					                                           .maxSendMessageSize = this->maxMessageSize,
-					                                           .maxSendBufferSize  = sctpSendBufferSize
+				const RTC::SCTP::SctpOptions sctpOptions = {
+					// TODO: SCTP: Sure?
+					.maxSendMessageSize = this->maxMessageSize,
+					.maxSendBufferSize  = sctpSendBufferSize,
+					// TODO: SCTP: We may need a separate option for this.
+					.perStreamSendQueueLimit = sctpSendBufferSize
 				};
 
 				this->sctpAssociation =


### PR DESCRIPTION
# Details

- Add `SctpOptions::Dump()`.
- Increase channel max message/payload length (just because it's free).
- Cosmetic and more SCPT TODO items.