### PR TITLE
Worker replace `absl-cpp` subproject with `ankerl/unordered dense`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /worker/out
 /worker/subprojects/*
 !/worker/subprojects/*.wrap
+!/worker/subprojects/packagefiles
 !/worker/subprojects/.clang-tidy
 
 ## Node.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### NEXT
 
-- Node: Make all public methods/getters that return an object/array, return a clone of that object/array ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Node: Make all public methods/getters that return an object/array, return a clone of that object/array ([PR #1811](https://github.com/versatica/mediasoup/pull/1811)).
+- Worker: replace `absl-cpp` subproject with `ankerl/unordered_dense` ([PR #1813](https://github.com/versatica/mediasoup/pull/1813)).
 
 ### 3.20.0
 

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"worker/scripts/*.py",
 		"worker/scripts/*.sh",
 		"worker/subprojects/*.wrap",
+		"worker/subprojects/packagefiles",
 		"worker/test/include",
 		"worker/test/src",
 		"worker/meson.build",

--- a/worker/deps/libwebrtc/meson.build
+++ b/worker/deps/libwebrtc/meson.build
@@ -49,8 +49,10 @@ abseil_cpp_proj = subproject(
   'abseil-cpp',
   default_options: [
     'warning_level=0',
+    'cpp_std=c++17',
   ],
 )
+
 local_include_directories = declare_dependency(
   include_directories: include_directories('libwebrtc')
 )
@@ -60,11 +62,12 @@ libwebrtc = library(
   libwebrtc_sources,
   dependencies: [
     local_include_directories,
+    libuv_proj.get_variable('libuv_dep'),
     openssl_proj.get_variable('openssl_dep'),
     abseil_cpp_proj.get_variable('absl_strings_dep'),
     abseil_cpp_proj.get_variable('absl_types_dep'),
+    ankerl_unordered_dense_dep,
     flatbuffers_proj.get_variable('flatbuffers_dep'),
-    libuv_proj.get_variable('libuv_dep'),
   ],
   include_directories: libwebrtc_include_directories,
   cpp_args: cpp_args,
@@ -75,6 +78,7 @@ libwebrtc_dep = declare_dependency(
     local_include_directories,
     abseil_cpp_proj.get_variable('absl_strings_dep'),
     abseil_cpp_proj.get_variable('absl_types_dep'),
+    ankerl_unordered_dense_dep,
   ],
   include_directories: include_directories('.'),
   link_with: libwebrtc,

--- a/worker/include/Channel/ChannelMessageRegistrator.hpp
+++ b/worker/include/Channel/ChannelMessageRegistrator.hpp
@@ -3,8 +3,8 @@
 
 #include "Channel/ChannelMessageRegistratorInterface.hpp"
 #include "Channel/ChannelSocket.hpp"
+#include <ankerl/unordered_dense.h>
 #include <string>
-#include <unordered_map>
 
 namespace Channel
 {
@@ -31,8 +31,9 @@ namespace Channel
 		ChannelSocket::NotificationHandler* GetChannelNotificationHandler(const std::string& id) override;
 
 	private:
-		std::unordered_map<std::string, ChannelSocket::RequestHandler*> mapChannelRequestHandlers;
-		std::unordered_map<std::string, ChannelSocket::NotificationHandler*> mapChannelNotificationHandlers;
+		ankerl::unordered_dense::map<std::string, ChannelSocket::RequestHandler*> mapChannelRequestHandlers;
+		ankerl::unordered_dense::map<std::string, ChannelSocket::NotificationHandler*>
+		  mapChannelNotificationHandlers;
 	};
 } // namespace Channel
 

--- a/worker/include/Channel/ChannelNotification.hpp
+++ b/worker/include/Channel/ChannelNotification.hpp
@@ -2,7 +2,6 @@
 #define MS_CHANNEL_NOTIFICATION_HPP
 
 #include "FBS/notification.h"
-#include <absl/container/flat_hash_map.h>
 #include <string>
 
 namespace Channel
@@ -11,9 +10,6 @@ namespace Channel
 	{
 	public:
 		using Event = FBS::Notification::Event;
-
-	private:
-		static const absl::flat_hash_map<FBS::Notification::Event, const char*> Event2String;
 
 	public:
 		explicit ChannelNotification(const FBS::Notification::Notification* notification);

--- a/worker/include/Channel/ChannelRequest.hpp
+++ b/worker/include/Channel/ChannelRequest.hpp
@@ -5,8 +5,6 @@
 #include "FBS/message.h"
 #include "FBS/request.h"
 #include "FBS/response.h"
-#include <flatbuffers/minireflect.h>
-#include <absl/container/flat_hash_map.h>
 #include <string>
 
 namespace Channel
@@ -22,7 +20,6 @@ namespace Channel
 
 	public:
 		static thread_local flatbuffers::FlatBufferBuilder bufferBuilder;
-		static const absl::flat_hash_map<FBS::Request::Method, const char*> Method2String;
 
 	public:
 		ChannelRequest(Channel::ChannelSocket* channel, const FBS::Request::Request* request);
@@ -49,7 +46,9 @@ namespace Channel
 			  FBS::Message::CreateMessage(builder, FBS::Message::Body::Response, response.Union());
 
 			builder.FinishSizePrefixed(message);
-			this->Send(builder.GetBufferPointer(), builder.GetSize());
+
+			Send(builder.GetBufferPointer(), builder.GetSize());
+
 			builder.Clear();
 		}
 

--- a/worker/include/DepLibSRTP.hpp
+++ b/worker/include/DepLibSRTP.hpp
@@ -2,8 +2,8 @@
 #define MS_DEP_LIBSRTP_HPP
 
 #include <srtp.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
-#include <unordered_map>
 
 class DepLibSRTP
 {
@@ -20,7 +20,7 @@ public:
 	static const std::string& GetErrorString(srtp_err_status_t code);
 
 private:
-	static const std::unordered_map<srtp_err_status_t, std::string> ErrorCode2String;
+	static const ankerl::unordered_dense::map<srtp_err_status_t, std::string> ErrorCode2String;
 };
 
 #endif

--- a/worker/include/RTC/ActiveSpeakerObserver.hpp
+++ b/worker/include/RTC/ActiveSpeakerObserver.hpp
@@ -4,7 +4,7 @@
 #include "handles/TimerHandleInterface.hpp"
 #include "RTC/RtpObserver.hpp"
 #include "SharedInterface.hpp"
-#include <absl/container/flat_hash_map.h>
+#include <ankerl/unordered_dense.h>
 #include <vector>
 
 // Implementation of Dominant Speaker Identification for Multipoint
@@ -101,7 +101,7 @@ namespace RTC
 		TimerHandleInterface* periodicTimer{ nullptr };
 		uint16_t interval{ 300u };
 		// Map of ProducerSpeakers indexed by Producer id.
-		absl::flat_hash_map<std::string, ProducerSpeaker*> mapProducerSpeakers;
+		ankerl::unordered_dense::map<std::string, ProducerSpeaker*> mapProducerSpeakers;
 		uint64_t lastLevelIdleTime{ 0u };
 	};
 } // namespace RTC

--- a/worker/include/RTC/AudioLevelObserver.hpp
+++ b/worker/include/RTC/AudioLevelObserver.hpp
@@ -4,7 +4,7 @@
 #include "handles/TimerHandleInterface.hpp"
 #include "RTC/RtpObserver.hpp"
 #include "SharedInterface.hpp"
-#include <absl/container/flat_hash_map.h>
+#include <ankerl/unordered_dense.h>
 
 namespace RTC
 {
@@ -50,7 +50,7 @@ namespace RTC
 		// Allocated by this.
 		TimerHandleInterface* periodicTimer{ nullptr };
 		// Others.
-		absl::flat_hash_map<RTC::Producer*, DBovs> mapProducerDBovs;
+		ankerl::unordered_dense::map<RTC::Producer*, DBovs> mapProducerDBovs;
 		bool silence{ true };
 	};
 } // namespace RTC

--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -17,7 +17,7 @@
 #include "RTC/RTP/SharedPacket.hpp"
 #include "RTC/RtpDictionaries.hpp"
 #include "SharedInterface.hpp"
-#include <absl/container/flat_hash_set.h>
+#include <bitset>
 #include <string>
 #include <vector>
 

--- a/worker/include/RTC/DataConsumer.hpp
+++ b/worker/include/RTC/DataConsumer.hpp
@@ -7,7 +7,7 @@
 #include "RTC/SCTP/public/Message.hpp"
 #include "RTC/SctpDictionaries.hpp"
 #include "SharedInterface.hpp"
-#include <absl/container/flat_hash_set.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
 
 namespace RTC
@@ -121,7 +121,7 @@ namespace RTC
 		RTC::SctpStreamParameters sctpStreamParameters;
 		std::string label;
 		std::string protocol;
-		absl::flat_hash_set<uint16_t> subchannels;
+		ankerl::unordered_dense::set<uint16_t> subchannels;
 		bool transportConnected{ false };
 		bool sctpAssociationConnected{ false };
 		bool paused{ false };

--- a/worker/include/RTC/DtlsTransport.hpp
+++ b/worker/include/RTC/DtlsTransport.hpp
@@ -9,7 +9,7 @@
 #include <openssl/bio.h>
 #include <openssl/ssl.h>
 #include <openssl/x509.h>
-#include <absl/container/flat_hash_map.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
 #include <vector>
 
@@ -129,9 +129,9 @@ namespace RTC
 		static thread_local EVP_PKEY* privateKey;
 		static thread_local SSL_CTX* sslCtx;
 		static thread_local uint8_t sslReadBuffer[];
-		static const absl::flat_hash_map<std::string, Role> String2Role;
-		static const absl::flat_hash_map<std::string, FingerprintAlgorithm> String2FingerprintAlgorithm;
-		static const absl::flat_hash_map<FingerprintAlgorithm, std::string> FingerprintAlgorithm2String;
+		static const ankerl::unordered_dense::map<std::string, Role> String2Role;
+		static const ankerl::unordered_dense::map<std::string, FingerprintAlgorithm> String2FingerprintAlgorithm;
+		static const ankerl::unordered_dense::map<FingerprintAlgorithm, std::string> FingerprintAlgorithm2String;
 		static thread_local std::vector<Fingerprint> localFingerprints;
 		static const std::vector<SrtpCryptoSuiteMapEntry> SrtpCryptoSuites;
 

--- a/worker/include/RTC/ICE/IceServer.hpp
+++ b/worker/include/RTC/ICE/IceServer.hpp
@@ -7,9 +7,9 @@
 #include "RTC/ICE/StunPacket.hpp"
 #include "RTC/TransportTuple.hpp"
 #include "SharedInterface.hpp"
+#include <ankerl/unordered_dense.h>
 #include <list>
 #include <string>
-#include <unordered_map>
 
 namespace RTC
 {
@@ -61,7 +61,7 @@ namespace RTC
 			static FBS::WebRtcTransport::IceState IceStateToFbs(IceState state);
 
 		private:
-			static std::unordered_map<IceState, std::string> iceStateToString;
+			static ankerl::unordered_dense::map<IceState, std::string> iceStateToString;
 
 		public:
 			IceServer(

--- a/worker/include/RTC/ICE/StunPacket.hpp
+++ b/worker/include/RTC/ICE/StunPacket.hpp
@@ -4,8 +4,8 @@
 #include "common.hpp"
 #include "RTC/Serializable.hpp"
 #include "Utils.hpp"
+#include <ankerl/unordered_dense.h>
 #include <string_view>
-#include <unordered_map>
 
 namespace RTC
 {
@@ -533,7 +533,7 @@ namespace RTC
 			StunPacket::Class klass{ StunPacket::Class::UNSET };
 			StunPacket::Method method{ StunPacket::Method::UNSET };
 			// Map of STUN attributes indexed by attribute type.
-			std::unordered_map<StunPacket::AttributeType, StunPacket::Attribute> attributes;
+			ankerl::unordered_dense::map<StunPacket::AttributeType, StunPacket::Attribute> attributes;
 		};
 	} // namespace ICE
 } // namespace RTC

--- a/worker/include/RTC/KeyFrameRequestManager.hpp
+++ b/worker/include/RTC/KeyFrameRequestManager.hpp
@@ -3,7 +3,7 @@
 
 #include "handles/TimerHandleInterface.hpp"
 #include "SharedInterface.hpp"
-#include <absl/container/flat_hash_map.h>
+#include <ankerl/unordered_dense.h>
 
 namespace RTC
 {
@@ -125,8 +125,8 @@ namespace RTC
 		Listener* listener{ nullptr };
 		SharedInterface* shared{ nullptr };
 		uint32_t keyFrameRequestDelay{ 0u }; // 0 means disabled.
-		absl::flat_hash_map<uint32_t, PendingKeyFrameInfo*> mapSsrcPendingKeyFrameInfo;
-		absl::flat_hash_map<uint32_t, KeyFrameRequestDelayer*> mapSsrcKeyFrameRequestDelayer;
+		ankerl::unordered_dense::map<uint32_t, PendingKeyFrameInfo*> mapSsrcPendingKeyFrameInfo;
+		ankerl::unordered_dense::map<uint32_t, KeyFrameRequestDelayer*> mapSsrcKeyFrameRequestDelayer;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/Parameters.hpp
+++ b/worker/include/RTC/Parameters.hpp
@@ -3,7 +3,7 @@
 
 #include "common.hpp"
 #include "FBS/rtpParameters.h"
-#include <absl/container/flat_hash_map.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
 #include <vector>
 
@@ -78,7 +78,7 @@ namespace RTC
 		const std::vector<int32_t>& GetArrayOfIntegers(const std::string& key) const;
 
 	private:
-		absl::flat_hash_map<std::string, Value> mapKeyValues;
+		ankerl::unordered_dense::map<std::string, Value> mapKeyValues;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/PipeConsumer.hpp
+++ b/worker/include/RTC/PipeConsumer.hpp
@@ -3,6 +3,7 @@
 
 #include "RTC/Consumer.hpp"
 #include "RTC/SeqManager.hpp"
+#include <ankerl/unordered_dense.h>
 #include <map>
 
 namespace RTC
@@ -77,14 +78,14 @@ namespace RTC
 		// Allocated by this.
 		std::vector<RTC::RTP::RtpStreamSend*> rtpStreams;
 		// Others.
-		absl::flat_hash_map<uint32_t, uint32_t> mapMappedSsrcSsrc;
-		absl::flat_hash_map<uint32_t, RTC::RTP::RtpStreamSend*> mapSsrcRtpStream;
+		ankerl::unordered_dense::map<uint32_t, uint32_t> mapMappedSsrcSsrc;
+		ankerl::unordered_dense::map<uint32_t, RTC::RTP::RtpStreamSend*> mapSsrcRtpStream;
 		bool keyFrameSupported{ false };
-		absl::flat_hash_map<RTC::RTP::RtpStreamSend*, bool> mapRtpStreamSyncRequired;
-		absl::flat_hash_map<RTC::RTP::RtpStreamSend*, RTC::SeqManager<uint16_t>> mapRtpStreamRtpSeqManager;
+		ankerl::unordered_dense::map<RTC::RTP::RtpStreamSend*, bool> mapRtpStreamSyncRequired;
+		ankerl::unordered_dense::map<RTC::RTP::RtpStreamSend*, RTC::SeqManager<uint16_t>> mapRtpStreamRtpSeqManager;
 		// Buffers to store packets that arrive earlier than the first packet of the
 		// video key frame.
-		absl::flat_hash_map<
+		ankerl::unordered_dense::map<
 		  RTC::RTP::RtpStreamSend*,
 		  std::map<uint16_t, RTC::RTP::SharedPacket, RTC::SeqManager<uint16_t>::SeqLowerThan>>
 		  mapRtpStreamTargetLayerRetransmissionBuffer;

--- a/worker/include/RTC/PlainTransport.hpp
+++ b/worker/include/RTC/PlainTransport.hpp
@@ -7,7 +7,6 @@
 #include "RTC/TransportTuple.hpp"
 #include "RTC/UdpSocket.hpp"
 #include "SharedInterface.hpp"
-#include <absl/container/flat_hash_map.h>
 
 namespace RTC
 {

--- a/worker/include/RTC/PortManager.hpp
+++ b/worker/include/RTC/PortManager.hpp
@@ -4,7 +4,7 @@
 #include "common.hpp"
 #include "RTC/Transport.hpp"
 #include <uv.h>
-#include <absl/container/flat_hash_map.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
 #include <vector>
 
@@ -78,7 +78,7 @@ namespace RTC
 		static uint8_t ConvertSocketFlags(RTC::Transport::SocketFlags& flags, Protocol protocol, int family);
 
 	private:
-		static thread_local absl::flat_hash_map<uint64_t, PortRange> mapPortRanges;
+		static thread_local ankerl::unordered_dense::map<uint64_t, PortRange> mapPortRanges;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -14,6 +14,7 @@
 #include "RTC/RTP/RtpStreamRecv.hpp"
 #include "RTC/RtpDictionaries.hpp"
 #include "SharedInterface.hpp"
+#include <ankerl/unordered_dense.h>
 #include <string>
 #include <vector>
 
@@ -61,7 +62,7 @@ namespace RTC
 	private:
 		struct RtpMapping
 		{
-			absl::flat_hash_map<uint8_t, uint8_t> codecs;
+			ankerl::unordered_dense::map<uint8_t, uint8_t> codecs;
 			std::vector<RtpEncodingMapping> encodings;
 		};
 
@@ -125,7 +126,7 @@ namespace RTC
 		{
 			return this->paused;
 		}
-		const absl::flat_hash_map<RTC::RTP::RtpStreamRecv*, uint32_t>& GetRtpStreams()
+		const ankerl::unordered_dense::map<RTC::RTP::RtpStreamRecv*, uint32_t>& GetRtpStreams()
 		{
 			return this->mapRtpStreamMappedSsrc;
 		}
@@ -182,7 +183,7 @@ namespace RTC
 		SharedInterface* shared{ nullptr };
 		RTC::Producer::Listener* listener{ nullptr };
 		// Allocated by this.
-		absl::flat_hash_map<uint32_t, RTC::RTP::RtpStreamRecv*> mapSsrcRtpStream;
+		ankerl::unordered_dense::map<uint32_t, RTC::RTP::RtpStreamRecv*> mapSsrcRtpStream;
 		RTC::KeyFrameRequestManager* keyFrameRequestManager{ nullptr };
 		// Others.
 		RTC::Media::Kind kind;
@@ -191,9 +192,9 @@ namespace RTC
 		struct RtpMapping rtpMapping;
 		std::vector<RTC::RTP::RtpStreamRecv*> rtpStreamByEncodingIdx;
 		std::vector<uint8_t> rtpStreamScores;
-		absl::flat_hash_map<uint32_t, RTC::RTP::RtpStreamRecv*> mapRtxSsrcRtpStream;
-		absl::flat_hash_map<RTC::RTP::RtpStreamRecv*, uint32_t> mapRtpStreamMappedSsrc;
-		absl::flat_hash_map<uint32_t, uint32_t> mapMappedSsrcSsrc;
+		ankerl::unordered_dense::map<uint32_t, RTC::RTP::RtpStreamRecv*> mapRtxSsrcRtpStream;
+		ankerl::unordered_dense::map<RTC::RTP::RtpStreamRecv*, uint32_t> mapRtpStreamMappedSsrc;
+		ankerl::unordered_dense::map<uint32_t, uint32_t> mapMappedSsrcSsrc;
 		struct RTC::RTP::HeaderExtensionIds rtpHeaderExtensionIds;
 		bool paused{ false };
 		bool enableMediasoupPacketIdHeaderExtension{ false };

--- a/worker/include/RTC/RTCP/Feedback.hpp
+++ b/worker/include/RTC/RTCP/Feedback.hpp
@@ -3,7 +3,6 @@
 
 #include "common.hpp"
 #include "RTC/RTCP/Packet.hpp"
-#include <absl/container/flat_hash_map.h>
 
 namespace RTC
 {
@@ -32,7 +31,7 @@ namespace RTC
 			static const std::string& MessageTypeToString(typename T::MessageType type);
 
 		private:
-			static const absl::flat_hash_map<typename T::MessageType, std::string> MessageType2String;
+			static const ankerl::unordered_dense::map<typename T::MessageType, std::string> MessageType2String;
 
 		public:
 			typename T::MessageType GetMessageType() const

--- a/worker/include/RTC/RTCP/FeedbackRtpTransport.hpp
+++ b/worker/include/RTC/RTCP/FeedbackRtpTransport.hpp
@@ -201,7 +201,7 @@ namespace RTC
 			static FeedbackRtpTransportPacket* Parse(const uint8_t* data, size_t len);
 
 		private:
-			static const absl::flat_hash_map<Status, std::string> Status2String;
+			static const ankerl::unordered_dense::map<Status, std::string> Status2String;
 
 		public:
 			FeedbackRtpTransportPacket(uint32_t senderSsrc, uint32_t mediaSsrc)

--- a/worker/include/RTC/RTCP/Packet.hpp
+++ b/worker/include/RTC/RTCP/Packet.hpp
@@ -2,7 +2,7 @@
 #define MS_RTC_RTCP_PACKET_HPP
 
 #include "common.hpp"
-#include <absl/container/flat_hash_map.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
 
 namespace RTC
@@ -77,7 +77,7 @@ namespace RTC
 			static const std::string& TypeToString(Type type);
 
 		private:
-			static const absl::flat_hash_map<Type, std::string> Type2String;
+			static const ankerl::unordered_dense::map<Type, std::string> Type2String;
 
 		public:
 			explicit Packet(Type type) : type(type)

--- a/worker/include/RTC/RTCP/Sdes.hpp
+++ b/worker/include/RTC/RTCP/Sdes.hpp
@@ -84,7 +84,7 @@ namespace RTC
 			std::unique_ptr<uint8_t[]> raw;
 
 		private:
-			static const absl::flat_hash_map<SdesItem::Type, std::string> Type2String;
+			static const ankerl::unordered_dense::map<SdesItem::Type, std::string> Type2String;
 		};
 
 		class SdesChunk

--- a/worker/include/RTC/RTP/Codecs/DependencyDescriptor.hpp
+++ b/worker/include/RTC/RTP/Codecs/DependencyDescriptor.hpp
@@ -3,6 +3,7 @@
 
 #include "common.hpp"
 #include "Utils.hpp" // BitStream.
+#include <ankerl/unordered_dense.h>
 
 namespace RTC
 {
@@ -31,7 +32,7 @@ namespace RTC
 				};
 
 			private:
-				static std::unordered_map<DecodeTargetIndication, std::string> dtiToString;
+				static ankerl::unordered_dense::map<DecodeTargetIndication, std::string> dtiToString;
 
 			private:
 				struct FrameDependencyTemplate

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -14,8 +14,7 @@
 #include "RTC/Transport.hpp"
 #include "RTC/WebRtcServer.hpp"
 #include "SharedInterface.hpp"
-#include <absl/container/flat_hash_map.h>
-#include <absl/container/flat_hash_set.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
 #include <vector>
 
@@ -122,17 +121,19 @@ namespace RTC
 		SharedInterface* shared{ nullptr };
 		Listener* listener{ nullptr };
 		// Allocated by this.
-		absl::flat_hash_map<std::string, RTC::Transport*> mapTransports;
-		absl::flat_hash_map<std::string, RTC::RtpObserver*> mapRtpObservers;
+		ankerl::unordered_dense::map<std::string, RTC::Transport*> mapTransports;
+		ankerl::unordered_dense::map<std::string, RTC::RtpObserver*> mapRtpObservers;
 		// Others.
-		absl::flat_hash_map<RTC::Producer*, absl::flat_hash_set<RTC::Consumer*>> mapProducerConsumers;
-		absl::flat_hash_map<RTC::Consumer*, RTC::Producer*> mapConsumerProducer;
-		absl::flat_hash_map<RTC::Producer*, absl::flat_hash_set<RTC::RtpObserver*>> mapProducerRtpObservers;
-		absl::flat_hash_map<std::string, RTC::Producer*> mapProducers;
-		absl::flat_hash_map<RTC::DataProducer*, absl::flat_hash_set<RTC::DataConsumer*>>
+		ankerl::unordered_dense::map<RTC::Producer*, ankerl::unordered_dense::set<RTC::Consumer*>>
+		  mapProducerConsumers;
+		ankerl::unordered_dense::map<RTC::Consumer*, RTC::Producer*> mapConsumerProducer;
+		ankerl::unordered_dense::map<RTC::Producer*, ankerl::unordered_dense::set<RTC::RtpObserver*>>
+		  mapProducerRtpObservers;
+		ankerl::unordered_dense::map<std::string, RTC::Producer*> mapProducers;
+		ankerl::unordered_dense::map<RTC::DataProducer*, ankerl::unordered_dense::set<RTC::DataConsumer*>>
 		  mapDataProducerDataConsumers;
-		absl::flat_hash_map<RTC::DataConsumer*, RTC::DataProducer*> mapDataConsumerDataProducer;
-		absl::flat_hash_map<std::string, RTC::DataProducer*> mapDataProducers;
+		ankerl::unordered_dense::map<RTC::DataConsumer*, RTC::DataProducer*> mapDataConsumerDataProducer;
+		ankerl::unordered_dense::map<std::string, RTC::DataProducer*> mapDataProducers;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/RtcLogger.hpp
+++ b/worker/include/RTC/RtcLogger.hpp
@@ -2,7 +2,7 @@
 #define MS_RTC_RTC_LOGGER_HPP
 
 #include "common.hpp"
-#include <absl/container/flat_hash_map.h>
+#include <ankerl/unordered_dense.h>
 
 namespace RTC
 {
@@ -30,7 +30,7 @@ namespace RTC
 				SEND_RTP_STREAM_DISCARDED
 			};
 
-			static const absl::flat_hash_map<DiscardReason, std::string> DiscardReason2String;
+			static const ankerl::unordered_dense::map<DiscardReason, std::string> DiscardReason2String;
 
 			RtpPacket()  = default;
 			~RtpPacket() = default;

--- a/worker/include/RTC/RtpDictionaries.hpp
+++ b/worker/include/RTC/RtpDictionaries.hpp
@@ -4,7 +4,7 @@
 #include "common.hpp"
 #include "FBS/rtpParameters.h"
 #include "RTC/Parameters.hpp"
-#include <absl/container/flat_hash_map.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
 #include <vector>
 
@@ -60,10 +60,10 @@ namespace RTC
 		};
 
 	public:
-		static const absl::flat_hash_map<std::string, Type> String2Type;
-		static const absl::flat_hash_map<Type, std::string> Type2String;
-		static const absl::flat_hash_map<std::string, Subtype> String2Subtype;
-		static const absl::flat_hash_map<Subtype, std::string> Subtype2String;
+		static const ankerl::unordered_dense::map<std::string, Type> String2Type;
+		static const ankerl::unordered_dense::map<Type, std::string> Type2String;
+		static const ankerl::unordered_dense::map<std::string, Subtype> String2Subtype;
+		static const ankerl::unordered_dense::map<Subtype, std::string> Subtype2String;
 
 	public:
 		RtpCodecMimeType() = default;
@@ -254,7 +254,7 @@ namespace RTC
 		static FBS::RtpParameters::Type TypeToFbs(Type type);
 
 	private:
-		static const absl::flat_hash_map<Type, std::string> Type2String;
+		static const ankerl::unordered_dense::map<Type, std::string> Type2String;
 
 	public:
 		RtpParameters() = default;

--- a/worker/include/RTC/RtpListener.hpp
+++ b/worker/include/RTC/RtpListener.hpp
@@ -4,8 +4,8 @@
 #include "common.hpp"
 #include "RTC/Producer.hpp"
 #include "RTC/RTP/Packet.hpp"
+#include <ankerl/unordered_dense.h>
 #include <string>
-#include <unordered_map>
 
 namespace RTC
 {
@@ -21,11 +21,11 @@ namespace RTC
 
 	public:
 		// Table of SSRC / Producer pairs.
-		std::unordered_map<uint32_t, RTC::Producer*> ssrcTable;
+		ankerl::unordered_dense::map<uint32_t, RTC::Producer*> ssrcTable;
 		//  Table of MID / Producer pairs.
-		std::unordered_map<std::string, RTC::Producer*> midTable;
+		ankerl::unordered_dense::map<std::string, RTC::Producer*> midTable;
 		//  Table of RID / Producer pairs.
-		std::unordered_map<std::string, RTC::Producer*> ridTable;
+		ankerl::unordered_dense::map<std::string, RTC::Producer*> ridTable;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/SCTP/packet/Chunk.hpp
+++ b/worker/include/RTC/SCTP/packet/Chunk.hpp
@@ -5,8 +5,8 @@
 #include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "RTC/SCTP/packet/TLV.hpp"
+#include <ankerl/unordered_dense.h>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace RTC
@@ -171,7 +171,7 @@ namespace RTC
 			static const std::string& ChunkTypeToString(ChunkType chunkType);
 
 		private:
-			static const std::unordered_map<ChunkType, std::string> ChunkType2String;
+			static const ankerl::unordered_dense::map<ChunkType, std::string> ChunkType2String;
 
 		protected:
 			/**

--- a/worker/include/RTC/SCTP/packet/ErrorCause.hpp
+++ b/worker/include/RTC/SCTP/packet/ErrorCause.hpp
@@ -3,8 +3,8 @@
 
 #include "common.hpp"
 #include "RTC/SCTP/packet/TLV.hpp"
+#include <ankerl/unordered_dense.h>
 #include <string>
-#include <unordered_map>
 
 namespace RTC
 {
@@ -111,7 +111,7 @@ namespace RTC
 			static const std::string& ErrorCauseCodeToString(ErrorCauseCode causeCode);
 
 		private:
-			static const std::unordered_map<ErrorCauseCode, std::string> ErrorCauseCode2String;
+			static const ankerl::unordered_dense::map<ErrorCauseCode, std::string> ErrorCauseCode2String;
 
 		protected:
 			/**

--- a/worker/include/RTC/SCTP/packet/Parameter.hpp
+++ b/worker/include/RTC/SCTP/packet/Parameter.hpp
@@ -3,8 +3,8 @@
 
 #include "common.hpp"
 #include "RTC/SCTP/packet/TLV.hpp"
+#include <ankerl/unordered_dense.h>
 #include <string>
-#include <unordered_map>
 
 namespace RTC
 {
@@ -126,7 +126,7 @@ namespace RTC
 			static const std::string& ParameterTypeToString(ParameterType parameterType);
 
 		private:
-			static const std::unordered_map<ParameterType, std::string> ParameterType2String;
+			static const ankerl::unordered_dense::map<ParameterType, std::string> ParameterType2String;
 
 		protected:
 			/**

--- a/worker/include/RTC/SCTP/packet/parameters/ReconfigurationResponseParameter.hpp
+++ b/worker/include/RTC/SCTP/packet/parameters/ReconfigurationResponseParameter.hpp
@@ -4,8 +4,8 @@
 #include "common.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "Utils.hpp"
+#include <ankerl/unordered_dense.h>
 #include <string>
-#include <unordered_map>
 
 namespace RTC
 {
@@ -87,7 +87,7 @@ namespace RTC
 			  const uint8_t* buffer, size_t bufferLength, uint16_t parameterLength, uint8_t padding);
 
 		private:
-			static const std::unordered_map<Result, std::string> Result2String;
+			static const ankerl::unordered_dense::map<Result, std::string> Result2String;
 
 		private:
 			/**

--- a/worker/include/RTC/SCTP/packet/parameters/ZeroChecksumAcceptableParameter.hpp
+++ b/worker/include/RTC/SCTP/packet/parameters/ZeroChecksumAcceptableParameter.hpp
@@ -4,8 +4,8 @@
 #include "common.hpp"
 #include "RTC/SCTP/packet/Parameter.hpp"
 #include "Utils.hpp"
+#include <ankerl/unordered_dense.h>
 #include <string>
-#include <unordered_map>
 
 namespace RTC
 {
@@ -78,7 +78,7 @@ namespace RTC
 			static ZeroChecksumAcceptableParameter* ParseStrict(
 			  const uint8_t* buffer, size_t bufferLength, uint16_t parameterLength, uint8_t padding);
 
-			static const std::unordered_map<AlternateErrorDetectionMethod, std::string>
+			static const ankerl::unordered_dense::map<AlternateErrorDetectionMethod, std::string>
 			  AlternateErrorDetectionMethod2String;
 
 		private:

--- a/worker/include/RTC/SctpListener.hpp
+++ b/worker/include/RTC/SctpListener.hpp
@@ -3,7 +3,7 @@
 
 #include "common.hpp"
 #include "RTC/DataProducer.hpp"
-#include <unordered_map>
+#include <ankerl/unordered_dense.h>
 
 namespace RTC
 {
@@ -18,7 +18,7 @@ namespace RTC
 
 	public:
 		// Table of streamId / DataProducer pairs.
-		std::unordered_map<uint16_t, RTC::DataProducer*> streamIdTable;
+		ankerl::unordered_dense::map<uint16_t, RTC::DataProducer*> streamIdTable;
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/SimulcastConsumer.hpp
+++ b/worker/include/RTC/SimulcastConsumer.hpp
@@ -4,6 +4,7 @@
 #include "RTC/Consumer.hpp"
 #include "RTC/RTP/Codecs/PayloadDescriptorHandler.hpp"
 #include "RTC/SeqManager.hpp"
+#include <ankerl/unordered_dense.h>
 #include <map>
 
 namespace RTC
@@ -111,7 +112,7 @@ namespace RTC
 		// Allocated by this.
 		RTC::RTP::RtpStreamSend* rtpStream{ nullptr };
 		// Others.
-		absl::flat_hash_map<uint32_t, int16_t> mapMappedSsrcSpatialLayer;
+		ankerl::unordered_dense::map<uint32_t, int16_t> mapMappedSsrcSpatialLayer;
 		std::vector<RTC::RTP::RtpStreamSend*> rtpStreams;
 		std::vector<RTC::RTP::RtpStreamRecv*> producerRtpStreams; // Indexed by spatial layer.
 		bool syncRequired{ false };

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -30,7 +30,7 @@
 #include "handles/TimerHandleInterface.hpp"
 #include "RTC/TransportCongestionControlClient.hpp"
 #include "RTC/TransportCongestionControlServer.hpp"
-#include <absl/container/flat_hash_map.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
 #include <vector>
 
@@ -338,13 +338,13 @@ namespace RTC
 		// Passed by argument.
 		Listener* listener{ nullptr };
 		// Allocated by this.
-		absl::flat_hash_map<std::string, RTC::Producer*> mapProducers;
-		absl::flat_hash_map<std::string, RTC::Consumer*> mapConsumers;
-		absl::flat_hash_map<std::string, RTC::DataProducer*> mapDataProducers;
-		absl::flat_hash_map<std::string, RTC::DataConsumer*> mapDataConsumers;
-		absl::flat_hash_map<uint16_t, RTC::DataConsumer*> mapSctpStreamIdDataConsumers;
-		absl::flat_hash_map<uint32_t, RTC::Consumer*> mapSsrcConsumer;
-		absl::flat_hash_map<uint32_t, RTC::Consumer*> mapRtxSsrcConsumer;
+		ankerl::unordered_dense::map<std::string, RTC::Producer*> mapProducers;
+		ankerl::unordered_dense::map<std::string, RTC::Consumer*> mapConsumers;
+		ankerl::unordered_dense::map<std::string, RTC::DataProducer*> mapDataProducers;
+		ankerl::unordered_dense::map<std::string, RTC::DataConsumer*> mapDataConsumers;
+		ankerl::unordered_dense::map<uint16_t, RTC::DataConsumer*> mapSctpStreamIdDataConsumers;
+		ankerl::unordered_dense::map<uint32_t, RTC::Consumer*> mapSsrcConsumer;
+		ankerl::unordered_dense::map<uint32_t, RTC::Consumer*> mapRtxSsrcConsumer;
 		TimerHandleInterface* rtcpTimer{ nullptr };
 		// Allocated by this.
 		std::unique_ptr<RTC::SCTP::AssociationInterface> sctpAssociation{ nullptr };

--- a/worker/include/RTC/WebRtcServer.hpp
+++ b/worker/include/RTC/WebRtcServer.hpp
@@ -11,8 +11,7 @@
 #include "RTC/WebRtcTransport.hpp"
 #include "SharedInterface.hpp"
 #include <flatbuffers/flatbuffers.h>
-#include <absl/container/flat_hash_map.h>
-#include <absl/container/flat_hash_set.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
 #include <vector>
 
@@ -116,11 +115,11 @@ namespace RTC
 		// Vector of UdpSockets and TcpServers in the user given order.
 		std::vector<UdpSocketOrTcpServer> udpSocketOrTcpServers;
 		// Set of WebRtcTransports.
-		absl::flat_hash_set<RTC::WebRtcTransport*> webRtcTransports;
+		ankerl::unordered_dense::set<RTC::WebRtcTransport*> webRtcTransports;
 		// Map of WebRtcTransports indexed by local ICE usernameFragment.
-		absl::flat_hash_map<std::string, RTC::WebRtcTransport*> mapLocalIceUsernameFragmentWebRtcTransport;
+		ankerl::unordered_dense::map<std::string, RTC::WebRtcTransport*> mapLocalIceUsernameFragmentWebRtcTransport;
 		// Map of WebRtcTransports indexed by TransportTuple.hash.
-		absl::flat_hash_map<uint64_t, RTC::WebRtcTransport*> mapTupleWebRtcTransport;
+		ankerl::unordered_dense::map<uint64_t, RTC::WebRtcTransport*> mapTupleWebRtcTransport;
 		// Whether the destructor has been called.
 		bool closing{ false };
 	};

--- a/worker/include/RTC/WebRtcTransport.hpp
+++ b/worker/include/RTC/WebRtcTransport.hpp
@@ -158,8 +158,8 @@ namespace RTC
 		// Allocated by this.
 		RTC::ICE::IceServer* iceServer{ nullptr };
 		// Map of UdpSocket/TcpServer and local announced address (if any).
-		absl::flat_hash_map<RTC::UdpSocket*, std::string> udpSockets;
-		absl::flat_hash_map<RTC::TcpServer*, std::string> tcpServers;
+		ankerl::unordered_dense::map<RTC::UdpSocket*, std::string> udpSockets;
+		ankerl::unordered_dense::map<RTC::TcpServer*, std::string> tcpServers;
 		RTC::DtlsTransport* dtlsTransport{ nullptr };
 		RTC::SrtpSession* srtpRecvSession{ nullptr };
 		RTC::SrtpSession* srtpSendSession{ nullptr };

--- a/worker/include/Settings.hpp
+++ b/worker/include/Settings.hpp
@@ -4,7 +4,7 @@
 #include "common.hpp"
 #include "Channel/ChannelRequest.hpp"
 #include "LogLevel.hpp"
-#include <absl/container/flat_hash_map.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
 #include <vector>
 
@@ -56,8 +56,8 @@ public:
 	static thread_local struct Configuration configuration;
 
 private:
-	static const absl::flat_hash_map<std::string, LogLevel> String2LogLevel;
-	static const absl::flat_hash_map<LogLevel, std::string> LogLevel2String;
+	static const ankerl::unordered_dense::map<std::string, LogLevel> String2LogLevel;
+	static const ankerl::unordered_dense::map<LogLevel, std::string> LogLevel2String;
 };
 
 #endif

--- a/worker/include/Worker.hpp
+++ b/worker/include/Worker.hpp
@@ -9,7 +9,7 @@
 #include "RTC/WebRtcServer.hpp"
 #include "SharedInterface.hpp"
 #include <flatbuffers/flatbuffer_builder.h>
-#include <absl/container/flat_hash_map.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
 
 class Worker : public Channel::ChannelSocket::Listener,
@@ -54,8 +54,8 @@ private:
 	// Allocated by this.
 	SignalHandle* signalHandle{ nullptr };
 	SharedInterface* shared{ nullptr };
-	absl::flat_hash_map<std::string, RTC::WebRtcServer*> mapWebRtcServers;
-	absl::flat_hash_map<std::string, RTC::Router*> mapRouters;
+	ankerl::unordered_dense::map<std::string, RTC::WebRtcServer*> mapWebRtcServers;
+	ankerl::unordered_dense::map<std::string, RTC::Router*> mapRouters;
 	// Others.
 	bool closed{ false };
 };

--- a/worker/include/handles/TcpServerHandle.hpp
+++ b/worker/include/handles/TcpServerHandle.hpp
@@ -4,7 +4,7 @@
 #include "common.hpp"
 #include "handles/TcpConnectionHandle.hpp"
 #include <uv.h>
-#include <absl/container/flat_hash_set.h>
+#include <ankerl/unordered_dense.h>
 #include <string>
 
 class TcpServerHandle : public TcpConnectionHandle::Listener
@@ -72,7 +72,7 @@ private:
 	// Allocated by this (may be passed by argument).
 	uv_tcp_t* uvHandle{ nullptr };
 	// Others.
-	absl::flat_hash_set<TcpConnectionHandle*> connections;
+	ankerl::unordered_dense::set<TcpConnectionHandle*> connections;
 	bool closed{ false };
 };
 

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -280,8 +280,6 @@ common_sources = [
   'src/RTC/SCTP/public/Message.cpp',
 ]
 
-ankerl_unordered_dense_dep = dependency('unordered_dense')
-
 libuv_proj = subproject(
   'libuv',
   default_options: [
@@ -316,6 +314,8 @@ abseil_cpp_proj = subproject(
   ],
 )
 
+ankerl_unordered_dense_dep = dependency('unordered_dense')
+
 flatbuffers_proj = subproject(
   'flatbuffers',
   default_options: [
@@ -327,31 +327,27 @@ flatbuffers_proj = subproject(
 subdir('fbs')
 
 # Add current build directory so libwebrtc has access to FBS folder.
-libwebrtc_include_directories = include_directories(
-  'include',
-  'fbs',
-  'subprojects/unordered_dense-4.8.1/include'
-)
+libwebrtc_include_directories = include_directories('include', 'fbs')
 
 subdir('deps/libwebrtc')
 
 dependencies = [
-  ankerl_unordered_dense_dep,
-  abseil_cpp_proj.get_variable('absl_container_dep'),
-  openssl_proj.get_variable('openssl_dep'),
   libuv_proj.get_variable('libuv_dep'),
+  openssl_proj.get_variable('openssl_dep'),
   libsrtp3_proj.get_variable('libsrtp3_dep'),
+  abseil_cpp_proj.get_variable('absl_container_dep'),
+  ankerl_unordered_dense_dep,
   flatbuffers_proj.get_variable('flatbuffers_dep'),
   flatbuffers_generator_dep,
   libwebrtc_dep,
 ]
 
 link_whole = [
-  abseil_cpp_proj.get_variable('absl_container_lib'),
+  libuv_proj.get_variable('libuv'),
   openssl_proj.get_variable('libcrypto_lib'),
   openssl_proj.get_variable('libssl_lib'),
-  libuv_proj.get_variable('libuv'),
   libsrtp3_proj.get_variable('libsrtp3'),
+  abseil_cpp_proj.get_variable('absl_container_lib'),
   flatbuffers_proj.get_variable('flatbuffers_lib'),
   libwebrtc,
 ]

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -280,6 +280,8 @@ common_sources = [
   'src/RTC/SCTP/public/Message.cpp',
 ]
 
+ankerl_unordered_dense_dep = dependency('unordered_dense')
+
 libuv_proj = subproject(
   'libuv',
   default_options: [
@@ -325,10 +327,16 @@ flatbuffers_proj = subproject(
 subdir('fbs')
 
 # Add current build directory so libwebrtc has access to FBS folder.
-libwebrtc_include_directories = include_directories('include', 'fbs')
+libwebrtc_include_directories = include_directories(
+  'include',
+  'fbs',
+  'subprojects/unordered_dense-4.8.1/include'
+)
+
 subdir('deps/libwebrtc')
 
 dependencies = [
+  ankerl_unordered_dense_dep,
   abseil_cpp_proj.get_variable('absl_container_dep'),
   openssl_proj.get_variable('openssl_dep'),
   libuv_proj.get_variable('libuv_dep'),

--- a/worker/mocks/include/Channel/MockChannelMessageRegistrator.hpp
+++ b/worker/mocks/include/Channel/MockChannelMessageRegistrator.hpp
@@ -4,8 +4,8 @@
 #include "Channel/ChannelMessageRegistratorInterface.hpp"
 // TODO: We should have a ChannelSocketInterface class instead.
 #include "Channel/ChannelSocket.hpp"
+#include <ankerl/unordered_dense.h>
 #include <string>
-#include <unordered_map>
 
 namespace mocks
 {
@@ -35,8 +35,9 @@ namespace mocks
 			  const std::string& id) override;
 
 		private:
-			std::unordered_map<std::string, ::Channel::ChannelSocket::RequestHandler*> mapChannelRequestHandlers;
-			std::unordered_map<std::string, ::Channel::ChannelSocket::NotificationHandler*>
+			ankerl::unordered_dense::map<std::string, ::Channel::ChannelSocket::RequestHandler*>
+			  mapChannelRequestHandlers;
+			ankerl::unordered_dense::map<std::string, ::Channel::ChannelSocket::NotificationHandler*>
 			  mapChannelNotificationHandlers;
 		};
 	} // namespace Channel

--- a/worker/src/Channel/ChannelNotification.cpp
+++ b/worker/src/Channel/ChannelNotification.cpp
@@ -4,13 +4,14 @@
 #include "Channel/ChannelNotification.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
+#include <ankerl/unordered_dense.h>
 
 namespace Channel
 {
-	/* Class variables. */
+	/* Static. */
 
 	// clang-format off
