### PR TITLE
Make `dataConsumer.send()` return current buffered amount

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### NEXT
 
 - `PortManager`: Replace `uint64_t` hash token with exact-tuple `PortRangeKey` ([PR #1812](https://github.com/versatica/mediasoup/pull/1812), by @999purple999 and @penguinol).
-- Make `DataConsumer.send()` return current buffered amount ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Make `DataConsumer.send()` return current buffered amount ([PR #1819](https://github.com/versatica/mediasoup/pull/1819)).
 
 ### 3.20.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - `PortManager`: Replace `uint64_t` hash token with exact-tuple `PortRangeKey` ([PR #1812](https://github.com/versatica/mediasoup/pull/1812), by @999purple999 and @penguinol).
+- Make `DataConsumer.send()` return current buffered amount ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
 
 ### 3.20.1
 

--- a/node/src/DataConsumer.ts
+++ b/node/src/DataConsumer.ts
@@ -314,7 +314,7 @@ export class DataConsumerImpl<DataConsumerAppData extends AppData = AppData>
 		return data.bufferedAmount();
 	}
 
-	async send(message: string | Buffer, ppid?: number): Promise<void> {
+	async send(message: string | Buffer, ppid?: number): Promise<number> {
 		if (typeof message !== 'string' && !Buffer.isBuffer(message)) {
 			throw new TypeError('message must be a string or a Buffer');
 		}
@@ -370,12 +370,18 @@ export class DataConsumerImpl<DataConsumerAppData extends AppData = AppData>
 			dataOffset
 		);
 
-		await this.#channel.request(
+		const response = await this.#channel.request(
 			FbsRequest.Method.DATACONSUMER_SEND,
 			FbsRequest.Body.DataConsumer_SendRequest,
 			requestOffset,
 			this.#internal.dataConsumerId
 		);
+
+		const data = new FbsDataConsumer.GetBufferedAmountResponse();
+
+		response.body(data);
+
+		return data.bufferedAmount();
 	}
 
 	async setSubchannels(subchannels: number[]): Promise<void> {

--- a/node/src/DataConsumerTypes.ts
+++ b/node/src/DataConsumerTypes.ts
@@ -203,19 +203,20 @@ export interface DataConsumer<
 	resume(): Promise<void>;
 
 	/**
-	 * Set buffered amount low threshold.
+	 * Set buffered amount low threshold (in bytes).
 	 */
 	setBufferedAmountLowThreshold(threshold: number): Promise<void>;
 
 	/**
-	 * Get buffered amount size.
+	 * Get buffered amount size (in bytes).
 	 */
 	getBufferedAmount(): Promise<number>;
 
 	/**
-	 * Send a message.
+	 * Send a message. Only for SCTP data consumers. It returns current buffered
+	 * amount size (in bytes) after sending/queing the message.
 	 */
-	send(message: string | Buffer, ppid?: number): Promise<void>;
+	send(message: string | Buffer, ppid?: number): Promise<number>;
 
 	/**
 	 * Set subchannels.

--- a/node/src/test/test-DataConsumer.ts
+++ b/node/src/test/test-DataConsumer.ts
@@ -340,6 +340,14 @@ test('dataConsumer.getStats() on a DirectTransport succeeds', async () => {
 	]);
 }, 2000);
 
+test('dataConsumer.send() on a DirectTransport rejects with TypeError', async () => {
+	const dataConsumer = await ctx.directTransport!.consumeData({
+		dataProducerId: ctx.sctpDataProducer!.id,
+	});
+
+	await expect(dataConsumer.send('foo')).rejects.toThrow(TypeError);
+}, 2000);
+
 test('dataConsumer.pause() and resume() succeed', async () => {
 	const onObserverPause = jest.fn();
 	const onObserverResume = jest.fn();

--- a/node/src/test/test-werift-sctp.ts
+++ b/node/src/test/test-werift-sctp.ts
@@ -221,20 +221,13 @@ test('ordered DataProducer delivers all SCTP messages to the DataConsumer', asyn
 		},
 	]);
 
-	// console.log(
-	// 	'--- getBufferedAmount():',
-	// 	await ctx.dataConsumer!.getBufferedAmount()
-	// );
-
-	for (let i = 0; i < 100000; i++) {
-		const bufferedAmount = await ctx.dataConsumer!.send('hola');
-		if (bufferedAmount > 0) {
-			console.log('--- bufferedAmount:', bufferedAmount);
-		}
-	}
-
-	console.log(
-		'--- FIN getBufferedAmount():',
-		await ctx.dataConsumer!.getBufferedAmount()
-	);
+	expect(await ctx.dataConsumer!.getBufferedAmount()).toBe(0);
 }, 10000);
+
+test('can send messages from the SCTP DataConsumer', async () => {
+	expect(await ctx.dataConsumer!.getBufferedAmount()).toBe(0);
+
+	// We can send messages directly from the DataConsumer and it should return
+	// current buffered amount, so 0 bytes.
+	await expect(ctx.dataConsumer!.send('foo')).resolves.toBe(0);
+}, 2000);

--- a/node/src/test/test-werift-sctp.ts
+++ b/node/src/test/test-werift-sctp.ts
@@ -220,4 +220,21 @@ test('ordered DataProducer delivers all SCTP messages to the DataConsumer', asyn
 			bytesSent: recvMessageBytes,
 		},
 	]);
+
+	// console.log(
+	// 	'--- getBufferedAmount():',
+	// 	await ctx.dataConsumer!.getBufferedAmount()
+	// );
+
+	for (let i = 0; i < 100000; i++) {
+		const bufferedAmount = await ctx.dataConsumer!.send('hola');
+		if (bufferedAmount > 0) {
+			console.log('--- bufferedAmount:', bufferedAmount);
+		}
+	}
+
+	console.log(
+		'--- FIN getBufferedAmount():',
+		await ctx.dataConsumer!.getBufferedAmount()
+	);
 }, 10000);

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### NEXT
 
+- `DataConsumer::send()`: Return the current buffered amount size (in bytes) after sending/queuing the message (PR #XXXX):
+  - Fix: move the `send()` method from `DirectDataConsumer` to `RegularDataConsumer` (where the worker actually accepts it).
+
 ### 0.22.0
 
 - New built-in SCTP stack (PR #1806):

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- `DataConsumer::send()`: Return the current buffered amount size (in bytes) after sending/queuing the message (PR #XXXX):
+- `DataConsumer::send()`: Return the current buffered amount size (in bytes) after sending/queuing the message (PR #1819):
   - Fix: move the `send()` method from `DirectDataConsumer` to `RegularDataConsumer` (where the worker actually accepts it).
 
 ### 0.22.0

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -3175,7 +3175,7 @@ pub(crate) struct DataConsumerSendRequest {
 impl Request for DataConsumerSendRequest {
     const METHOD: request::Method = request::Method::DataconsumerSend;
     type HandlerId = DataConsumerId;
-    type Response = ();
+    type Response = u32;
 
     fn into_bytes(self, id: u32, handler_id: Self::HandlerId) -> Vec<u8> {
         let mut builder = Builder::new();
@@ -3197,9 +3197,15 @@ impl Request for DataConsumerSendRequest {
     }
 
     fn convert_response(
-        _response: Option<response::BodyRef<'_>>,
+        response: Option<response::BodyRef<'_>>,
     ) -> Result<Self::Response, Box<dyn Error + Send + Sync>> {
-        Ok(())
+        let Some(response::BodyRef::DataConsumerSendResponse(data)) = response else {
+            panic!("Wrong message from worker: {response:?}");
+        };
+
+        let data = data_consumer::SendResponse::try_from(data)?;
+
+        Ok(data.buffered_amount)
     }
 }
 

--- a/rust/src/router/data_consumer.rs
+++ b/rust/src/router/data_consumer.rs
@@ -965,9 +965,16 @@ impl DataConsumer {
     }
 }
 
-impl DirectDataConsumer {
-    /// Sends direct messages from the Rust process.
-    pub async fn send(&self, message: WebRtcMessage<'_>) -> Result<(), RequestError> {
+impl RegularDataConsumer {
+    /// Sends a message to the consuming endpoint over the SCTP association.
+    ///
+    /// Only available on data consumers created on a transport other than
+    /// [`DirectTransport`](crate::direct_transport::DirectTransport) (i.e. of type
+    /// [`DataConsumerType::Sctp`]), since the worker rejects this request for data consumers of
+    /// type [`DataConsumerType::Direct`].
+    ///
+    /// Returns the current buffered amount size (in bytes) after sending/queuing the message.
+    pub async fn send(&self, message: WebRtcMessage<'_>) -> Result<u32, RequestError> {
         let (ppid, payload) = message.into_ppid_and_payload();
 
         self.inner

--- a/worker/fbs/dataConsumer.fbs
+++ b/worker/fbs/dataConsumer.fbs
@@ -44,6 +44,10 @@ table SendRequest {
     data: [uint8] (required);
 }
 
+table SendResponse {
+    buffered_amount: uint32 = 0;
+}
+
 table SetSubchannelsRequest {
     subchannels: [uint16] (required);
 }

--- a/worker/fbs/response.fbs
+++ b/worker/fbs/response.fbs
@@ -39,6 +39,7 @@ union Body {
     DataConsumer_GetBufferedAmountResponse: FBS.DataConsumer.GetBufferedAmountResponse,
     DataConsumer_DumpResponse: FBS.DataConsumer.DumpResponse,
     DataConsumer_GetStatsResponse: FBS.DataConsumer.GetStatsResponse,
+    DataConsumer_SendResponse: FBS.DataConsumer.SendResponse,
     DataConsumer_SetSubchannelsResponse: FBS.DataConsumer.SetSubchannelsResponse,
     DataConsumer_AddSubchannelResponse: FBS.DataConsumer.AddSubchannelResponse,
     DataConsumer_RemoveSubchannelResponse: FBS.DataConsumer.RemoveSubchannelResponse

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -278,11 +278,18 @@ namespace RTC
 				}
 
 				const auto* cb = new onQueuedCallback(
-				  [&request](bool queued, bool sctpSendBufferFull)
+				  [this, &request](bool queued, bool sctpSendBufferFull)
 				  {
 					  if (queued)
 					  {
-						  request->Accept();
+						  uint32_t bufferedAmount{ 0 };
+
+						  this->listener->OnDataConsumerNeedBufferedAmount(this, bufferedAmount);
+
+						  auto responseOffset = FBS::DataConsumer::CreateGetBufferedAmountResponse(
+						    request->GetBufferBuilder(), bufferedAmount);
+
+						  request->Accept(FBS::Response::Body::DataConsumer_SendResponse, responseOffset);
 					  }
 					  else
 					  {

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -277,6 +277,9 @@ namespace RTC
 					  len);
 				}
 
+				// NOTE: Capturing `this` and `request` (by reference) is safe here because the
+				// callback is always invoked synchronously within this same call stack (never
+				// deferred).
 				const auto* cb = new onQueuedCallback(
 				  [this, &request](bool queued, bool sctpSendBufferFull)
 				  {


### PR DESCRIPTION
# Details

- Make `DataConsumer.send()` return current buffered amount instead of `void`. Why? Because it's useful and because the existing `DataConsumer.getBufferedAmount()` is an async method (so hard to use).
- Rust: Fix `send()` method which should exist in SCTP `RegularDataConsumer` rather than in `DirectDataConsumer`.

## TODO

* [ ] Document the change in the website.