### PR TITLE
PortManager: replace uint64_t hash token with exact-tuple PortRangeKey (closes #1805)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- `PortManager`: Replace `uint64_t` hash token with exact-tuple `PortRangeKey` ([PR #1812](https://github.com/versatica/mediasoup/pull/1812), by @999purple999).
+- `PortManager`: Replace `uint64_t` hash token with exact-tuple `PortRangeKey` ([PR #1812](https://github.com/versatica/mediasoup/pull/1812), by @999purple999 and @penguinol).
 
 ### 3.20.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- `PortManager`: Replace `uint64_t` hash token with exact-tuple `PortRangeKey` ([PR #1812](https://github.com/versatica/mediasoup/pull/1812), by @999purple999).
+
 ### 3.20.1
 
 - Node: Make all public methods/getters that return an object/array, return a clone of that object/array ([PR #1811](https://github.com/versatica/mediasoup/pull/1811)).
@@ -1196,7 +1198,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 ### 3.5.9
 
 - `libwebrtc`: Apply patch by @sspanak and @Ivaka to avoid crash. Related issue: #357.
-- `PortManager.cpp`: Do not use `UV_UDP_RECVMMSG` in Windows due to a bug in `libuv` 1.37.0.
+- `PortManager`: Do not use `UV_UDP_RECVMMSG` in Windows due to a bug in `libuv` 1.37.0.
 - Update Node deps.
 
 ### 3.5.8
@@ -1290,7 +1292,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 ### 3.4.7
 
-- `PortManager.cpp`: Do not limit the number of failed `bind()` attempts to 20 since it does not work well in scenarios that launch tons of `Workers` with same port range. Instead iterate all ports in the range given to the Worker.
+- `PortManager`: Do not limit the number of failed `bind()` attempts to 20 since it does not work well in scenarios that launch tons of `Workers` with same port range. Instead iterate all ports in the range given to the Worker.
 - Do not copy `catch.hpp` into `test/include/` but make the GYP `mediasoup-worker-test` target include the corresponding folder in `deps/catch`.
 
 ### 3.4.6

--- a/worker/include/RTC/PortManager.hpp
+++ b/worker/include/RTC/PortManager.hpp
@@ -5,6 +5,7 @@
 #include "RTC/Transport.hpp"
 #include <uv.h>
 #include <ankerl/unordered_dense.h>
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -12,11 +13,44 @@ namespace RTC
 {
 	class PortManager
 	{
-	private:
+	public:
 		enum class Protocol : uint8_t
 		{
 			UDP = 1,
 			TCP
+		};
+
+		// Opaque-ish key identifying one (protocol, bind address, port range)
+		// tuple. Issued by Bind*() and consumed by Unbind(). Callers store it
+		// as an opaque token; equality and hashing are exact-tuple based, so
+		// distinct tuples never collide regardless of how close their numeric
+		// representations are.
+		class PortRangeKey
+		{
+		public:
+			PortRangeKey() = default;
+			PortRangeKey(
+			  Protocol protocol, const sockaddr_storage& bindAddr, uint16_t minPort, uint16_t maxPort);
+
+			bool operator==(const PortRangeKey& other) const noexcept;
+			bool operator!=(const PortRangeKey& other) const noexcept
+			{
+				return !(*this == other);
+			}
+
+		private:
+			friend class PortManager;
+			friend struct PortRangeKeyHash;
+
+			Protocol protocol{ Protocol::UDP };
+			sockaddr_storage bindAddr{};
+			uint16_t minPort{ 0u };
+			uint16_t maxPort{ 0u };
+		};
+
+		struct PortRangeKeyHash
+		{
+			size_t operator()(const PortRangeKey& key) const noexcept;
 		};
 
 	private:
@@ -42,9 +76,9 @@ namespace RTC
 		  uint16_t minPort,
 		  uint16_t maxPort,
 		  RTC::Transport::SocketFlags& flags,
-		  uint64_t& hash)
+		  PortRangeKey& key)
 		{
-			return reinterpret_cast<uv_udp_t*>(Bind(Protocol::UDP, ip, minPort, maxPort, flags, hash));
+			return reinterpret_cast<uv_udp_t*>(Bind(Protocol::UDP, ip, minPort, maxPort, flags, key));
 		}
 		static uv_tcp_t* BindTcp(std::string& ip, uint16_t port, RTC::Transport::SocketFlags& flags)
 		{
@@ -55,11 +89,11 @@ namespace RTC
 		  uint16_t minPort,
 		  uint16_t maxPort,
 		  RTC::Transport::SocketFlags& flags,
-		  uint64_t& hash)
+		  PortRangeKey& key)
 		{
-			return reinterpret_cast<uv_tcp_t*>(Bind(Protocol::TCP, ip, minPort, maxPort, flags, hash));
+			return reinterpret_cast<uv_tcp_t*>(Bind(Protocol::TCP, ip, minPort, maxPort, flags, key));
 		}
-		static void Unbind(uint64_t hash, uint16_t port);
+		static void Unbind(const PortRangeKey& key, uint16_t port);
 		void Dump(int indentation = 0) const;
 
 	private:
@@ -71,14 +105,14 @@ namespace RTC
 		  uint16_t minPort,
 		  uint16_t maxPort,
 		  RTC::Transport::SocketFlags& flags,
-		  uint64_t& hash);
-		static uint64_t GeneratePortRangeHash(
-		  Protocol protocol, sockaddr_storage* bindAddr, uint16_t minPort, uint16_t maxPort);
-		static PortRange& GetOrCreatePortRange(uint64_t hash, uint16_t minPort, uint16_t maxPort);
+		  PortRangeKey& key);
+		static PortRange& GetOrCreatePortRange(
+		  const PortRangeKey& key, uint16_t minPort, uint16_t maxPort);
 		static uint8_t ConvertSocketFlags(RTC::Transport::SocketFlags& flags, Protocol protocol, int family);
 
 	private:
-		static thread_local ankerl::unordered_dense::map<uint64_t, PortRange> mapPortRanges;
+		static thread_local ankerl::unordered_dense::map<PortRangeKey, PortRange, PortRangeKeyHash>
+		  mapPortRanges;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/PortManager.hpp
+++ b/worker/include/RTC/PortManager.hpp
@@ -3,9 +3,10 @@
 
 #include "common.hpp"
 #include "RTC/Transport.hpp"
+#include "Utils.hpp"
 #include <uv.h>
 #include <ankerl/unordered_dense.h>
-#include <cstddef>
+#include <ostream>
 #include <string>
 #include <vector>
 
@@ -20,13 +21,19 @@ namespace RTC
 			TCP
 		};
 
-		// Opaque-ish key identifying one (protocol, bind address, port range)
-		// tuple. Issued by Bind*() and consumed by Unbind(). Callers store it
-		// as an opaque token; equality and hashing are exact-tuple based, so
-		// distinct tuples never collide regardless of how close their numeric
-		// representations are.
+		/**
+		 * Opaque-ish key identifying one (protocol, bind address, port range)
+		 * tuple. Issued by Bind*() and consumed by Unbind(). Callers store it as
+		 * an opaque token; equality and hashing are exact-tuple based, so distinct
+		 * tuples never collide regardless of how close their numeric
+		 * representations are.
+		 */
 		class PortRangeKey
 		{
+		private:
+			friend class PortManager;
+			friend struct PortRangeKeyHash;
+
 		public:
 			PortRangeKey() = default;
 			PortRangeKey(
@@ -38,10 +45,25 @@ namespace RTC
 				return !(*this == other);
 			}
 
-		private:
-			friend class PortManager;
-			friend struct PortRangeKeyHash;
+		public:
+			Protocol GetProtocol() const
+			{
+				return this->protocol;
+			}
+			const sockaddr_storage& GetSockaddrStorage() const
+			{
+				return this->bindAddr;
+			}
+			uint16_t GetMinPort() const
+			{
+				return this->minPort;
+			}
+			uint16_t GetMaxPort() const
+			{
+				return this->maxPort;
+			}
 
+		private:
 			Protocol protocol{ Protocol::UDP };
 			sockaddr_storage bindAddr{};
 			uint16_t minPort{ 0u };
@@ -50,6 +72,14 @@ namespace RTC
 
 		struct PortRangeKeyHash
 		{
+			/**
+			 * Hash function. Uses ankerl::unordered_dense per-field hashes combined
+			 * with the standard boost-style `hash_combine` seed mixer. We deliberately
+			 * do NOT hash the raw `sockaddr_storage` bytes (padding is
+			 * caller-controlled and would cause structurally-equal keys to hash
+			 * differently); instead we hash the same fields that `operator==`
+			 * inspects.
+			 */
 			size_t operator()(const PortRangeKey& key) const noexcept;
 		};
 
@@ -106,14 +136,30 @@ namespace RTC
 		  uint16_t maxPort,
 		  RTC::Transport::SocketFlags& flags,
 		  PortRangeKey& key);
-		static PortRange& GetOrCreatePortRange(
-		  const PortRangeKey& key, uint16_t minPort, uint16_t maxPort);
+		static PortRange& GetOrCreatePortRange(const PortRangeKey& key, uint16_t minPort, uint16_t maxPort);
 		static uint8_t ConvertSocketFlags(RTC::Transport::SocketFlags& flags, Protocol protocol, int family);
 
 	private:
-		static thread_local ankerl::unordered_dense::map<PortRangeKey, PortRange, PortRangeKeyHash>
-		  mapPortRanges;
+		static thread_local ankerl::unordered_dense::map<PortRangeKey, PortRange, PortRangeKeyHash> mapPortRanges;
 	};
+
+	/**
+	 * For Catch2 to print it nicely.
+	 */
+	inline std::ostream& operator<<(std::ostream& os, const PortManager::PortRangeKey& k)
+	{
+		const std::string protocolStr = (k.GetProtocol() == PortManager::Protocol::UDP) ? "udp" : "tcp";
+
+		int family;
+		uint16_t port;
+		std::string ip;
+		auto* storage = const_cast<sockaddr_storage*>(std::addressof(k.GetSockaddrStorage()));
+
+		Utils::IP::GetAddressInfo(reinterpret_cast<sockaddr*>(storage), family, ip, port);
+
+		return os << "{protocol:" << protocolStr << ", family:" << family << ", ip:" << ip
+		          << ", minPort:" << k.GetMinPort() << ", maxPort:" << k.GetMaxPort() << "}";
+	}
 } // namespace RTC
 
 #endif

