### PR TITLE
Add `invoke/make check-wrap-status`

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -162,9 +162,13 @@ Cleans subprojects downloaded with Meson.
 
 Cleans built objects and binaries, `meson` and `ninja` installed in local prefix with pip and all subprojects downloaded with Meson.
 
+### `invoke check-wrap-status`
+
+Check the status of the Meson subprojects. It also prints whether there are updates available.
+
 ### `invoke update-wrap-file [subproject]`
 
-Updates the wrap file of a subproject (those in `worker/subprojects` folder) with Meson. After updating it, `invoke setup` must be called by passing `MESON_ARGS="--reconfigure"` environment variable. Usage example:
+Updates the wrap file of a Meson subproject (those in `worker/subprojects` folder). After updating it, `invoke setup` must be called by passing `MESON_ARGS="--reconfigure"` environment variable. Usage example:
 
 ```bash
 cd worker

--- a/worker/Makefile
+++ b/worker/Makefile
@@ -24,6 +24,7 @@ endif
 	clean-pip \
 	clean-subprojects \
 	clean-all \
+	check-wrap-status \
 	update-wrap-file \
 	mediasoup-worker \
 	libmediasoup-worker \
@@ -75,9 +76,12 @@ clean-subprojects: invoke
 clean-all: invoke
 	"$(PYTHON)" -m invoke clean-all
 
+check-wrap-status: invoke
+	"$(PYTHON)" -m invoke check-wrap-status
+
 # It requires the SUBPROJECT environment variable.
 update-wrap-file: invoke
-	"$(PYTHON)" -m invoke subprojects $(SUBPROJECT)
+	"$(PYTHON)" -m invoke update-wrap-file $(SUBPROJECT)
 
 mediasoup-worker: invoke
 	"$(PYTHON)" -m invoke mediasoup-worker

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -237,6 +237,19 @@ def clean_all(ctx):
 
 
 @task(pre=[meson_ninja])
+def check_wrap_status(ctx):
+    """
+    Check status of subprojects
+    """
+    with cd_worker():
+        ctx.run(
+            f'"{MESON}" wrap status',
+            echo=True,
+            pty=PTY_SUPPORTED,
+            shell=SHELL
+        );
+
+@task(pre=[meson_ninja])
 def update_wrap_file(ctx, subproject):
     """
     Update the wrap file of a subproject


### PR DESCRIPTION
# Details

In `worker/` dir:

```bash
invoke check-wrap-status
```

```
Subproject status
 catch2 up to date. Branch 3.14.0, revision 1.
 openssl up to date. Branch 3.0.8, revision 3.
 unordered-dense not available in wrapdb.
 abseil-cpp not up to date. Have 20240722.0 4, but 20250814.1 1 is available.
 wingetopt not available in wrapdb.
 flatbuffers up to date. Branch 24.3.25, revision 1.
 libuv up to date. Branch 1.51.0, revision 1.
 libsrtp3 not available in wrapdb.
 liburing up to date. Branch 2.14, revision 1.
```

Bonus tracks:
- Fix `make update-wrap-file`.