### PR TITLE
Fix svc consumer preferred layers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Node: Make all public methods/getters that return an object/array, return a clone of that object/array ([PR #1811](https://github.com/versatica/mediasoup/pull/1811)).
 - Worker: replace `absl-cpp` subproject with `ankerl/unordered_dense` ([PR #1813](https://github.com/versatica/mediasoup/pull/1813)).
+- Worker: Fix `SvcConsumer` ignoring the `temporalLayer` of `preferredLayers` given at consume time ([PR #1814](https://github.com/versatica/mediasoup/pull/1814)).
 
 ### 3.20.0
 

--- a/node/src/test/test-Consumer.ts
+++ b/node/src/test/test-Consumer.ts
@@ -17,6 +17,10 @@ type TestContext = {
 	audioProducerOptions: mediasoup.types.ProducerOptions;
 	videoProducerOptions: mediasoup.types.ProducerOptions;
 	consumerDeviceCapabilities: mediasoup.types.RtpCapabilities;
+	vpxMediaCodecs: mediasoup.types.RouterRtpCodecCapability[];
+	vp9SvcProducerOptions: mediasoup.types.ProducerOptions;
+	vp8SimulcastProducerOptions: mediasoup.types.ProducerOptions;
+	vpxConsumerDeviceCapabilities: mediasoup.types.RtpCapabilities;
 	worker?: mediasoup.types.Worker;
 	router?: mediasoup.types.Router;
 	webRtcTransport1?: mediasoup.types.WebRtcTransport;
@@ -228,6 +232,113 @@ const ctx: TestContext = {
 			],
 		}
 	),
+	vpxMediaCodecs: utils.deepFreeze<mediasoup.types.RouterRtpCodecCapability[]>([
+		{
+			kind: 'video',
+			mimeType: 'video/VP8',
+			clockRate: 90000,
+			rtcpFeedback: [
+				{ type: 'nack', parameter: '' },
+				{ type: 'nack', parameter: 'pli' },
+				{ type: 'ccm', parameter: 'fir' },
+				{ type: 'goog-remb', parameter: '' },
+			],
+		},
+		{
+			kind: 'video',
+			mimeType: 'video/VP9',
+			clockRate: 90000,
+			rtcpFeedback: [
+				{ type: 'nack', parameter: '' },
+				{ type: 'nack', parameter: 'pli' },
+				{ type: 'ccm', parameter: 'fir' },
+				{ type: 'goog-remb', parameter: '' },
+			],
+		},
+	]),
+	vp9SvcProducerOptions: utils.deepFreeze<mediasoup.types.ProducerOptions>({
+		kind: 'video',
+		rtpParameters: {
+			mid: 'VIDEOSVC',
+			codecs: [
+				{
+					mimeType: 'video/VP9',
+					payloadType: 96,
+					clockRate: 90000,
+					parameters: {},
+					rtcpFeedback: [
+						{ type: 'nack', parameter: '' },
+						{ type: 'nack', parameter: 'pli' },
+						{ type: 'ccm', parameter: 'fir' },
+						{ type: 'goog-remb', parameter: '' },
+					],
+				},
+			],
+			headerExtensions: [],
+			encodings: [{ ssrc: 33333333, scalabilityMode: 'L3T3' }],
+			rtcp: { cname: 'FOOBAR' },
+		},
+		appData: { foo: 1, bar: '2' },
+	}),
+	vp8SimulcastProducerOptions:
+		utils.deepFreeze<mediasoup.types.ProducerOptions>({
+			kind: 'video',
+			rtpParameters: {
+				mid: 'VIDEOVP8',
+				codecs: [
+					{
+						mimeType: 'video/VP8',
+						payloadType: 96,
+						clockRate: 90000,
+						parameters: {},
+						rtcpFeedback: [
+							{ type: 'nack', parameter: '' },
+							{ type: 'nack', parameter: 'pli' },
+							{ type: 'ccm', parameter: 'fir' },
+							{ type: 'goog-remb', parameter: '' },
+						],
+					},
+				],
+				headerExtensions: [],
+				encodings: [
+					{ ssrc: 44444441, scalabilityMode: 'L1T5' },
+					{ ssrc: 44444442, scalabilityMode: 'L1T5' },
+					{ ssrc: 44444443, scalabilityMode: 'L1T5' },
+				],
+				rtcp: { cname: 'FOOBAR' },
+			},
+			appData: { foo: 1, bar: '2' },
+		}),
+	vpxConsumerDeviceCapabilities:
+		utils.deepFreeze<mediasoup.types.RtpCapabilities>({
+			codecs: [
+				{
+					kind: 'video',
+					mimeType: 'video/VP8',
+					preferredPayloadType: 101,
+					clockRate: 90000,
+					rtcpFeedback: [
+						{ type: 'nack', parameter: '' },
+						{ type: 'nack', parameter: 'pli' },
+						{ type: 'ccm', parameter: 'fir' },
+						{ type: 'goog-remb', parameter: '' },
+					],
+				},
+				{
+					kind: 'video',
+					mimeType: 'video/VP9',
+					preferredPayloadType: 102,
+					clockRate: 90000,
+					rtcpFeedback: [
+						{ type: 'nack', parameter: '' },
+						{ type: 'nack', parameter: 'pli' },
+						{ type: 'ccm', parameter: 'fir' },
+						{ type: 'goog-remb', parameter: '' },
+					],
+				},
+			],
+			headerExtensions: [],
+		}),
 };
 
 beforeEach(async () => {
@@ -937,6 +1048,119 @@ test('consumer.setPreferredLayers() with wrong arguments rejects with TypeError'
 		// @ts-expect-error --- Testing purposes.
 		videoConsumer.setPreferredLayers({ temporalLayer: 2 })
 	).rejects.toThrow(TypeError);
+}, 2000);
+
+test('transport.consume() for an SVC producer honors preferredLayers', async () => {
+	const router = await ctx.worker!.createRouter({
+		mediaCodecs: ctx.vpxMediaCodecs,
+	});
+	const transport1 = await router.createWebRtcTransport({
+		listenIps: ['127.0.0.1'],
+	});
+	const transport2 = await router.createWebRtcTransport({
+		listenIps: ['127.0.0.1'],
+	});
+
+	const deviceCapabilities = ctx.vpxConsumerDeviceCapabilities;
+
+	const svcProducer = await transport1.produce(ctx.vp9SvcProducerOptions);
+
+	expect(
+		router.canConsume({
+			producerId: svcProducer.id,
+			rtpCapabilities: deviceCapabilities,
+		})
+	).toBe(true);
+
+	const svcConsumer = await transport2.consume({
+		producerId: svcProducer.id,
+		rtpCapabilities: deviceCapabilities,
+		paused: true,
+		preferredLayers: { spatialLayer: 1, temporalLayer: 0 },
+	});
+
+	expect(svcConsumer.type).toBe('svc');
+	expect(svcConsumer.preferredLayers).toEqual({
+		spatialLayer: 1,
+		temporalLayer: 0,
+	});
+
+	// Out-of-range spatial and temporal layers are clamped to the max.
+	const svcConsumerClamped = await transport2.consume({
+		producerId: svcProducer.id,
+		rtpCapabilities: deviceCapabilities,
+		paused: true,
+		preferredLayers: { spatialLayer: 9, temporalLayer: 9 },
+	});
+
+	expect(svcConsumerClamped.preferredLayers).toEqual({
+		spatialLayer: 2,
+		temporalLayer: 2,
+	});
+
+	// When no temporal layer is given it defaults to the max temporal layer.
+	const svcConsumerNoTemporal = await transport2.consume({
+		producerId: svcProducer.id,
+		rtpCapabilities: deviceCapabilities,
+		paused: true,
+		preferredLayers: { spatialLayer: 1 },
+	});
+
+	expect(svcConsumerNoTemporal.preferredLayers).toEqual({
+		spatialLayer: 1,
+		temporalLayer: 2,
+	});
+}, 2000);
+
+test('transport.consume() for a simulcast producer honors preferredLayers', async () => {
+	const router = await ctx.worker!.createRouter({
+		mediaCodecs: ctx.vpxMediaCodecs,
+	});
+	const transport1 = await router.createWebRtcTransport({
+		listenIps: ['127.0.0.1'],
+	});
+	const transport2 = await router.createWebRtcTransport({
+		listenIps: ['127.0.0.1'],
+	});
+
+	const deviceCapabilities = ctx.vpxConsumerDeviceCapabilities;
+
+	const simulcastProducer = await transport1.produce(
+		ctx.vp8SimulcastProducerOptions
+	);
+
+	expect(
+		router.canConsume({
+			producerId: simulcastProducer.id,
+			rtpCapabilities: deviceCapabilities,
+		})
+	).toBe(true);
+
+	const simulcastConsumer = await transport2.consume({
+		producerId: simulcastProducer.id,
+		rtpCapabilities: deviceCapabilities,
+		paused: true,
+		preferredLayers: { spatialLayer: 1, temporalLayer: 0 },
+	});
+
+	expect(simulcastConsumer.type).toBe('simulcast');
+	expect(simulcastConsumer.preferredLayers).toEqual({
+		spatialLayer: 1,
+		temporalLayer: 0,
+	});
+
+	// Out-of-range spatial layer is clamped to the max (2 = number of encodings - 1).
+	const simulcastConsumerClamped = await transport2.consume({
+		producerId: simulcastProducer.id,
+		rtpCapabilities: deviceCapabilities,
+		paused: true,
+		preferredLayers: { spatialLayer: 9, temporalLayer: 9 },
+	});
+
+	expect(simulcastConsumerClamped.preferredLayers).toEqual({
+		spatialLayer: 2,
+		temporalLayer: 4,
+	});
 }, 2000);
 
 test('consumer.setPriority() succeed', async () => {

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -70,6 +70,151 @@ fn media_codecs() -> Vec<RtpCodecCapability> {
     ]
 }
 
+fn media_codecs_vpx() -> Vec<RtpCodecCapability> {
+    vec![
+        RtpCodecCapability::Video {
+            mime_type: MimeTypeVideo::Vp8,
+            preferred_payload_type: None,
+            clock_rate: NonZeroU32::new(90000).unwrap(),
+            parameters: RtpCodecParametersParameters::default(),
+            rtcp_feedback: vec![
+                RtcpFeedback::Nack,
+                RtcpFeedback::NackPli,
+                RtcpFeedback::CcmFir,
+                RtcpFeedback::GoogRemb,
+            ],
+        },
+        RtpCodecCapability::Video {
+            mime_type: MimeTypeVideo::Vp9,
+            preferred_payload_type: None,
+            clock_rate: NonZeroU32::new(90000).unwrap(),
+            parameters: RtpCodecParametersParameters::default(),
+            rtcp_feedback: vec![
+                RtcpFeedback::Nack,
+                RtcpFeedback::NackPli,
+                RtcpFeedback::CcmFir,
+                RtcpFeedback::GoogRemb,
+            ],
+        },
+    ]
+}
+
+fn consumer_device_capabilities_vpx() -> RtpCapabilities {
+    RtpCapabilities {
+        codecs: vec![
+            RtpCodecCapability::Video {
+                mime_type: MimeTypeVideo::Vp8,
+                preferred_payload_type: Some(101),
+                clock_rate: NonZeroU32::new(90000).unwrap(),
+                parameters: RtpCodecParametersParameters::default(),
+                rtcp_feedback: vec![
+                    RtcpFeedback::Nack,
+                    RtcpFeedback::NackPli,
+                    RtcpFeedback::CcmFir,
+                    RtcpFeedback::GoogRemb,
+                ],
+            },
+            RtpCodecCapability::Video {
+                mime_type: MimeTypeVideo::Vp9,
+                preferred_payload_type: Some(102),
+                clock_rate: NonZeroU32::new(90000).unwrap(),
+                parameters: RtpCodecParametersParameters::default(),
+                rtcp_feedback: vec![
+                    RtcpFeedback::Nack,
+                    RtcpFeedback::NackPli,
+                    RtcpFeedback::CcmFir,
+                    RtcpFeedback::GoogRemb,
+                ],
+            },
+        ],
+        header_extensions: vec![],
+    }
+}
+
+fn vp9_svc_producer_options() -> ProducerOptions {
+    let mut options = ProducerOptions::new(
+        MediaKind::Video,
+        RtpParameters {
+            mid: Some("VIDEOSVC".to_string()),
+            codecs: vec![RtpCodecParameters::Video {
+                mime_type: MimeTypeVideo::Vp9,
+                payload_type: 96,
+                clock_rate: NonZeroU32::new(90000).unwrap(),
+                parameters: RtpCodecParametersParameters::default(),
+                rtcp_feedback: vec![
+                    RtcpFeedback::Nack,
+                    RtcpFeedback::NackPli,
+                    RtcpFeedback::CcmFir,
+                    RtcpFeedback::GoogRemb,
+                ],
+            }],
+            header_extensions: vec![],
+            encodings: vec![RtpEncodingParameters {
+                ssrc: Some(33333333),
+                scalability_mode: "L3T3".parse().unwrap(),
+                ..RtpEncodingParameters::default()
+            }],
+            rtcp: RtcpParameters {
+                cname: Some("FOOBAR".to_string()),
+                ..RtcpParameters::default()
+            },
+            msid: None,
+        },
+    );
+
+    options.app_data = AppData::new(ProducerAppData { _foo: 1, _bar: "2" });
+
+    options
+}
+
+fn vp8_simulcast_producer_options() -> ProducerOptions {
+    let mut options = ProducerOptions::new(
+        MediaKind::Video,
+        RtpParameters {
+            mid: Some("VIDEOVP8".to_string()),
+            codecs: vec![RtpCodecParameters::Video {
+                mime_type: MimeTypeVideo::Vp8,
+                payload_type: 96,
+                clock_rate: NonZeroU32::new(90000).unwrap(),
+                parameters: RtpCodecParametersParameters::default(),
+                rtcp_feedback: vec![
+                    RtcpFeedback::Nack,
+                    RtcpFeedback::NackPli,
+                    RtcpFeedback::CcmFir,
+                    RtcpFeedback::GoogRemb,
+                ],
+            }],
+            header_extensions: vec![],
+            encodings: vec![
+                RtpEncodingParameters {
+                    ssrc: Some(44444441),
+                    scalability_mode: "L1T5".parse().unwrap(),
+                    ..RtpEncodingParameters::default()
+                },
+                RtpEncodingParameters {
+                    ssrc: Some(44444442),
+                    scalability_mode: "L1T5".parse().unwrap(),
+                    ..RtpEncodingParameters::default()
+                },
+                RtpEncodingParameters {
+                    ssrc: Some(44444443),
+                    scalability_mode: "L1T5".parse().unwrap(),
+                    ..RtpEncodingParameters::default()
+                },
+            ],
+            rtcp: RtcpParameters {
+                cname: Some("FOOBAR".to_string()),
+                ..RtcpParameters::default()
+            },
+            msid: None,
+        },
+    );
+
+    options.app_data = AppData::new(ProducerAppData { _foo: 1, _bar: "2" });
+
+    options
+}
+
 fn audio_producer_options() -> ProducerOptions {
     let mut options = ProducerOptions::new(
         MediaKind::Audio,
@@ -339,6 +484,18 @@ async fn init() -> (
     WebRtcTransport,
     WebRtcTransport,
 ) {
+    init_with_media_codecs(media_codecs()).await
+}
+
+async fn init_with_media_codecs(
+    media_codecs: Vec<RtpCodecCapability>,
+) -> (
+    ExecutorGuard,
+    Worker,
+    Router,
+    WebRtcTransport,
+    WebRtcTransport,
+) {
     {
         let mut builder = env_logger::builder();
         if env::var(env_logger::DEFAULT_FILTER_ENV).is_err() {
@@ -357,7 +514,7 @@ async fn init() -> (
         .expect("Failed to create worker");
 
     let router = worker
-        .create_router(RouterOptions::new(media_codecs()))
+        .create_router(RouterOptions::new(media_codecs))
         .await
         .expect("Failed to create router");
 
@@ -1407,6 +1564,155 @@ fn set_preferred_layers_succeeds() {
                 })
             );
         }
+    });
+}
+
+#[test]
+fn consume_svc_honors_preferred_layers() {
+    future::block_on(async move {
+        let (_executor_guard, _worker, router, transport_1, transport_2) =
+            init_with_media_codecs(media_codecs_vpx()).await;
+
+        let device_capabilities = consumer_device_capabilities_vpx();
+
+        let svc_producer = transport_1
+            .produce(vp9_svc_producer_options())
+            .await
+            .expect("Failed to produce VP9 SVC video");
+
+        assert!(router.can_consume(&svc_producer.id(), &device_capabilities));
+
+        let svc_consumer = transport_2
+            .consume({
+                let mut options =
+                    ConsumerOptions::new(svc_producer.id(), device_capabilities.clone());
+                options.paused = true;
+                options.preferred_layers = Some(ConsumerLayers {
+                    spatial_layer: 1,
+                    temporal_layer: Some(0),
+                });
+                options
+            })
+            .await
+            .expect("Failed to consume VP9 SVC video");
+
+        assert_eq!(svc_consumer.r#type(), ConsumerType::Svc);
+        assert_eq!(
+            svc_consumer.preferred_layers(),
+            Some(ConsumerLayers {
+                spatial_layer: 1,
+                temporal_layer: Some(0),
+            })
+        );
+
+        // Out-of-range spatial and temporal layers are clamped to the max.
+        let svc_consumer_clamped = transport_2
+            .consume({
+                let mut options =
+                    ConsumerOptions::new(svc_producer.id(), device_capabilities.clone());
+                options.paused = true;
+                options.preferred_layers = Some(ConsumerLayers {
+                    spatial_layer: 9,
+                    temporal_layer: Some(9),
+                });
+                options
+            })
+            .await
+            .expect("Failed to consume VP9 SVC video (clamped)");
+
+        assert_eq!(
+            svc_consumer_clamped.preferred_layers(),
+            Some(ConsumerLayers {
+                spatial_layer: 2,
+                temporal_layer: Some(2),
+            })
+        );
+
+        // When no temporal layer is given it defaults to the max temporal layer.
+        let svc_consumer_no_temporal = transport_2
+            .consume({
+                let mut options =
+                    ConsumerOptions::new(svc_producer.id(), device_capabilities.clone());
+                options.paused = true;
+                options.preferred_layers = Some(ConsumerLayers {
+                    spatial_layer: 1,
+                    temporal_layer: None,
+                });
+                options
+            })
+            .await
+            .expect("Failed to consume VP9 SVC video (no temporal)");
+
+        assert_eq!(
+            svc_consumer_no_temporal.preferred_layers(),
+            Some(ConsumerLayers {
+                spatial_layer: 1,
+                temporal_layer: Some(2),
+            })
+        );
+    });
+}
+
+#[test]
+fn consume_simulcast_honors_preferred_layers() {
+    future::block_on(async move {
+        let (_executor_guard, _worker, router, transport_1, transport_2) =
+            init_with_media_codecs(media_codecs_vpx()).await;
+
+        let device_capabilities = consumer_device_capabilities_vpx();
+
+        let simulcast_producer = transport_1
+            .produce(vp8_simulcast_producer_options())
+            .await
+            .expect("Failed to produce VP8 simulcast video");
+
+        assert!(router.can_consume(&simulcast_producer.id(), &device_capabilities));
+
+        let simulcast_consumer = transport_2
+            .consume({
+                let mut options =
+                    ConsumerOptions::new(simulcast_producer.id(), device_capabilities.clone());
+                options.paused = true;
+                options.preferred_layers = Some(ConsumerLayers {
+                    spatial_layer: 1,
+                    temporal_layer: Some(0),
+                });
+                options
+            })
+            .await
+            .expect("Failed to consume VP8 simulcast video");
+
+        assert_eq!(simulcast_consumer.r#type(), ConsumerType::Simulcast);
+        assert_eq!(
+            simulcast_consumer.preferred_layers(),
+            Some(ConsumerLayers {
+                spatial_layer: 1,
+                temporal_layer: Some(0),
+            })
+        );
+
+        // Out-of-range spatial layer is clamped to the max (2 = number of encodings - 1).
+        let simulcast_consumer_clamped = transport_2
+            .consume({
+                let mut options =
+                    ConsumerOptions::new(simulcast_producer.id(), device_capabilities.clone());
+                options.paused = true;
+                options.preferred_layers = Some(ConsumerLayers {
+                    spatial_layer: 9,
+                    temporal_layer: Some(9),
+                });
+                options
+            })
+            .await
+            .expect("Failed to consume VP8 simulcast video (clamped)");
+
+        assert_eq!(
+            simulcast_consumer_clamped.preferred_layers(),
+            Some(ConsumerLayers {
+                spatial_layer: 2,
+                temporal_layer: Some(4),
+            })
+        );
     });
 }
 

--- a/worker/src/RTC/SvcConsumer.cpp
+++ b/worker/src/RTC/SvcConsumer.cpp
@@ -48,15 +48,19 @@ namespace RTC
 		// Set preferredLayers (if given).
 		if (flatbuffers::IsFieldPresent(data, FBS::Transport::ConsumeRequest::VT_PREFERREDLAYERS))
 		{
-			this->preferredLayers.spatial = data->preferredLayers()->spatialLayer();
+			const auto* preferredLayers = data->preferredLayers();
+
+			this->preferredLayers.spatial = preferredLayers->spatialLayer();
 
 			if (this->preferredLayers.spatial > encoding.spatialLayers - 1)
 			{
 				this->preferredLayers.spatial = static_cast<int16_t>(encoding.spatialLayers - 1);
 			}
 
-			if (flatbuffers::IsFieldPresent(data->preferredLayers(), FBS::Consumer::ConsumerLayers::VT_TEMPORALLAYER))
+			if (auto preferredTemporalLayer = preferredLayers->temporalLayer(); preferredTemporalLayer.has_value())
 			{
+				this->preferredLayers.temporal = preferredTemporalLayer.value();
+
 				if (this->preferredLayers.temporal > encoding.temporalLayers - 1)
 				{
 					this->preferredLayers.temporal = static_cast<int16_t>(encoding.temporalLayers - 1);


### PR DESCRIPTION
SVC consumer not reading provided temporal layer during construction:
https://github.com/versatica/mediasoup/blob/2c26c08dc11a39815f7656ee1609cbc35cc0341d/worker/src/RTC/SvcConsumer.cpp#L58-L64

The simulcast consumer has no such problem:
https://github.com/versatica/mediasoup/blob/2c26c08dc11a39815f7656ee1609cbc35cc0341d/worker/src/RTC/SimulcastConsumer.cpp#L70-L78

The SVC consumer construction had read the field from `JSON` in the past:
https://github.com/versatica/mediasoup/blob/0b4d4ef9f2bb0b9d117e48f707c970d406ee5022/worker/src/RTC/SvcConsumer.cpp#L64-L74

But does not read from flat buffers, which is regression [introduced](https://github.com/versatica/mediasoup/commit/a7d46d816778729ff250c0d9aeae16ef5ca98682#diff-6ffaa63138a8f226de6f2835d1d9781843f633f8d4f304547c0807f2adea7fb1L70) within https://github.com/versatica/mediasoup/pull/1064.