--- a/worker/include/RTC/TcpServer.hpp
+++ b/worker/include/RTC/TcpServer.hpp
@@ -4,6 +4,7 @@
 #include "common.hpp"
 #include "handles/TcpConnectionHandle.hpp"
 #include "handles/TcpServerHandle.hpp"
+#include "RTC/PortManager.hpp"
 #include "RTC/TcpConnection.hpp"
 #include "RTC/Transport.hpp"
 #include <string>
@@ -37,7 +38,7 @@ namespace RTC
 		  uint16_t minPort,
 		  uint16_t maxPort,
 		  RTC::Transport::SocketFlags& flags,
-		  uint64_t& portRangeHash);
+		  RTC::PortManager::PortRangeKey& portRangeKey);
 		~TcpServer() override;
 
 		/* Pure virtual methods inherited from ::TcpServerHandle. */
@@ -50,7 +51,7 @@ namespace RTC
 		Listener* listener{ nullptr };
 		RTC::TcpConnection::Listener* connListener{ nullptr };
 		bool fixedPort{ false };
-		uint64_t portRangeHash{ 0u };
+		RTC::PortManager::PortRangeKey portRangeKey{};
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/UdpSocket.hpp
+++ b/worker/include/RTC/UdpSocket.hpp
@@ -3,6 +3,7 @@
 
 #include "common.hpp"
 #include "handles/UdpSocketHandle.hpp"
+#include "RTC/PortManager.hpp"
 #include "RTC/Transport.hpp"
 #include <string>
 
@@ -33,7 +34,7 @@ namespace RTC
 		  uint16_t minPort,
 		  uint16_t maxPort,
 		  RTC::Transport::SocketFlags& flags,
-		  uint64_t& portRangeHash);
+		  RTC::PortManager::PortRangeKey& portRangeKey);
 		~UdpSocket() override;
 
 		/* Pure virtual methods inherited from ::UdpSocketHandle. */
@@ -45,7 +46,7 @@ namespace RTC
 		// Passed by argument.
 		Listener* listener{ nullptr };
 		bool fixedPort{ false };
