### PR TITLE
Fix SCTP crash when the t3-rtx timer expires

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Fix SCTP crash when the t3-rtx timer expires ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 3.20.2
 
 - `PortManager`: Replace `uint64_t` hash token with exact-tuple `PortRangeKey` ([PR #1812](https://github.com/versatica/mediasoup/pull/1812), by @999purple999 and @penguinol).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Fix SCTP crash when the t3-rtx timer expires ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Fix SCTP crash when the t3-rtx timer expires ([PR #1822](https://github.com/versatica/mediasoup/pull/1822)).
 
 ### 3.20.2
 

--- a/worker/Cargo.toml
+++ b/worker/Cargo.toml
@@ -23,6 +23,7 @@ include = [
     "!/scripts/node_modules",
     "/src",
     "/subprojects/*.wrap",
+    "/subprojects/packagefiles",
     "/test/include",
     "/test/src",
     "/build.rs",

--- a/worker/include/RTC/SCTP/association/HeartbeatHandler.hpp
+++ b/worker/include/RTC/SCTP/association/HeartbeatHandler.hpp
@@ -3,10 +3,10 @@
 
 #include "common.hpp"
 #include "handles/BackoffTimerHandleInterface.hpp"
+#include "RTC/SCTP/association/AssociationListenerDeferrer.hpp"
 #include "RTC/SCTP/association/TransmissionControlBlockContextInterface.hpp"
 #include "RTC/SCTP/packet/chunks/HeartbeatAckChunk.hpp"
 #include "RTC/SCTP/packet/chunks/HeartbeatRequestChunk.hpp"
-#include "RTC/SCTP/public/AssociationListenerInterface.hpp"
 #include "RTC/SCTP/public/SctpOptions.hpp"
 #include "SharedInterface.hpp"
 
@@ -26,7 +26,7 @@ namespace RTC
 		{
 		public:
 			HeartbeatHandler(
-			  AssociationListenerInterface& associationListener,
+			  AssociationListenerDeferrer& associationListenerDeferrer,
 			  const SctpOptions& sctpOptions,
 			  SharedInterface* shared,
 			  TransmissionControlBlockContextInterface* tcbContext);
@@ -63,7 +63,7 @@ namespace RTC
 			  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
 
 		private:
-			AssociationListenerInterface& associationListener;
+			AssociationListenerDeferrer& associationListenerDeferrer;
 			const SctpOptions sctpOptions;
 			SharedInterface* shared;
 			TransmissionControlBlockContextInterface* tcbContext;

--- a/worker/include/RTC/SCTP/association/StreamResetHandler.hpp
+++ b/worker/include/RTC/SCTP/association/StreamResetHandler.hpp
@@ -4,13 +4,13 @@
 #include "common.hpp"
 #include "Utils/UnwrappedSequenceNumber.hpp"
 #include "handles/BackoffTimerHandleInterface.hpp"
+#include "RTC/SCTP/association/AssociationListenerDeferrer.hpp"
 #include "RTC/SCTP/association/TransmissionControlBlockContextInterface.hpp"
 #include "RTC/SCTP/packet/Packet.hpp"
 #include "RTC/SCTP/packet/chunks/ReConfigChunk.hpp"
 #include "RTC/SCTP/packet/parameters/IncomingSsnResetRequestParameter.hpp"
 #include "RTC/SCTP/packet/parameters/OutgoingSsnResetRequestParameter.hpp"
 #include "RTC/SCTP/packet/parameters/ReconfigurationResponseParameter.hpp"
-#include "RTC/SCTP/public/AssociationListenerInterface.hpp"
 #include "RTC/SCTP/rx/DataTracker.hpp"
 #include "RTC/SCTP/rx/ReassemblyQueue.hpp"
 #include "RTC/SCTP/tx/RetransmissionQueue.hpp"
@@ -168,7 +168,7 @@ namespace RTC
 
 		public:
 			StreamResetHandler(
-			  AssociationListenerInterface& associationListener,
+			  AssociationListenerDeferrer& associationListenerDeferrer,
 			  SharedInterface* shared,
 			  TransmissionControlBlockContextInterface* tcbContext,
 			  DataTracker* dataTracker,
@@ -263,7 +263,7 @@ namespace RTC
 			  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
 
 		private:
-			AssociationListenerInterface& associationListener;
+			AssociationListenerDeferrer& associationListenerDeferrer;
 			SharedInterface* shared;
 			TransmissionControlBlockContextInterface* tcbContext;
 			DataTracker* dataTracker;

--- a/worker/include/RTC/SCTP/association/TransmissionControlBlock.hpp
+++ b/worker/include/RTC/SCTP/association/TransmissionControlBlock.hpp
@@ -3,13 +3,13 @@
 
 #include "common.hpp"
 #include "handles/BackoffTimerHandleInterface.hpp"
+#include "RTC/SCTP/association/AssociationListenerDeferrer.hpp"
 #include "RTC/SCTP/association/HeartbeatHandler.hpp"
 #include "RTC/SCTP/association/NegotiatedCapabilities.hpp"
 #include "RTC/SCTP/association/PacketSender.hpp"
 #include "RTC/SCTP/association/StreamResetHandler.hpp"
 #include "RTC/SCTP/association/TransmissionControlBlockContextInterface.hpp"
 #include "RTC/SCTP/packet/Packet.hpp"
-#include "RTC/SCTP/public/AssociationListenerInterface.hpp"
 #include "RTC/SCTP/public/SctpOptions.hpp"
 #include "RTC/SCTP/rx/DataTracker.hpp"
 #include "RTC/SCTP/rx/ReassemblyQueue.hpp"
@@ -37,7 +37,7 @@ namespace RTC
 		{
 		public:
 			TransmissionControlBlock(
-			  AssociationListenerInterface& associationListener,
+			  AssociationListenerDeferrer& associationListenerDeferrer,
 			  const SctpOptions& sctpOptions,
 			  SharedInterface* shared,
 			  SendQueueInterface& sendQueue,
@@ -288,7 +288,7 @@ namespace RTC
 			  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
 
 		private:
-			AssociationListenerInterface& associationListener;
+			AssociationListenerDeferrer& associationListenerDeferrer;
 			const SctpOptions sctpOptions;
 			SharedInterface* shared;
 			PacketSender& packetSender;

--- a/worker/src/RTC/SCTP/association/HeartbeatHandler.cpp
+++ b/worker/src/RTC/SCTP/association/HeartbeatHandler.cpp
@@ -19,11 +19,11 @@ namespace RTC
 		/* Instance methods. */
 
 		HeartbeatHandler::HeartbeatHandler(
-		  AssociationListenerInterface& associationListener,
+		  AssociationListenerDeferrer& associationListenerDeferrer,
 		  const SctpOptions& sctpOptions,
 		  SharedInterface* shared,
 		  TransmissionControlBlockContextInterface* tcbContext)
-		  : associationListener(associationListener),
+		  : associationListenerDeferrer(associationListenerDeferrer),
 		    sctpOptions(sctpOptions),
 		    shared(shared),
 		    tcbContext(tcbContext),
@@ -124,7 +124,7 @@ namespace RTC
 
 			if (!heartbeatInfoParameter)
 			{
-				this->associationListener.OnAssociationError(
+				this->associationListenerDeferrer.OnAssociationError(
 				  Types::ErrorKind::PARSE_FAILED,
 				  "ignoring HEARTBEAT-ACK chunk without Heartbeat Info parameter");
 
@@ -136,14 +136,14 @@ namespace RTC
 
 			if (!info)
 			{
-				this->associationListener.OnAssociationError(
+				this->associationListenerDeferrer.OnAssociationError(
 				  Types::ErrorKind::PARSE_FAILED, "ignoring Heartbeat Info parameter without info field");
 
 				return;
 			}
 			else if (infoLen != HeartbeatInfoLength)
 			{
-				this->associationListener.OnAssociationError(
+				this->associationListenerDeferrer.OnAssociationError(
 				  Types::ErrorKind::PARSE_FAILED, "ignoring Heartbeat Info parameter with wrong length");
 
 				return;
@@ -180,6 +180,11 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			// This is a top-level timer entry point (invoked by libuv outside any other
+			// SCTP API call), so it must establish the deferrer scope itself, just like
+			// Association does in its own timer handlers.
+			const AssociationListenerDeferrer::ScopedDeferrer deferrer(this->associationListenerDeferrer);
+
 			if (!this->tcbContext->IsAssociationEstablished())
 			{
 				MS_DEBUG_DEV("won't send HEARTBEAT-REQUEST when SCTP association is not established");
@@ -213,6 +218,11 @@ namespace RTC
 		void HeartbeatHandler::OnTimeoutTimer(uint64_t& /*baseTimeoutMs*/, bool& /*stop*/)
 		{
 			MS_TRACE();
+
+			// This is a top-level timer entry point (invoked by libuv outside any other
+			// SCTP API call), so it must establish the deferrer scope itself, just like
+			// Association does in its own timer handlers.
+			const AssociationListenerDeferrer::ScopedDeferrer deferrer(this->associationListenerDeferrer);
 
 			// Note that the timeout timer is not restarted. It will be started again when
 			// the interval timer expires.

--- a/worker/src/RTC/SCTP/association/StreamResetHandler.cpp
+++ b/worker/src/RTC/SCTP/association/StreamResetHandler.cpp
@@ -13,13 +13,13 @@ namespace RTC
 		/* Instance methods. */
 
 		StreamResetHandler::StreamResetHandler(
-		  AssociationListenerInterface& associationListener,
+		  AssociationListenerDeferrer& associationListenerDeferrer,
 		  SharedInterface* shared,
 		  TransmissionControlBlockContextInterface* tcbContext,
 		  DataTracker* dataTracker,
 		  ReassemblyQueue* reassemblyQueue,
 		  RetransmissionQueue* retransmissionQueue)
-		  : associationListener(associationListener),
+		  : associationListenerDeferrer(associationListenerDeferrer),
 		    shared(shared),
 		    tcbContext(tcbContext),
 		    dataTracker(dataTracker),
@@ -89,7 +89,7 @@ namespace RTC
 
 			if (!ValidateReceivedReConfigChunk(receivedReConfigChunk))
 			{
-				this->associationListener.OnAssociationError(
+				this->associationListenerDeferrer.OnAssociationError(
 				  Types::ErrorKind::PARSE_FAILED, "invalid RE-CONFIG command received");
 
 				return;
@@ -334,7 +334,7 @@ namespace RTC
 				this->reassemblyQueue->ResetStreamsAndLeaveDeferredReset(
 				  receivedOutgoingSsnResetRequestParameter->GetStreamIds());
 
-				this->associationListener.OnAssociationInboundStreamsReset(
+				this->associationListenerDeferrer.OnAssociationInboundStreamsReset(
 				  receivedOutgoingSsnResetRequestParameter->GetStreamIds());
 
 				this->lastProcessedReqResult = ReconfigurationResponseParameter::Result::SUCCESS_PERFORMED;
@@ -412,7 +412,7 @@ namespace RTC
 						MS_DEBUG_DEV(
 						  "reset stream success [reqSeqNbr:%" PRIu32 "]", this->currentRequest->GetReqSeqNbr());
 
-						this->associationListener.OnAssociationStreamsResetPerformed(
+						this->associationListenerDeferrer.OnAssociationStreamsResetPerformed(
 						  this->currentRequest->GetStreamIds());
 
 						this->currentRequest = std::nullopt;
@@ -450,7 +450,7 @@ namespace RTC
 						    receivedReconfigurationResponseParameter->GetResult())
 						    .c_str());
 
-						this->associationListener.OnAssociationStreamsResetFailed(
+						this->associationListenerDeferrer.OnAssociationStreamsResetFailed(
 						  this->currentRequest->GetStreamIds(),
 						  ReconfigurationResponseParameter::ResultToString(
 						    receivedReconfigurationResponseParameter->GetResult()));
@@ -468,6 +468,11 @@ namespace RTC
 		void StreamResetHandler::OnReConfigTimer(uint64_t& baseTimeoutMs, bool& /*stop*/)
 		{
 			MS_TRACE();
+
+			// This is a top-level timer entry point (invoked by libuv outside any other
+			// SCTP API call), so it must establish the deferrer scope itself, just like
+			// Association does in its own timer handlers.
+			const AssociationListenerDeferrer::ScopedDeferrer deferrer(this->associationListenerDeferrer);
 
 			if (this->currentRequest && this->currentRequest->HasBeenSent())
 			{

--- a/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
+++ b/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
@@ -21,7 +21,7 @@ namespace RTC
 		/* Instance methods. */
 
 		TransmissionControlBlock::TransmissionControlBlock(
-		  AssociationListenerInterface& associationListener,
+		  AssociationListenerDeferrer& associationListenerDeferrer,
 		  const SctpOptions& sctpOptions,
 		  SharedInterface* shared,
 		  SendQueueInterface& sendQueue,
@@ -35,7 +35,7 @@ namespace RTC
 		  const NegotiatedCapabilities& negotiatedCapabilities,
 		  size_t maxPacketLength,
 		  std::function<bool()> isAssociationEstablished)
-		  : associationListener(associationListener),
+		  : associationListenerDeferrer(associationListenerDeferrer),
 		    sctpOptions(sctpOptions),
 		    shared(shared),
 		    packetSender(packetSender),
@@ -71,7 +71,7 @@ namespace RTC
 		      sctpOptions.maxReceiverWindowBufferSize, negotiatedCapabilities.messageInterleaving),
 		    retransmissionQueue(
 		      this,
-		      this->associationListener,
+		      this->associationListenerDeferrer,
 		      localInitialTsn,
 		      remoteAdvertisedReceiverWindowCredit,
 		      sendQueue,
@@ -80,13 +80,13 @@ namespace RTC
 		      negotiatedCapabilities.partialReliability,
 		      negotiatedCapabilities.messageInterleaving),
 		    streamResetHandler(
-		      this->associationListener,
+		      this->associationListenerDeferrer,
 		      this->shared,
 		      this,
 		      std::addressof(this->dataTracker),
 		      std::addressof(this->reassemblyQueue),
 		      std::addressof(this->retransmissionQueue)),
-		    heartbeatHandler(this->associationListener, sctpOptions, this->shared, this)
+		    heartbeatHandler(this->associationListenerDeferrer, sctpOptions, this->shared, this)
 		{
 			MS_TRACE();
 
@@ -411,6 +411,11 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			// This is a top-level timer entry point (invoked by libuv outside any other
+			// SCTP API call), so it must establish the deferrer scope itself, just like
+			// Association does in its own timer handlers.
+			const AssociationListenerDeferrer::ScopedDeferrer deferrer(this->associationListenerDeferrer);
+
 			// In the COOKIE-ECHO state, let the T1-COOKIE timer trigger
 			// retransmissions, to avoid having two timers doing that.
 			if (this->remoteStateCookie.has_value())
@@ -433,6 +438,11 @@ namespace RTC
 		void TransmissionControlBlock::OnDelayedAckTimer(uint64_t& /*baseTimeoutMs*/, bool& /*stop*/)
 		{
 			MS_TRACE();
+
+			// This is a top-level timer entry point (invoked by libuv outside any other
+			// SCTP API call), so it must establish the deferrer scope itself, just like
+			// Association does in its own timer handlers.
+			const AssociationListenerDeferrer::ScopedDeferrer deferrer(this->associationListenerDeferrer);
 
 			this->dataTracker.HandleDelayedAckTimerExpiry();
 

--- a/worker/test/src/RTC/SCTP/association/TestHeartbeatHandler.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestHeartbeatHandler.cpp
@@ -1,4 +1,5 @@
 #include "common.hpp"
+#include "RTC/SCTP/association/AssociationListenerDeferrer.hpp"
 #include "RTC/SCTP/association/HeartbeatHandler.hpp"
 #include "RTC/SCTP/packet/Packet.hpp"
 #include "RTC/SCTP/packet/chunks/HeartbeatAckChunk.hpp"
@@ -38,7 +39,7 @@ SCENARIO("SCTP HeartbeatHandler", "[sctp][heartbeathandler]")
 			           return this->nowMs;
 		           }),
 		    heartbeatHandler(
-		      this->associationListener,
+		      this->associationListenerDeferrer,
 		      this->sctpOptions,
 		      std::addressof(this->shared),
 		      std::addressof(this->tcbContext))
@@ -60,6 +61,8 @@ SCENARIO("SCTP HeartbeatHandler", "[sctp][heartbeathandler]")
 	public:
 		RTC::SCTP::SctpOptions sctpOptions;
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
+		RTC::SCTP::AssociationListenerDeferrer associationListenerDeferrer{ std::addressof(
+			this->associationListener) };
 		mocks::RTC::SCTP::MockTransmissionControlBlockContext tcbContext;
 		mocks::MockShared shared;
 		RTC::SCTP::HeartbeatHandler heartbeatHandler;

--- a/worker/test/src/RTC/SCTP/association/TestTransmissionControlBlock.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestTransmissionControlBlock.cpp
@@ -1,5 +1,6 @@
 #include "common.hpp"
 #include "DepLibUV.hpp"
+#include "RTC/SCTP/association/AssociationListenerDeferrer.hpp"
 #include "RTC/SCTP/association/NegotiatedCapabilities.hpp"
 #include "RTC/SCTP/association/PacketSender.hpp"
 #include "RTC/SCTP/association/TransmissionControlBlock.hpp"
@@ -32,6 +33,8 @@ SCENARIO("SCTP TransmissionControlBlock", "[sctp][transmissioncontrolblock]")
 	const RTC::SCTP::SctpOptions sctpOptions;
 
 	mocks::RTC::SCTP::MockAssociationListener associationListener;
+	RTC::SCTP::AssociationListenerDeferrer associationListenerDeferrer(
+	  std::addressof(associationListener));
 	mocks::MockShared shared(/*getTimeMs*/
 	                         []()
 	                         {
@@ -54,7 +57,7 @@ SCENARIO("SCTP TransmissionControlBlock", "[sctp][transmissioncontrolblock]")
 		sendQueue.ExpectEnableMessageInterleavingCalledWith(false);
 
 		const RTC::SCTP::TransmissionControlBlock tcb(
-		  associationListener,
+		  associationListenerDeferrer,
 		  sctpOptions,
 		  std::addressof(shared),
 		  sendQueue,
@@ -79,7 +82,7 @@ SCENARIO("SCTP TransmissionControlBlock", "[sctp][transmissioncontrolblock]")
 		sendQueue.ExpectEnableMessageInterleavingCalledWith(true);
 
 		const RTC::SCTP::TransmissionControlBlock tcb(
-		  associationListener,
+		  associationListenerDeferrer,
 		  sctpOptions,
 		  std::addressof(shared),
 		  sendQueue,


### PR DESCRIPTION
# Details

- The mediasoup SCTP stack aborts the process under some scenarios when the SCTP t3-rtx timer expires:
  ```
  mediasoup:mediasoup:ERROR:Worker (ABORT)
  RTC::SCTP::AssociationListenerDeferrer::OnAssociationStreamBufferedAmountLow() | failed
  assertion this->ready: not ready
  ```
- The problem is that timers in `TransmissionControlBlock` (t3-rtx, delayed-ack), `HeartbeatHandler` and `StreamResetHandler` are direct entry points invoked by libuv but, unlike in libwebrtc/dcsctp, which handles all timers through `DcSctpSocket::HandleTimeout()` and creates a `CallbackDeferrer::ScopedDeferrer` there, these handlers in mediasoup's SCTP stack don't open the deferrer scope. When a SCTP t3-rtx timer expires it ends up invoking a deferred callback (e.g. `OnAssociationStreamBufferedAmountLow()` via `SendBufferedPackets()`) and triggers a failed assertion on `this->ready` and aborts the worker.
- The fix: Each component owning its own timers now opens an `AssociationListenerDeferrer::ScopedDeferrer` at the start of its timer handlers (`OnT3RtxTimer()`/`OnDelayedAckTimer()`, `OnIntervalTimer()`/`OnTimeoutTimer()`, `OnReConfigTimer()`), just like `Association` already does in its `OnXxxxTimer()` callbacks. To allow this, the argument and member change from `AssociationListenerInterface&` to `AssociationListenerDeferrer&`.
  - _NOTE:_ `PacketSender` and `RetransmissionQueue` keep the `AssociationListenerInterface` class since they are not entry points.
  - _NOTE:_ `PacketSender` invokes `this->associationListener.OnAssociationSendData()`, however such a callback is not deferred so we are good. Similar stuff for `RetransmissionQueue`.
- Test updated.
