### PR TITLE
Check packages publishing in CI

### DIFF
--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -46,6 +46,7 @@ jobs:
             meson_args: '-Db_sanitize=address'
             npm-audit: true
             run-lint: true
+            run-publish-dry-run: true
           - os: ubuntu-24.04
             node: 24
             cc: gcc
@@ -142,3 +143,8 @@ jobs:
       - if: ${{ !matrix.build.skip-test-in-debug-build-type || matrix.build-type != 'Debug' }}
         name: npm run test:node
         run: npm run test:node
+
+      # Only in Release build type to avoid running it twice (Release + Debug).
+      - if: ${{ matrix.build.run-publish-dry-run && matrix.build-type == 'Release' }}
+        name: npm run publish:dry-run
+        run: npm run publish:dry-run

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -38,6 +38,7 @@ jobs:
         build:
           - os: ubuntu-24.04
             run-cargo-fmt: true
+            run-cargo-dry-run: true
           - os: ubuntu-24.04-arm
           - os: macos-15
           - os: windows-2022
@@ -83,3 +84,17 @@ jobs:
         env:
           DOCS_RS: '1'
           RUSTDOCFLAGS: '-D rustdoc::broken-intra-doc-links -D rustdoc::private_intra_doc_links'
+
+      # NOTE: No need to unset the job-level KEEP_BUILD_ARTIFACTS here:
+      # `mediasoup-sys`'s build.rs detects the `cargo publish` verification step
+      # and always cleans the Meson subprojects it extracts into the source
+      # tree, avoiding the "Source directory was modified by build.rs" error.
+      # NOTE: Passing the three crates together as a single group (a
+      # `package-workspace` feature, stable since Rust 1.90) makes Cargo resolve
+      # the dependencies among them against the locally packaged copies instead
+      # of crates.io. This way `mediasoup` verifies fine even when the versions
+      # of `mediasoup-sys` / `mediasoup-types` it depends on have been bumped but
+      # not yet published.
+      - if: ${{ matrix.build.run-cargo-dry-run }}
+        name: cargo publish --dry-run -p mediasoup-types -p mediasoup-sys -p mediasoup
+        run: cargo publish --dry-run -p mediasoup-types -p mediasoup-sys -p mediasoup

--- a/doc/Rust-crates.md
+++ b/doc/Rust-crates.md
@@ -39,6 +39,7 @@ cargo publish
 ## Notes
 
 - Depending on the state in `worker` directory you may need to run `invoke clean-all` or `make clean-all` in `worker` directory first.