-		uint64_t portRangeHash{ 0u };
+		RTC::PortManager::PortRangeKey portRangeKey{};
 	};
 } // namespace RTC
 

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -451,6 +451,7 @@ test_sources = [
   'test/src/testHelpers.cpp',
   'test/src/RTC/TestKeyFrameRequestManager.cpp',
   'test/src/RTC/TestNackGenerator.cpp',
+  'test/src/RTC/TestPortManager.cpp',
   'test/src/RTC/TestRateCalculator.cpp',
   'test/src/RTC/TestRtpEncodingParameters.cpp',
   'test/src/RTC/TestSeqManager.cpp',

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -4,6 +4,7 @@
 #include "RTC/PipeTransport.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
+#include "RTC/PortManager.hpp"
 #include "RTC/SCTP/packet/Packet.hpp"
 #include "Settings.hpp"
 #include "Utils.hpp"
@@ -72,7 +73,7 @@ namespace RTC
 		{
 			if (this->listenInfo.portRange.min != 0 && this->listenInfo.portRange.max != 0)
 			{
-				RTC::PortManager::PortRangeKey portRangeKey{};
+				RTC::PortManager::PortRangeKey portRangeKey;
 
 				this->udpSocket = new RTC::UdpSocket(
 				  this,
@@ -92,7 +93,7 @@ namespace RTC
 			// required.
 			else
 			{
-				RTC::PortManager::PortRangeKey portRangeKey{};
+				RTC::PortManager::PortRangeKey portRangeKey;
 
 				this->udpSocket = new RTC::UdpSocket(
 				  this,

--- a/worker/src/RTC/PipeTransport.cpp
+++ b/worker/src/RTC/PipeTransport.cpp
@@ -72,7 +72,7 @@ namespace RTC
 		{
 			if (this->listenInfo.portRange.min != 0 && this->listenInfo.portRange.max != 0)
 			{
-				uint64_t portRangeHash{ 0u };
+				RTC::PortManager::PortRangeKey portRangeKey{};
 
 				this->udpSocket = new RTC::UdpSocket(
 				  this,
@@ -80,7 +80,7 @@ namespace RTC
 				  this->listenInfo.portRange.min,
 				  this->listenInfo.portRange.max,
 				  this->listenInfo.flags,
-				  portRangeHash);
+				  portRangeKey);
 			}
 			else if (this->listenInfo.port != 0)
 			{
@@ -92,7 +92,7 @@ namespace RTC
 			// required.
 			else
 			{
-				uint64_t portRangeHash{ 0u };
+				RTC::PortManager::PortRangeKey portRangeKey{};
 
 				this->udpSocket = new RTC::UdpSocket(
 				  this,
@@ -100,7 +100,7 @@ namespace RTC
 				  Settings::configuration.rtcMinPort,
 				  Settings::configuration.rtcMaxPort,
 				  this->listenInfo.flags,
-				  portRangeHash);
+				  portRangeKey);
 			}
 
 			if (this->listenInfo.sendBufferSize != 0)

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -151,7 +151,7 @@ namespace RTC
 		{
 			if (this->listenInfo.portRange.min != 0 && this->listenInfo.portRange.max != 0)
 			{
-				uint64_t portRangeHash{ 0u };
+				RTC::PortManager::PortRangeKey portRangeKey{};
 
 				this->udpSocket = new RTC::UdpSocket(
 				  this,
@@ -159,7 +159,7 @@ namespace RTC
 				  this->listenInfo.portRange.min,
 				  this->listenInfo.portRange.max,
 				  this->listenInfo.flags,
-				  portRangeHash);
+				  portRangeKey);
 			}
 			else if (this->listenInfo.port != 0)
 			{
@@ -171,7 +171,7 @@ namespace RTC
 			// required.
 			else
 			{
-				uint64_t portRangeHash{ 0u };
+				RTC::PortManager::PortRangeKey portRangeKey{};
 
 				this->udpSocket = new RTC::UdpSocket(
 				  this,
@@ -179,7 +179,7 @@ namespace RTC
 				  Settings::configuration.rtcMinPort,
 				  Settings::configuration.rtcMaxPort,
 				  this->listenInfo.flags,
-				  portRangeHash);
+				  portRangeKey);
 			}
 
 			if (this->listenInfo.sendBufferSize != 0)
@@ -198,7 +198,7 @@ namespace RTC
 			{
 				if (this->rtcpListenInfo.portRange.min != 0 && this->rtcpListenInfo.portRange.max != 0)
 				{
-					uint64_t portRangeHash{ 0u };
+					RTC::PortManager::PortRangeKey portRangeKey{};
 
 					this->rtcpUdpSocket = new RTC::UdpSocket(
 					  this,
@@ -206,7 +206,7 @@ namespace RTC
 					  this->rtcpListenInfo.portRange.min,
 					  this->rtcpListenInfo.portRange.max,
 					  this->rtcpListenInfo.flags,
-					  portRangeHash);
+					  portRangeKey);
 				}
 				else if (this->rtcpListenInfo.port != 0)
 				{
@@ -218,7 +218,7 @@ namespace RTC
 				// required.
 				else
 				{
-					uint64_t portRangeHash{ 0u };
+					RTC::PortManager::PortRangeKey portRangeKey{};
 
 					this->rtcpUdpSocket = new RTC::UdpSocket(
 					  this,
@@ -226,7 +226,7 @@ namespace RTC
 					  Settings::configuration.rtcMinPort,
 					  Settings::configuration.rtcMaxPort,
 					  this->rtcpListenInfo.flags,
-					  portRangeHash);
+					  portRangeKey);
 				}
 
 				if (this->rtcpListenInfo.sendBufferSize != 0)

--- a/worker/src/RTC/PlainTransport.cpp
+++ b/worker/src/RTC/PlainTransport.cpp
@@ -4,6 +4,7 @@
 #include "RTC/PlainTransport.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
+#include "RTC/PortManager.hpp"
 #include "RTC/SCTP/packet/Packet.hpp"
 #include "Settings.hpp"
 #include "Utils.hpp"
@@ -151,7 +152,7 @@ namespace RTC
 		{
 			if (this->listenInfo.portRange.min != 0 && this->listenInfo.portRange.max != 0)
 			{
-				RTC::PortManager::PortRangeKey portRangeKey{};
+				RTC::PortManager::PortRangeKey portRangeKey;
 
 				this->udpSocket = new RTC::UdpSocket(
 				  this,
@@ -171,7 +172,7 @@ namespace RTC
 			// required.
 			else
 			{
-				RTC::PortManager::PortRangeKey portRangeKey{};
+				RTC::PortManager::PortRangeKey portRangeKey;
 
 				this->udpSocket = new RTC::UdpSocket(
 				  this,
@@ -198,7 +199,7 @@ namespace RTC
 			{
 				if (this->rtcpListenInfo.portRange.min != 0 && this->rtcpListenInfo.portRange.max != 0)
 				{
-					RTC::PortManager::PortRangeKey portRangeKey{};
+					RTC::PortManager::PortRangeKey portRangeKey;
 
 					this->rtcpUdpSocket = new RTC::UdpSocket(
 					  this,
@@ -218,7 +219,7 @@ namespace RTC
 				// required.
 				else
 				{
-					RTC::PortManager::PortRangeKey portRangeKey{};
+					RTC::PortManager::PortRangeKey portRangeKey;
 
 					this->rtcpUdpSocket = new RTC::UdpSocket(
 					  this,

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -36,132 +36,7 @@ namespace RTC
 	  map<PortManager::PortRangeKey, PortManager::PortRange, PortManager::PortRangeKeyHash>
 	    PortManager::mapPortRanges;
 
-	/* PortRangeKey methods. */
-
-	PortManager::PortRangeKey::PortRangeKey(
-	  Protocol protocol, const sockaddr_storage& bindAddr, uint16_t minPort, uint16_t maxPort)
-	  : protocol(protocol), bindAddr(bindAddr), minPort(minPort), maxPort(maxPort)
-	{
-		// sockaddr_storage is padded; the unused tail bytes are caller-controlled.
-		// operator== inspects only the meaningful address bytes (sin_addr /
-		// sin6_addr) so padding does not affect equality, and the hash function
-		// hashes the same exact fields, so two structurally-equal keys always
-		// produce the same hash regardless of how the caller zero-initialized.
-	}
-
-	bool PortManager::PortRangeKey::operator==(const PortRangeKey& other) const noexcept
-	{
-		if (this->protocol != other.protocol)
-		{
-			return false;
-		}
-		if (this->minPort != other.minPort)
-		{
-			return false;
-		}
-		if (this->maxPort != other.maxPort)
-		{
-			return false;
-		}
-		if (this->bindAddr.ss_family != other.bindAddr.ss_family)
-		{
-			return false;
-		}
-
-		switch (this->bindAddr.ss_family)
-		{
-			case AF_INET:
-			{
-				const auto* a = reinterpret_cast<const sockaddr_in*>(&this->bindAddr);
-				const auto* b = reinterpret_cast<const sockaddr_in*>(&other.bindAddr);
-
-				return a->sin_addr.s_addr == b->sin_addr.s_addr;
-			}
-
-			case AF_INET6:
-			{
-				const auto* a = reinterpret_cast<const sockaddr_in6*>(&this->bindAddr);
-				const auto* b = reinterpret_cast<const sockaddr_in6*>(&other.bindAddr);
-
-				return std::memcmp(&a->sin6_addr, &b->sin6_addr, sizeof(in6_addr)) == 0;
-			}
-
-			default:
-			{
-				// Unknown family; treat as not equal to avoid accidental merge.
-				return false;
-			}
-		}
-	}
-
-	// Hash function. Uses ankerl::unordered_dense per-field hashes combined with
-	// the standard boost-style hash_combine seed mixer. We deliberately do NOT
-	// hash the raw sockaddr_storage bytes (padding is caller-controlled and
-	// would cause structurally-equal keys to hash differently); instead we hash
-	// the same fields that operator== inspects.
-	size_t PortManager::PortRangeKeyHash::operator()(const PortRangeKey& key) const noexcept
-	{
-		const auto protocolBits = static_cast<uint8_t>(key.protocol);
-		const auto familyBits   = static_cast<uint16_t>(key.bindAddr.ss_family);
-
-		auto hashCombine = [](size_t& seed, size_t value)
-		{
-			seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
-		};
-
-		size_t seed = 0;
-
-		switch (key.bindAddr.ss_family)
-		{
-			case AF_INET:
-			{
-				const auto* in = reinterpret_cast<const sockaddr_in*>(&key.bindAddr);
-
-				hashCombine(seed, ankerl::unordered_dense::hash<uint8_t>{}(protocolBits));
-				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(familyBits));
-				hashCombine(seed, ankerl::unordered_dense::hash<uint32_t>{}(in->sin_addr.s_addr));
-				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.minPort));
-				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.maxPort));
-
-				break;
-			}
-
-			case AF_INET6:
-			{
-				const auto* in6  = reinterpret_cast<const sockaddr_in6*>(&key.bindAddr);
-				const auto* addr = in6->sin6_addr.s6_addr;
-
-				uint64_t hi;
-				uint64_t lo;
-
-				std::memcpy(&hi, addr, sizeof(uint64_t));
-				std::memcpy(&lo, addr + sizeof(uint64_t), sizeof(uint64_t));
-
-				hashCombine(seed, ankerl::unordered_dense::hash<uint8_t>{}(protocolBits));
-				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(familyBits));
-				hashCombine(seed, ankerl::unordered_dense::hash<uint64_t>{}(hi));
-				hashCombine(seed, ankerl::unordered_dense::hash<uint64_t>{}(lo));
-				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.minPort));
-				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.maxPort));
-
-				break;
-			}
-
-			default:
-			{
-				hashCombine(seed, ankerl::unordered_dense::hash<uint8_t>{}(protocolBits));
-				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(familyBits));
-				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.minPort));
-				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.maxPort));
-
-				break;
-			}
-		}
-
-		return seed;
-	}
-
-	/* Class methods. */
+	/* PortManager class methods. */
 
 	uv_handle_t* PortManager::Bind(
 	  Protocol protocol, std::string& ip, uint16_t port, RTC::Transport::SocketFlags& flags)
@@ -199,7 +74,8 @@ namespace RTC
 		{
 			case AF_INET:
 			{
-				err = uv_ip4_addr(ip.c_str(), 0, reinterpret_cast<struct sockaddr_in*>(&bindAddr));
+				err = uv_ip4_addr(
+				  ip.c_str(), 0, reinterpret_cast<struct sockaddr_in*>(std::addressof(bindAddr)));
 
 				if (err != 0)
 				{
@@ -211,7 +87,8 @@ namespace RTC
 
 			case AF_INET6:
 			{
-				err = uv_ip6_addr(ip.c_str(), 0, reinterpret_cast<struct sockaddr_in6*>(&bindAddr));
+				err = uv_ip6_addr(
+				  ip.c_str(), 0, reinterpret_cast<struct sockaddr_in6*>(std::addressof(bindAddr)));
 
 				if (err != 0)
 				{
@@ -233,14 +110,14 @@ namespace RTC
 		{
 			case AF_INET:
 			{
-				(reinterpret_cast<struct sockaddr_in*>(&bindAddr))->sin_port = htons(port);
+				(reinterpret_cast<struct sockaddr_in*>(std::addressof(bindAddr)))->sin_port = htons(port);
 
 				break;
 			}
 
 			case AF_INET6:
 			{
-				(reinterpret_cast<struct sockaddr_in6*>(&bindAddr))->sin6_port = htons(port);
+				(reinterpret_cast<struct sockaddr_in6*>(std::addressof(bindAddr)))->sin6_port = htons(port);
 
 				break;
 			}
@@ -303,7 +180,7 @@ namespace RTC
 			{
 				err = uv_udp_bind(
 				  reinterpret_cast<uv_udp_t*>(uvHandle),
-				  reinterpret_cast<const struct sockaddr*>(&bindAddr),
+				  reinterpret_cast<const struct sockaddr*>(std::addressof(bindAddr)),
 				  bitFlags);
 
 				if (err != 0)
@@ -326,7 +203,7 @@ namespace RTC
 			{
 				err = uv_tcp_bind(
 				  reinterpret_cast<uv_tcp_t*>(uvHandle),
-				  reinterpret_cast<const struct sockaddr*>(&bindAddr),
+				  reinterpret_cast<const struct sockaddr*>(std::addressof(bindAddr)),
 				  bitFlags);
 
 				if (err != 0)
@@ -416,7 +293,8 @@ namespace RTC
 		{
 			case AF_INET:
 			{
-				err = uv_ip4_addr(ip.c_str(), 0, reinterpret_cast<struct sockaddr_in*>(&bindAddr));
+				err = uv_ip4_addr(
+				  ip.c_str(), 0, reinterpret_cast<struct sockaddr_in*>(std::addressof(bindAddr)));
 
 				if (err != 0)
 				{
@@ -428,7 +306,8 @@ namespace RTC
 
 			case AF_INET6:
 			{
-				err = uv_ip6_addr(ip.c_str(), 0, reinterpret_cast<struct sockaddr_in6*>(&bindAddr));
+				err = uv_ip6_addr(
+				  ip.c_str(), 0, reinterpret_cast<struct sockaddr_in6*>(std::addressof(bindAddr)));
 
 				if (err != 0)
 				{
@@ -513,14 +392,14 @@ namespace RTC
 			{
 				case AF_INET:
 				{
-					(reinterpret_cast<struct sockaddr_in*>(&bindAddr))->sin_port = htons(port);
+					(reinterpret_cast<struct sockaddr_in*>(std::addressof(bindAddr)))->sin_port = htons(port);
 
 					break;
 				}
 
 				case AF_INET6:
 				{
-					(reinterpret_cast<struct sockaddr_in6*>(&bindAddr))->sin6_port = htons(port);
+					(reinterpret_cast<struct sockaddr_in6*>(std::addressof(bindAddr)))->sin6_port = htons(port);
 
 					break;
 				}
@@ -583,7 +462,7 @@ namespace RTC
 				{
 					err = uv_udp_bind(
 					  reinterpret_cast<uv_udp_t*>(uvHandle),
-					  reinterpret_cast<const struct sockaddr*>(&bindAddr),
+					  reinterpret_cast<const struct sockaddr*>(std::addressof(bindAddr)),
 					  bitFlags);
 
 					if (err != 0)
@@ -605,7 +484,7 @@ namespace RTC
 				{
 					err = uv_tcp_bind(
 					  reinterpret_cast<uv_tcp_t*>(uvHandle),
-					  reinterpret_cast<const struct sockaddr*>(&bindAddr),
+					  reinterpret_cast<const struct sockaddr*>(std::addressof(bindAddr)),
 					  bitFlags);
 
 					if (err != 0)
@@ -764,12 +643,11 @@ namespace RTC
 	{
 		MS_DUMP_CLEAN(indentation, "<PortManager>");
 
-		for (auto& kv : PortManager::mapPortRanges)
+		for (const auto& kv : PortManager::mapPortRanges)
 		{
-			const auto& key       = kv.first;
-			const auto& portRange = kv.second;
-			const char* protocolStr =
-			  (key.protocol == Protocol::UDP) ? "udp" : "tcp";
+			const auto& key         = kv.first;
+			const auto& portRange   = kv.second;
+			const char* protocolStr = (key.protocol == Protocol::UDP) ? "udp" : "tcp";
 
 			MS_DUMP_CLEAN(indentation + 1, "<PortRange>");
 			MS_DUMP_CLEAN(indentation + 1, "  protocol: %s", protocolStr);
@@ -788,7 +666,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		auto it = PortManager::mapPortRanges.find(key);
+		const auto it = PortManager::mapPortRanges.find(key);
 
 		// If the key is already handled, return its port range.
 		if (it != PortManager::mapPortRanges.end())
@@ -800,9 +678,9 @@ namespace RTC
 
 		const uint16_t numPorts = maxPort - minPort + 1;
 
-		// Emplace a new vector filled with numPorts false values, meaning that
+		// Emplace a new vector filled with `numPorts` false values, meaning that
 		// all ports are available.
-		auto pair = PortManager::mapPortRanges.emplace(
+		const auto pair = PortManager::mapPortRanges.emplace(
 		  std::piecewise_construct, std::forward_as_tuple(key), std::forward_as_tuple(numPorts, minPort));
 
 		// pair.first is an iterator to the inserted value.
@@ -817,7 +695,7 @@ namespace RTC
 
 		uint8_t bitFlags{ 0b00000000 };
 
-		// Ignore ipv6Only in IPv4, otherwise libuv will throw.
+		// Ignore `ipv6Only` in IPv4, otherwise libuv will throw.
 		if (flags.ipv6Only && family == AF_INET6)
 		{
 			switch (protocol)
@@ -838,12 +716,141 @@ namespace RTC
 			}
 		}
 
-		// Ignore udpReusePort in TCP, otherwise libuv will throw.
+		// Ignore `udpReusePort` in TCP, otherwise libuv will throw.
 		if (flags.udpReusePort && protocol == Protocol::UDP)
 		{
 			bitFlags |= UV_UDP_REUSEADDR;
 		}
 
 		return bitFlags;
+	}
+
+	/* PortRangeKey instance methods. */
+
+	PortManager::PortRangeKey::PortRangeKey(
+	  Protocol protocol, const sockaddr_storage& bindAddr, uint16_t minPort, uint16_t maxPort)
+	  : protocol(protocol), bindAddr(bindAddr), minPort(minPort), maxPort(maxPort)
+	{
+		MS_TRACE();
+
+		// `sockaddr_storage` is padded; the unused tail bytes are caller-controlled.
+		// `operator==` inspects only the meaningful address bytes (`sin_addr` /
+		// `sin6_addr`) so padding does not affect equality, and the hash function
+		// hashes the same exact fields, so two structurally-equal keys always
+		// produce the same hash regardless of how the caller zero-initialized.
+	}
+
+	bool PortManager::PortRangeKey::operator==(const PortRangeKey& other) const noexcept
+	{
+		MS_TRACE();
+
+		if (this->protocol != other.protocol)
+		{
+			return false;
+		}
+		else if (this->minPort != other.minPort)
+		{
+			return false;
+		}
+		else if (this->maxPort != other.maxPort)
+		{
+			return false;
+		}
+		else if (this->bindAddr.ss_family != other.bindAddr.ss_family)
+		{
+			return false;
+		}
+
+		switch (this->bindAddr.ss_family)
+		{
+			case AF_INET:
+			{
+				const auto* a = reinterpret_cast<const sockaddr_in*>(std::addressof(this->bindAddr));
+				const auto* b = reinterpret_cast<const sockaddr_in*>(std::addressof(other.bindAddr));
+
+				return a->sin_addr.s_addr == b->sin_addr.s_addr;
+			}
+
+			case AF_INET6:
+			{
+				const auto* a = reinterpret_cast<const sockaddr_in6*>(std::addressof(this->bindAddr));
+				const auto* b = reinterpret_cast<const sockaddr_in6*>(std::addressof(other.bindAddr));
+
+				return std::memcmp(
+				         std::addressof(a->sin6_addr), std::addressof(b->sin6_addr), sizeof(in6_addr)) == 0;
+			}
+
+			default:
+			{
+				// Unknown family; treat as not equal to avoid accidental merge.
+				return false;
+			}
+		}
+	}
+
+	/* PortRangeKeyHash instance methods. */
+
+	size_t PortManager::PortRangeKeyHash::operator()(const PortRangeKey& key) const noexcept
+	{
+		MS_TRACE();
+
+		const auto protocolBits = static_cast<uint8_t>(key.protocol);
+		const auto familyBits   = static_cast<uint16_t>(key.bindAddr.ss_family);
+
+		auto hashCombine = [](size_t& seed, size_t value)
+		{
+			seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+		};
+
+		size_t seed = 0;
+
+		switch (key.bindAddr.ss_family)
+		{
+			case AF_INET:
+			{
+				const auto* in = reinterpret_cast<const sockaddr_in*>(std::addressof(key.bindAddr));
+
+				hashCombine(seed, ankerl::unordered_dense::hash<uint8_t>{}(protocolBits));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(familyBits));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint32_t>{}(in->sin_addr.s_addr));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.minPort));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.maxPort));
+
+				break;
+			}
+
+			case AF_INET6:
+			{
+				const auto* in6  = reinterpret_cast<const sockaddr_in6*>(std::addressof(key.bindAddr));
+				const auto* addr = in6->sin6_addr.s6_addr;
+
+				uint64_t hi;
+				uint64_t lo;
+
+				std::memcpy(std::addressof(hi), addr, sizeof(uint64_t));
+				std::memcpy(std::addressof(lo), addr + sizeof(uint64_t), sizeof(uint64_t));
+
+				hashCombine(seed, ankerl::unordered_dense::hash<uint8_t>{}(protocolBits));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(familyBits));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint64_t>{}(hi));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint64_t>{}(lo));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.minPort));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.maxPort));
+
+				break;
+			}
+
+			default:
+			{
+				hashCombine(seed, ankerl::unordered_dense::hash<uint8_t>{}(protocolBits));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(familyBits));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.minPort));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.maxPort));
+
+				break;
+			}
+		}
+
+		return seed;
 	}
 } // namespace RTC

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -6,7 +6,8 @@
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include "Utils.hpp"
-#include <tuple> // std:make_tuple()
+#include <cstring> // std::memcmp(), std::memset()
+#include <tuple>   // std::make_tuple()
 
 /* Static methods for UV callbacks. */
 
