### PR TITLE
Node: Make all public methods/getters that return an object/array, return a clone of that object/array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Node: Make all public methods/getters that return an object/array, return a clone of that object/array ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 3.20.0
 
 - Node: Update TypeScript to v6 ([PR #1790](https://github.com/versatica/mediasoup/pull/1790)).

--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -33,6 +33,7 @@ import {
 import { parseRtpStreamStats } from './rtpStreamStatsFbsUtils';
 import type { AppData } from './types';
 import * as fbsUtils from './fbsUtils';
+import * as utils from './utils';
 import { Event, Notification } from './fbs/notification';
 import { TraceDirection as FbsTraceDirection } from './fbs/common';
 import * as FbsRequest from './fbs/request';
@@ -151,7 +152,7 @@ export class ConsumerImpl<ConsumerAppData extends AppData = AppData>
 	}
 
 	get rtpParameters(): RtpParameters {
-		return this.#data.rtpParameters;
+		return utils.clone(this.#data.rtpParameters);
 	}
 
 	get type(): ConsumerType {
@@ -171,15 +172,15 @@ export class ConsumerImpl<ConsumerAppData extends AppData = AppData>
 	}
 
 	get score(): ConsumerScore {
-		return this.#score;
+		return utils.clone(this.#score);
 	}
 
 	get preferredLayers(): ConsumerLayers | undefined {
-		return this.#preferredLayers;
+		return utils.clone(this.#preferredLayers);
 	}
 
 	get currentLayers(): ConsumerLayers | undefined {
-		return this.#currentLayers;
+		return utils.clone(this.#currentLayers);
 	}
 
 	get appData(): ConsumerAppData {

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -14,6 +14,7 @@ import type { TransportInternal } from './Transport';
 import type { SctpStreamParameters } from './sctpParametersTypes';
 import { parseSctpStreamParameters } from './sctpParametersFbsUtils';
 import type { AppData } from './types';
+import * as utils from './utils';
 import * as fbsUtils from './fbsUtils';
 import { Event, Notification } from './fbs/notification';
 import * as FbsTransport from './fbs/transport';
@@ -118,7 +119,7 @@ export class DataConsumerImpl<DataConsumerAppData extends AppData = AppData>
 	}
 
 	get sctpStreamParameters(): SctpStreamParameters | undefined {
-		return this.#data.sctpStreamParameters;
+		return utils.clone(this.#data.sctpStreamParameters);
 	}
 
 	get label(): string {

--- a/node/src/DataProducer.ts
+++ b/node/src/DataProducer.ts
@@ -14,6 +14,7 @@ import type { TransportInternal } from './Transport';
 import type { SctpStreamParameters } from './sctpParametersTypes';
 import { parseSctpStreamParameters } from './sctpParametersFbsUtils';
 import type { AppData } from './types';
+import * as utils from './utils';
 import * as FbsTransport from './fbs/transport';
 import * as FbsNotification from './fbs/notification';
 import * as FbsRequest from './fbs/request';
@@ -98,7 +99,7 @@ export class DataProducerImpl<DataProducerAppData extends AppData = AppData>
 	}
 
 	get sctpStreamParameters(): SctpStreamParameters | undefined {
-		return this.#data.sctpStreamParameters;
+		return utils.clone(this.#data.sctpStreamParameters);
 	}
 
 	get label(): string {

--- a/node/src/PipeTransport.ts
+++ b/node/src/PipeTransport.ts
@@ -39,6 +39,7 @@ import {
 	serializeSrtpParameters,
 } from './srtpParametersFbsUtils';
 import type { AppData } from './types';
+import * as utils from './utils';
 import { generateUUIDv4 } from './utils';
 import { MediaKind as FbsMediaKind } from './fbs/rtp-parameters/media-kind';
 import * as FbsRtpParameters from './fbs/rtp-parameters';
@@ -105,11 +106,11 @@ export class PipeTransportImpl<PipeTransportAppData extends AppData = AppData>
 	}
 
 	get tuple(): TransportTuple {
-		return this.#data.tuple;
+		return utils.clone(this.#data.tuple);
 	}
 
 	get sctpParameters(): SctpParameters | undefined {
-		return this.#data.sctpParameters;
+		return utils.clone(this.#data.sctpParameters);
 	}
 
 	get sctpState(): SctpState | undefined {
@@ -117,11 +118,11 @@ export class PipeTransportImpl<PipeTransportAppData extends AppData = AppData>
 	}
 
 	get sctpNegotiatedCapabilities(): SctpNegotiatedCapabilities | undefined {
-		return this.#data.sctpNegotiatedCapabilities;
+		return utils.clone(this.#data.sctpNegotiatedCapabilities);
 	}
 
 	get srtpParameters(): SrtpParameters | undefined {
-		return this.#data.srtpParameters;
+		return utils.clone(this.#data.srtpParameters);
 	}
 
 	override close(): void {

--- a/node/src/PlainTransport.ts
+++ b/node/src/PlainTransport.ts
@@ -29,6 +29,7 @@ import {
 	serializeSrtpParameters,
 } from './srtpParametersFbsUtils';
 import type { AppData } from './types';
+import * as utils from './utils';
 import { Event, Notification } from './fbs/notification';
 import * as FbsRequest from './fbs/request';
 import * as FbsTransport from './fbs/transport';
@@ -98,15 +99,15 @@ export class PlainTransportImpl<PlainTransportAppData extends AppData = AppData>
 	}
 
 	get tuple(): TransportTuple {
-		return this.#data.tuple;
+		return utils.clone(this.#data.tuple);
 	}
 
 	get rtcpTuple(): TransportTuple | undefined {
-		return this.#data.rtcpTuple;
+		return utils.clone(this.#data.rtcpTuple);
 	}
 
 	get sctpParameters(): SctpParameters | undefined {
-		return this.#data.sctpParameters;
+		return utils.clone(this.#data.sctpParameters);
 	}
 
 	get sctpState(): SctpState | undefined {
@@ -114,11 +115,11 @@ export class PlainTransportImpl<PlainTransportAppData extends AppData = AppData>
 	}
 
 	get sctpNegotiatedCapabilities(): SctpNegotiatedCapabilities | undefined {
-		return this.#data.sctpNegotiatedCapabilities;
+		return utils.clone(this.#data.sctpNegotiatedCapabilities);
 	}
 
 	get srtpParameters(): SrtpParameters | undefined {
-		return this.#data.srtpParameters;
+		return utils.clone(this.#data.srtpParameters);
 	}
 
 	override close(): void {

--- a/node/src/Producer.ts
+++ b/node/src/Producer.ts
@@ -19,6 +19,7 @@ import type { MediaKind, RtpParameters } from './rtpParametersTypes';
 import { parseRtpParameters } from './rtpParametersFbsUtils';
 import { parseRtpStreamRecvStats } from './rtpStreamStatsFbsUtils';
 import type { AppData } from './types';
+import * as utils from './utils';
 import * as fbsUtils from './fbsUtils';
 import { Event, Notification } from './fbs/notification';
 import { TraceDirection as FbsTraceDirection } from './fbs/common';
@@ -111,7 +112,7 @@ export class ProducerImpl<ProducerAppData extends AppData = AppData>
 	}
 
 	get rtpParameters(): RtpParameters {
-		return this.#data.rtpParameters;
+		return utils.clone(this.#data.rtpParameters);
 	}
 
 	get type(): ProducerType {
@@ -119,7 +120,7 @@ export class ProducerImpl<ProducerAppData extends AppData = AppData>
 	}
 
 	get consumableRtpParameters(): RtpParameters {
-		return this.#data.consumableRtpParameters;
+		return utils.clone(this.#data.consumableRtpParameters);
 	}
 
 	get paused(): boolean {
@@ -127,7 +128,7 @@ export class ProducerImpl<ProducerAppData extends AppData = AppData>
 	}
 
 	get score(): ProducerScore[] {
-		return this.#score;
+		return utils.clone(this.#score);
 	}
 
 	get appData(): ProducerAppData {

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -167,7 +167,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 	}
 
 	get rtpCapabilities(): RtpCapabilities {
-		return this.#data.rtpCapabilities;
+		return utils.clone(this.#data.rtpCapabilities);
 	}
 
 	get appData(): RouterAppData {

--- a/node/src/WebRtcTransport.ts
+++ b/node/src/WebRtcTransport.ts
@@ -36,6 +36,7 @@ import type {
 	SctpNegotiatedCapabilities,
 } from './sctpParametersTypes';
 import type { AppData } from './types';
+import * as utils from './utils';
 import * as fbsUtils from './fbsUtils';
 import { Event, Notification } from './fbs/notification';
 import * as FbsRequest from './fbs/request';
@@ -129,7 +130,7 @@ export class WebRtcTransportImpl<
 	}
 
 	get iceCandidates(): IceCandidate[] {
-		return this.#data.iceCandidates;
+		return utils.clone(this.#data.iceCandidates);
 	}
 
 	get iceState(): IceState {
@@ -137,11 +138,11 @@ export class WebRtcTransportImpl<
 	}
 
 	get iceSelectedTuple(): TransportTuple | undefined {
-		return this.#data.iceSelectedTuple;
+		return utils.clone(this.#data.iceSelectedTuple);
 	}
 
 	get dtlsParameters(): DtlsParameters {
-		return this.#data.dtlsParameters;
+		return utils.clone(this.#data.dtlsParameters);
 	}
 
 	get dtlsState(): DtlsState {
@@ -153,7 +154,7 @@ export class WebRtcTransportImpl<
 	}
 
 	get sctpParameters(): SctpParameters | undefined {
-		return this.#data.sctpParameters;
+		return utils.clone(this.#data.sctpParameters);
 	}
 
 	get sctpState(): SctpState | undefined {
@@ -161,7 +162,7 @@ export class WebRtcTransportImpl<
 	}
 
 	get sctpNegotiatedCapabilities(): SctpNegotiatedCapabilities | undefined {
-		return this.#data.sctpNegotiatedCapabilities;
+		return utils.clone(this.#data.sctpNegotiatedCapabilities);
 	}
 
 	override close(): void {

--- a/node/src/test/test-Router.ts
+++ b/node/src/test/test-Router.ts
@@ -150,6 +150,23 @@ test('worker.createRouter() rejects with InvalidStateError if Worker is closed',
 	).rejects.toThrow(InvalidStateError);
 }, 2000);
 
+test('router.rtpCapabilities getter returns cloned RTP capabilities', async () => {
+	const router = await ctx.worker!.createRouter({
+		mediaCodecs: ctx.mediaCodecs,
+	});
+
+	const originalRouterRtpCapabilities = router.rtpCapabilities;
+	const clonedOriginalRouterRtpCapabilities = utils.deepFreeze(
+		originalRouterRtpCapabilities
+	);
+
+	// Application attempts to modify router RTP capabilities, but it's modifying
+	// a returned clone of them.
+	router.rtpCapabilities.headerExtensions = [];
+
+	expect(router.rtpCapabilities).toEqual(clonedOriginalRouterRtpCapabilities);
+}, 2000);
+
 test('router.updateMediaCodecs() succeeds', async () => {
 	const router = await ctx.worker!.createRouter({
 		mediaCodecs: ctx.mediaCodecs,

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"eslint": "^10.4.0",
 				"eslint-config-prettier": "^10.1.8",
 				"eslint-plugin-jest": "^29.15.2",
-				"eslint-plugin-prettier": "^5.5.5",
+				"eslint-plugin-prettier": "^5.5.6",
 				"globals": "^17.6.0",
 				"ini": "^6.0.0",
 				"jest": "^30.4.2",
@@ -2221,13 +2221,13 @@
 			}
 		},
 		"node_modules/@pkgr/core": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-			"integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+			"integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": "^12.20.0 || ^14.18.0 || >=16.0.0"
+				"node": "^14.18.0 || >=16.0.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/pkgr"
@@ -3898,14 +3898,14 @@
 			}
 		},
 		"node_modules/eslint-plugin-prettier": {
-			"version": "5.5.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-			"integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
+			"version": "5.5.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+			"integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"prettier-linter-helpers": "^1.0.1",
-				"synckit": "^0.11.12"
+				"synckit": "^0.11.13"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -6845,13 +6845,13 @@
 			}
 		},
 		"node_modules/synckit": {
-			"version": "0.11.12",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+			"version": "0.11.13",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+			"integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@pkgr/core": "^0.2.9"
+				"@pkgr/core": "^0.3.6"
 			},
 			"engines": {
 				"node": "^14.18.0 || >=16.0.0"
@@ -9040,9 +9040,9 @@
 			"optional": true
 		},
 		"@pkgr/core": {
-			"version": "0.2.9",
-			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.2.9.tgz",
-			"integrity": "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA==",
+			"version": "0.3.6",
+			"resolved": "https://registry.npmjs.org/@pkgr/core/-/core-0.3.6.tgz",
+			"integrity": "sha512-SEeaJLb3qBNF/OaXnaR1NmmBbFYk1zC0ZH/52fATcRPLFg/p791YrcyFFy44Bo9sLaGuSuLp5Q6axbb/O+v/RA==",
 			"dev": true
 		},
 		"@shinyoshiaki/jspack": {
@@ -10139,13 +10139,13 @@
 			}
 		},
 		"eslint-plugin-prettier": {
-			"version": "5.5.5",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.5.tgz",
-			"integrity": "sha512-hscXkbqUZ2sPithAuLm5MXL+Wph+U7wHngPBv9OMWwlP8iaflyxpjTYZkmdgB4/vPIhemRlBEoLrH7UC1n7aUw==",
+			"version": "5.5.6",
+			"resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-5.5.6.tgz",
+			"integrity": "sha512-ifetmTcxWfz+4qRW3pH/ujdTq2jQIj59AxJMIN26K5avYgU8dxycUETQonWiW+wPrYXA0j3Try0l1CnwVQtDqQ==",
 			"dev": true,
 			"requires": {
 				"prettier-linter-helpers": "^1.0.1",
-				"synckit": "^0.11.12"
+				"synckit": "^0.11.13"
 			}
 		},
 		"eslint-scope": {
@@ -12054,12 +12054,12 @@
 			"integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="
 		},
 		"synckit": {
-			"version": "0.11.12",
-			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.12.tgz",
-			"integrity": "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==",
+			"version": "0.11.13",
+			"resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.13.tgz",
+			"integrity": "sha512-eNRKgb3z66Yp3D2CixVujOUvXLFUTij/zVnV8KRyvFdQwpz7I5DS8UfRkTeLzb64u+dkzDSdelE24izu+zSSUg==",
 			"dev": true,
 			"requires": {
-				"@pkgr/core": "^0.2.9"
+				"@pkgr/core": "^0.3.6"
 			}
 		},
 		"tar": {

--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
 		"eslint": "^10.4.0",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-jest": "^29.15.2",
-		"eslint-plugin-prettier": "^5.5.5",
+		"eslint-plugin-prettier": "^5.5.6",
 		"globals": "^17.6.0",
 		"ini": "^6.0.0",
 		"jest": "^30.4.2",


### PR DESCRIPTION
# Details

- Make public methods return a clone instead of giving the caller/application access to modify internal members of the mediasoup classes.