-	const absl::flat_hash_map<FBS::Notification::Event, const char*> ChannelNotification::Event2String =
+	static const ankerl::unordered_dense::map<FBS::Notification::Event, const char*> Event2String =
 	{
 		{ FBS::Notification::Event::WORKER_CLOSE,        "worker.close"       },
 		{ FBS::Notification::Event::TRANSPORT_SEND_RTCP, "transport.sendRtcp" },
@@ -28,9 +29,9 @@ namespace Channel
 		this->data  = notification;
 		this->event = notification->event();
 
-		auto eventCStrIt = ChannelNotification::Event2String.find(this->event);
+		auto eventCStrIt = Event2String.find(this->event);
 
-		if (eventCStrIt == ChannelNotification::Event2String.end())
+		if (eventCStrIt == Event2String.end())
 		{
 			MS_THROW_ERROR("unknown event '%" PRIu8 "'", static_cast<uint8_t>(this->event));
 		}

--- a/worker/src/Channel/ChannelRequest.cpp
+++ b/worker/src/Channel/ChannelRequest.cpp
@@ -4,15 +4,14 @@
 #include "Channel/ChannelRequest.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
+#include <ankerl/unordered_dense.h>
 
 namespace Channel
 {
-	/* Class variables. */
-
-	thread_local flatbuffers::FlatBufferBuilder ChannelRequest::bufferBuilder{};
+	/* Static. */
 
 	// clang-format off
-	const absl::flat_hash_map<FBS::Request::Method, const char*> ChannelRequest::Method2String =
+	static const ankerl::unordered_dense::map<FBS::Request::Method, const char*> Method2String =
 	{
 		{ FBS::Request::Method::WORKER_DUMP,                                    "worker.dump"                                },
 		{ FBS::Request::Method::WORKER_GET_RESOURCE_USAGE,                      "worker.getResourceUsage"                    },
@@ -85,6 +84,10 @@ namespace Channel
 	};
 	// clang-format on
 
+	/* Class variables. */
+
+	thread_local flatbuffers::FlatBufferBuilder ChannelRequest::bufferBuilder{};
+
 	/* Instance methods. */
 
 	/**
@@ -99,9 +102,9 @@ namespace Channel
 		this->id     = request->id();
 		this->method = request->method();
 
-		const auto methodCStrIt = ChannelRequest::Method2String.find(this->method);
+		const auto methodCStrIt = Method2String.find(this->method);
 
-		if (methodCStrIt == ChannelRequest::Method2String.end())
+		if (methodCStrIt == Method2String.end())
 		{
 			Error("unknown method");
 

--- a/worker/src/DepLibSRTP.cpp
+++ b/worker/src/DepLibSRTP.cpp
@@ -16,7 +16,7 @@ static size_t GlobalInstances = 0;
 //   https://github.com/cisco/libsrtp/blob/main/include/srtp.h
 //
 // clang-format off
-const std::unordered_map<srtp_err_status_t, std::string> DepLibSRTP::ErrorCode2String =
+const ankerl::unordered_dense::map<srtp_err_status_t, std::string> DepLibSRTP::ErrorCode2String =
 {
 	{ srtp_err_status_ok,            "nothing to report" },
 	{ srtp_err_status_fail,          "unspecified failure" },

--- a/worker/src/RTC/AudioLevelObserver.cpp
+++ b/worker/src/RTC/AudioLevelObserver.cpp
@@ -5,8 +5,8 @@
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include "RTC/RtpDictionaries.hpp"
-#include <absl/container/btree_map.h>
 #include <cmath> // std::lround()
+#include <map>   // std::multimap
 
 namespace RTC
 {
@@ -143,7 +143,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		absl::btree_multimap<int8_t, RTC::Producer*> mapDBovsProducer;
+		std::multimap<int8_t, RTC::Producer*> mapDBovsProducer;
 
 		for (auto& kv : this->mapProducerDBovs)
 		{

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -124,7 +124,7 @@ namespace RTC
 	thread_local EVP_PKEY* DtlsTransport::privateKey{ nullptr };
 	thread_local SSL_CTX* DtlsTransport::sslCtx{ nullptr };
 	thread_local uint8_t DtlsTransport::sslReadBuffer[SslReadBufferSize];
-	const absl::flat_hash_map<std::string, DtlsTransport::FingerprintAlgorithm>
+	const ankerl::unordered_dense::map<std::string, DtlsTransport::FingerprintAlgorithm>
 	  DtlsTransport::String2FingerprintAlgorithm = {
 		  { "sha-1",   DtlsTransport::FingerprintAlgorithm::SHA1   },
 		  { "sha-224", DtlsTransport::FingerprintAlgorithm::SHA224 },
@@ -132,7 +132,7 @@ namespace RTC
 		  { "sha-384", DtlsTransport::FingerprintAlgorithm::SHA384 },
 		  { "sha-512", DtlsTransport::FingerprintAlgorithm::SHA512 }
   };
-	const absl::flat_hash_map<DtlsTransport::FingerprintAlgorithm, std::string>
+	const ankerl::unordered_dense::map<DtlsTransport::FingerprintAlgorithm, std::string>
 	  DtlsTransport::FingerprintAlgorithm2String = {
 		  { DtlsTransport::FingerprintAlgorithm::SHA1,   "sha-1"   },
 		  { DtlsTransport::FingerprintAlgorithm::SHA224, "sha-224" },
@@ -140,7 +140,7 @@ namespace RTC
 		  { DtlsTransport::FingerprintAlgorithm::SHA384, "sha-384" },
 		  { DtlsTransport::FingerprintAlgorithm::SHA512, "sha-512" }
   };
-	const absl::flat_hash_map<std::string, DtlsTransport::Role> DtlsTransport::String2Role = {
+	const ankerl::unordered_dense::map<std::string, DtlsTransport::Role> DtlsTransport::String2Role = {
 		{ "auto",   DtlsTransport::Role::AUTO   },
 		{ "client", DtlsTransport::Role::CLIENT },
 		{ "server", DtlsTransport::Role::SERVER }

--- a/worker/src/RTC/ICE/IceServer.cpp
+++ b/worker/src/RTC/ICE/IceServer.cpp
@@ -20,7 +20,7 @@ namespace RTC
 		/* Class variables. */
 
 		// clang-format off
-		std::unordered_map<IceServer::IceState, std::string> IceServer::iceStateToString =
+		ankerl::unordered_dense::map<IceServer::IceState, std::string> IceServer::iceStateToString =
 		{
 			{ IceServer::IceState::NEW,          "new"          },
 			{ IceServer::IceState::CONNECTED,    "connected"    },

--- a/worker/src/RTC/PortManager.cpp
+++ b/worker/src/RTC/PortManager.cpp
@@ -31,7 +31,7 @@ namespace RTC
 {
 	/* Class variables. */
 
-	thread_local absl::flat_hash_map<uint64_t, PortManager::PortRange> PortManager::mapPortRanges;
+	thread_local ankerl::unordered_dense::map<uint64_t, PortManager::PortRange> PortManager::mapPortRanges;
 
 	/* Class methods. */
 

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -12,7 +12,6 @@
 #ifdef MS_RTC_LOGGER_RTP
 #include "RTC/RtcLogger.hpp"
 #endif
-#include <absl/container/inlined_vector.h>
 #include <cstring> // std::memcpy()
 
 namespace RTC

--- a/worker/src/RTC/RTCP/Feedback.cpp
+++ b/worker/src/RTC/RTCP/Feedback.cpp
@@ -99,7 +99,7 @@ namespace RTC
 
 		// clang-format off
 		template<>
-		const absl::flat_hash_map<FeedbackPs::MessageType, std::string> FeedbackPacket<FeedbackPs>::MessageType2String =
+		const ankerl::unordered_dense::map<FeedbackPs::MessageType, std::string> FeedbackPacket<FeedbackPs>::MessageType2String =
 		{
 			{ FeedbackPs::MessageType::PLI,   "PLI"   },
 			{ FeedbackPs::MessageType::SLI,   "SLI"   },
@@ -189,7 +189,7 @@ namespace RTC
 
 		// clang-format off
 		template<>
-		const absl::flat_hash_map<FeedbackRtp::MessageType, std::string> FeedbackPacket<FeedbackRtp>::MessageType2String =
+		const ankerl::unordered_dense::map<FeedbackRtp::MessageType, std::string> FeedbackPacket<FeedbackRtp>::MessageType2String =
 		{
 			{ FeedbackRtp::MessageType::NACK,   "NACK"   },
 			{ FeedbackRtp::MessageType::TMMBR,  "TMMBR"  },

--- a/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
+++ b/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
@@ -19,7 +19,7 @@ namespace RTC
 		int16_t FeedbackRtpTransportPacket::maxPacketDelta{ 0x7FFF };
 
 		// clang-format off
-		const absl::flat_hash_map<FeedbackRtpTransportPacket::Status, std::string> FeedbackRtpTransportPacket::Status2String =
+		const ankerl::unordered_dense::map<FeedbackRtpTransportPacket::Status, std::string> FeedbackRtpTransportPacket::Status2String =
 		{
 			{ FeedbackRtpTransportPacket::Status::NotReceived, "NR" },
 			{ FeedbackRtpTransportPacket::Status::SmallDelta,  "SD" },

--- a/worker/src/RTC/RTCP/Packet.cpp
+++ b/worker/src/RTC/RTCP/Packet.cpp
@@ -21,7 +21,7 @@ namespace RTC
 		/* Class variables. */
 
 		// clang-format off
-		const absl::flat_hash_map<Type, std::string> Packet::Type2String =
+		const ankerl::unordered_dense::map<Type, std::string> Packet::Type2String =
 		{
 			{ Type::SR,    "SR"    },
 			{ Type::RR,    "RR"    },

--- a/worker/src/RTC/RTCP/Sdes.cpp
+++ b/worker/src/RTC/RTCP/Sdes.cpp
@@ -13,7 +13,7 @@ namespace RTC
 		/* Item Class variables. */
 
 		// clang-format off
-		const absl::flat_hash_map<SdesItem::Type, std::string> SdesItem::Type2String =
+		const ankerl::unordered_dense::map<SdesItem::Type, std::string> SdesItem::Type2String =
 		{
 			{ SdesItem::Type::END,   "END"   },
 			{ SdesItem::Type::CNAME, "CNAME" },

--- a/worker/src/RTC/RTP/Codecs/DependencyDescriptor.cpp
+++ b/worker/src/RTC/RTP/Codecs/DependencyDescriptor.cpp
@@ -3,6 +3,7 @@
 
 #include "RTC/RTP/Codecs/DependencyDescriptor.hpp"
 #include "Logger.hpp"
+#include <bitset>
 #include <string>
 #include <vector>
 
@@ -15,7 +16,7 @@ namespace RTC
 			/* Static members. */
 
 			// clang-format off
-			std::unordered_map<DependencyDescriptor::DecodeTargetIndication, std::string> DependencyDescriptor::dtiToString =
+			ankerl::unordered_dense::map<DependencyDescriptor::DecodeTargetIndication, std::string> DependencyDescriptor::dtiToString =
 			{
 				{ DependencyDescriptor::DecodeTargetIndication::NOT_PRESENT, "-" },
 				{ DependencyDescriptor::DecodeTargetIndication::DISCARDABLE, "D" },

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -427,7 +427,7 @@ namespace RTC
 				{
 					auto& rtpObservers = kv.second;
 
-					rtpObservers.erase(rtpObserver);
+					rtpObservers.erase(const_cast<RTC::RtpObserver*>(rtpObserver));
 				}
 
 				MS_DEBUG_DEV("RtpObserver closed [rtpObserverId:%s]", rtpObserver->id.c_str());

--- a/worker/src/RTC/RtcLogger.cpp
+++ b/worker/src/RTC/RtcLogger.cpp
@@ -10,7 +10,7 @@ namespace RTC
 	namespace RtcLogger
 	{
 		// clang-format off
-		const absl::flat_hash_map<RtpPacket::DiscardReason, std::string> RtpPacket::DiscardReason2String = {
+		const ankerl::unordered_dense::map<RtpPacket::DiscardReason, std::string> RtpPacket::DiscardReason2String = {
 			{ RtpPacket::DiscardReason::NONE,                                    "None"                               },
 			{ RtpPacket::DiscardReason::PRODUCER_NOT_FOUND,                      "ProducerNotFound"                   },
 			{ RtpPacket::DiscardReason::RECV_RTP_STREAM_NOT_FOUND,               "RecvRtpStreamNotFound"              },

--- a/worker/src/RTC/RtpDictionaries/RtpCodecMimeType.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpCodecMimeType.cpp
@@ -11,17 +11,17 @@ namespace RTC
 	/* Class variables. */
 
 	// clang-format off
-	const absl::flat_hash_map<std::string, RtpCodecMimeType::Type> RtpCodecMimeType::String2Type =
+	const ankerl::unordered_dense::map<std::string, RtpCodecMimeType::Type> RtpCodecMimeType::String2Type =
 	{
 		{ "audio", RtpCodecMimeType::Type::AUDIO },
 		{ "video", RtpCodecMimeType::Type::VIDEO }
 	};
-	const absl::flat_hash_map<RtpCodecMimeType::Type, std::string> RtpCodecMimeType::Type2String =
+	const ankerl::unordered_dense::map<RtpCodecMimeType::Type, std::string> RtpCodecMimeType::Type2String =
 	{
 		{ RtpCodecMimeType::Type::AUDIO, "audio" },
 		{ RtpCodecMimeType::Type::VIDEO, "video" }
 	};
-	const absl::flat_hash_map<std::string, RtpCodecMimeType::Subtype> RtpCodecMimeType::String2Subtype =
+	const ankerl::unordered_dense::map<std::string, RtpCodecMimeType::Subtype> RtpCodecMimeType::String2Subtype =
 	{
 		// Audio codecs:
 		{ "opus",            RtpCodecMimeType::Subtype::OPUS            },
@@ -47,7 +47,7 @@ namespace RTC
 		{ "x-ulpfecuc",      RtpCodecMimeType::Subtype::X_ULPFECUC      },
 		{ "red",             RtpCodecMimeType::Subtype::RED             }
 	};
-	const absl::flat_hash_map<RtpCodecMimeType::Subtype, std::string> RtpCodecMimeType::Subtype2String =
+	const ankerl::unordered_dense::map<RtpCodecMimeType::Subtype, std::string> RtpCodecMimeType::Subtype2String =
 	{
 		// Audio codecs:
 		{ RtpCodecMimeType::Subtype::OPUS,            "opus"            },

--- a/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtpParameters.cpp
@@ -5,14 +5,13 @@
 #include "MediaSoupErrors.hpp"
 #include "RTC/RTP/Codecs/Tools.hpp"
 #include "RTC/RtpDictionaries.hpp"
-#include <absl/container/flat_hash_set.h>
 
 namespace RTC
 {
 	/* Class variables. */
 
 	// clang-format off
-	const absl::flat_hash_map<RtpParameters::Type, std::string> RtpParameters::Type2String = {
+	const ankerl::unordered_dense::map<RtpParameters::Type, std::string> RtpParameters::Type2String = {
 		{ RtpParameters::Type::SIMPLE, "simple" },
 		{ RtpParameters::Type::SIMULCAST, "simulcast" },
 		{ RtpParameters::Type::SVC, "svc" },
@@ -249,7 +248,7 @@ namespace RTC
 
 		static const std::string AptString{ "apt" };
 
-		absl::flat_hash_set<uint8_t> payloadTypes;
+		ankerl::unordered_dense::set<uint8_t> payloadTypes;
 
 		for (auto& codec : this->codecs)
 		{

--- a/worker/src/RTC/SCTP/packet/Chunk.cpp
+++ b/worker/src/RTC/SCTP/packet/Chunk.cpp
@@ -44,7 +44,7 @@ namespace RTC
 		/* Class variables. */
 
 		// clang-format off
-		const std::unordered_map<Chunk::ChunkType, std::string> Chunk::ChunkType2String =
+		const ankerl::unordered_dense::map<Chunk::ChunkType, std::string> Chunk::ChunkType2String =
 		{
 			{ Chunk::ChunkType::DATA,              "DATA"              },
 			{ Chunk::ChunkType::INIT,              "INIT"              },

--- a/worker/src/RTC/SCTP/packet/ErrorCause.cpp
+++ b/worker/src/RTC/SCTP/packet/ErrorCause.cpp
@@ -12,7 +12,7 @@ namespace RTC
 		/* Class variables. */
 
 		// clang-format off
-		const std::unordered_map<ErrorCause::ErrorCauseCode, std::string> ErrorCause::ErrorCauseCode2String =
+		const ankerl::unordered_dense::map<ErrorCause::ErrorCauseCode, std::string> ErrorCause::ErrorCauseCode2String =
 		{
 			{ ErrorCause::ErrorCauseCode::INVALID_STREAM_IDENTIFIER,                    "INVALID-STREAM-IDENTIFIER"                    },
 			{ ErrorCause::ErrorCauseCode::MISSING_MANDATORY_PARAMETER,                  "MISSING-MANDATORY-PARAMETER"                  },

--- a/worker/src/RTC/SCTP/packet/Parameter.cpp
+++ b/worker/src/RTC/SCTP/packet/Parameter.cpp
@@ -12,7 +12,7 @@ namespace RTC
 		/* Class variables. */
 
 		// clang-format off
-		const std::unordered_map<Parameter::ParameterType, std::string> Parameter::ParameterType2String =
+		const ankerl::unordered_dense::map<Parameter::ParameterType, std::string> Parameter::ParameterType2String =
 		{
 			{ Parameter::ParameterType::HEARTBEAT_INFO,               "HEARTBEAT-INFO"               },
 			{ Parameter::ParameterType::IPV4_ADDRESS,                 "IPV4-ADDRESS"                 },

--- a/worker/src/RTC/SCTP/packet/parameters/ReconfigurationResponseParameter.cpp
+++ b/worker/src/RTC/SCTP/packet/parameters/ReconfigurationResponseParameter.cpp
@@ -12,7 +12,7 @@ namespace RTC
 		/* Class variables. */
 
 		// clang-format off
-		const std::unordered_map<ReconfigurationResponseParameter::Result, std::string> ReconfigurationResponseParameter::Result2String =
+		const ankerl::unordered_dense::map<ReconfigurationResponseParameter::Result, std::string> ReconfigurationResponseParameter::Result2String =
 		{
 			{ ReconfigurationResponseParameter::Result::SUCCESS_NOTHING_TO_DO,             "SUCCESS_NOTHING_TO_DO"             },
 			{ ReconfigurationResponseParameter::Result::SUCCESS_PERFORMED,                 "SUCCESS_PERFORMED"                 },

--- a/worker/src/RTC/SCTP/packet/parameters/ZeroChecksumAcceptableParameter.cpp
+++ b/worker/src/RTC/SCTP/packet/parameters/ZeroChecksumAcceptableParameter.cpp
@@ -12,7 +12,7 @@ namespace RTC
 		/* Class variables. */
 
 		// clang-format off
-		const std::unordered_map<ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod, std::string> ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod2String =
+		const ankerl::unordered_dense::map<ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod, std::string> ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod2String =
 		{
 			{ ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::NONE,           "NONE"           },
 			{ ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::SCTP_OVER_DTLS, "SCTP_OVER_DTLS" },

--- a/worker/src/RTC/SCTP/rx/InterleavedReassemblyStreams.cpp
+++ b/worker/src/RTC/SCTP/rx/InterleavedReassemblyStreams.cpp
@@ -3,6 +3,7 @@
 
 #include "RTC/SCTP/rx/InterleavedReassemblyStreams.hpp"
 #include "Logger.hpp"
+#include <numeric> // std::accumulate()
 
 namespace RTC
 {

--- a/worker/src/RTC/SCTP/rx/TraditionalReassemblyStreams.cpp
+++ b/worker/src/RTC/SCTP/rx/TraditionalReassemblyStreams.cpp
@@ -3,6 +3,7 @@
 
 #include "RTC/SCTP/rx/TraditionalReassemblyStreams.hpp"
 #include "Logger.hpp"
+#include <numeric> // std::accumulate()
 
 namespace RTC
 {

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -23,14 +23,14 @@ static std::mutex GlobalSyncMutex;
 
 thread_local struct Settings::Configuration Settings::configuration;
 // clang-format off
-const absl::flat_hash_map<std::string, LogLevel> Settings::String2LogLevel =
+const ankerl::unordered_dense::map<std::string, LogLevel> Settings::String2LogLevel =
 {
 	{ "debug", LogLevel::LOG_DEBUG },
 	{ "warn",  LogLevel::LOG_WARN  },
 	{ "error", LogLevel::LOG_ERROR },
 	{ "none",  LogLevel::LOG_NONE  }
 };
-const absl::flat_hash_map<LogLevel, std::string> Settings::LogLevel2String =
+const ankerl::unordered_dense::map<LogLevel, std::string> Settings::LogLevel2String =
 {
 	{ LogLevel::LOG_DEBUG, "debug" },
 	{ LogLevel::LOG_WARN,  "warn"  },

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -21,7 +21,6 @@
 #include "Shared.hpp"
 #include "Utils.hpp"
 #include "Worker.hpp"
-#include <absl/container/flat_hash_map.h>
 #include <csignal> // sigaction()
 #include <string>
 
@@ -210,7 +209,7 @@ static void ignoreSignals()
 	struct sigaction act{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
 	// clang-format off
-	absl::flat_hash_map<std::string, int> const ignoredSignals =
+	ankerl::unordered_dense::map<std::string, int> const ignoredSignals =
 	{
 		{ "PIPE", SIGPIPE },
 		{ "HUP",  SIGHUP  },

--- a/worker/subprojects/packagefiles/ankerl-unordered-dense/meson.build
+++ b/worker/subprojects/packagefiles/ankerl-unordered-dense/meson.build
@@ -1,0 +1,5 @@
+project('ankerl-unordered-dense', 'cpp', version: '4.8.1', license: 'MIT')
+
+ankerl_unordered_dense_dep = declare_dependency(
+  include_directories: include_directories('include')
+)

--- a/worker/subprojects/unordered-dense.wrap
+++ b/worker/subprojects/unordered-dense.wrap
@@ -1,0 +1,9 @@
+[wrap-file]
+directory = unordered_dense-4.8.1
+source_url = https://github.com/martinus/unordered_dense/archive/refs/tags/v4.8.1.tar.gz
+source_filename = unordered_dense-4.8.1.tar.gz
+source_hash = 9f7202ec6d8353932ef865d33f5872e4b7a1356e9032da7cd09c3a0c5bb2b7de
+patch_directory = ankerl-unordered-dense
+
+[provide]
+unordered_dense = ankerl_unordered_dense_dep

--- a/worker/test/src/Utils/TestCrypto.cpp
+++ b/worker/test/src/Utils/TestCrypto.cpp
@@ -1,8 +1,8 @@
 #include "common.hpp"
 #include "Utils.hpp"
+#include <ankerl/unordered_dense.h>
 #include <catch2/catch_test_macros.hpp>
 #include <limits> // std::numeric_limits()
-#include <set>
 
 SCENARIO("Utils::Crypto", "[utils][crypto]")
 {
@@ -79,8 +79,8 @@ SCENARIO("Utils::Crypto", "[utils][crypto]")
 
 SCENARIO("Utils::Crypto::GetRandomUInt()", "[utils][crypto]")
 {
-	std::set<uint32_t> randomUint32Numbers;
-	std::set<uint32_t> randomUint64Numbers;
+	ankerl::unordered_dense::set<uint32_t> randomUint32Numbers;
+	ankerl::unordered_dense::set<uint32_t> randomUint64Numbers;
 
 	for (size_t i = 0; i < 200; ++i)
 	{


### PR DESCRIPTION
# Details

- [ankerl/unordered_dense](https://github.com/martinus/unordered_dense) provides a header-only unordered hashmap and hashset library.
- Replace `absl-cpp` with `ankerl/unordered_dense` everywhere.
  - Ok, we cannot get rid of `absl-cpp` because `subprojects/libwebrtc` uses it.
- Replace all `absl::flat_hash_map` with `ankerl::unordered_dense::map`.
- Replace all `absl::flat_hash_set` with `ankerl::unordered_dense::set`.
- Replace all `std::unordered_map` with `ankerl::unordered_dense::map`.
- Replace all `std::unordered_set` with `ankerl::unordered_dense::set`.

## Why?

Because `ankerl/unordered_dense` is super efficient and we don't want to depend on Google complex libraries that are already causing problems. For example we cannot update to the latest version of `absl-cpp` (available in Meson WrapDB) because it fails to compile in Windows.