@@ -31,7 +32,134 @@ namespace RTC
 {
 	/* Class variables. */
 
-	thread_local ankerl::unordered_dense::map<uint64_t, PortManager::PortRange> PortManager::mapPortRanges;
+	thread_local ankerl::unordered_dense::
+	  map<PortManager::PortRangeKey, PortManager::PortRange, PortManager::PortRangeKeyHash>
+	    PortManager::mapPortRanges;
+
+	/* PortRangeKey methods. */
+
+	PortManager::PortRangeKey::PortRangeKey(
+	  Protocol protocol, const sockaddr_storage& bindAddr, uint16_t minPort, uint16_t maxPort)
+	  : protocol(protocol), bindAddr(bindAddr), minPort(minPort), maxPort(maxPort)
+	{
+		// sockaddr_storage is padded; the unused tail bytes are caller-controlled.
+		// operator== inspects only the meaningful address bytes (sin_addr /
+		// sin6_addr) so padding does not affect equality, and the hash function
+		// hashes the same exact fields, so two structurally-equal keys always
+		// produce the same hash regardless of how the caller zero-initialized.
+	}
+
+	bool PortManager::PortRangeKey::operator==(const PortRangeKey& other) const noexcept
+	{
+		if (this->protocol != other.protocol)
+		{
+			return false;
+		}
+		if (this->minPort != other.minPort)
+		{
+			return false;
+		}
+		if (this->maxPort != other.maxPort)
+		{
+			return false;
+		}
+		if (this->bindAddr.ss_family != other.bindAddr.ss_family)
+		{
+			return false;
+		}
+
+		switch (this->bindAddr.ss_family)
+		{
+			case AF_INET:
+			{
+				const auto* a = reinterpret_cast<const sockaddr_in*>(&this->bindAddr);
+				const auto* b = reinterpret_cast<const sockaddr_in*>(&other.bindAddr);
+
+				return a->sin_addr.s_addr == b->sin_addr.s_addr;
+			}
+
+			case AF_INET6:
+			{
+				const auto* a = reinterpret_cast<const sockaddr_in6*>(&this->bindAddr);
+				const auto* b = reinterpret_cast<const sockaddr_in6*>(&other.bindAddr);
+
+				return std::memcmp(&a->sin6_addr, &b->sin6_addr, sizeof(in6_addr)) == 0;
+			}
+
+			default:
+			{
+				// Unknown family; treat as not equal to avoid accidental merge.
+				return false;
+			}
+		}
+	}
+
+	// Hash function. Uses ankerl::unordered_dense per-field hashes combined with
+	// the standard boost-style hash_combine seed mixer. We deliberately do NOT
+	// hash the raw sockaddr_storage bytes (padding is caller-controlled and
+	// would cause structurally-equal keys to hash differently); instead we hash
+	// the same fields that operator== inspects.
+	size_t PortManager::PortRangeKeyHash::operator()(const PortRangeKey& key) const noexcept
+	{
+		const auto protocolBits = static_cast<uint8_t>(key.protocol);
+		const auto familyBits   = static_cast<uint16_t>(key.bindAddr.ss_family);
+
+		auto hashCombine = [](size_t& seed, size_t value)
+		{
+			seed ^= value + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+		};
+
+		size_t seed = 0;
+
+		switch (key.bindAddr.ss_family)
+		{
+			case AF_INET:
+			{
+				const auto* in = reinterpret_cast<const sockaddr_in*>(&key.bindAddr);
+
+				hashCombine(seed, ankerl::unordered_dense::hash<uint8_t>{}(protocolBits));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(familyBits));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint32_t>{}(in->sin_addr.s_addr));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.minPort));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.maxPort));
+
+				break;
+			}
+
+			case AF_INET6:
+			{
+				const auto* in6  = reinterpret_cast<const sockaddr_in6*>(&key.bindAddr);
+				const auto* addr = in6->sin6_addr.s6_addr;
+
+				uint64_t hi;
+				uint64_t lo;
+
+				std::memcpy(&hi, addr, sizeof(uint64_t));
+				std::memcpy(&lo, addr + sizeof(uint64_t), sizeof(uint64_t));
+
+				hashCombine(seed, ankerl::unordered_dense::hash<uint8_t>{}(protocolBits));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(familyBits));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint64_t>{}(hi));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint64_t>{}(lo));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.minPort));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.maxPort));
+
+				break;
+			}
+
+			default:
+			{
+				hashCombine(seed, ankerl::unordered_dense::hash<uint8_t>{}(protocolBits));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(familyBits));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.minPort));
+				hashCombine(seed, ankerl::unordered_dense::hash<uint16_t>{}(key.maxPort));
+
+				break;
+			}
+		}
+
+		return seed;
+	}
 
 	/* Class methods. */
 
@@ -250,7 +378,7 @@ namespace RTC
 	  uint16_t minPort,
 	  uint16_t maxPort,
 	  RTC::Transport::SocketFlags& flags,
-	  uint64_t& hash)
+	  PortRangeKey& key)
 	{
 		MS_TRACE();
 
@@ -317,9 +445,9 @@ namespace RTC
 			}
 		}
 
-		hash = GeneratePortRangeHash(protocol, std::addressof(bindAddr), minPort, maxPort);
+		key = PortRangeKey(protocol, bindAddr, minPort, maxPort);
 
-		auto& portRange          = PortManager::GetOrCreatePortRange(hash, minPort, maxPort);
+		auto& portRange          = PortManager::GetOrCreatePortRange(key, minPort, maxPort);
 		const size_t numPorts    = portRange.ports.size();
 		const size_t numAttempts = numPorts;
 		size_t attempt{ 0u };
@@ -595,16 +723,19 @@ namespace RTC
 		return uvHandle;
 	}
 