+- You can have `KEEP_BUILD_ARTIFACTS=1` exported in your shell (handy to speed up regular local builds) and still publish: `mediasoup-sys`'s `build.rs` detects the `cargo publish` / `cargo package` verification step (Cargo builds the crate inside `target/package/`) and always cleans the Meson subprojects it extracts into the source tree, regardless of `KEEP_BUILD_ARTIFACTS`. This avoids the "Source directory was modified by build.rs" error.
 - `cargo publish` will create the crate package, check if all necessary dependencies are already present on [crates.io](https://crates.io/), will then compile the package (to ensure that you don't publish a broken version) and will upload it to [crates.io](https://crates.io/).
 - Never publish from random branches or local state that is not on GitHub. If you have local files modified Cargo will refuse to publish until you commit all the changes.
 
@@ -46,7 +47,15 @@ cargo publish
 
 ### Check crate without publishing
 
-If you want to do everything except publishing itself, `cargo package` command exists. You can also run `cargo package --dry-run` to avoid package generation or `cargo publish --dry-run`.
+- If you want to do everything except the upload itself, run `cargo publish --dry-run`, which creates the package and compiles it for verification but does not upload anything.
+- To dry-run all crates at once (recommended before bumping versions), pass them as a single group so Cargo resolves the dependencies among them against the locally packaged copies instead of [crates.io](https://crates.io/). This works even if the new versions are not published yet:
+
+```sh
+cargo publish --dry-run -p mediasoup-types -p mediasoup-sys -p mediasoup
+```
+
+- To only build the package tarball without uploading, use `cargo package`.
+- To just list the files that would be included, use `cargo package --list`.
 
 ### Update required Rust version
 

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -232,6 +232,12 @@ async function run() {
 			break;
 		}
 
+		case 'publish:dry-run': {
+			publishDryRun();
+
+			break;
+		}
+
 		case 'release:check': {
 			await checkRelease();
 
@@ -511,6 +517,23 @@ function installNodeDeps() {
 	executeCmd('npm audit --prefix worker/scripts');
 }
 
+function publishDryRun() {
+	logInfo('publishDryRun()');
+
+	// NOTE: We use `npm pack --dry-run` rather than `npm publish --dry-run`
+	// because the latter contacts the registry and fails with "You cannot
+	// publish over the previously published versions" whenever the version in
+	// package.json is already published (which is the usual state between
+	// releases), making it useless in CI.
+	//
+	// `npm pack --dry-run` still runs the `prepare` script (flatbuffers
+	// generation and TypeScript build) and assembles the tarball exactly as a
+	// real publish would, reporting its contents without writing any file or
+	// contacting the registry. Useful to validate the `files` list in
+	// package.json and that the package builds before tagging a release.
+	executeCmd('npm pack --dry-run');
+}
+
 async function checkRelease() {
 	logInfo('checkRelease()');
 
@@ -522,6 +545,9 @@ async function checkRelease() {
 	lintWorker();
 	testNode();
 	testWorker();
+	// Validate packaging (the `files` list in package.json) before the
+	// irreversible release steps (git push, GitHub release, npm publish).
+	publishDryRun();
 }
 
 async function release() {

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
 		"test:worker": "node npm-scripts.mjs test:worker",
 		"coverage": "node npm-scripts.mjs coverage:node",
 		"coverage:node": "node npm-scripts.mjs coverage:node",
+		"publish:dry-run": "node npm-scripts.mjs publish:dry-run",
 		"release:check": "node npm-scripts.mjs release:check",
 		"release": "node npm-scripts.mjs release"
 	},

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -23,6 +23,7 @@ include = [
     "!/scripts/node_modules",
     "/src",
     "/subprojects/*.wrap",
+    "/subprojects/packagefiles",
     "/test/include",
     "/test/src",
     "/build.rs",

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -202,7 +202,20 @@ fn main() {
         fs::remove_dir_all(packagecache).expect("Failed to remove subprojects/packagecache");
     }
 
-    if env::var("KEEP_BUILD_ARTIFACTS") != Ok("1".to_string()) {
+    // Detect whether this build is the verification step of `cargo publish` /
+    // `cargo package`. In that case Cargo unpacks the crate into
+    // `<workspace>/target/package/<name>-<version>/` and builds it there, so
+    // `CARGO_MANIFEST_DIR` points inside `target/package`. During that step the
+    // source tree must be left untouched, otherwise Cargo fails with "Source
+    // directory was modified by build.rs". Meson extracts the wrap subprojects
+    // into the source tree, so we must always clean them here regardless of
+    // `KEEP_BUILD_ARTIFACTS` (which a developer may have exported to speed up
+    // their regular local builds).
+    let is_publish_verification = env::var("CARGO_MANIFEST_DIR")
+        .map(|dir| dir.replace('\\', "/").contains("/target/package/"))
+        .unwrap_or(false);
+
+    if is_publish_verification || env::var("KEEP_BUILD_ARTIFACTS") != Ok("1".to_string()) {
         // Clean
         if !Command::new(python)
             .arg("-m")


### PR DESCRIPTION
# Details

- Node: Simulate NPM package publishing in CI job.
- Rust: Simulate crates publishing in CI job.
- Tust: Ignore `KEEP_BUILD_ARTIFACTS=1` when running `cargo publish` so no need to start a fresh terminal session or unset the environment variable when publishing a new crate version after doing local work.