### PR TITLE
Acknowledge libwebrtc/dcsctp copyright in mediasoup SCTP stack

### DIFF
--- a/worker/deps/libwebrtc/README.md
+++ b/worker/deps/libwebrtc/README.md
@@ -2,10 +2,10 @@
 
 This folder contains a modified/adapted subset of the libwebrtc library, which is used by mediasoup for transport congestion purposes.
 
-* libwebrtc branch: m77
-* libwebrtc commit: 2bac7da1349c75e5cf89612ab9619a1920d5d974
+- libwebrtc branch: m77
+- libwebrtc commit: 2bac7da1349c75e5cf89612ab9619a1920d5d974
 
-The file `libwebrtc/mediasoup_helpers.h` includes some utilities to plug mediasoup classes into libwebrtc.
+The `libwebrtc/mediasoup_helpers.h` file includes some utilities to plug mediasoup classes into libwebrtc and vice-versa.
 
 The file `worker/deps/libwebrtc/deps/abseil-cpp/abseil-cpp/absl/synchronization/internal/graphcycles.cc` has `#include <limits>` added to it to fix CI builds with Clang.
 

--- a/worker/deps/libwebrtc/libwebrtc/mediasoup_helpers.h
+++ b/worker/deps/libwebrtc/libwebrtc/mediasoup_helpers.h
@@ -2,9 +2,7 @@
 #define LIBWEBRTC_MEDIASOUP_HELPERS_H
 
 #include "modules/rtp_rtcp/source/rtp_packet/transport_feedback.h"
-
 #include "RTC/RTCP/FeedbackRtpTransport.hpp"
-
 #include <cstdint>
 #include <vector>
 
@@ -16,28 +14,33 @@ namespace mediasoup_helpers
 	namespace FeedbackRtpTransport
 	{
 		const std::vector<webrtc::rtcp::ReceivedPacket> GetReceivedPackets(
-			const RTC::RTCP::FeedbackRtpTransportPacket* packet)
+		  const RTC::RTCP::FeedbackRtpTransportPacket* packet)
 		{
 			std::vector<webrtc::rtcp::ReceivedPacket> receivedPackets;
 
 			for (auto& packetResult : packet->GetPacketResults())
 			{
-			  if (packetResult.received)
-			    receivedPackets.emplace_back(packetResult.sequenceNumber, packetResult.delta);
+				if (packetResult.received)
+				{
+					receivedPackets.emplace_back(packetResult.sequenceNumber, packetResult.delta);
+				}
 			}
 
 			return receivedPackets;
 		}
 
-		// Get the reference time in microseconds, including any precision loss.
+		/**
+		 * Get the reference time in microseconds, including any precision loss.
+		 */
 		int64_t GetBaseTimeUs(const RTC::RTCP::FeedbackRtpTransportPacket* packet)
 		{
 			return packet->GetReferenceTimestamp() * 1000;
 		}
 
-		// Get the unwrapped delta between current base time and |prev_timestamp_us|.
-		int64_t GetBaseDeltaUs(
-		  const RTC::RTCP::FeedbackRtpTransportPacket* packet, int64_t prev_timestamp_us)
+		/**
+		 * Get the unwrapped delta between current base time and |prev_timestamp_us|.
+		 */
+		int64_t GetBaseDeltaUs(const RTC::RTCP::FeedbackRtpTransportPacket* packet, int64_t prev_timestamp_us)
 		{
 			return packet->GetBaseDelta(prev_timestamp_us / 1000) * 1000;
 		}

--- a/worker/scripts/clang-scripts.mjs
+++ b/worker/scripts/clang-scripts.mjs
@@ -21,6 +21,7 @@ const CLANG_FORMAT_PATHS = [
 	'../fuzzer/include/**/*.hpp',
 	'../mocks/src/**/*.cpp',
 	'../mocks/include/**/*.hpp',
+	'../deps/libwebrtc/libwebrtc/mediasoup_helpers.h',
 ];
 
 const CLANG_TIDY_PATHS = [

--- a/worker/src/RTC/SCTP/LICENSE
+++ b/worker/src/RTC/SCTP/LICENSE
@@ -1,3 +1,18 @@
+The SCTP packet and chunk parsers, factories, and several additional
+classes, as well as other components of the mediasoup SCTP stack, have
+been implemented from scratch. However, most of the core SCTP protocol
+logic is derived from the dcsctp component of the WebRTC project.
+
+The SCTP source code in mediasoup is distributed under the copyright
+and license terms specified in the LICENSE file located in the
+mediasoup root directory.
+
+To acknowledge and preserve the copyright notices and licensing terms
+of dcsctp and the WebRTC project, the corresponding license text is
+reproduced below.
+
+----
+
 Copyright (c) 2011, The WebRTC project authors. All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION
# Details

- Honor the WebRTC/dcsctp license and copyright.
- Cosmetic changes.