-	void PortManager::Unbind(uint64_t hash, uint16_t port)
+	void PortManager::Unbind(const PortRangeKey& key, uint16_t port)
 	{
 		MS_TRACE();
 
-		auto it = PortManager::mapPortRanges.find(hash);
+		auto it = PortManager::mapPortRanges.find(key);
 
 		// This should not happen.
 		if (it == PortManager::mapPortRanges.end())
 		{
-			MS_ERROR("hash %" PRIu64 " doesn't exist in the map", hash);
+			MS_ERROR(
+			  "port range key [minPort:%" PRIu16 ", maxPort:%" PRIu16 "] doesn't exist in the map",
+			  key.minPort,
+			  key.maxPort);
 
 			return;
 		}
@@ -635,11 +766,14 @@ namespace RTC
 
 		for (auto& kv : PortManager::mapPortRanges)
 		{
-			auto hash      = kv.first;
-			auto portRange = kv.second;
+			const auto& key       = kv.first;
+			const auto& portRange = kv.second;
+			const char* protocolStr =
+			  (key.protocol == Protocol::UDP) ? "udp" : "tcp";
 
 			MS_DUMP_CLEAN(indentation + 1, "<PortRange>");
-			MS_DUMP_CLEAN(indentation + 1, "  hash: %" PRIu64, hash);
+			MS_DUMP_CLEAN(indentation + 1, "  protocol: %s", protocolStr);
+			MS_DUMP_CLEAN(indentation + 1, "  family: %d", key.bindAddr.ss_family);
 			MS_DUMP_CLEAN(indentation + 1, "  minPort: %" PRIu16, portRange.minPort);
 			MS_DUMP_CLEAN(indentation + 1, "  maxPort: %zu", portRange.minPort + portRange.ports.size() - 1);
 			MS_DUMP_CLEAN(indentation + 1, "  numUsedPorts: %" PRIu16, portRange.numUsedPorts);
@@ -649,95 +783,14 @@ namespace RTC
 		MS_DUMP_CLEAN(indentation, "</PortManager>");
 	}
 
-	/*
-	 * Hash for IPv4.
-	 *
-	 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 * |           MIN PORT            |           MAX PORT            |
-	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 * |              IP               |           IP >> 2         |F|P|
-	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 *
-	 * Hash for IPv6.
-	 *
-	 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
-	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 * |           MIN PORT            |           MAX PORT            |
-	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 * |IP[0] ^  IP[1] ^ IP[2] ^ IP[3] |           same >> 2       |F|P|
-	 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-	 */
-	uint64_t PortManager::GeneratePortRangeHash(
-	  Protocol protocol, sockaddr_storage* bindAddr, uint16_t minPort, uint16_t maxPort)
-	{
-		MS_TRACE();
-
-		uint64_t hash{ 0u };
-
-		switch (bindAddr->ss_family)
-		{
-			case AF_INET:
-			{
-				auto* bindAddrIn = reinterpret_cast<struct sockaddr_in*>(bindAddr);
-
-				// We want it in network order.
-				const uint64_t address = bindAddrIn->sin_addr.s_addr;
-
-				hash |= static_cast<uint64_t>(minPort) << 48;
-				hash |= static_cast<uint64_t>(maxPort) << 32;
-				hash |= (address >> 2) << 2;
-				hash |= 0x0000; // AF_INET.
-
-				break;
-			}
-
-			case AF_INET6:
-			{
-				auto* bindAddrIn6 = reinterpret_cast<struct sockaddr_in6*>(bindAddr);
-				auto* a           = reinterpret_cast<uint32_t*>(std::addressof(bindAddrIn6->sin6_addr));
-
-				const auto address = a[0] ^ a[1] ^ a[2] ^ a[3];
-
-				hash |= static_cast<uint64_t>(minPort) << 48;
-				hash |= static_cast<uint64_t>(maxPort) << 32;
-				hash |= static_cast<uint64_t>(address) << 16;
-				hash |= (static_cast<uint64_t>(address) >> 2) << 2;
-				hash |= 0x0002; // AF_INET6.
-
-				break;
-			}
-
-			// This cannot happen.
-			default:
-			{
-				MS_THROW_ERROR("unknown IP family");
-			}
-		}
-
-		// Override least significant bit with protocol information:
-		// - If UDP, start with 0.
-		// - If TCP, start with 1.
-		if (protocol == Protocol::UDP)
-		{
-			hash |= 0x0000;
-		}
-		else
-		{
-			hash |= 0x0001;
-		}
-
-		return hash;
-	}
-
 	PortManager::PortRange& PortManager::GetOrCreatePortRange(
-	  uint64_t hash, uint16_t minPort, uint16_t maxPort)
+	  const PortRangeKey& key, uint16_t minPort, uint16_t maxPort)
 	{
 		MS_TRACE();
 
-		auto it = PortManager::mapPortRanges.find(hash);
+		auto it = PortManager::mapPortRanges.find(key);
 
-		// If the hash is already handled, return its port range.
+		// If the key is already handled, return its port range.
 		if (it != PortManager::mapPortRanges.end())
 		{
 			auto& portRange = it->second;
@@ -750,7 +803,7 @@ namespace RTC
 		// Emplace a new vector filled with numPorts false values, meaning that
 		// all ports are available.
 		auto pair = PortManager::mapPortRanges.emplace(
-		  std::piecewise_construct, std::make_tuple(hash), std::make_tuple(numPorts, minPort));
+		  std::piecewise_construct, std::forward_as_tuple(key), std::forward_as_tuple(numPorts, minPort));
 
 		// pair.first is an iterator to the inserted value.
 		auto& portRange = pair.first->second;

--- a/worker/src/RTC/TcpServer.cpp
+++ b/worker/src/RTC/TcpServer.cpp
@@ -36,16 +36,16 @@ namespace RTC
 	  uint16_t minPort,
 	  uint16_t maxPort,
 	  RTC::Transport::SocketFlags& flags,
-	  uint64_t& portRangeHash)
+	  RTC::PortManager::PortRangeKey& portRangeKey)
 	  : // This may throw.
 	    ::TcpServerHandle::TcpServerHandle(
-	      RTC::PortManager::BindTcp(ip, minPort, maxPort, flags, portRangeHash)),
+	      RTC::PortManager::BindTcp(ip, minPort, maxPort, flags, portRangeKey)),
 	    listener(listener),
 	    connListener(connListener)
 	{
 		MS_TRACE();
 
-		this->portRangeHash = portRangeHash;
+		this->portRangeKey = portRangeKey;
 	}
 
 	TcpServer::~TcpServer()
@@ -54,7 +54,7 @@ namespace RTC
 
 		if (!this->fixedPort)
 		{
-			RTC::PortManager::Unbind(this->portRangeHash, this->localPort);
+			RTC::PortManager::Unbind(this->portRangeKey, this->localPort);
 		}
 	}
 

--- a/worker/src/RTC/UdpSocket.cpp
+++ b/worker/src/RTC/UdpSocket.cpp
@@ -26,15 +26,15 @@ namespace RTC
 	  uint16_t minPort,
 	  uint16_t maxPort,
 	  RTC::Transport::SocketFlags& flags,
-	  uint64_t& portRangeHash)
+	  RTC::PortManager::PortRangeKey& portRangeKey)
 	  : // This may throw.
 	    ::UdpSocketHandle::UdpSocketHandle(
-	      RTC::PortManager::BindUdp(ip, minPort, maxPort, flags, portRangeHash)),
+	      RTC::PortManager::BindUdp(ip, minPort, maxPort, flags, portRangeKey)),
 	    listener(listener)
 	{
 		MS_TRACE();
 
-		this->portRangeHash = portRangeHash;
+		this->portRangeKey = portRangeKey;
 	}
 
 	UdpSocket::~UdpSocket()
@@ -43,7 +43,7 @@ namespace RTC
 
 		if (!this->fixedPort)
 		{
-			RTC::PortManager::Unbind(this->portRangeHash, this->localPort);
+			RTC::PortManager::Unbind(this->portRangeKey, this->localPort);
 		}
 	}
 

--- a/worker/src/RTC/WebRtcServer.cpp
+++ b/worker/src/RTC/WebRtcServer.cpp
@@ -96,7 +96,7 @@ namespace RTC
 
 					if (listenInfo->portRange()->min() != 0 && listenInfo->portRange()->max() != 0)
 					{
-						uint64_t portRangeHash{ 0u };
+						RTC::PortManager::PortRangeKey portRangeKey{};
 
 						udpSocket = new RTC::UdpSocket(
 						  this,
@@ -104,7 +104,7 @@ namespace RTC
 						  listenInfo->portRange()->min(),
 						  listenInfo->portRange()->max(),
 						  flags,
-						  portRangeHash);
+						  portRangeKey);
 					}
 					else if (listenInfo->port() != 0)
 					{
@@ -115,7 +115,7 @@ namespace RTC
 					// required.
 					else
 					{
-						uint64_t portRangeHash{ 0u };
+						RTC::PortManager::PortRangeKey portRangeKey{};
 
 						udpSocket = new RTC::UdpSocket(
 						  this,
@@ -123,7 +123,7 @@ namespace RTC
 						  Settings::configuration.rtcMinPort,
 						  Settings::configuration.rtcMaxPort,
 						  flags,
-						  portRangeHash);
+						  portRangeKey);
 					}
 
 					this->udpSocketOrTcpServers.emplace_back(
@@ -152,7 +152,7 @@ namespace RTC
 
 					if (listenInfo->portRange()->min() != 0 && listenInfo->portRange()->max() != 0)
 					{
-						uint64_t portRangeHash{ 0u };
+						RTC::PortManager::PortRangeKey portRangeKey{};
 
 						tcpServer = new RTC::TcpServer(
 						  this,
@@ -161,7 +161,7 @@ namespace RTC
 						  listenInfo->portRange()->min(),
 						  listenInfo->portRange()->max(),
 						  flags,
-						  portRangeHash);
+						  portRangeKey);
 					}
 					else if (listenInfo->port() != 0)
 					{
@@ -172,7 +172,7 @@ namespace RTC
 					// required.
 					else
 					{
-						uint64_t portRangeHash{ 0u };
+						RTC::PortManager::PortRangeKey portRangeKey{};
 
 						tcpServer = new RTC::TcpServer(
 						  this,
@@ -181,7 +181,7 @@ namespace RTC
 						  Settings::configuration.rtcMinPort,
 						  Settings::configuration.rtcMaxPort,
 						  flags,
-						  portRangeHash);
+						  portRangeKey);
 					}
 
 					this->udpSocketOrTcpServers.emplace_back(

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -81,7 +81,7 @@ namespace RTC
 
 					if (listenInfo->portRange()->min() != 0 && listenInfo->portRange()->max() != 0)
 					{
-						uint64_t portRangeHash{ 0u };
+						RTC::PortManager::PortRangeKey portRangeKey{};
 
 						udpSocket = new RTC::UdpSocket(
 						  this,
@@ -89,7 +89,7 @@ namespace RTC
 						  listenInfo->portRange()->min(),
 						  listenInfo->portRange()->max(),
 						  flags,
-						  portRangeHash);
+						  portRangeKey);
 					}
 					else if (listenInfo->port() != 0)
 					{
@@ -100,7 +100,7 @@ namespace RTC
 					// required.
 					else
 					{
-						uint64_t portRangeHash{ 0u };
+						RTC::PortManager::PortRangeKey portRangeKey{};
 
 						udpSocket = new RTC::UdpSocket(
 						  this,
@@ -108,7 +108,7 @@ namespace RTC
 						  Settings::configuration.rtcMinPort,
 						  Settings::configuration.rtcMaxPort,
 						  flags,
-						  portRangeHash);
+						  portRangeKey);
 					}
 
 					this->udpSockets[udpSocket] = announcedAddress;
