### PR TITLE
New releases for mediasoup NPM and mediasoup Rust crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+### 3.20.0
+
 - Node: Update TypeScript to v6 ([PR #1790](https://github.com/versatica/mediasoup/pull/1790)).
 - New built-in SCTP stack ([PR #1806](https://github.com/versatica/mediasoup/pull/1806)):
   - **Breaking change:** Remove `useBuiltInSctpStack` option in `WorkerSettngs`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1530,7 +1530,7 @@ checksum = "b6e8aaa3f231bb4bd57b84b2d5dc3ae7f350265df8aa96492e0bc394a1571909"
 
 [[package]]
 name = "mediasoup"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "actix",
  "actix-web",
@@ -1568,7 +1568,7 @@ dependencies = [
 
 [[package]]
 name = "mediasoup-sys"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "planus",
  "planus-codegen",
@@ -1578,7 +1578,7 @@ dependencies = [
 
 [[package]]
 name = "mediasoup-types"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "once_cell",
  "regex",

--- a/doc/Rust-crates.md
+++ b/doc/Rust-crates.md
@@ -12,7 +12,7 @@ There are 3 crates: `mediasoup`, `mediasoup-sys` and `mediasoup-types`:
 
 ## Steps to publish new mediasoup crates
 
-1. Update versions in `worker/Cargo.toml` (for `mediasoup-sys` crate), `rust/types/Cargo.toml` (for `mediasoup-types` crate) and `rust/Cargo.toml` (for `mediasoup` crate). Note that in `rust/Cargo.toml` you may need to update the version of `[dependencies.mediasoup-sys]` and/or `[dependencies.mediasoup-types]` if it also changed.
+1. Update versions in `worker/Cargo.toml` (for `mediasoup-sys` crate), `rust/types/Cargo.toml` (for `mediasoup-types` crate) and `rust/Cargo.toml` (for `mediasoup` crate). Note that in `rust/Cargo.toml` you may need to update the version of `[dependencies.mediasoup-sys]` and/or `[dependencies.mediasoup-types]` if they also changed.
 2. Update `rust/CHANGELOG.md`.
 3. Run `cargo build` to reflect changes in `Cargo.lock`.
 4. Create PR and have it merged in mediasoup main branch.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "mediasoup",
-	"version": "3.19.22",
+	"version": "3.20.0",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "mediasoup",
-			"version": "3.19.22",
+			"version": "3.20.0",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "mediasoup",
-	"version": "3.19.22",
+	"version": "3.20.0",
 	"description": "Cutting Edge WebRTC Video Conferencing",
 	"contributors": [
 		"Iñaki Baz Castillo <ibc@aliax.net> (https://inakibaz.me)",

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+### 0.22.0
+
 - New built-in SCTP stack (PR #1806):
   - Remove `useBuiltInSctpStack` worker option.
   - `WebRtcTransport`, `PlainTransport`, `PipeTransport`: Add `sctp_negotiated_capabilities()` getter.

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup"
-version = "0.21.0"
+version = "0.22.0"
 description = "Cutting Edge WebRTC Video Conferencing in Rust"
 categories = ["api-bindings", "multimedia", "network-programming"]
 authors = [
@@ -46,11 +46,11 @@ version = "0.8.1"
 
 [dependencies.mediasoup-sys]
 path = "../worker"
-version = "0.11.0"
+version = "0.12.0"
 
 [dependencies.mediasoup-types]
 path = "./types"
-version = "0.3.0"
+version = "0.4.0"
 
 [dependencies.parking_lot]
 version = "0.12.1"

--- a/rust/types/CHANGELOG.md
+++ b/rust/types/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+### 0.4.0
+
 - New built-in SCTP stack (PR #1806):
   - Remove `NumSctpStreams` type.
   - Add `SctpNegotiatedCapabilities` type.

--- a/rust/types/Cargo.toml
+++ b/rust/types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup-types"
-version = "0.3.0"
+version = "0.4.0"
 description = "Type definitions and shared data structures for the mediasoup crate"
 authors = [
     "Nazar Mokrynskyi <nazar@mokrynskyi.com>",

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mediasoup-sys"
-version = "0.11.0"
+version = "0.12.0"
 description = "FFI bindings to C++ libmediasoup-worker"
 authors = [
     "Nazar Mokrynskyi <nazar@mokrynskyi.com>",


### PR DESCRIPTION
# Details

- mediasoup Node 3.2.0
- mediasoup Rust crate 0.22.0
- mediasoup-sys Rust crate 0.12.0
- mediasoup-types Rust crate 0.4.0