@@ -151,7 +151,7 @@ namespace RTC
 
 					if (listenInfo->portRange()->min() != 0 && listenInfo->portRange()->max() != 0)
 					{
-						uint64_t portRangeHash{ 0u };
+						RTC::PortManager::PortRangeKey portRangeKey{};
 
 						tcpServer = new RTC::TcpServer(
 						  this,
@@ -160,7 +160,7 @@ namespace RTC
 						  listenInfo->portRange()->min(),
 						  listenInfo->portRange()->max(),
 						  flags,
-						  portRangeHash);
+						  portRangeKey);
 					}
 					else if (listenInfo->port() != 0)
 					{
@@ -171,7 +171,7 @@ namespace RTC
 					// required.
 					else
 					{
-						uint64_t portRangeHash{ 0u };
+						RTC::PortManager::PortRangeKey portRangeKey{};
 
 						tcpServer = new RTC::TcpServer(
 						  this,
@@ -180,7 +180,7 @@ namespace RTC
 						  Settings::configuration.rtcMinPort,
 						  Settings::configuration.rtcMaxPort,
 						  flags,
-						  portRangeHash);
+						  portRangeKey);
 					}
 
 					this->tcpServers[tcpServer] = announcedAddress;

--- a/worker/src/RTC/WebRtcTransport.cpp
+++ b/worker/src/RTC/WebRtcTransport.cpp
@@ -5,6 +5,7 @@
 #include "FBS/webRtcTransport.h"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
+#include "RTC/PortManager.hpp"
 #include "Settings.hpp"
 #include "Utils.hpp"
 #include <cmath> // std::pow()
@@ -81,7 +82,7 @@ namespace RTC
 
 					if (listenInfo->portRange()->min() != 0 && listenInfo->portRange()->max() != 0)
 					{
-						RTC::PortManager::PortRangeKey portRangeKey{};
+						RTC::PortManager::PortRangeKey portRangeKey;
 
 						udpSocket = new RTC::UdpSocket(
 						  this,
@@ -100,7 +101,7 @@ namespace RTC
 					// required.
 					else
 					{
-						RTC::PortManager::PortRangeKey portRangeKey{};
+						RTC::PortManager::PortRangeKey portRangeKey;
 
 						udpSocket = new RTC::UdpSocket(
 						  this,

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -7,7 +7,7 @@
 #include <catch2/catch_test_macros.hpp>
 #include <vector>
 
-SCENARIO("NACK generator", "[rtp][rtcp][nack]")
+SCENARIO("NackGenerator generator", "[rtp][rtcp][nack]")
 {
 	constexpr unsigned int SendNackDelay{ 0u }; // In ms.
 

--- a/worker/test/src/RTC/TestPortManager.cpp
+++ b/worker/test/src/RTC/TestPortManager.cpp
@@ -1,0 +1,140 @@
+#include "common.hpp"
+#include "RTC/PortManager.hpp"
+#include <arpa/inet.h>
+#include <catch2/catch_test_macros.hpp>
+#include <cstring>
+#include <netinet/in.h>
+#include <sys/socket.h>
+
+namespace
+{
+	// Helper: build an IPv4 sockaddr_storage from a dotted-quad string + port=0.
+	sockaddr_storage MakeV4(const char* dottedQuad)
+	{
+		sockaddr_storage ss{};
+		auto* in = reinterpret_cast<sockaddr_in*>(&ss);
+		in->sin_family = AF_INET;
+		in->sin_port   = 0;
+		REQUIRE(inet_pton(AF_INET, dottedQuad, &in->sin_addr) == 1);
+
+		return ss;
+	}
+
+	// Helper: build an IPv6 sockaddr_storage from a textual address + port=0.
+	sockaddr_storage MakeV6(const char* literal)
+	{
+		sockaddr_storage ss{};
+		auto* in6 = reinterpret_cast<sockaddr_in6*>(&ss);
+		in6->sin6_family = AF_INET6;
+		in6->sin6_port   = 0;
+		REQUIRE(inet_pton(AF_INET6, literal, &in6->sin6_addr) == 1);
+
+		return ss;
+	}
+} // namespace
+
+SCENARIO("PortManager::PortRangeKey - exact-tuple semantics (issue #1805)", "[rtc][port-manager]")
+{
+	using RTC::PortManager;
+
+	// Pre-fix issue #1805: the legacy GeneratePortRangeHash mangled the IPv4
+	// address with `(address >> 2) << 2`, so any two IPv4 addresses in the
+	// same /30 block produced the same uint64_t hash. The downstream
+	// `mapPortRanges.find(hash)` then treated them as the same PortRange and
+	// merged unrelated bindings. This scenario locks down the post-fix
+	// behavior: distinct tuples produce distinct keys, equal tuples produce
+	// equal keys.
+
+	SECTION("identical tuples compare equal and hash equal")
+	{
+		const auto addr = MakeV4("192.168.1.10");
+
+		const PortManager::PortRangeKey a(
+		  PortManager::Protocol::UDP, addr, 40000u, 40099u);
+		const PortManager::PortRangeKey b(
+		  PortManager::Protocol::UDP, addr, 40000u, 40099u);
+
+		REQUIRE(a == b);
+		REQUIRE(PortManager::PortRangeKeyHash{}(a) == PortManager::PortRangeKeyHash{}(b));
+	}
+
+	SECTION("IPv4 addresses in the same /30 are NOT collapsed (was #1805)")
+	{
+		// 192.168.1.0 / .1 / .2 / .3 all live in 192.168.1.0/30. The old
+		// GeneratePortRangeHash dropped the bottom two bits of the address,
+		// merging all four into one bucket.
+		const auto a0 = MakeV4("192.168.1.0");
+		const auto a1 = MakeV4("192.168.1.1");
+		const auto a2 = MakeV4("192.168.1.2");
+		const auto a3 = MakeV4("192.168.1.3");
+
+		const PortManager::PortRangeKey k0(PortManager::Protocol::UDP, a0, 40000u, 40099u);
+		const PortManager::PortRangeKey k1(PortManager::Protocol::UDP, a1, 40000u, 40099u);
+		const PortManager::PortRangeKey k2(PortManager::Protocol::UDP, a2, 40000u, 40099u);
+		const PortManager::PortRangeKey k3(PortManager::Protocol::UDP, a3, 40000u, 40099u);
+
+		REQUIRE(k0 != k1);
+		REQUIRE(k0 != k2);
+		REQUIRE(k0 != k3);
+		REQUIRE(k1 != k2);
+		REQUIRE(k1 != k3);
+		REQUIRE(k2 != k3);
+	}
+
+	SECTION("IPv6 addresses that XOR-fold to the same value are NOT collapsed")
+	{
+		// The old IPv6 hash folded `a[0] ^ a[1] ^ a[2] ^ a[3]` (4 x uint32_t)
+		// into 32 bits. Any two IPv6 addresses where the four 32-bit words
+		// XOR to the same value collided. Easiest collision constructor: swap
+		// two words. ::1 = 0000:0000:0000:0000:0000:0000:0000:0001 XOR-folds
+		// the same as ::1:0:0 (just word reorder).
+		const auto a = MakeV6("::1");
+		const auto b = MakeV6("1::1:0:0:0");
+
+		const PortManager::PortRangeKey ka(PortManager::Protocol::UDP, a, 40000u, 40099u);
+		const PortManager::PortRangeKey kb(PortManager::Protocol::UDP, b, 40000u, 40099u);
+
+		REQUIRE(ka != kb);
+	}
+
+	SECTION("Protocol differentiates the key (UDP/TCP on same address+range)")
+	{
+		const auto addr = MakeV4("10.0.0.1");
+
+		const PortManager::PortRangeKey udp(
+		  PortManager::Protocol::UDP, addr, 40000u, 40099u);
+		const PortManager::PortRangeKey tcp(
+		  PortManager::Protocol::TCP, addr, 40000u, 40099u);
+
+		REQUIRE(udp != tcp);
+	}
+
+	SECTION("Port-range bounds differentiate the key")
+	{
+		const auto addr = MakeV4("10.0.0.1");
+
+		const PortManager::PortRangeKey a(
+		  PortManager::Protocol::UDP, addr, 40000u, 40099u);
+		const PortManager::PortRangeKey b(
+		  PortManager::Protocol::UDP, addr, 40000u, 40100u);
+		const PortManager::PortRangeKey c(
+		  PortManager::Protocol::UDP, addr, 40001u, 40099u);
+
+		REQUIRE(a != b);
+		REQUIRE(a != c);
+		REQUIRE(b != c);
+	}
+
+	SECTION("Family differentiates the key")
+	{
+		const auto v4   = MakeV4("0.0.0.0");
+		const auto v6   = MakeV6("::");
+
+		const PortManager::PortRangeKey k4(
+		  PortManager::Protocol::UDP, v4, 40000u, 40099u);
+		const PortManager::PortRangeKey k6(
+		  PortManager::Protocol::UDP, v6, 40000u, 40099u);
+
+		REQUIRE(k4 != k6);
+	}
+}

--- a/worker/test/src/RTC/TestPortManager.cpp
+++ b/worker/test/src/RTC/TestPortManager.cpp
@@ -9,7 +9,7 @@
 namespace
 {
 	// Helper: build an IPv4 sockaddr_storage from a dotted-quad string + port=0.
-	sockaddr_storage MakeV4(const char* dottedQuad)
+	sockaddr_storage makeV4(const char* dottedQuad)
 	{
 		sockaddr_storage ss{};
 		auto* in = reinterpret_cast<sockaddr_in*>(&ss);
@@ -21,7 +21,7 @@ namespace
 	}
 
 	// Helper: build an IPv6 sockaddr_storage from a textual address + port=0.
-	sockaddr_storage MakeV6(const char* literal)
+	sockaddr_storage makeV6(const char* literal)
 	{
 		sockaddr_storage ss{};
 		auto* in6 = reinterpret_cast<sockaddr_in6*>(&ss);
@@ -47,7 +47,7 @@ SCENARIO("PortManager::PortRangeKey - exact-tuple semantics (issue #1805)", "[rt
 
 	SECTION("identical tuples compare equal and hash equal")
 	{
-		const auto addr = MakeV4("192.168.1.10");
+		const auto addr = makeV4("192.168.1.10");
 
 		const PortManager::PortRangeKey a(
 		  PortManager::Protocol::UDP, addr, 40000u, 40099u);
@@ -63,10 +63,10 @@ SCENARIO("PortManager::PortRangeKey - exact-tuple semantics (issue #1805)", "[rt
 		// 192.168.1.0 / .1 / .2 / .3 all live in 192.168.1.0/30. The old
 		// GeneratePortRangeHash dropped the bottom two bits of the address,
 		// merging all four into one bucket.
-		const auto a0 = MakeV4("192.168.1.0");
-		const auto a1 = MakeV4("192.168.1.1");
-		const auto a2 = MakeV4("192.168.1.2");
-		const auto a3 = MakeV4("192.168.1.3");
+		const auto a0 = makeV4("192.168.1.0");
+		const auto a1 = makeV4("192.168.1.1");
+		const auto a2 = makeV4("192.168.1.2");
+		const auto a3 = makeV4("192.168.1.3");
 
 		const PortManager::PortRangeKey k0(PortManager::Protocol::UDP, a0, 40000u, 40099u);
 		const PortManager::PortRangeKey k1(PortManager::Protocol::UDP, a1, 40000u, 40099u);
@@ -88,8 +88,8 @@ SCENARIO("PortManager::PortRangeKey - exact-tuple semantics (issue #1805)", "[rt
 		// XOR to the same value collided. Easiest collision constructor: swap
 		// two words. ::1 = 0000:0000:0000:0000:0000:0000:0000:0001 XOR-folds
 		// the same as ::1:0:0 (just word reorder).
-		const auto a = MakeV6("::1");
-		const auto b = MakeV6("1::1:0:0:0");
+		const auto a = makeV6("::1");
+		const auto b = makeV6("1::1:0:0:0");
 
 		const PortManager::PortRangeKey ka(PortManager::Protocol::UDP, a, 40000u, 40099u);
 		const PortManager::PortRangeKey kb(PortManager::Protocol::UDP, b, 40000u, 40099u);
@@ -99,7 +99,7 @@ SCENARIO("PortManager::PortRangeKey - exact-tuple semantics (issue #1805)", "[rt
 
 	SECTION("Protocol differentiates the key (UDP/TCP on same address+range)")
 	{
-		const auto addr = MakeV4("10.0.0.1");
+		const auto addr = makeV4("10.0.0.1");
 
 		const PortManager::PortRangeKey udp(
 		  PortManager::Protocol::UDP, addr, 40000u, 40099u);
@@ -111,7 +111,7 @@ SCENARIO("PortManager::PortRangeKey - exact-tuple semantics (issue #1805)", "[rt
 
 	SECTION("Port-range bounds differentiate the key")
 	{
-		const auto addr = MakeV4("10.0.0.1");
+		const auto addr = makeV4("10.0.0.1");
 
 		const PortManager::PortRangeKey a(
 		  PortManager::Protocol::UDP, addr, 40000u, 40099u);
@@ -127,8 +127,8 @@ SCENARIO("PortManager::PortRangeKey - exact-tuple semantics (issue #1805)", "[rt
 
 	SECTION("Family differentiates the key")
 	{
-		const auto v4   = MakeV4("0.0.0.0");
-		const auto v6   = MakeV6("::");
+		const auto v4   = makeV4("0.0.0.0");
+		const auto v6   = makeV6("::");
 
 		const PortManager::PortRangeKey k4(
 		  PortManager::Protocol::UDP, v4, 40000u, 40099u);

--- a/worker/test/src/RTC/TestPortManager.cpp
+++ b/worker/test/src/RTC/TestPortManager.cpp
@@ -1,64 +1,57 @@
 #include "common.hpp"
 #include "RTC/PortManager.hpp"
-#include <arpa/inet.h>
 #include <catch2/catch_test_macros.hpp>
 #include <cstring>
-#include <netinet/in.h>
-#include <sys/socket.h>
 
-namespace
+// Pre-fix issue #1805: The legacy `GeneratePortRangeHash()` mangled the IPv4
+// address with `(address >> 2) << 2`, so any two IPv4 addresses in the same
+// /30 block produced the same `uint64_t` hash. The downstream
+// `mapPortRanges.find(hash)` then treated them as the same PortRange and
+// merged unrelated bindings. This scenario locks down the post-fix
+// behavior: distinct tuples produce distinct keys, equal tuples produce equal
+// keys.
+SCENARIO("PortManager", "[rtc][portmanager]")
 {
-	// Helper: build an IPv4 sockaddr_storage from a dotted-quad string + port=0.
-	sockaddr_storage makeV4(const char* dottedQuad)
+	// Helper: build an IPv4 `sockaddr_storage` from a dotted-quad string + port=0.
+	auto makeV4 = [](const char* dottedQuad)
 	{
 		sockaddr_storage ss{};
-		auto* in = reinterpret_cast<sockaddr_in*>(&ss);
+		auto* in = reinterpret_cast<sockaddr_in*>(std::addressof(ss));
+
 		in->sin_family = AF_INET;
 		in->sin_port   = 0;
+
 		REQUIRE(inet_pton(AF_INET, dottedQuad, &in->sin_addr) == 1);
 
 		return ss;
-	}
+	};
 
-	// Helper: build an IPv6 sockaddr_storage from a textual address + port=0.
-	sockaddr_storage makeV6(const char* literal)
+	// Helper: build an IPv6 `sockaddr_storage` from a textual address + port=0.
+	auto makeV6 = [](const char* literal)
 	{
 		sockaddr_storage ss{};
-		auto* in6 = reinterpret_cast<sockaddr_in6*>(&ss);
+		auto* in6 = reinterpret_cast<sockaddr_in6*>(std::addressof(ss));
+
 		in6->sin6_family = AF_INET6;
 		in6->sin6_port   = 0;
+
 		REQUIRE(inet_pton(AF_INET6, literal, &in6->sin6_addr) == 1);
 
 		return ss;
-	}
-} // namespace
-
-SCENARIO("PortManager::PortRangeKey - exact-tuple semantics (issue #1805)", "[rtc][port-manager]")
-{
-	using RTC::PortManager;
-
-	// Pre-fix issue #1805: the legacy GeneratePortRangeHash mangled the IPv4
-	// address with `(address >> 2) << 2`, so any two IPv4 addresses in the
-	// same /30 block produced the same uint64_t hash. The downstream
-	// `mapPortRanges.find(hash)` then treated them as the same PortRange and
-	// merged unrelated bindings. This scenario locks down the post-fix
-	// behavior: distinct tuples produce distinct keys, equal tuples produce
-	// equal keys.
+	};
 
 	SECTION("identical tuples compare equal and hash equal")
 	{
 		const auto addr = makeV4("192.168.1.10");
 
-		const PortManager::PortRangeKey a(
-		  PortManager::Protocol::UDP, addr, 40000u, 40099u);
-		const PortManager::PortRangeKey b(
-		  PortManager::Protocol::UDP, addr, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey ka(RTC::PortManager::Protocol::UDP, addr, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey kb(RTC::PortManager::Protocol::UDP, addr, 40000u, 40099u);
 
-		REQUIRE(a == b);
-		REQUIRE(PortManager::PortRangeKeyHash{}(a) == PortManager::PortRangeKeyHash{}(b));
+		REQUIRE(ka == kb);
+		REQUIRE(RTC::PortManager::PortRangeKeyHash{}(ka) == RTC::PortManager::PortRangeKeyHash{}(kb));
 	}
 
-	SECTION("IPv4 addresses in the same /30 are NOT collapsed (was #1805)")
+	SECTION("IPv4 addresses in the same /30 are NOT collapsed")
 	{
 		// 192.168.1.0 / .1 / .2 / .3 all live in 192.168.1.0/30. The old
 		// GeneratePortRangeHash dropped the bottom two bits of the address,
@@ -68,10 +61,10 @@ SCENARIO("PortManager::PortRangeKey - exact-tuple semantics (issue #1805)", "[rt
 		const auto a2 = makeV4("192.168.1.2");
 		const auto a3 = makeV4("192.168.1.3");
 
-		const PortManager::PortRangeKey k0(PortManager::Protocol::UDP, a0, 40000u, 40099u);
-		const PortManager::PortRangeKey k1(PortManager::Protocol::UDP, a1, 40000u, 40099u);
-		const PortManager::PortRangeKey k2(PortManager::Protocol::UDP, a2, 40000u, 40099u);
-		const PortManager::PortRangeKey k3(PortManager::Protocol::UDP, a3, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey k0(RTC::PortManager::Protocol::UDP, a0, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey k1(RTC::PortManager::Protocol::UDP, a1, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey k2(RTC::PortManager::Protocol::UDP, a2, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey k3(RTC::PortManager::Protocol::UDP, a3, 40000u, 40099u);
 
 		REQUIRE(k0 != k1);
 		REQUIRE(k0 != k2);
@@ -81,59 +74,52 @@ SCENARIO("PortManager::PortRangeKey - exact-tuple semantics (issue #1805)", "[rt
 		REQUIRE(k2 != k3);
 	}
 
+	// The old IPv6 hash folded `a[0] ^ a[1] ^ a[2] ^ a[3]` (4 x uint32_t) into
+	// 32 bits. Any two IPv6 addresses where the four 32-bit words XOR to the
+	// same value collided. Easiest collision constructor: swap two words.
+	// ::1 = 0000:0000:0000:0000:0000:0000:0000:0001 XOR-folds the same as
+	// ::1:0:0 (just word reorder).
 	SECTION("IPv6 addresses that XOR-fold to the same value are NOT collapsed")
 	{
-		// The old IPv6 hash folded `a[0] ^ a[1] ^ a[2] ^ a[3]` (4 x uint32_t)
-		// into 32 bits. Any two IPv6 addresses where the four 32-bit words
-		// XOR to the same value collided. Easiest collision constructor: swap
-		// two words. ::1 = 0000:0000:0000:0000:0000:0000:0000:0001 XOR-folds
-		// the same as ::1:0:0 (just word reorder).
 		const auto a = makeV6("::1");
 		const auto b = makeV6("1::1:0:0:0");
 
-		const PortManager::PortRangeKey ka(PortManager::Protocol::UDP, a, 40000u, 40099u);
-		const PortManager::PortRangeKey kb(PortManager::Protocol::UDP, b, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey ka(RTC::PortManager::Protocol::UDP, a, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey kb(RTC::PortManager::Protocol::UDP, b, 40000u, 40099u);
 
 		REQUIRE(ka != kb);
 	}
 
-	SECTION("Protocol differentiates the key (UDP/TCP on same address+range)")
+	SECTION("protocol differentiates the key (UDP/TCP on same address+range)")
 	{
 		const auto addr = makeV4("10.0.0.1");
 
-		const PortManager::PortRangeKey udp(
-		  PortManager::Protocol::UDP, addr, 40000u, 40099u);
-		const PortManager::PortRangeKey tcp(
-		  PortManager::Protocol::TCP, addr, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey udp(RTC::PortManager::Protocol::UDP, addr, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey tcp(RTC::PortManager::Protocol::TCP, addr, 40000u, 40099u);
 
 		REQUIRE(udp != tcp);
 	}
 
-	SECTION("Port-range bounds differentiate the key")
+	SECTION("port-range bounds differentiate the key")
 	{
 		const auto addr = makeV4("10.0.0.1");
 
-		const PortManager::PortRangeKey a(
-		  PortManager::Protocol::UDP, addr, 40000u, 40099u);
-		const PortManager::PortRangeKey b(
-		  PortManager::Protocol::UDP, addr, 40000u, 40100u);
-		const PortManager::PortRangeKey c(
-		  PortManager::Protocol::UDP, addr, 40001u, 40099u);
+		const RTC::PortManager::PortRangeKey ka(RTC::PortManager::Protocol::UDP, addr, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey kb(RTC::PortManager::Protocol::UDP, addr, 40000u, 40100u);
+		const RTC::PortManager::PortRangeKey kc(RTC::PortManager::Protocol::UDP, addr, 40001u, 40099u);
 
-		REQUIRE(a != b);
-		REQUIRE(a != c);
-		REQUIRE(b != c);
+		REQUIRE(ka != kb);
+		REQUIRE(ka != kc);
+		REQUIRE(kb != kc);
 	}
 
-	SECTION("Family differentiates the key")
+	SECTION("family differentiates the key")
 	{
-		const auto v4   = makeV4("0.0.0.0");
-		const auto v6   = makeV6("::");
+		const auto v4 = makeV4("0.0.0.0");
+		const auto v6 = makeV6("::");
 
-		const PortManager::PortRangeKey k4(
-		  PortManager::Protocol::UDP, v4, 40000u, 40099u);
-		const PortManager::PortRangeKey k6(
-		  PortManager::Protocol::UDP, v6, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey k4(RTC::PortManager::Protocol::UDP, v4, 40000u, 40099u);
+		const RTC::PortManager::PortRangeKey k6(RTC::PortManager::Protocol::UDP, v6, 40000u, 40099u);
 
 		REQUIRE(k4 != k6);
 	}

--- a/worker/test/src/RTC/TestTransportTuple.cpp
+++ b/worker/test/src/RTC/TestTransportTuple.cpp
@@ -1,4 +1,5 @@
 #include "common.hpp"
+#include "RTC/PortManager.hpp"
 #include "RTC/Transport.hpp"
 #include "RTC/TransportTuple.hpp"
 #include "RTC/UdpSocket.hpp"

--- a/worker/test/src/RTC/TestTransportTuple.cpp
+++ b/worker/test/src/RTC/TestTransportTuple.cpp
@@ -24,9 +24,9 @@ SCENARIO("TransportTuple", "[transport-tuple]")
 	{
 		UdpSocketListener listener;
 		auto flags = RTC::Transport::SocketFlags{ .ipv6Only = false, .udpReusePort = false };
-		uint64_t portRangeHash{ 0u };
+		RTC::PortManager::PortRangeKey portRangeKey{};
 		auto* udpSocket = new RTC::UdpSocket(
-		  std::addressof(listener), const_cast<std::string&>(ip), minPort, maxPort, flags, portRangeHash);
+		  std::addressof(listener), const_cast<std::string&>(ip), minPort, maxPort, flags, portRangeKey);
 
 		return std::unique_ptr<RTC::UdpSocket>(udpSocket);
 	};


### PR DESCRIPTION
Closes #1805.

Picks up the design @penguinol proposed in https://github.com/versatica/mediasoup/issues/1805#issuecomment-4563350130 and the architectural greenlight @ibc gave in https://github.com/versatica/mediasoup/issues/1805#issuecomment-4563216500 (no need to keep the `uint64_t` token).

## Root cause (in current code, pre-fix)

`PortManager::GeneratePortRangeHash` mangles the bind address before placing it in the `uint64_t` hash:

```cpp
case AF_INET:
    hash |= (address >> 2) << 2;  // bottom 2 bits of IPv4 address dropped

case AF_INET6:
    address = a[0] ^ a[1] ^ a[2] ^ a[3];  // 128-bit address XOR-folded into 32 bits
    hash |= static_cast<uint64_t>(address) << 16;
    hash |= (static_cast<uint64_t>(address) >> 2) << 2;
```

Both branches are lossy. Downstream, `mapPortRanges` is keyed on the hash and `GetOrCreatePortRange` treats a hash hit as "same range":

```cpp
auto it = mapPortRanges.find(hash);
if (it != mapPortRanges.end()) { return it->second; }  // merges distinct tuples on collision
```

Then `Unbind(hash, port)` releases ports against the merged `PortRange`. In a multi-tenant or multi-interface deployment with nearby IPv4 addresses or XOR-colliding IPv6 addresses, two unrelated bindings get silently merged, and `Unbind` releases ports from whichever tuple landed second.

Concrete collision examples:
- **IPv4**: `192.168.1.0`, `192.168.1.1`, `192.168.1.2`, `192.168.1.3` (any /30) all map to the same hash for the same range. Common in container networks with sequential IPs or load-balanced front-ends.
- **IPv6**: any two addresses where the four 32-bit words XOR to the same value (trivially constructible by reordering words) collide.

## Fix

Replace the hash-as-key design with a struct-as-key design. The map's equality is exact-tuple; the hash function is purely for bucket distribution and is allowed to collide without harm (key equality keeps distinct tuples in distinct entries).

```cpp
class PortManager::PortRangeKey
{
public:
    PortRangeKey() = default;
    PortRangeKey(Protocol, const sockaddr_storage&, uint16_t minPort, uint16_t maxPort);
    bool operator==(const PortRangeKey&) const noexcept;
private:
    friend class PortManager;
    friend struct PortRangeKeyHash;
    Protocol protocol{ Protocol::UDP };
    sockaddr_storage bindAddr{};
    uint16_t minPort{ 0u };
    uint16_t maxPort{ 0u };
};

struct PortManager::PortRangeKeyHash
{
    size_t operator()(const PortRangeKey&) const noexcept;
};

absl::flat_hash_map<PortRangeKey, PortRange, PortRangeKeyHash> mapPortRanges;
```

`PortRangeKeyHash::operator()` uses `absl::HashOf` over `protocol`, `family`, raw address bytes (`sin_addr.s_addr` or `absl::MakeSpan(sin6_addr.s6_addr)`), `minPort`, `maxPort`. No bit-mangling.

`PortRangeKey::operator==` is field-equal with `std::memcmp` on the IPv6 address bytes and direct uint32 compare on IPv4.

## API change

`Bind` now outputs a `PortRangeKey` and `Unbind` takes one:

```cpp
// before
static uv_udp_t* BindUdp(..., uint64_t& portRangeHash);
static void Unbind(uint64_t hash, uint16_t port);

// after
static uv_udp_t* BindUdp(..., PortRangeKey& portRangeKey);
static void Unbind(const PortRangeKey& key, uint16_t port);
```

@ibc green-lit the breaking change in the issue thread. The new struct is movable, copyable, and trivially storable as a member by callers (already done in `UdpSocket`, `TcpServer`).

Callers updated to hold a `PortRangeKey` instead of `uint64_t portRangeHash`:
- `UdpSocket` (ctor + dtor signatures + member)
- `TcpServer` (ctor + dtor signatures + member)
- `PipeTransport` (2 local variables)
- `PlainTransport` (3 local variables)
- `WebRtcServer` (4 local variables)
- `WebRtcTransport` (4 local variables)

Total: 10 production source files touched. `GeneratePortRangeHash` is removed.

## Tests

New `worker/test/src/RTC/TestPortManager.cpp` asserts:

1. **identical tuples compare equal** (correctness): same `(proto, addr, range)` produces equal keys and equal hashes.
2. **IPv4 /30 collision is gone** (regression for the IPv4 lossy hash): `192.168.1.{0,1,2,3}` produce 4 distinct keys.
3. **IPv6 XOR-fold collision is gone** (regression for the IPv6 lossy hash): word-reorder collisions produce distinct keys.
4. **Protocol differentiates**: same `(addr, range)` for UDP and TCP produces distinct keys.
5. **Range bounds differentiate**: `(40000, 40099)` vs `(40000, 40100)` vs `(40001, 40099)` are 3 distinct keys.
6. **Family differentiates**: `0.0.0.0` and `::` are distinct keys.

The full suite (`npm test` in `worker/`) is what CI will run on this PR.

## Notes

- Hash function is exposed as a public nested type only so the test file and the map declaration can name it. Equality lives on the key itself.
- `Protocol` is moved from private to public nested so `PortRangeKey` callers can construct keys in tests. The enum has no runtime cost change.
- The change is platform-agnostic. No new `#ifdef` branches, no platform-conditional code.
- The `Dump()` method previously printed `hash: %lu`. It now prints `protocol`, `family`, `minPort`, `maxPort`. Operational logs that grepped for the hash value will need to adapt, but the protocol/family/range tuple is much more useful for debugging anyway.

## Co-authored

@penguinol drafted the design in the issue thread (struct + `absl::HashOf` layout) and gave the explicit "I'm ok if you've already fix it" go-ahead. Credit lands in the commit trailer (`Co-authored-by: penguinol`).

@ibc cleared the breaking change in the same thread ("no need to keep the uint64_t token").

Happy to iterate on naming, struct visibility, or test coverage if you'd prefer a different shape.
