### PR TITLE
SCTP: Fixes and more tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- SCTP: Fix `HeartbeatHandler` timers and close the association with `TOO_MANY_RETRIES` error when t3-rtx timer, heartbeat-timeout timer and RE-CONFIG timer expire ([PR #1824](https://github.com/versatica/mediasoup/pull/1824)).
+
 ### 3.20.3
 
 - Fix SCTP crash when the t3-rtx timer expires ([PR #1822](https://github.com/versatica/mediasoup/pull/1822)).

--- a/doc/Rust-crates.md
+++ b/doc/Rust-crates.md
@@ -42,7 +42,7 @@ cargo publish --locked
 - You can have `KEEP_BUILD_ARTIFACTS=1` exported in your shell (handy to speed up regular local builds) and still publish: `mediasoup-sys`'s `build.rs` detects the `cargo publish` / `cargo package` verification step (Cargo builds the crate inside `target/package/`) and always cleans the Meson subprojects it extracts into the source tree, regardless of `KEEP_BUILD_ARTIFACTS`. This avoids the "Source directory was modified by build.rs" error.
 - `cargo publish` will create the crate package, check if all necessary dependencies are already present on [crates.io](https://crates.io/), will then compile the package (to ensure that you don't publish a broken version) and will upload it to [crates.io](https://crates.io/).
 - Never publish from random branches or local state that is not on GitHub. If you have local files modified Cargo will refuse to publish until you commit all the changes.
-- Use `cargo publish --locked`. The dirty-repo check runs *before* the verification build, but the verification build is exactly when Cargo regenerates `Cargo.lock`, so a stale lock slips past the dirty check and gets silently updated. `--locked` makes `cargo publish` fail up front if `Cargo.lock` needs updating, forcing step 3 to have been done and committed first.
+- Use `cargo publish --locked`. The dirty-repo check runs _before_ the verification build, but the verification build is exactly when Cargo regenerates `Cargo.lock`, so a stale lock slips past the dirty check and gets silently updated. `--locked` makes `cargo publish` fail up front if `Cargo.lock` needs updating, forcing step 3 to have been done and committed first.
 
 ## Extras
 

--- a/worker/include/RTC/SCTP/association/Association.hpp
+++ b/worker/include/RTC/SCTP/association/Association.hpp
@@ -53,7 +53,8 @@ namespace RTC
 		 */
 		class Association : public AssociationInterface,
 		                    public PacketSender::Listener,
-		                    public BackoffTimerHandleInterface::Listener
+		                    public BackoffTimerHandleInterface::Listener,
+		                    public TransmissionControlBlockContextInterface::Listener
 		{
 		public:
 			/**
@@ -172,7 +173,13 @@ namespace RTC
 			  const SctpOptions& sctpOptions,
 			  AssociationListenerInterface* listener,
 			  SharedInterface* shared,
-			  bool isDataChannel);
+			  bool isDataChannel,
+			  // Whether `MayConnect()` should be called when SCTP data is received.
+			  // This is always true in production (the association auto-initiates the
+			  // connection as soon as the transport is ready or data arrives). It's
+			  // only set to false in tests that need a purely passive peer to mimic
+			  // dcsctp's asymmetric handshake.
+			  bool mayConnectOnReceivedSctpData);
 
 			~Association() override;
 
@@ -494,6 +501,10 @@ namespace RTC
 			void OnBackoffTimer(
 			  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
 
+			/* Pure virtual methods inherited from TransmissionControlBlockContextInterface::Listener. */
+		public:
+			void OnTransmissionControlBlockTooManyTxErrors() override;
+
 		private:
 			// SCTP options given in the constructor.
 			SctpOptions sctpOptions;
@@ -526,6 +537,9 @@ namespace RTC
 			const size_t maxPacketLength;
 			// Whether this is DataChannel based SCTP.
 			bool isDataChannel;
+			// Whether `MayConnect()` should be called when SCTP data is received.
+			// See the constructor for details.
+			bool mayConnectOnReceivedSctpData;
 		};
 	} // namespace SCTP
 } // namespace RTC

--- a/worker/include/RTC/SCTP/association/TransmissionControlBlock.hpp
+++ b/worker/include/RTC/SCTP/association/TransmissionControlBlock.hpp
@@ -37,6 +37,7 @@ namespace RTC
 		{
 		public:
 			TransmissionControlBlock(
+			  TransmissionControlBlockContextInterface::Listener* listener,
 			  AssociationListenerDeferrer& associationListenerDeferrer,
 			  const SctpOptions& sctpOptions,
 			  SharedInterface* shared,
@@ -250,7 +251,20 @@ namespace RTC
 			 */
 			bool IncrementTxErrorCounter(std::string_view reason) override
 			{
-				return this->txErrorCounter.Increment(reason);
+				const bool withinLimit = this->txErrorCounter.Increment(reason);
+
+				if (!withinLimit)
+				{
+					// NOTE: This closes (and destroys) this TCB synchronously. It's safe to
+					// do so from within a timer handler because the handler sets the
+					// BackoffTimerHandle `stop` flag and doesn't touch any member
+					// afterwards, so the (now destroyed) firing timer won't be accessed.
+					this->listener->OnTransmissionControlBlockTooManyTxErrors();
+				}
+
+				// NOTE: `withinLimit` is a local, so this is safe even if `this` was
+				// destroyed above.
+				return withinLimit;
 			}
 
 			/**
@@ -288,6 +302,7 @@ namespace RTC
 			  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop) override;
 
 		private:
+			TransmissionControlBlockContextInterface::Listener* listener;
 			AssociationListenerDeferrer& associationListenerDeferrer;
 			const SctpOptions sctpOptions;
 			SharedInterface* shared;

--- a/worker/include/RTC/SCTP/association/TransmissionControlBlockContextInterface.hpp
+++ b/worker/include/RTC/SCTP/association/TransmissionControlBlockContextInterface.hpp
@@ -17,10 +17,13 @@ namespace RTC
 			public:
 				virtual ~Listener() = default;
 
+			public:
 				/**
 				 * Called when the transmission error counter has exceeded its limit and
-				 * the association must therefore be closed. Mirrors dcsctp's
-				 * `CloseConnectionBecauseOfTooManyTransmissionErrors()`.
+				 * the association must therefore be closed.
+				 *
+				 * @remarks
+				 * - It mirrors dcsctp's `CloseConnectionBecauseOfTooManyTransmissionErrors()`.
 				 */
 				virtual void OnTransmissionControlBlockTooManyTxErrors() = 0;
 			};
@@ -58,8 +61,8 @@ namespace RTC
 
 			/**
 			 * Increments the transmission error counter, given a human readable
-			 * reason. Returns `true` if the maximum error count has been reached,
-			 * `false` will be returned.
+			 * reason. Returns `false` if the maximum error count has been reached,
+			 * `true` otherwise.
 			 */
 			virtual bool IncrementTxErrorCounter(std::string_view reason) = 0;
 

--- a/worker/include/RTC/SCTP/association/TransmissionControlBlockContextInterface.hpp
+++ b/worker/include/RTC/SCTP/association/TransmissionControlBlockContextInterface.hpp
@@ -12,6 +12,20 @@ namespace RTC
 		class TransmissionControlBlockContextInterface
 		{
 		public:
+			class Listener
+			{
+			public:
+				virtual ~Listener() = default;
+
+				/**
+				 * Called when the transmission error counter has exceeded its limit and
+				 * the association must therefore be closed. Mirrors dcsctp's
+				 * `CloseConnectionBecauseOfTooManyTransmissionErrors()`.
+				 */
+				virtual void OnTransmissionControlBlockTooManyTxErrors() = 0;
+			};
+
+		public:
 			virtual ~TransmissionControlBlockContextInterface() = default;
 
 			/**

--- a/worker/include/RTC/SCTP/tx/RetransmissionErrorCounter.hpp
+++ b/worker/include/RTC/SCTP/tx/RetransmissionErrorCounter.hpp
@@ -26,14 +26,13 @@ namespace RTC
 			void Dump(int indentation = 0) const;
 
 			/**
-			 * Increments the retransmission timer. Returns `true` if the maximum
-			 * error count has been reached, `false` will be returned.
+			 * Increments the retransmission timer. Returns `false` if the maximum
+			 * error count has been reached, `true` otherwise.
 			 */
 			bool Increment(std::string_view reason);
 
 			/**
 			 * Whether maximum error count has been reached.
-			 * @return [description]
 			 */
 			bool IsExhausted() const
 			{

--- a/worker/include/RTC/SCTP/tx/RetransmissionErrorCounter.hpp
+++ b/worker/include/RTC/SCTP/tx/RetransmissionErrorCounter.hpp
@@ -18,7 +18,7 @@ namespace RTC
 		class RetransmissionErrorCounter
 		{
 		public:
-			RetransmissionErrorCounter(const SctpOptions& sctpOptions);
+			explicit RetransmissionErrorCounter(const SctpOptions& sctpOptions);
 
 			~RetransmissionErrorCounter();
 

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -497,6 +497,7 @@ test_sources = [
   'test/src/RTC/SCTP/association/TestAssociation.cpp',
   'test/src/RTC/SCTP/association/TestHeartbeatHandler.cpp',
   'test/src/RTC/SCTP/association/TestNegotiatedCapabilities.cpp',
+  'test/src/RTC/SCTP/association/TestPacketSender.cpp',
   'test/src/RTC/SCTP/association/TestStateCookie.cpp',
   'test/src/RTC/SCTP/association/TestStreamResetHandler.cpp',
   'test/src/RTC/SCTP/association/TestTransmissionControlBlock.cpp',

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -494,6 +494,7 @@ test_sources = [
   'test/src/RTC/RTCP/TestPacket.cpp',
   'test/src/RTC/RTCP/TestXr.cpp',
   'test/src/RTC/SCTP/sctpCommon.cpp',
+  'test/src/RTC/SCTP/association/TestAssociation.cpp',
   'test/src/RTC/SCTP/association/TestHeartbeatHandler.cpp',
   'test/src/RTC/SCTP/association/TestNegotiatedCapabilities.cpp',
   'test/src/RTC/SCTP/association/TestStateCookie.cpp',

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -498,6 +498,7 @@ test_sources = [
   'test/src/RTC/SCTP/association/TestHeartbeatHandler.cpp',
   'test/src/RTC/SCTP/association/TestNegotiatedCapabilities.cpp',
   'test/src/RTC/SCTP/association/TestStateCookie.cpp',
+  'test/src/RTC/SCTP/association/TestStreamResetHandler.cpp',
   'test/src/RTC/SCTP/association/TestTransmissionControlBlock.cpp',
   'test/src/RTC/SCTP/rx/TestDataTracker.cpp',
   'test/src/RTC/SCTP/rx/TestInterleavedReassemblyStreams.cpp',

--- a/worker/mocks/include/RTC/SCTP/association/MockAssociationListener.hpp
+++ b/worker/mocks/include/RTC/SCTP/association/MockAssociationListener.hpp
@@ -21,7 +21,7 @@ namespace mocks
 				{
 					this->sentPackets.emplace_back(data, data + len);
 
-					return true;
+					return this->sendDataResult;
 				}
 
 				void OnAssociationConnecting() override
@@ -253,6 +253,15 @@ namespace mocks
 					return this->inboundStreamsReset.contains(streamId);
 				}
 
+				/**
+				 * Sets the value that `OnAssociationSendData()` will return, allowing
+				 * tests to simulate a failed send.
+				 */
+				void SetSendDataResult(bool sendDataResult)
+				{
+					this->sendDataResult = sendDataResult;
+				}
+
 				bool HasSentPackets() const
 				{
 					return !this->sentPackets.empty();
@@ -344,6 +353,7 @@ namespace mocks
 				std::set<uint16_t /*streamId*/> streamsResetFailed;
 				size_t onInboundStreamsResetCalls{ 0 };
 				std::set<uint16_t /*streamId*/> inboundStreamsReset;
+				bool sendDataResult{ true };
 				std::deque<std::vector<uint8_t>> sentPackets;
 				std::deque<::RTC::SCTP::Message> receivedMessages;
 				bool transportReady{ true };

--- a/worker/mocks/include/RTC/SCTP/association/MockAssociationListener.hpp
+++ b/worker/mocks/include/RTC/SCTP/association/MockAssociationListener.hpp
@@ -75,20 +75,35 @@ namespace mocks
 					this->receivedMessages.emplace_back(std::move(message));
 				}
 
-				void OnAssociationStreamsResetPerformed(std::span<const uint16_t> /*outboundStreamIds*/) override
+				void OnAssociationStreamsResetPerformed(std::span<const uint16_t> outboundStreamIds) override
 				{
-					// TODO: Do something here for tests.
+					++this->onStreamsResetPerformedCalls;
+
+					for (const auto streamId : outboundStreamIds)
+					{
+						this->streamsResetPerformed.insert(streamId);
+					}
 				}
 
 				void OnAssociationStreamsResetFailed(
-				  std::span<const uint16_t> /*outboundStreamIds*/, std::string_view /*errorMessage*/) override
+				  std::span<const uint16_t> outboundStreamIds, std::string_view /*errorMessage*/) override
 				{
-					// TODO: Do something here for tests.
+					++this->onStreamsResetFailedCalls;
+
+					for (const auto streamId : outboundStreamIds)
+					{
+						this->streamsResetFailed.insert(streamId);
+					}
 				}
 
-				void OnAssociationInboundStreamsReset(std::span<const uint16_t> /*inboundStreamIds*/) override
+				void OnAssociationInboundStreamsReset(std::span<const uint16_t> inboundStreamIds) override
 				{
-					// TODO: Do something here for tests.
+					++this->onInboundStreamsResetCalls;
+
+					for (const auto streamId : inboundStreamIds)
+					{
+						this->inboundStreamsReset.insert(streamId);
+					}
 				}
 
 				void OnAssociationStreamBufferedAmountLow(uint16_t streamId) override
@@ -208,6 +223,36 @@ namespace mocks
 					return this->onTotalBufferedAmountLowCalls;
 				}
 
+				size_t CountOnStreamsResetPerformedCalls() const
+				{
+					return this->onStreamsResetPerformedCalls;
+				}
+
+				bool HasStreamsResetPerformedForStreamId(uint16_t streamId) const
+				{
+					return this->streamsResetPerformed.contains(streamId);
+				}
+
+				size_t CountOnStreamsResetFailedCalls() const
+				{
+					return this->onStreamsResetFailedCalls;
+				}
+
+				bool HasStreamsResetFailedForStreamId(uint16_t streamId) const
+				{
+					return this->streamsResetFailed.contains(streamId);
+				}
+
+				size_t CountOnInboundStreamsResetCalls() const
+				{
+					return this->onInboundStreamsResetCalls;
+				}
+
+				bool HasInboundStreamsResetForStreamId(uint16_t streamId) const
+				{
+					return this->inboundStreamsReset.contains(streamId);
+				}
+
 				bool HasSentPackets() const
 				{
 					return !this->sentPackets.empty();
@@ -293,6 +338,12 @@ namespace mocks
 				std::string erroredErrorMessage;
 				std::map<uint16_t /*streamId*/, size_t /*count*/> onStreamBufferedAmountLowCalls;
 				size_t onTotalBufferedAmountLowCalls{ 0 };
+				size_t onStreamsResetPerformedCalls{ 0 };
+				std::set<uint16_t /*streamId*/> streamsResetPerformed;
+				size_t onStreamsResetFailedCalls{ 0 };
+				std::set<uint16_t /*streamId*/> streamsResetFailed;
+				size_t onInboundStreamsResetCalls{ 0 };
+				std::set<uint16_t /*streamId*/> inboundStreamsReset;
 				std::deque<std::vector<uint8_t>> sentPackets;
 				std::deque<::RTC::SCTP::Message> receivedMessages;
 				bool transportReady{ true };

--- a/worker/mocks/include/handles/MockBackoffTimerHandle.hpp
+++ b/worker/mocks/include/handles/MockBackoffTimerHandle.hpp
@@ -36,14 +36,20 @@ namespace mocks
 
 		void Start() override
 		{
-			this->running     = true;
-			this->expiresAtMs = this->getTimeMs() + ComputeNextTimeoutMs();
+			this->running = true;
+			// NOTE: Reset the expiration count, just like the real BackoffTimerHandle
+			// does, so that the backoff starts over from the base timeout.
+			this->expirationCount = 0;
+			this->expiresAtMs     = this->getTimeMs() + ComputeNextTimeoutMs();
 		}
 
 		void Stop() override
 		{
-			this->running     = false;
-			this->expiresAtMs = std::numeric_limits<uint64_t>::max();
+			this->running = false;
+			// NOTE: Reset the expiration count, just like the real BackoffTimerHandle
+			// does.
+			this->expirationCount = 0;
+			this->expiresAtMs     = std::numeric_limits<uint64_t>::max();
 		}
 
 		/**

--- a/worker/mocks/src/handles/MockBackoffTimerHandle.cpp
+++ b/worker/mocks/src/handles/MockBackoffTimerHandle.cpp
@@ -123,5 +123,12 @@ namespace mocks
 		{
 			this->expiresAtMs = this->getTimeMs() + ComputeNextTimeoutMs();
 		}
+		// Once the timer is no longer running (e.g. max restarts reached), the real
+		// BackoffTimerHandle doesn't restart the underlying timer, so it won't fire
+		// again. Mirror that here so a stopped timer doesn't keep expiring.
+		else
+		{
+			this->expiresAtMs = std::numeric_limits<uint64_t>::max();
+		}
 	}
 } // namespace mocks

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -40,7 +40,8 @@ namespace RTC
 		  const SctpOptions& sctpOptions,
 		  AssociationListenerInterface* listener,
 		  SharedInterface* shared,
-		  bool isDataChannel)
+		  bool isDataChannel,
+		  bool mayConnectOnReceivedSctpData)
 		  : sctpOptions(sctpOptions),
 		    // Our `listener` member is a `AssociationListenerDeferrer` which takes
 		    // `listener` argument as constructor argument.
@@ -78,7 +79,8 @@ namespace RTC
 		        .maxBackoffTimeoutMs = sctpOptions.timerMaxBackoffTimeoutMs,
 		        .maxRestarts         = sctpOptions.maxRetransmissions })),
 		    maxPacketLength(Utils::Byte::PadDownTo4Bytes(this->sctpOptions.mtu)),
-		    isDataChannel(isDataChannel)
+		    isDataChannel(isDataChannel),
+		    mayConnectOnReceivedSctpData(mayConnectOnReceivedSctpData)
 		{
 			MS_TRACE();
 		}
@@ -542,7 +544,13 @@ namespace RTC
 
 			// If we are received SCTP data from the remote peer it means that we may
 			// initiate the SCTP association (if not already connected).
-			MayConnect();
+			//
+			// NOTE: This is disabled in tests that need a purely passive peer to
+			// mimic dcsctp's asymmetric handshake.
+			if (this->mayConnectOnReceivedSctpData)
+			{
+				MayConnect();
+			}
 
 			// NOTE: It's important to create the deferrer here, otherwise it may
 			// happen that MayConnect() ends calling to Connect() so we end with two
@@ -749,6 +757,7 @@ namespace RTC
 			MS_TRACE();
 
 			this->tcb = std::make_unique<TransmissionControlBlock>(
+			  this,
 			  this->associationListenerDeferrer,
 			  this->sctpOptions,
 			  this->shared,
@@ -2832,6 +2841,19 @@ namespace RTC
 			{
 				OnT2ShutdownTimer(baseTimeoutMs, stop);
 			}
+		}
+
+		void Association::OnTransmissionControlBlockTooManyTxErrors()
+		{
+			MS_TRACE();
+
+			// NOTE: This is invoked from within a TCB timer handler (t3-rtx, heartbeat
+			// or RE-CONFIG timeout). `InternalClose()` destroys the TCB synchronously,
+			// which is safe because the calling timer handler sets the BackoffTimerHandle
+			// `stop` flag and doesn't touch any member afterwards. `InternalClose()` does
+			// not establish its own deferrer scope, so it relies on the active one set up
+			// by the timer handler.
+			InternalClose(Types::ErrorKind::TOO_MANY_RETRIES, "too many transmission errors");
 		}
 	} // namespace SCTP
 } // namespace RTC

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -2434,6 +2434,15 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			const auto maxRestarts = this->t1InitTimer->GetMaxRestarts();
+
+			MS_DEBUG_TAG(
+			  sctp,
+			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
+			  this->t1InitTimer->GetLabel().c_str(),
+			  this->t1InitTimer->GetExpirationCount(),
+			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");
+
 			const AssociationListenerDeferrer::ScopedDeferrer deferrer(this->associationListenerDeferrer);
 
 			AssertState(State::COOKIE_WAIT);
@@ -2453,6 +2462,15 @@ namespace RTC
 		void Association::OnT1CookieTimer(uint64_t& /*baseTimeoutMs*/, bool& /*stop*/)
 		{
 			MS_TRACE();
+
+			const auto maxRestarts = this->t1CookieTimer->GetMaxRestarts();
+
+			MS_DEBUG_TAG(
+			  sctp,
+			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
+			  this->t1CookieTimer->GetLabel().c_str(),
+			  this->t1CookieTimer->GetExpirationCount(),
+			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");
 
 			const AssociationListenerDeferrer::ScopedDeferrer deferrer(this->associationListenerDeferrer);
 
@@ -2475,6 +2493,15 @@ namespace RTC
 		void Association::OnT2ShutdownTimer(uint64_t& baseTimeoutMs, bool& /*stop*/)
 		{
 			MS_TRACE();
+
+			const auto maxRestarts = this->t2ShutdownTimer->GetMaxRestarts();
+
+			MS_DEBUG_TAG(
+			  sctp,
+			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
+			  this->t2ShutdownTimer->GetLabel().c_str(),
+			  this->t2ShutdownTimer->GetExpirationCount(),
+			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");
 
 			AssertState(State::SHUTDOWN_SENT, State::SHUTDOWN_ACK_SENT);
 			AssertHasTcb();
@@ -2819,15 +2846,6 @@ namespace RTC
 		  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop)
 		{
 			MS_TRACE();
-
-			const auto maxRestarts = backoffTimer->GetMaxRestarts();
-
-			MS_DEBUG_TAG(
-			  sctp,
-			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
-			  backoffTimer->GetLabel().c_str(),
-			  backoffTimer->GetExpirationCount(),
-			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");
 
 			if (backoffTimer == this->t1InitTimer.get())
 			{

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -2824,7 +2824,7 @@ namespace RTC
 
 			MS_DEBUG_TAG(
 			  sctp,
-			  "%s timer has expired [expìrations:%zu/%s]",
+			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
 			  backoffTimer->GetLabel().c_str(),
 			  backoffTimer->GetExpirationCount(),
 			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");

--- a/worker/src/RTC/SCTP/association/HeartbeatHandler.cpp
+++ b/worker/src/RTC/SCTP/association/HeartbeatHandler.cpp
@@ -180,6 +180,18 @@ namespace RTC
 		{
 			MS_TRACE();
 
+#if MS_LOG_DEV_LEVEL == 3
+			const auto maxRestarts = this->intervalTimer->GetMaxRestarts();
+#endif
+
+			// NOTE: This timer expires periodically on idle connections (forever), so
+			// it's logged at dev level to avoid being noisy.
+			MS_DEBUG_DEV(
+			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
+			  this->intervalTimer->GetLabel().c_str(),
+			  this->intervalTimer->GetExpirationCount(),
+			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");
+
 			// This is a top-level timer entry point (invoked by libuv outside any other
 			// SCTP API call), so it must establish the deferrer scope itself, just like
 			// Association does in its own timer handlers.
@@ -219,6 +231,15 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			const auto maxRestarts = this->timeoutTimer->GetMaxRestarts();
+
+			MS_DEBUG_TAG(
+			  sctp,
+			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
+			  this->timeoutTimer->GetLabel().c_str(),
+			  this->timeoutTimer->GetExpirationCount(),
+			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");
+
 			// This is a top-level timer entry point (invoked by libuv outside any other
 			// SCTP API call), so it must establish the deferrer scope itself, just like
 			// Association does in its own timer handlers.
@@ -243,15 +264,6 @@ namespace RTC
 		  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop)
 		{
 			MS_TRACE();
-
-			const auto maxRestarts = backoffTimer->GetMaxRestarts();
-
-			MS_DEBUG_TAG(
-			  sctp,
-			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
-			  backoffTimer->GetLabel().c_str(),
-			  backoffTimer->GetExpirationCount(),
-			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");
 
 			if (backoffTimer == this->intervalTimer.get())
 			{

--- a/worker/src/RTC/SCTP/association/HeartbeatHandler.cpp
+++ b/worker/src/RTC/SCTP/association/HeartbeatHandler.cpp
@@ -34,7 +34,7 @@ namespace RTC
 		        .listener            = this,
 		        .label               = "sctp-heartbeat-interval",
 		        .baseTimeoutMs       = sctpOptions.initialRtoMs,
-		        .backoffAlgorithm    = BackoffTimerHandleInterface::BackoffAlgorithm::EXPONENTIAL,
+		        .backoffAlgorithm    = BackoffTimerHandleInterface::BackoffAlgorithm::FIXED,
 		        .maxBackoffTimeoutMs = sctpOptions.timerMaxBackoffTimeoutMs,
 		        .maxRestarts         = std::nullopt })),
 		    timeoutTimer(this->shared->CreateBackoffTimer(
@@ -42,7 +42,7 @@ namespace RTC
 		        .listener            = this,
 		        .label               = "sctp-heartbeat-timeout",
 		        .baseTimeoutMs       = sctpOptions.initialRtoMs,
-		        .backoffAlgorithm    = BackoffTimerHandleInterface::BackoffAlgorithm::FIXED,
+		        .backoffAlgorithm    = BackoffTimerHandleInterface::BackoffAlgorithm::EXPONENTIAL,
 		        .maxBackoffTimeoutMs = std::nullopt,
 		        .maxRestarts         = 0 }))
 		{
@@ -215,7 +215,7 @@ namespace RTC
 			this->tcbContext->SendPacket(packet.get());
 		}
 
-		void HeartbeatHandler::OnTimeoutTimer(uint64_t& /*baseTimeoutMs*/, bool& /*stop*/)
+		void HeartbeatHandler::OnTimeoutTimer(uint64_t& /*baseTimeoutMs*/, bool& stop)
 		{
 			MS_TRACE();
 
@@ -228,7 +228,15 @@ namespace RTC
 			// the interval timer expires.
 			MS_ASSERT(!this->timeoutTimer->IsRunning(), "timeout timer shouldn't be running");
 
-			this->tcbContext->IncrementTxErrorCounter("hearbeat timeout");
+			if (!this->tcbContext->IncrementTxErrorCounter("hearbeat timeout"))
+			{
+				// `IncrementTxErrorCounter()` has closed (and destroyed) the TCB (and
+				// hence this HeartbeatHandler and its timers). Signal the firing timer to
+				// stop and don't touch any member afterwards.
+				stop = true;
+
+				return;
+			}
 		}
 
 		void HeartbeatHandler::OnBackoffTimer(

--- a/worker/src/RTC/SCTP/association/HeartbeatHandler.cpp
+++ b/worker/src/RTC/SCTP/association/HeartbeatHandler.cpp
@@ -248,7 +248,7 @@ namespace RTC
 
 			MS_DEBUG_TAG(
 			  sctp,
-			  "%s timer has expired [expìrations:%zu/%s]",
+			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
 			  backoffTimer->GetLabel().c_str(),
 			  backoffTimer->GetExpirationCount(),
 			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");

--- a/worker/src/RTC/SCTP/association/StreamResetHandler.cpp
+++ b/worker/src/RTC/SCTP/association/StreamResetHandler.cpp
@@ -519,7 +519,7 @@ namespace RTC
 
 			MS_DEBUG_TAG(
 			  sctp,
-			  "%s timer has expired [expìrations:%zu/%s]",
+			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
 			  backoffTimer->GetLabel().c_str(),
 			  backoffTimer->GetExpirationCount(),
 			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");

--- a/worker/src/RTC/SCTP/association/StreamResetHandler.cpp
+++ b/worker/src/RTC/SCTP/association/StreamResetHandler.cpp
@@ -465,7 +465,7 @@ namespace RTC
 			}
 		}
 
-		void StreamResetHandler::OnReConfigTimer(uint64_t& baseTimeoutMs, bool& /*stop*/)
+		void StreamResetHandler::OnReConfigTimer(uint64_t& baseTimeoutMs, bool& stop)
 		{
 			MS_TRACE();
 
@@ -486,7 +486,11 @@ namespace RTC
 				// response.
 				else if (!this->tcbContext->IncrementTxErrorCounter("RECONFIG timeout"))
 				{
-					// Timed out. The connection will close after processing the timers.
+					// `IncrementTxErrorCounter()` has closed (and destroyed) the TCB (and
+					// hence this StreamResetHandler and its timer). Signal the firing timer
+					// to stop and don't touch any member afterwards.
+					stop = true;
+
 					return;
 				}
 			}

--- a/worker/src/RTC/SCTP/association/StreamResetHandler.cpp
+++ b/worker/src/RTC/SCTP/association/StreamResetHandler.cpp
@@ -469,6 +469,15 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			const auto maxRestarts = this->reConfigTimer->GetMaxRestarts();
+
+			MS_DEBUG_TAG(
+			  sctp,
+			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
+			  this->reConfigTimer->GetLabel().c_str(),
+			  this->reConfigTimer->GetExpirationCount(),
+			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");
+
 			// This is a top-level timer entry point (invoked by libuv outside any other
 			// SCTP API call), so it must establish the deferrer scope itself, just like
 			// Association does in its own timer handlers.
@@ -514,15 +523,6 @@ namespace RTC
 		  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop)
 		{
 			MS_TRACE();
-
-			const auto maxRestarts = backoffTimer->GetMaxRestarts();
-
-			MS_DEBUG_TAG(
-			  sctp,
-			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
-			  backoffTimer->GetLabel().c_str(),
-			  backoffTimer->GetExpirationCount(),
-			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");
 
 			if (backoffTimer == this->reConfigTimer.get())
 			{

--- a/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
+++ b/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
@@ -469,7 +469,7 @@ namespace RTC
 
 			MS_DEBUG_TAG(
 			  sctp,
-			  "%s timer has expired [expìrations:%zu/%s]",
+			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
 			  backoffTimer->GetLabel().c_str(),
 			  backoffTimer->GetExpirationCount(),
 			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");

--- a/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
+++ b/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
@@ -413,6 +413,15 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			const auto maxRestarts = this->t3RtxTimer->GetMaxRestarts();
+
+			MS_DEBUG_TAG(
+			  sctp,
+			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
+			  this->t3RtxTimer->GetLabel().c_str(),
+			  this->t3RtxTimer->GetExpirationCount(),
+			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");
+
 			// This is a top-level timer entry point (invoked by libuv outside any other
 			// SCTP API call), so it must establish the deferrer scope itself, just like
 			// Association does in its own timer handlers.
@@ -450,6 +459,18 @@ namespace RTC
 		{
 			MS_TRACE();
 
+#if MS_LOG_DEV_LEVEL == 3
+			const auto maxRestarts = this->delayedAckTimer->GetMaxRestarts();
+#endif
+
+			// NOTE: This timer expires very frequently (whenever received data is
+			// pending to be acked), so it's logged at dev level to avoid being noisy.
+			MS_DEBUG_DEV(
+			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
+			  this->delayedAckTimer->GetLabel().c_str(),
+			  this->delayedAckTimer->GetExpirationCount(),
+			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");
+
 			// This is a top-level timer entry point (invoked by libuv outside any other
 			// SCTP API call), so it must establish the deferrer scope itself, just like
 			// Association does in its own timer handlers.
@@ -464,15 +485,6 @@ namespace RTC
 		  BackoffTimerHandleInterface* backoffTimer, uint64_t& baseTimeoutMs, bool& stop)
 		{
 			MS_TRACE();
-
-			const auto maxRestarts = backoffTimer->GetMaxRestarts();
-
-			MS_DEBUG_TAG(
-			  sctp,
-			  "%s timer has expired [expirations:%zu, maxRestarts:%s]",
-			  backoffTimer->GetLabel().c_str(),
-			  backoffTimer->GetExpirationCount(),
-			  maxRestarts ? std::to_string(maxRestarts.value()).c_str() : "Infinite");
 
 			if (backoffTimer == this->t3RtxTimer.get())
 			{

--- a/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
+++ b/worker/src/RTC/SCTP/association/TransmissionControlBlock.cpp
@@ -21,6 +21,7 @@ namespace RTC
 		/* Instance methods. */
 
 		TransmissionControlBlock::TransmissionControlBlock(
+		  TransmissionControlBlockContextInterface::Listener* listener,
 		  AssociationListenerDeferrer& associationListenerDeferrer,
 		  const SctpOptions& sctpOptions,
 		  SharedInterface* shared,
@@ -35,7 +36,8 @@ namespace RTC
 		  const NegotiatedCapabilities& negotiatedCapabilities,
 		  size_t maxPacketLength,
 		  std::function<bool()> isAssociationEstablished)
-		  : associationListenerDeferrer(associationListenerDeferrer),
+		  : listener(listener),
+		    associationListenerDeferrer(associationListenerDeferrer),
 		    sctpOptions(sctpOptions),
 		    shared(shared),
 		    packetSender(packetSender),
@@ -407,7 +409,7 @@ namespace RTC
 			}
 		}
 
-		void TransmissionControlBlock::OnT3RtxTimer(uint64_t& /*baseTimeoutMs*/, bool& /*stop*/)
+		void TransmissionControlBlock::OnT3RtxTimer(uint64_t& /*baseTimeoutMs*/, bool& stop)
 		{
 			MS_TRACE();
 
@@ -431,6 +433,15 @@ namespace RTC
 					const uint64_t nowMs = this->shared->GetTimeMs();
 
 					SendBufferedPackets(nowMs);
+				}
+				else
+				{
+					// `IncrementTxErrorCounter()` has closed (and destroyed) this TCB and
+					// its timers. Signal the firing timer to stop and don't touch any
+					// member afterwards.
+					stop = true;
+
+					return;
 				}
 			}
 		}

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -91,7 +91,7 @@ namespace RTC
 			};
 
 			this->sctpAssociation = std::make_unique<RTC::SCTP::Association>(
-			  sctpOptions, this, this->shared, options->isDataChannel());
+			  sctpOptions, this, this->shared, options->isDataChannel(), /*mayConnectOnReceivedSctpData*/ true);
 		}
 
 		// Create the RTCP timer.

--- a/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
@@ -877,7 +877,7 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 	SECTION("initial metrics are unset")
 	{
-	 	const AssociationUnderTest a;
+		const AssociationUnderTest a;
 
 		REQUIRE(a.association.MakeMetrics().has_value() == false);
 	}

--- a/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
@@ -798,7 +798,7 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 		connectAssociations(a, z);
 
-		std::vector<uint8_t> payload(a.sctpOptions.mtu * 20);
+		const std::vector<uint8_t> payload(a.sctpOptions.mtu * 20);
 
 		sendMessage(a, 1, 53, payload);
 

--- a/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
@@ -1,53 +1,51 @@
 #include "common.hpp"
 #include "RTC/SCTP/association/Association.hpp"
+#include "RTC/SCTP/packet/ErrorCause.hpp"
 #include "RTC/SCTP/packet/Packet.hpp"
 #include "RTC/SCTP/packet/chunks/AbortAssociationChunk.hpp"
 #include "RTC/SCTP/packet/chunks/CookieAckChunk.hpp"
 #include "RTC/SCTP/packet/chunks/CookieEchoChunk.hpp"
 #include "RTC/SCTP/packet/chunks/DataChunk.hpp"
+#include "RTC/SCTP/packet/chunks/HeartbeatAckChunk.hpp"
 #include "RTC/SCTP/packet/chunks/HeartbeatRequestChunk.hpp"
 #include "RTC/SCTP/packet/chunks/IDataChunk.hpp"
 #include "RTC/SCTP/packet/chunks/InitAckChunk.hpp"
 #include "RTC/SCTP/packet/chunks/InitChunk.hpp"
+#include "RTC/SCTP/packet/chunks/OperationErrorChunk.hpp"
 #include "RTC/SCTP/packet/chunks/SackChunk.hpp"
 #include "RTC/SCTP/packet/chunks/ShutdownAckChunk.hpp"
 #include "RTC/SCTP/packet/chunks/ShutdownChunk.hpp"
 #include "RTC/SCTP/packet/chunks/ShutdownCompleteChunk.hpp"
+#include "RTC/SCTP/packet/errorCauses/UnrecognizedChunkTypeErrorCause.hpp"
+#include "RTC/SCTP/packet/parameters/HeartbeatInfoParameter.hpp"
 #include "RTC/SCTP/public/Message.hpp"
 #include "RTC/SCTP/public/SctpOptions.hpp"
 #include "RTC/SCTP/public/SctpTypes.hpp"
 #include "mocks/include/MockShared.hpp"
 #include "mocks/include/RTC/SCTP/association/MockAssociationListener.hpp"
-#include <catch2/catch_test_macros.hpp>
 #include <array>
+#include <catch2/catch_test_macros.hpp>
 #include <span>
 #include <string_view>
 #include <vector>
-
-// NOTE: This test mirrors libwebrtc's dcsctp/socket/dcsctp_socket_test.cc. The
-// mediasoup SCTP::Association class is the equivalent of dcsctp's DcSctpSocket.
-// Instead of relying on gmock matchers (as dcsctp does) we use the inspection
-// API already exposed by SCTP::Packet and SCTP::Chunk.
 
 namespace
 {
 	// Initial value of the simulated clock (ms).
 	constexpr uint64_t InitialNowMs{ 1000000 };
 
-	// All backoff timer labels an SCTP Association may create. Used by RunTimers()
-	// to fire whichever timers have expired after advancing time, mirroring
-	// dcsctp's RunTimers() test helper.
+	// All backoff timer labels an SCTP association may create. Used by `runTimers()`
+	// to fire whichever timers have expired after advancing time.
 	constexpr std::array<std::string_view, 8> SctpTimerLabels{
-		"sctp-t1-init",          "sctp-t1-cookie",   "sctp-t2-shutdown", "sctp-t3-rtx",
-		"sctp-delayed-ack",      "sctp-heartbeat-interval", "sctp-heartbeat-timeout",
-		"sctp-re-config",
+		"sctp-t1-init",     "sctp-t1-cookie",          "sctp-t2-shutdown",       "sctp-t3-rtx",
+		"sctp-delayed-ack", "sctp-heartbeat-interval", "sctp-heartbeat-timeout", "sctp-re-config",
 	};
 
 	/**
 	 * Builds the default SctpOptions used in tests. Tweaked to make timers
-	 * predictable, as dcsctp's FixupOptions() does.
+	 * predictable.
 	 */
-	RTC::SCTP::SctpOptions MakeSctpOptions()
+	RTC::SCTP::SctpOptions makeSctpOptions()
 	{
 		RTC::SCTP::SctpOptions sctpOptions;
 
@@ -60,7 +58,7 @@ namespace
 
 	/**
 	 * An SCTP Association under test, together with its simulated clock and
-	 * listener. This is the equivalent of dcsctp's SocketUnderTest.
+	 * listener.
 	 */
 	class AssociationUnderTest
 	{
@@ -74,7 +72,8 @@ namespace
 		 * packet sequences and counts match.
 		 */
 		explicit AssociationUnderTest(
-		  RTC::SCTP::SctpOptions sctpOptions = MakeSctpOptions(), bool mayConnectOnReceivedSctpData = false)
+		  RTC::SCTP::SctpOptions sctpOptions = makeSctpOptions(),
+		  bool mayConnectOnReceivedSctpData  = false)
 		  // NOTE: The order in which these members are initialized is **critical**.
 		  : sctpOptions(sctpOptions),
 		    shared(/*getTimeMs*/
@@ -108,9 +107,9 @@ namespace
 	};
 
 	/**
-	 * Parses a previously consumed sent packet buffer into a SCTP::Packet.
+	 * Parses a previously consumed sent packet buffer into a `SCTP::Packet`.
 	 */
-	std::unique_ptr<RTC::SCTP::Packet> ParsePacket(const std::vector<uint8_t>& buffer)
+	std::unique_ptr<RTC::SCTP::Packet> parsePacket(const std::vector<uint8_t>& buffer)
 	{
 		return std::unique_ptr<RTC::SCTP::Packet>(RTC::SCTP::Packet::Parse(buffer.data(), buffer.size()));
 	}
@@ -119,9 +118,9 @@ namespace
 	 * Returns true if the packet contains a single chunk of the given type.
 	 */
 	template<typename ChunkType>
-	bool PacketHasSingleChunkOfType(const std::vector<uint8_t>& buffer)
+	bool packetHasSingleChunkOfType(const std::vector<uint8_t>& buffer)
 	{
-		const auto packet = ParsePacket(buffer);
+		const auto packet = parsePacket(buffer);
 
 		return packet && packet->GetChunksCount() == 1 &&
 		       packet->GetFirstChunkOfType<ChunkType>() != nullptr;
@@ -130,9 +129,9 @@ namespace
 	/**
 	 * Returns true if the packet contains a DATA or I-DATA chunk.
 	 */
-	bool PacketHasDataChunk(const std::vector<uint8_t>& buffer)
+	bool packetHasDataChunk(const std::vector<uint8_t>& buffer)
 	{
-		const auto packet = ParsePacket(buffer);
+		const auto packet = parsePacket(buffer);
 
 		return packet && (packet->GetFirstChunkOfType<RTC::SCTP::DataChunk>() != nullptr ||
 		                  packet->GetFirstChunkOfType<RTC::SCTP::IDataChunk>() != nullptr);
@@ -141,20 +140,20 @@ namespace
 	/**
 	 * Delivers a single sent packet from `from` to `to`. The packet must exist.
 	 */
-	void DeliverFirstSentPacket(AssociationUnderTest& from, AssociationUnderTest& to)
+	void deliverFirstSentPacket(AssociationUnderTest& from, AssociationUnderTest& to)
 	{
-		const auto packet = from.listener.ConsumeFirstSentPacket();
+		const auto buffer = from.listener.ConsumeFirstSentPacket();
 
-		REQUIRE(!packet.empty());
+		REQUIRE(!buffer.empty());
 
-		to.association.ReceiveSctpData(packet.data(), packet.size());
+		to.association.ReceiveSctpData(buffer.data(), buffer.size());
 	}
 
 	/**
 	 * Delivers all currently queued packets between `a` and `z` back and forth
 	 * until neither has anything more to send.
 	 */
-	void ExchangeMessages(AssociationUnderTest& a, AssociationUnderTest& z)
+	void exchangeMessages(AssociationUnderTest& a, AssociationUnderTest& z)
 	{
 		bool deliveredPacket{ false };
 
@@ -162,29 +161,29 @@ namespace
 		{
 			deliveredPacket = false;
 
-			auto packetFromA = a.listener.ConsumeFirstSentPacket();
+			auto bufferFromA = a.listener.ConsumeFirstSentPacket();
 
-			if (!packetFromA.empty())
+			if (!bufferFromA.empty())
 			{
 				deliveredPacket = true;
-				z.association.ReceiveSctpData(packetFromA.data(), packetFromA.size());
+				z.association.ReceiveSctpData(bufferFromA.data(), bufferFromA.size());
 			}
 
-			auto packetFromZ = z.listener.ConsumeFirstSentPacket();
+			auto bufferFromZ = z.listener.ConsumeFirstSentPacket();
 
-			if (!packetFromZ.empty())
+			if (!bufferFromZ.empty())
 			{
 				deliveredPacket = true;
-				a.association.ReceiveSctpData(packetFromZ.data(), packetFromZ.size());
+				a.association.ReceiveSctpData(bufferFromZ.data(), bufferFromZ.size());
 			}
 		} while (deliveredPacket);
 	}
 
 	/**
 	 * Fires every Association backoff timer that has expired, looping until none
-	 * remain expired. This is the equivalent of dcsctp's RunTimers().
+	 * remain expired.
 	 */
-	void RunTimers(AssociationUnderTest& s)
+	void runTimers(AssociationUnderTest& s)
 	{
 		bool fired{ false };
 
@@ -196,8 +195,8 @@ namespace
 			{
 				auto* timer = s.shared.GetBackoffTimer(label);
 
-				// NOTE: We must check IsRunning() because MockBackoffTimerHandle's
-				// EvaluateHasExpired() only compares times: a stopped timer whose
+				// NOTE: We must check `IsRunning()` because MockBackoffTimerHandle's
+				// `EvaluateHasExpired()` only compares times. A stopped timer whose
 				// expiry time is in the past would otherwise be fired again and again.
 				if (timer && timer->IsRunning() && timer->EvaluateHasExpired())
 				{
@@ -209,35 +208,94 @@ namespace
 
 	/**
 	 * Advances the simulated clock of both associations by `durationMs` and fires
-	 * any timer that has expired. This is the equivalent of dcsctp's AdvanceTime().
+	 * any timer that has expired.
 	 */
-	void AdvanceTime(AssociationUnderTest& a, AssociationUnderTest& z, uint64_t durationMs)
+	void advanceTimeMs(AssociationUnderTest& a, AssociationUnderTest& z, uint64_t durationMs)
 	{
 		a.AdvanceTimeMs(durationMs);
 		z.AdvanceTimeMs(durationMs);
 
-		RunTimers(a);
-		RunTimers(z);
+		runTimers(a);
+		runTimers(z);
 	}
 
 	/**
-	 * Calls Connect() on `a` (the active peer) and drives the handshake to
-	 * completion against `z` (the passive peer). This is the equivalent of
-	 * dcsctp's ConnectSockets().
+	 * Calls `Connect()` on `a` (the active peer) and drives the handshake to
+	 * completion against `z` (the passive peer).
 	 */
-	void ConnectAssociations(AssociationUnderTest& a, AssociationUnderTest& z)
+	void connectAssociations(AssociationUnderTest& a, AssociationUnderTest& z)
 	{
 		a.association.Connect();
-		ExchangeMessages(a, z);
+		exchangeMessages(a, z);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 	}
 
 	/**
+	 * Connects `a` (active) against `z` (passive) and returns `a`'s local
+	 * verification tag, i.e. the tag that the peer must put in packets sent to
+	 * `a`. It's captured from the COOKIE-ACK that `z` sends to `a`, and is needed
+	 * to craft raw packets to be injected into `a`.
+	 */
+	uint32_t connectAndGetVerificationTag(AssociationUnderTest& a, AssociationUnderTest& z)
+	{
+		a.association.Connect();
+		// Z reads INIT, produces INIT-ACK.
+		deliverFirstSentPacket(a, z);
+		// A reads INIT-ACK, produces COOKIE-ECHO.
+		deliverFirstSentPacket(z, a);
+		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
+		deliverFirstSentPacket(a, z);
+
+		// Z now has a pending COOKIE-ACK destined to A; its verification tag is A's
+		// local verification tag.
+		const auto buffer = z.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(!buffer.empty());
+
+		const uint32_t verificationTag = parsePacket(buffer)->GetVerificationTag();
+
+		// Deliver the COOKIE-ACK so the connection is fully established on A.
+		a.association.ReceiveSctpData(buffer.data(), buffer.size());
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+
+		return verificationTag;
+	}
+
+	/**
+	 * Creates an empty SCTP packet addressed to a peer, carrying the given
+	 * verification tag. `buffer` must outlive the returned packet, as the packet
+	 * is built in place on it.
+	 */
+	std::unique_ptr<RTC::SCTP::Packet> buildPacket(std::vector<uint8_t>& buffer, uint32_t verificationTag)
+	{
+		std::unique_ptr<RTC::SCTP::Packet> packet(
+		  RTC::SCTP::Packet::Factory(buffer.data(), buffer.size()));
+
+		packet->SetSourcePort(5000);
+		packet->SetDestinationPort(5000);
+		packet->SetVerificationTag(verificationTag);
+
+		return packet;
+	}
+
+	/**
+	 * Writes the packet checksum and injects it into the given association.
+	 */
+	void injectPacket(AssociationUnderTest& target, RTC::SCTP::Packet* packet)
+	{
+		packet->WriteCRC32cChecksum();
+
+		target.association.ReceiveSctpData(packet->GetBuffer(), packet->GetLength());
+	}
+
+	/**
 	 * Enqueues a message to be sent on the given association.
 	 */
-	RTC::SCTP::Types::SendMessageStatus SendMessage(
+	RTC::SCTP::Types::SendMessageStatus sendMessage(
 	  AssociationUnderTest& s,
 	  uint16_t streamId,
 	  uint32_t ppid,
@@ -246,6 +304,29 @@ namespace
 	{
 		return s.association.SendMessage(
 		  RTC::SCTP::Message(streamId, ppid, std::move(payload)), sendMessageOptions);
+	}
+
+	/**
+	 * Consumes every received message on the given association and returns their
+	 * payload protocol identifiers, in the order they were received.
+	 */
+	std::vector<uint32_t> getReceivedMessagePpids(AssociationUnderTest& s)
+	{
+		std::vector<uint32_t> ppids;
+
+		for (;;)
+		{
+			const auto message = s.listener.ConsumeFirstReceivedMessage();
+
+			if (!message.has_value())
+			{
+				break;
+			}
+
+			ppids.push_back(message->GetPayloadProtocolId());
+		}
+
+		return ppids;
 	}
 } // namespace
 
@@ -258,13 +339,13 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 		a.association.Connect();
 		// Z reads INIT, produces INIT-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads INIT-ACK, produces COOKIE-ECHO.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads COOKIE-ACK.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
@@ -282,7 +363,7 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		a.association.Connect();
 		z.association.Connect();
 
-		ExchangeMessages(a, z);
+		exchangeMessages(a, z);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
@@ -303,16 +384,16 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		z.association.Connect();
 
 		// A reads INIT, produces INIT-ACK.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 		// Z reads INIT-ACK, sends COOKIE-ECHO.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads COOKIE-ECHO, establishes connection.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 
 		// Proceed with the remaining packets.
-		ExchangeMessages(a, z);
+		exchangeMessages(a, z);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
@@ -327,11 +408,11 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 		a.association.Connect();
 		// Z reads INIT, produces INIT-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads INIT-ACK, produces COOKIE-ECHO.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// COOKIE-ACK is lost.
 		z.listener.ConsumeFirstSentPacket();
 
@@ -339,12 +420,12 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 
 		// This will make A re-send the COOKIE-ECHO.
-		AdvanceTime(a, z, a.sctpOptions.t1CookieTimeoutMs);
+		advanceTimeMs(a, z, a.sctpOptions.t1CookieTimeoutMs);
 
 		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads COOKIE-ACK.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
@@ -358,18 +439,19 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		a.association.Connect();
 
 		// INIT is never received by Z.
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::InitChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+		REQUIRE(
+		  packetHasSingleChunkOfType<RTC::SCTP::InitChunk>(a.listener.ConsumeFirstSentPacket()) == true);
 
-		AdvanceTime(a, z, a.sctpOptions.t1InitTimeoutMs);
+		advanceTimeMs(a, z, a.sctpOptions.t1InitTimeoutMs);
 
 		// Z reads INIT, produces INIT-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads INIT-ACK, produces COOKIE-ECHO.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads COOKIE-ACK.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
@@ -383,20 +465,22 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		a.association.Connect();
 
 		// INIT is never received by Z.
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::InitChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+		REQUIRE(
+		  packetHasSingleChunkOfType<RTC::SCTP::InitChunk>(a.listener.ConsumeFirstSentPacket()) == true);
 
 		const auto maxInitRetransmissions = a.sctpOptions.maxInitRetransmissions.value();
 
 		for (size_t i = 0; i < maxInitRetransmissions; ++i)
 		{
-			AdvanceTime(a, z, a.sctpOptions.t1InitTimeoutMs * (1u << i));
+			advanceTimeMs(a, z, a.sctpOptions.t1InitTimeoutMs * (1u << i));
 
 			// INIT is resent.
-			REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::InitChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+			REQUIRE(
+			  packetHasSingleChunkOfType<RTC::SCTP::InitChunk>(a.listener.ConsumeFirstSentPacket()) == true);
 		}
 
 		// Another timeout, after the max init retransmits.
-		AdvanceTime(a, z, a.sctpOptions.t1InitTimeoutMs * (1u << maxInitRetransmissions));
+		advanceTimeMs(a, z, a.sctpOptions.t1InitTimeoutMs * (1u << maxInitRetransmissions));
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
 		REQUIRE(a.listener.HasFailed() == true);
@@ -411,19 +495,21 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		a.association.Connect();
 
 		// Z reads INIT, produces INIT-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads INIT-ACK, produces COOKIE-ECHO.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		// COOKIE-ECHO is never received by Z.
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::CookieEchoChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+		REQUIRE(
+		  packetHasSingleChunkOfType<RTC::SCTP::CookieEchoChunk>(a.listener.ConsumeFirstSentPacket()) ==
+		  true);
 
-		AdvanceTime(a, z, a.sctpOptions.t1CookieTimeoutMs);
+		advanceTimeMs(a, z, a.sctpOptions.t1CookieTimeoutMs);
 
 		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads COOKIE-ACK.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
@@ -437,25 +523,29 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		a.association.Connect();
 
 		// Z reads INIT, produces INIT-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads INIT-ACK, produces COOKIE-ECHO.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		// COOKIE-ECHO is never received by Z.
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::CookieEchoChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+		REQUIRE(
+		  packetHasSingleChunkOfType<RTC::SCTP::CookieEchoChunk>(a.listener.ConsumeFirstSentPacket()) ==
+		  true);
 
 		const auto maxInitRetransmissions = a.sctpOptions.maxInitRetransmissions.value();
 
 		for (size_t i = 0; i < maxInitRetransmissions; ++i)
 		{
-			AdvanceTime(a, z, a.sctpOptions.t1CookieTimeoutMs * (1u << i));
+			advanceTimeMs(a, z, a.sctpOptions.t1CookieTimeoutMs * (1u << i));
 
 			// COOKIE-ECHO is resent.
-			REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::CookieEchoChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+			REQUIRE(
+			  packetHasSingleChunkOfType<RTC::SCTP::CookieEchoChunk>(a.listener.ConsumeFirstSentPacket()) ==
+			  true);
 		}
 
 		// Another timeout, after the max init retransmits.
-		AdvanceTime(a, z, a.sctpOptions.t1CookieTimeoutMs * (1u << maxInitRetransmissions));
+		advanceTimeMs(a, z, a.sctpOptions.t1CookieTimeoutMs * (1u << maxInitRetransmissions));
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
 		REQUIRE(a.listener.HasFailed() == true);
@@ -470,11 +560,11 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		a.association.Connect();
 
 		// Z reads INIT, produces INIT-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads INIT-ACK, produces COOKIE-ECHO.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// Drop COOKIE-ACK, just to more easily verify shutdown protocol.
 		z.listener.ConsumeFirstSentPacket();
 
@@ -488,11 +578,11 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		a.association.Shutdown();
 
 		// Z reads SHUTDOWN, produces SHUTDOWN-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads SHUTDOWN-ACK, produces SHUTDOWN-COMPLETE.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 		// Z reads SHUTDOWN-COMPLETE.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 
 		REQUIRE(a.listener.ConsumeFirstSentPacket().empty() == true);
 		REQUIRE(z.listener.ConsumeFirstSentPacket().empty() == true);
@@ -506,15 +596,15 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		a.association.Shutdown();
 		// Z reads SHUTDOWN, produces SHUTDOWN-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads SHUTDOWN-ACK, produces SHUTDOWN-COMPLETE.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 		// Z reads SHUTDOWN-COMPLETE.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
 		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
@@ -527,7 +617,7 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		a.association.Shutdown();
 		// Drop the first SHUTDOWN packet.
@@ -539,21 +629,24 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 		for (size_t i = 0; i < maxRetransmissions; ++i)
 		{
-			AdvanceTime(a, z, a.sctpOptions.initialRtoMs * (1u << i));
+			advanceTimeMs(a, z, a.sctpOptions.initialRtoMs * (1u << i));
 
 			// SHUTDOWN is resent (and dropped).
-			REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::ShutdownChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+			REQUIRE(
+			  packetHasSingleChunkOfType<RTC::SCTP::ShutdownChunk>(a.listener.ConsumeFirstSentPacket()) ==
+			  true);
 		}
 
 		// The last expiry makes it abort the connection.
-		AdvanceTime(a, z, a.sctpOptions.initialRtoMs * (1u << maxRetransmissions));
+		advanceTimeMs(a, z, a.sctpOptions.initialRtoMs * (1u << maxRetransmissions));
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
 		REQUIRE(a.listener.IsClosed() == true);
 		REQUIRE(a.listener.GetClosedErrorKind() == RTC::SCTP::Types::ErrorKind::TOO_MANY_RETRIES);
 		// An ABORT chunk is sent.
 		REQUIRE(
-		  PacketHasSingleChunkOfType<RTC::SCTP::AbortAssociationChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+		  packetHasSingleChunkOfType<RTC::SCTP::AbortAssociationChunk>(
+		    a.listener.ConsumeFirstSentPacket()) == true);
 	}
 
 	SECTION("T2-shutdown timer expiry resends SHUTDOWN-ACK")
@@ -561,24 +654,28 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		z.association.Shutdown();
 
 		// A receives SHUTDOWN, sends SHUTDOWN-ACK. A is now in SHUTDOWN-ACK-SENT
 		// state.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		// Consume the SHUTDOWN-ACK sent by A (drop it).
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::ShutdownAckChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+		REQUIRE(
+		  packetHasSingleChunkOfType<RTC::SCTP::ShutdownAckChunk>(a.listener.ConsumeFirstSentPacket()) ==
+		  true);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::SHUTTING_DOWN);
 		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::SHUTTING_DOWN);
 
 		// Advance time to trigger timer expiry, which makes A resend SHUTDOWN-ACK.
-		AdvanceTime(a, z, a.sctpOptions.initialRtoMs);
+		advanceTimeMs(a, z, a.sctpOptions.initialRtoMs);
 
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::ShutdownAckChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+		REQUIRE(
+		  packetHasSingleChunkOfType<RTC::SCTP::ShutdownAckChunk>(a.listener.ConsumeFirstSentPacket()) ==
+		  true);
 	}
 
 	SECTION("shutdown is ignored in SHUTDOWN-RECEIVED state")
@@ -586,13 +683,16 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		z.association.Shutdown();
 
 		// A reads SHUTDOWN, produces SHUTDOWN-ACK.
-		DeliverFirstSentPacket(z, a);
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::ShutdownAckChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+		deliverFirstSentPacket(z, a);
+
+		REQUIRE(
+		  packetHasSingleChunkOfType<RTC::SCTP::ShutdownAckChunk>(a.listener.ConsumeFirstSentPacket()) ==
+		  true);
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::SHUTTING_DOWN);
 
 		// Second shutdown while already shutting down, must be ignored.
@@ -605,14 +705,14 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		// Send a message that will remain outstanding (unacknowledged) which
 		// transitions the association to SHUTDOWN-PENDING instead of SHUTDOWN-SENT.
-		SendMessage(a, 1, 53, { 1, 2 });
+		sendMessage(a, 1, 53, { 1, 2 });
 		a.association.Shutdown();
 
-		REQUIRE(PacketHasDataChunk(a.listener.ConsumeFirstSentPacket()) == true);
+		REQUIRE(packetHasDataChunk(a.listener.ConsumeFirstSentPacket()) == true);
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::SHUTTING_DOWN);
 
 		// Second shutdown while already shutting down, must be ignored.
@@ -627,22 +727,22 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 		a.association.Connect();
 
-		SendMessage(a, 1, 53, { 1, 2 });
+		sendMessage(a, 1, 53, { 1, 2 });
 
 		// Z reads INIT, produces INIT-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads INIT-ACK, produces COOKIE-ECHO.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads COOKIE-ACK.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 
 		// Deliver the remaining packets so that the message reaches Z.
-		ExchangeMessages(a, z);
+		exchangeMessages(a, z);
 
 		const auto message = z.listener.ConsumeFirstReceivedMessage();
 
@@ -655,11 +755,11 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
-		SendMessage(a, 1, 53, { 1, 2 });
+		sendMessage(a, 1, 53, { 1, 2 });
 		// Z reads the DATA chunk.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 
 		const auto message = z.listener.ConsumeFirstReceivedMessage();
 
@@ -673,17 +773,17 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
-		SendMessage(a, 1, 53, { 1, 2 });
+		sendMessage(a, 1, 53, { 1, 2 });
 		// Drop the first DATA packet.
 		a.listener.ConsumeFirstSentPacket();
 
 		// Advance time so that the T3-RTX timer expires and the DATA is resent.
-		AdvanceTime(a, z, a.sctpOptions.initialRtoMs);
+		advanceTimeMs(a, z, a.sctpOptions.initialRtoMs);
 
 		// Z reads the retransmitted DATA chunk.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 
 		const auto message = z.listener.ConsumeFirstReceivedMessage();
 
@@ -696,19 +796,19 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		std::vector<uint8_t> payload(a.sctpOptions.mtu * 20);
 
-		SendMessage(a, 1, 53, payload);
+		sendMessage(a, 1, 53, payload);
 
 		// Z reads the first DATA.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// Second DATA is lost.
 		a.listener.ConsumeFirstSentPacket();
 
 		// Retransmit and handle the rest.
-		ExchangeMessages(a, z);
+		exchangeMessages(a, z);
 
 		const auto message = z.listener.ConsumeFirstReceivedMessage();
 
@@ -722,20 +822,20 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		REQUIRE(a.listener.ConsumeFirstSentPacket().empty() == true);
 
 		// Let the heartbeat interval timer expire.
-		AdvanceTime(a, z, a.sctpOptions.heartbeatIntervalMs);
+		advanceTimeMs(a, z, a.sctpOptions.heartbeatIntervalMs);
 
 		const auto buffer = a.listener.ConsumeFirstSentPacket();
 
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(buffer) == true);
+		REQUIRE(packetHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(buffer) == true);
 
 		// Feed it to Z and expect a HEARTBEAT-ACK that is propagated back to A.
 		z.association.ReceiveSctpData(buffer.data(), buffer.size());
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 	}
 
 	SECTION("sends many messages")
@@ -743,7 +843,7 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		constexpr int Iterations{ 100 };
 
@@ -765,7 +865,7 @@ SCENARIO("SCTP Association", "[sctp][association]")
 			REQUIRE(status == RTC::SCTP::Types::SendMessageStatus::SUCCESS);
 		}
 
-		ExchangeMessages(a, z);
+		exchangeMessages(a, z);
 
 		for (int i = 0; i < Iterations; ++i)
 		{
@@ -788,15 +888,18 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		{
 			for (const bool zEnable : { false, true })
 			{
-				auto aSctpOptions                      = MakeSctpOptions();
+				auto aSctpOptions = makeSctpOptions();
+
 				aSctpOptions.enableMessageInterleaving = aEnable;
-				auto zSctpOptions                      = MakeSctpOptions();
+
+				auto zSctpOptions = makeSctpOptions();
+
 				zSctpOptions.enableMessageInterleaving = zEnable;
 
 				AssociationUnderTest a(aSctpOptions);
 				AssociationUnderTest z(zSctpOptions);
 
-				ConnectAssociations(a, z);
+				connectAssociations(a, z);
 
 				REQUIRE(a.association.MakeMetrics()->usesMessageInterleaving == (aEnable && zEnable));
 			}
@@ -808,7 +911,7 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		// A sent INIT and COOKIE-ECHO, received INIT-ACK and COOKIE-ACK.
 		REQUIRE(a.association.MakeMetrics()->txPacketsCount == 2);
@@ -821,14 +924,14 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		REQUIRE(z.association.MakeMetrics()->rxPacketsCount == 2);
 		REQUIRE(z.association.MakeMetrics()->rxMessagesCount == 0);
 
-		SendMessage(a, 1, 53, { 1, 2 });
+		sendMessage(a, 1, 53, { 1, 2 });
 
 		REQUIRE(a.association.MakeMetrics()->unackDataCount == 1);
 
 		// Z reads DATA.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads SACK.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		REQUIRE(a.association.MakeMetrics()->unackDataCount == 0);
 		REQUIRE(z.listener.ConsumeFirstReceivedMessage().has_value() == true);
@@ -843,56 +946,65 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 	SECTION("streams have initial priority")
 	{
-		auto sctpOptions                  = MakeSctpOptions();
+		auto sctpOptions = makeSctpOptions();
+
 		sctpOptions.defaultStreamPriority = 42;
 
 		AssociationUnderTest a(sctpOptions);
 
 		REQUIRE(a.association.GetStreamPriority(1) == 42);
 
-		SendMessage(a, 2, 53, { 1, 2 });
+		sendMessage(a, 2, 53, { 1, 2 });
 
 		REQUIRE(a.association.GetStreamPriority(2) == 42);
 	}
 
 	SECTION("can change stream priority")
 	{
-		auto sctpOptions                  = MakeSctpOptions();
+		auto sctpOptions = makeSctpOptions();
+
 		sctpOptions.defaultStreamPriority = 42;
 
 		AssociationUnderTest a(sctpOptions);
 
 		a.association.SetStreamPriority(1, 43);
+
 		REQUIRE(a.association.GetStreamPriority(1) == 43);
 
-		SendMessage(a, 2, 53, { 1, 2 });
+		sendMessage(a, 2, 53, { 1, 2 });
 
 		a.association.SetStreamPriority(2, 43);
+
 		REQUIRE(a.association.GetStreamPriority(2) == 43);
 	}
 
 	SECTION("respects the per-stream queue limit")
 	{
-		auto sctpOptions                    = MakeSctpOptions();
+		auto sctpOptions = makeSctpOptions();
+
 		sctpOptions.maxSendBufferSize       = 4000;
 		sctpOptions.perStreamSendQueueLimit = 1000;
 
 		AssociationUnderTest a(sctpOptions);
 
 		REQUIRE(
-		  SendMessage(a, 1, 53, std::vector<uint8_t>(600)) == RTC::SCTP::Types::SendMessageStatus::SUCCESS);
+		  sendMessage(a, 1, 53, std::vector<uint8_t>(600)) ==
+		  RTC::SCTP::Types::SendMessageStatus::SUCCESS);
 		REQUIRE(
-		  SendMessage(a, 1, 53, std::vector<uint8_t>(600)) == RTC::SCTP::Types::SendMessageStatus::SUCCESS);
+		  sendMessage(a, 1, 53, std::vector<uint8_t>(600)) ==
+		  RTC::SCTP::Types::SendMessageStatus::SUCCESS);
 		REQUIRE(
-		  SendMessage(a, 1, 53, std::vector<uint8_t>(600)) ==
+		  sendMessage(a, 1, 53, std::vector<uint8_t>(600)) ==
 		  RTC::SCTP::Types::SendMessageStatus::ERROR_RESOURCE_EXHAUSTION);
 		// The per-stream limit for stream 1 is reached, but not for stream 2.
 		REQUIRE(
-		  SendMessage(a, 2, 53, std::vector<uint8_t>(600)) == RTC::SCTP::Types::SendMessageStatus::SUCCESS);
+		  sendMessage(a, 2, 53, std::vector<uint8_t>(600)) ==
+		  RTC::SCTP::Types::SendMessageStatus::SUCCESS);
 		REQUIRE(
-		  SendMessage(a, 2, 53, std::vector<uint8_t>(600)) == RTC::SCTP::Types::SendMessageStatus::SUCCESS);
+		  sendMessage(a, 2, 53, std::vector<uint8_t>(600)) ==
+		  RTC::SCTP::Types::SendMessageStatus::SUCCESS);
 		REQUIRE(
-		  SendMessage(a, 2, 53, std::vector<uint8_t>(600)) ==
+		  sendMessage(a, 2, 53, std::vector<uint8_t>(600)) ==
 		  RTC::SCTP::Types::SendMessageStatus::ERROR_RESOURCE_EXHAUSTION);
 	}
 
@@ -901,13 +1013,13 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		REQUIRE(a.association.GetStreamBufferedAmount(1) == 0);
 
 		// Sending a small message will directly send it as a single packet, so
 		// nothing is left in the queue.
-		SendMessage(a, 1, 53, std::vector<uint8_t>(10));
+		sendMessage(a, 1, 53, std::vector<uint8_t>(10));
 
 		REQUIRE(a.association.GetStreamBufferedAmount(1) == 0);
 
@@ -915,7 +1027,7 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		// buffered amount is not the full message size.
 		const size_t largeSize = a.sctpOptions.mtu * 20;
 
-		SendMessage(a, 1, 53, std::vector<uint8_t>(largeSize));
+		sendMessage(a, 1, 53, std::vector<uint8_t>(largeSize));
 
 		REQUIRE(a.association.GetStreamBufferedAmount(1) > 0);
 		REQUIRE(a.association.GetStreamBufferedAmount(1) < largeSize);
@@ -935,10 +1047,10 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 		REQUIRE(a.listener.HasOnStreamBufferedAmountLowBeenCalledWithStreamId(1) == false);
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
-		SendMessage(a, 1, 53, std::vector<uint8_t>(10));
-		ExchangeMessages(a, z);
+		sendMessage(a, 1, 53, std::vector<uint8_t>(10));
+		exchangeMessages(a, z);
 
 		REQUIRE(a.listener.HasOnStreamBufferedAmountLowBeenCalledWithStreamId(1) == true);
 	}
@@ -948,15 +1060,17 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		// Both peers are mediasoup.
 		REQUIRE(
-		  a.association.MakeMetrics()->peerImplementation == RTC::SCTP::Types::SctpImplementation::MEDIASOUP);
+		  a.association.MakeMetrics()->peerImplementation ==
+		  RTC::SCTP::Types::SctpImplementation::MEDIASOUP);
 		// As A initiated the connection establishment, the passive peer Z will not
 		// receive enough information to know about A's implementation.
 		REQUIRE(
-		  z.association.MakeMetrics()->peerImplementation == RTC::SCTP::Types::SctpImplementation::UNKNOWN);
+		  z.association.MakeMetrics()->peerImplementation ==
+		  RTC::SCTP::Types::SctpImplementation::UNKNOWN);
 	}
 
 	SECTION("both peers detect the peer implementation")
@@ -967,28 +1081,32 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		a.association.Connect();
 		z.association.Connect();
 
-		ExchangeMessages(a, z);
+		exchangeMessages(a, z);
 
 		REQUIRE(
-		  a.association.MakeMetrics()->peerImplementation == RTC::SCTP::Types::SctpImplementation::MEDIASOUP);
+		  a.association.MakeMetrics()->peerImplementation ==
+		  RTC::SCTP::Types::SctpImplementation::MEDIASOUP);
 		REQUIRE(
-		  z.association.MakeMetrics()->peerImplementation == RTC::SCTP::Types::SctpImplementation::MEDIASOUP);
+		  z.association.MakeMetrics()->peerImplementation ==
+		  RTC::SCTP::Types::SctpImplementation::MEDIASOUP);
 	}
 
 	SECTION("exposes the number of negotiated streams")
 	{
-		auto aSctpOptions                       = MakeSctpOptions();
-		aSctpOptions.announcedMaxInboundStreams = 12;
+		auto aSctpOptions = makeSctpOptions();
+
+		aSctpOptions.announcedMaxInboundStreams  = 12;
 		aSctpOptions.announcedMaxOutboundStreams = 45;
 
-		auto zSctpOptions                       = MakeSctpOptions();
-		zSctpOptions.announcedMaxInboundStreams = 23;
+		auto zSctpOptions = makeSctpOptions();
+
+		zSctpOptions.announcedMaxInboundStreams  = 23;
 		zSctpOptions.announcedMaxOutboundStreams = 34;
 
 		AssociationUnderTest a(aSctpOptions);
 		AssociationUnderTest z(zSctpOptions);
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		const auto metricsA = a.association.MakeMetrics();
 
@@ -1003,7 +1121,8 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 	SECTION("always sends INIT with non-zero checksum")
 	{
-		auto sctpOptions = MakeSctpOptions();
+		auto sctpOptions = makeSctpOptions();
+
 		sctpOptions.zeroChecksumAlternateErrorDetectionMethod =
 		  RTC::SCTP::ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::SCTP_OVER_DTLS;
 
@@ -1013,13 +1132,14 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 		const auto buffer = a.listener.ConsumeFirstSentPacket();
 
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::InitChunk>(buffer) == true);
-		REQUIRE(ParsePacket(buffer)->GetChecksum() != 0);
+		REQUIRE(packetHasSingleChunkOfType<RTC::SCTP::InitChunk>(buffer) == true);
+		REQUIRE(parsePacket(buffer)->GetChecksum() != 0);
 	}
 
 	SECTION("may send INIT-ACK with zero checksum")
 	{
-		auto sctpOptions = MakeSctpOptions();
+		auto sctpOptions = makeSctpOptions();
+
 		sctpOptions.zeroChecksumAlternateErrorDetectionMethod =
 		  RTC::SCTP::ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::SCTP_OVER_DTLS;
 
@@ -1028,17 +1148,18 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 		a.association.Connect();
 		// Z reads INIT, produces INIT-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 
 		const auto buffer = z.listener.ConsumeFirstSentPacket();
 
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::InitAckChunk>(buffer) == true);
-		REQUIRE(ParsePacket(buffer)->GetChecksum() == 0);
+		REQUIRE(packetHasSingleChunkOfType<RTC::SCTP::InitAckChunk>(buffer) == true);
+		REQUIRE(parsePacket(buffer)->GetChecksum() == 0);
 	}
 
 	SECTION("always sends COOKIE-ECHO with non-zero checksum")
 	{
-		auto sctpOptions = MakeSctpOptions();
+		auto sctpOptions = makeSctpOptions();
+
 		sctpOptions.zeroChecksumAlternateErrorDetectionMethod =
 		  RTC::SCTP::ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::SCTP_OVER_DTLS;
 
@@ -1047,19 +1168,20 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 		a.association.Connect();
 		// Z reads INIT, produces INIT-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads INIT-ACK, produces COOKIE-ECHO.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		const auto buffer = a.listener.ConsumeFirstSentPacket();
 
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::CookieEchoChunk>(buffer) == true);
-		REQUIRE(ParsePacket(buffer)->GetChecksum() != 0);
+		REQUIRE(packetHasSingleChunkOfType<RTC::SCTP::CookieEchoChunk>(buffer) == true);
+		REQUIRE(parsePacket(buffer)->GetChecksum() != 0);
 	}
 
 	SECTION("sends COOKIE-ACK with zero checksum")
 	{
-		auto sctpOptions = MakeSctpOptions();
+		auto sctpOptions = makeSctpOptions();
+
 		sctpOptions.zeroChecksumAlternateErrorDetectionMethod =
 		  RTC::SCTP::ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::SCTP_OVER_DTLS;
 
@@ -1068,80 +1190,88 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 		a.association.Connect();
 		// Z reads INIT, produces INIT-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 		// A reads INIT-ACK, produces COOKIE-ECHO.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 
 		const auto buffer = z.listener.ConsumeFirstSentPacket();
 
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::CookieAckChunk>(buffer) == true);
-		REQUIRE(ParsePacket(buffer)->GetChecksum() == 0);
+		REQUIRE(packetHasSingleChunkOfType<RTC::SCTP::CookieAckChunk>(buffer) == true);
+		REQUIRE(parsePacket(buffer)->GetChecksum() == 0);
 	}
 
 	SECTION("sends DATA with zero checksum")
 	{
-		auto sctpOptions = MakeSctpOptions();
+		auto sctpOptions = makeSctpOptions();
+
 		sctpOptions.zeroChecksumAlternateErrorDetectionMethod =
 		  RTC::SCTP::ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::SCTP_OVER_DTLS;
 
 		AssociationUnderTest a(sctpOptions);
 		AssociationUnderTest z(sctpOptions);
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
-		SendMessage(a, 1, 53, std::vector<uint8_t>(a.sctpOptions.mtu - 100));
+		sendMessage(a, 1, 53, std::vector<uint8_t>(a.sctpOptions.mtu - 100));
 
 		const auto buffer = a.listener.ConsumeFirstSentPacket();
 
-		REQUIRE(PacketHasDataChunk(buffer) == true);
-		REQUIRE(ParsePacket(buffer)->GetChecksum() == 0);
+		REQUIRE(packetHasDataChunk(buffer) == true);
+		REQUIRE(parsePacket(buffer)->GetChecksum() == 0);
 	}
 
 	SECTION("both sides send heartbeats")
 	{
 		// Make them have slightly different heartbeat intervals, to validate that
 		// sending an ack by Z doesn't restart its heartbeat timer.
-		auto aSctpOptions                = MakeSctpOptions();
+		auto aSctpOptions = makeSctpOptions();
+
 		aSctpOptions.heartbeatIntervalMs = 1000;
-		auto zSctpOptions                = MakeSctpOptions();
+
+		auto zSctpOptions = makeSctpOptions();
+
 		zSctpOptions.heartbeatIntervalMs = 1100;
 
 		AssociationUnderTest a(aSctpOptions);
 		AssociationUnderTest z(zSctpOptions);
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
-		AdvanceTime(a, z, 1000);
+		advanceTimeMs(a, z, 1000);
 
 		const auto bufferA = a.listener.ConsumeFirstSentPacket();
 
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(bufferA) == true);
+		REQUIRE(packetHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(bufferA) == true);
+
 		// Z receives the heartbeat and sends an ACK that is propagated back to A.
 		z.association.ReceiveSctpData(bufferA.data(), bufferA.size());
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		// A little while later, Z should send heartbeats to A.
-		AdvanceTime(a, z, 100);
+		advanceTimeMs(a, z, 100);
 
 		const auto bufferZ = z.listener.ConsumeFirstSentPacket();
 
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(bufferZ) == true);
+		REQUIRE(packetHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(bufferZ) == true);
+
 		// A receives the heartbeat and sends an ACK that is propagated back to Z.
 		a.association.ReceiveSctpData(bufferZ.data(), bufferZ.size());
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 	}
 
 	SECTION("closes connection after too many lost heartbeats")
 	{
 		AssociationUnderTest a;
 		// Disable Z's heartbeats so that it doesn't interfere.
-		auto zSctpOptions                = MakeSctpOptions();
+		auto zSctpOptions = makeSctpOptions();
+
 		zSctpOptions.heartbeatIntervalMs = 0;
+
 		AssociationUnderTest z(zSctpOptions);
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		REQUIRE(a.listener.ConsumeFirstSentPacket().empty() == true);
 
@@ -1152,27 +1282,28 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		for (size_t i = 0; i < maxRetransmissions; ++i)
 		{
 			// Let the heartbeat interval timer expire, sending a heartbeat.
-			AdvanceTime(a, z, timeToNextHeartbeatMs);
+			advanceTimeMs(a, z, timeToNextHeartbeatMs);
 
 			// Drop every heartbeat.
 			REQUIRE(
-			  PacketHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(
+			  packetHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(
 			    a.listener.ConsumeFirstSentPacket()) == true);
 
 			// Let the heartbeat timeout expire.
-			AdvanceTime(a, z, 1000);
+			advanceTimeMs(a, z, 1000);
 
 			timeToNextHeartbeatMs = a.sctpOptions.heartbeatIntervalMs - 1000;
 		}
 
 		// The last heartbeat.
-		AdvanceTime(a, z, timeToNextHeartbeatMs);
+		advanceTimeMs(a, z, timeToNextHeartbeatMs);
 
 		REQUIRE(a.listener.HasSentPackets() == true);
+
 		a.listener.ConsumeFirstSentPacket();
 
 		// Should suffice as exceeding RTO, which aborts the connection.
-		AdvanceTime(a, z, 1000);
+		advanceTimeMs(a, z, 1000);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
 		REQUIRE(a.listener.IsClosed() == true);
@@ -1183,11 +1314,13 @@ SCENARIO("SCTP Association", "[sctp][association]")
 	{
 		AssociationUnderTest a;
 		// Disable Z's heartbeats so that it doesn't interfere.
-		auto zSctpOptions                = MakeSctpOptions();
+		auto zSctpOptions = makeSctpOptions();
+
 		zSctpOptions.heartbeatIntervalMs = 0;
+
 		AssociationUnderTest z(zSctpOptions);
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
 		REQUIRE(a.listener.ConsumeFirstSentPacket().empty() == true);
 
@@ -1197,40 +1330,40 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 		for (size_t i = 0; i < maxRetransmissions; ++i)
 		{
-			AdvanceTime(a, z, timeToNextHeartbeatMs);
+			advanceTimeMs(a, z, timeToNextHeartbeatMs);
 
 			// Drop every heartbeat.
 			a.listener.ConsumeFirstSentPacket();
 
 			// Let the heartbeat timeout expire.
-			AdvanceTime(a, z, 1000);
+			advanceTimeMs(a, z, 1000);
 
 			timeToNextHeartbeatMs = a.sctpOptions.heartbeatIntervalMs - 1000;
 		}
 
 		// Get the last heartbeat and ack it (round trip through Z).
-		AdvanceTime(a, z, timeToNextHeartbeatMs);
+		advanceTimeMs(a, z, timeToNextHeartbeatMs);
 
 		const auto buffer = a.listener.ConsumeFirstSentPacket();
 
-		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(buffer) == true);
+		REQUIRE(packetHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(buffer) == true);
 
 		z.association.ReceiveSctpData(buffer.data(), buffer.size());
 		// A reads the HEARTBEAT-ACK, which clears the error counter.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		// Should suffice as exceeding RTO, but the timer will not fire as it was
 		// stopped by the ack.
-		AdvanceTime(a, z, 1000);
+		advanceTimeMs(a, z, 1000);
 
 		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
 		REQUIRE(a.listener.IsClosed() == false);
 
 		// Verify that we get new heartbeats again.
-		AdvanceTime(a, z, timeToNextHeartbeatMs);
+		advanceTimeMs(a, z, timeToNextHeartbeatMs);
 
 		REQUIRE(
-		  PacketHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(
+		  packetHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(
 		    a.listener.ConsumeFirstSentPacket()) == true);
 	}
 
@@ -1239,16 +1372,16 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		AssociationUnderTest a;
 		AssociationUnderTest z;
 
-		ConnectAssociations(a, z);
+		connectAssociations(a, z);
 
-		SendMessage(a, 1, 53, { 1, 2 });
+		sendMessage(a, 1, 53, { 1, 2 });
 		// Z reads the DATA chunk.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 
 		REQUIRE(z.listener.ConsumeFirstReceivedMessage().has_value() == true);
 
 		// A reads the SACK.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		// Reset the outgoing stream. This will directly send a RE-CONFIG.
 		const std::vector<uint16_t> streamIds{ 1 };
@@ -1257,13 +1390,363 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 		// Z reads the RE-CONFIG, which triggers OnAssociationInboundStreamsReset and
 		// sends a RE-CONFIG response.
-		DeliverFirstSentPacket(a, z);
+		deliverFirstSentPacket(a, z);
 
 		REQUIRE(z.listener.HasInboundStreamsResetForStreamId(1) == true);
 
 		// A reads the response, which triggers OnAssociationStreamsResetPerformed.
-		DeliverFirstSentPacket(z, a);
+		deliverFirstSentPacket(z, a);
 
 		REQUIRE(a.listener.HasStreamsResetPerformedForStreamId(1) == true);
+	}
+
+	SECTION("small messages with priority arrive in a specific order")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		a.association.SetStreamPriority(1, 700);
+		a.association.SetStreamPriority(2, 200);
+		a.association.SetStreamPriority(3, 100);
+
+		// Enqueue messages before connecting, to ensure they aren't sent as soon as
+		// sendMessage() is called.
+		sendMessage(a, 3, 301, std::vector<uint8_t>(10));
+		sendMessage(a, 1, 101, std::vector<uint8_t>(10));
+		sendMessage(a, 2, 201, std::vector<uint8_t>(10));
+		sendMessage(a, 1, 102, std::vector<uint8_t>(10));
+		sendMessage(a, 1, 103, std::vector<uint8_t>(10));
+
+		connectAssociations(a, z);
+		exchangeMessages(a, z);
+
+		REQUIRE(getReceivedMessagePpids(z) == std::vector<uint32_t>{ 101, 102, 103, 201, 301 });
+	}
+
+	SECTION("large messages with priority arrive in a specific order")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		const size_t largeSize = a.sctpOptions.mtu * 20;
+
+		a.association.SetStreamPriority(1, 700);
+		a.association.SetStreamPriority(2, 200);
+		a.association.SetStreamPriority(3, 100);
+
+		// Enqueue messages before connecting, to ensure they aren't sent as soon as
+		// sendMessage() is called.
+		sendMessage(a, 3, 301, std::vector<uint8_t>(largeSize));
+		sendMessage(a, 1, 101, std::vector<uint8_t>(largeSize));
+		sendMessage(a, 2, 201, std::vector<uint8_t>(largeSize));
+		sendMessage(a, 1, 102, std::vector<uint8_t>(largeSize));
+
+		connectAssociations(a, z);
+		exchangeMessages(a, z);
+
+		REQUIRE(getReceivedMessagePpids(z) == std::vector<uint32_t>{ 101, 102, 201, 301 });
+	}
+
+	SECTION("a higher priority message interrupts a lower priority message")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		connectAssociations(a, z);
+
+		const size_t largeSize = a.sctpOptions.mtu * 20;
+
+		a.association.SetStreamPriority(2, 128);
+		sendMessage(a, 2, 201, std::vector<uint8_t>(largeSize));
+
+		// Due to a non-zero initial congestion window, the message will already
+		// start to send, but will not be sent completely. Now enqueue two messages
+		// on a higher priority stream: one small and one large.
+		a.association.SetStreamPriority(1, 512);
+		sendMessage(a, 1, 101, std::vector<uint8_t>(10));
+		sendMessage(a, 1, 102, std::vector<uint8_t>(largeSize));
+
+		exchangeMessages(a, z);
+
+		REQUIRE(getReceivedMessagePpids(z) == std::vector<uint32_t>{ 101, 102, 201 });
+	}
+
+	SECTION("lifecycle events are generated for acked messages")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		connectAssociations(a, z);
+
+		const size_t largeSize = a.sctpOptions.mtu * 20;
+
+		sendMessage(a, 2, 101, std::vector<uint8_t>(largeSize), { .lifecycleId = 41 });
+		sendMessage(a, 2, 102, std::vector<uint8_t>(largeSize));
+		sendMessage(a, 2, 103, std::vector<uint8_t>(largeSize), { .lifecycleId = 42 });
+
+		exchangeMessages(a, z);
+		// In case of delayed ack.
+		advanceTimeMs(a, z, a.sctpOptions.delayedAckMaxTimeoutMs);
+		exchangeMessages(a, z);
+
+		REQUIRE(a.listener.HasOnAssociationLifecycleMessageDeliveredBeenCalledWithLifecycleId(41) == true);
+		REQUIRE(a.listener.HasOnAssociationLifecycleMessageEndBeenCalledWithLifecycleId(41) == true);
+		REQUIRE(a.listener.HasOnAssociationLifecycleMessageDeliveredBeenCalledWithLifecycleId(42) == true);
+		REQUIRE(a.listener.HasOnAssociationLifecycleMessageEndBeenCalledWithLifecycleId(42) == true);
+
+		REQUIRE(getReceivedMessagePpids(z) == std::vector<uint32_t>{ 101, 102, 103 });
+	}
+
+	SECTION("lifecycle events for an expired message with a lifetime limit")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		// Send it before the association is connected, to prevent it from being
+		// sent too quickly. The idea is that it should be expired before even
+		// attempting to send it in full.
+		sendMessage(a, 1, 51, std::vector<uint8_t>(10), { .lifetimeMs = 100, .lifecycleId = 1 });
+
+		advanceTimeMs(a, z, 200);
+
+		connectAssociations(a, z);
+		exchangeMessages(a, z);
+
+		REQUIRE(
+		  a.listener.HasOnAssociationLifecycleMessageExpiredSentBeenCalledWithLifecycleId(
+		    1, /*maybeDelivered*/ false) == true);
+		REQUIRE(a.listener.HasOnAssociationLifecycleMessageEndBeenCalledWithLifecycleId(1) == true);
+
+		REQUIRE(getReceivedMessagePpids(z).empty() == true);
+	}
+
+	SECTION("responds with an error to an unknown chunk")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		const uint32_t verificationTag = connectAndGetVerificationTag(a, z);
+
+		std::vector<uint8_t> buffer(a.sctpOptions.mtu);
+		auto packet = buildPacket(buffer, verificationTag);
+
+		// Build a 4-byte chunk and patch its type to an unknown value (0x49), whose
+		// top two bits (01) request the receiver to skip it and report an error.
+		auto* cookieAckChunk = packet->BuildChunkInPlace<RTC::SCTP::CookieAckChunk>();
+
+		cookieAckChunk->Consolidate();
+
+		const_cast<uint8_t*>(packet->GetBuffer())[12] = 0x49;
+
+		injectPacket(a, packet.get());
+
+		// A replies with an OPERATION-ERROR chunk carrying an Unrecognized Chunk
+		// Type error cause.
+		const auto buffer2     = a.listener.ConsumeFirstSentPacket();
+		const auto replyPacket = parsePacket(buffer2);
+
+		REQUIRE(replyPacket);
+
+		const auto* operationErrorChunk =
+		  replyPacket->GetFirstChunkOfType<RTC::SCTP::OperationErrorChunk>();
+
+		REQUIRE(operationErrorChunk);
+
+		const auto* errorCause = operationErrorChunk->GetErrorCauseAt(0);
+
+		REQUIRE(errorCause);
+		REQUIRE(errorCause->GetCode() == RTC::SCTP::ErrorCause::ErrorCauseCode::UNRECOGNIZED_CHUNK_TYPE);
+	}
+
+	SECTION("reports a received error chunk as a callback")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		const uint32_t verificationTag = connectAndGetVerificationTag(a, z);
+
+		std::vector<uint8_t> buffer(a.sctpOptions.mtu);
+		auto packet = buildPacket(buffer, verificationTag);
+
+		auto* operationErrorChunk = packet->BuildChunkInPlace<RTC::SCTP::OperationErrorChunk>();
+		auto* unrecognizedChunkTypeErrorCause =
+		  operationErrorChunk->BuildErrorCauseInPlace<RTC::SCTP::UnrecognizedChunkTypeErrorCause>();
+
+		const uint8_t unknownChunk[]{ 0x49, 0x00, 0x00, 0x04 };
+
+		unrecognizedChunkTypeErrorCause->SetUnrecognizedChunk(unknownChunk, sizeof(unknownChunk));
+		unrecognizedChunkTypeErrorCause->Consolidate();
+		operationErrorChunk->Consolidate();
+
+		injectPacket(a, packet.get());
+
+		REQUIRE(a.listener.HasErrored() == true);
+		REQUIRE(a.listener.GetErroredErrorKind() == RTC::SCTP::Types::ErrorKind::PEER_REPORTED);
+	}
+
+	SECTION("answers a heartbeat request with an ack")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		const uint32_t verificationTag = connectAndGetVerificationTag(a, z);
+
+		std::vector<uint8_t> buffer(a.sctpOptions.mtu);
+		auto packet = buildPacket(buffer, verificationTag);
+
+		auto* heartbeatRequestChunk = packet->BuildChunkInPlace<RTC::SCTP::HeartbeatRequestChunk>();
+		auto* heartbeatInfoParameter =
+		  heartbeatRequestChunk->BuildParameterInPlace<RTC::SCTP::HeartbeatInfoParameter>();
+
+		const uint8_t info[]{ 1, 2, 3, 4 };
+
+		heartbeatInfoParameter->SetInfo(info, sizeof(info));
+		heartbeatInfoParameter->Consolidate();
+		heartbeatRequestChunk->Consolidate();
+
+		injectPacket(a, packet.get());
+
+		// A replies with a HEARTBEAT-ACK chunk echoing the Heartbeat Info.
+		const auto buffer2     = a.listener.ConsumeFirstSentPacket();
+		const auto replyPacket = parsePacket(buffer2);
+
+		REQUIRE(replyPacket);
+
+		const auto* heartbeatAckChunk = replyPacket->GetFirstChunkOfType<RTC::SCTP::HeartbeatAckChunk>();
+
+		REQUIRE(heartbeatAckChunk);
+
+		const auto* replyInfoParameter =
+		  heartbeatAckChunk->GetFirstParameterOfType<RTC::SCTP::HeartbeatInfoParameter>();
+
+		REQUIRE(replyInfoParameter);
+		REQUIRE(replyInfoParameter->HasInfo() == true);
+	}
+
+	SECTION("sends a message with limited retransmissions")
+	{
+		// Disable message interleaving so that ordered DATA chunks (with SSN) are
+		// used.
+		auto sctpOptions = makeSctpOptions();
+
+		sctpOptions.enableMessageInterleaving = false;
+
+		AssociationUnderTest a(sctpOptions);
+		AssociationUnderTest z(sctpOptions);
+
+		connectAssociations(a, z);
+
+		RTC::SCTP::SendMessageOptions sendMessageOptions;
+
+		sendMessageOptions.maxRetransmissions = 0;
+
+		const std::vector<uint8_t> payload(a.sctpOptions.mtu - 100);
+
+		sendMessage(a, 1, 51, payload, sendMessageOptions);
+		sendMessage(a, 1, 52, payload, sendMessageOptions);
+		sendMessage(a, 1, 53, payload, sendMessageOptions);
+
+		// Z reads the first DATA.
+		deliverFirstSentPacket(a, z);
+		// Second DATA is lost.
+		a.listener.ConsumeFirstSentPacket();
+		// Z reads the third DATA.
+		deliverFirstSentPacket(a, z);
+
+		// Let everything settle: the missing chunk will be nacked, and only after
+		// the t3-rtx timer expires will it be marked for retransmission and then,
+		// since it has no retransmissions left, abandoned (triggering a FORWARD-TSN).
+		// We exchange packets and advance timers (delayed ack and RTO) until there's
+		// nothing more to do, instead of asserting the exact intermediate sequence.
+		exchangeMessages(a, z);
+		advanceTimeMs(a, z, a.sctpOptions.delayedAckMaxTimeoutMs);
+		exchangeMessages(a, z);
+		advanceTimeMs(a, z, a.sctpOptions.initialRtoMs);
+		exchangeMessages(a, z);
+		advanceTimeMs(a, z, a.sctpOptions.delayedAckMaxTimeoutMs);
+		exchangeMessages(a, z);
+
+		// The first and third messages are delivered; the second one is abandoned.
+		REQUIRE(getReceivedMessagePpids(z) == std::vector<uint32_t>{ 51, 53 });
+	}
+
+	SECTION("lifecycle events for fail on max retransmissions")
+	{
+		auto sctpOptions = makeSctpOptions();
+
+		sctpOptions.enableMessageInterleaving = false;
+
+		AssociationUnderTest a(sctpOptions);
+		AssociationUnderTest z(sctpOptions);
+
+		connectAssociations(a, z);
+
+		const std::vector<uint8_t> payload(a.sctpOptions.mtu - 100);
+
+		sendMessage(a, 1, 51, payload, { .maxRetransmissions = 0, .lifecycleId = 1 });
+		sendMessage(a, 1, 52, payload, { .maxRetransmissions = 0, .lifecycleId = 2 });
+		sendMessage(a, 1, 53, payload, { .maxRetransmissions = 0, .lifecycleId = 3 });
+
+		// Z reads the first DATA.
+		deliverFirstSentPacket(a, z);
+		// Second DATA is lost.
+		a.listener.ConsumeFirstSentPacket();
+
+		exchangeMessages(a, z);
+
+		// Handle the delayed SACK.
+		advanceTimeMs(a, z, a.sctpOptions.delayedAckMaxTimeoutMs);
+		exchangeMessages(a, z);
+
+		// The chunk is now nacked. Let the RTO expire to discard the message.
+		advanceTimeMs(a, z, a.sctpOptions.initialRtoMs);
+		exchangeMessages(a, z);
+
+		// Handle the delayed SACK.
+		advanceTimeMs(a, z, a.sctpOptions.delayedAckMaxTimeoutMs);
+		exchangeMessages(a, z);
+
+		REQUIRE(a.listener.HasOnAssociationLifecycleMessageDeliveredBeenCalledWithLifecycleId(1) == true);
+		REQUIRE(a.listener.HasOnAssociationLifecycleMessageEndBeenCalledWithLifecycleId(1) == true);
+		REQUIRE(
+		  a.listener.HasOnAssociationLifecycleMessageExpiredSentBeenCalledWithLifecycleId(
+		    2, /*maybeDelivered*/ true) == true);
+		REQUIRE(a.listener.HasOnAssociationLifecycleMessageEndBeenCalledWithLifecycleId(2) == true);
+		REQUIRE(a.listener.HasOnAssociationLifecycleMessageDeliveredBeenCalledWithLifecycleId(3) == true);
+		REQUIRE(a.listener.HasOnAssociationLifecycleMessageEndBeenCalledWithLifecycleId(3) == true);
+
+		REQUIRE(getReceivedMessagePpids(z) == std::vector<uint32_t>{ 51, 53 });
+	}
+
+	SECTION("lifecycle events for an expired message with a retransmit limit")
+	{
+		auto sctpOptions = makeSctpOptions();
+
+		sctpOptions.enableMessageInterleaving = false;
+
+		AssociationUnderTest a(sctpOptions);
+		AssociationUnderTest z(sctpOptions);
+
+		connectAssociations(a, z);
+
+		// Will not be able to send it in full within the congestion window, so it
+		// will need SACKs to be received for more fragments to be sent.
+		const std::vector<uint8_t> payload(a.sctpOptions.mtu * 20);
+
+		sendMessage(a, 1, 51, payload, { .maxRetransmissions = 0, .lifecycleId = 1 });
+
+		// Z reads the first DATA.
+		deliverFirstSentPacket(a, z);
+		// Second DATA is lost.
+		a.listener.ConsumeFirstSentPacket();
+
+		exchangeMessages(a, z);
+
+		REQUIRE(
+		  a.listener.HasOnAssociationLifecycleMessageExpiredSentBeenCalledWithLifecycleId(
+		    1, /*maybeDelivered*/ false) == true);
+		REQUIRE(a.listener.HasOnAssociationLifecycleMessageEndBeenCalledWithLifecycleId(1) == true);
+
+		REQUIRE(getReceivedMessagePpids(z).empty() == true);
 	}
 }

--- a/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
@@ -161,7 +161,7 @@ namespace
 		{
 			deliveredPacket = false;
 
-			auto bufferFromA = a.listener.ConsumeFirstSentPacket();
+			const auto bufferFromA = a.listener.ConsumeFirstSentPacket();
 
 			if (!bufferFromA.empty())
 			{
@@ -169,7 +169,7 @@ namespace
 				z.association.ReceiveSctpData(bufferFromA.data(), bufferFromA.size());
 			}
 
-			auto bufferFromZ = z.listener.ConsumeFirstSentPacket();
+			const auto bufferFromZ = z.listener.ConsumeFirstSentPacket();
 
 			if (!bufferFromZ.empty())
 			{
@@ -1528,7 +1528,8 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		const uint32_t verificationTag = connectAndGetVerificationTag(a, z);
 
 		std::vector<uint8_t> buffer(a.sctpOptions.mtu);
-		auto packet = buildPacket(buffer, verificationTag);
+
+		const auto packet = buildPacket(buffer, verificationTag);
 
 		// Build a 4-byte chunk and patch its type to an unknown value (0x49), whose
 		// top two bits (01) request the receiver to skip it and report an error.
@@ -1566,7 +1567,8 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		const uint32_t verificationTag = connectAndGetVerificationTag(a, z);
 
 		std::vector<uint8_t> buffer(a.sctpOptions.mtu);
-		auto packet = buildPacket(buffer, verificationTag);
+
+		const auto packet = buildPacket(buffer, verificationTag);
 
 		auto* operationErrorChunk = packet->BuildChunkInPlace<RTC::SCTP::OperationErrorChunk>();
 		auto* unrecognizedChunkTypeErrorCause =
@@ -1592,7 +1594,8 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		const uint32_t verificationTag = connectAndGetVerificationTag(a, z);
 
 		std::vector<uint8_t> buffer(a.sctpOptions.mtu);
-		auto packet = buildPacket(buffer, verificationTag);
+
+		const auto packet = buildPacket(buffer, verificationTag);
 
 		auto* heartbeatRequestChunk = packet->BuildChunkInPlace<RTC::SCTP::HeartbeatRequestChunk>();
 		auto* heartbeatInfoParameter =

--- a/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
@@ -1,0 +1,1269 @@
+#include "common.hpp"
+#include "RTC/SCTP/association/Association.hpp"
+#include "RTC/SCTP/packet/Packet.hpp"
+#include "RTC/SCTP/packet/chunks/AbortAssociationChunk.hpp"
+#include "RTC/SCTP/packet/chunks/CookieAckChunk.hpp"
+#include "RTC/SCTP/packet/chunks/CookieEchoChunk.hpp"
+#include "RTC/SCTP/packet/chunks/DataChunk.hpp"
+#include "RTC/SCTP/packet/chunks/HeartbeatRequestChunk.hpp"
+#include "RTC/SCTP/packet/chunks/IDataChunk.hpp"
+#include "RTC/SCTP/packet/chunks/InitAckChunk.hpp"
+#include "RTC/SCTP/packet/chunks/InitChunk.hpp"
+#include "RTC/SCTP/packet/chunks/SackChunk.hpp"
+#include "RTC/SCTP/packet/chunks/ShutdownAckChunk.hpp"
+#include "RTC/SCTP/packet/chunks/ShutdownChunk.hpp"
+#include "RTC/SCTP/packet/chunks/ShutdownCompleteChunk.hpp"
+#include "RTC/SCTP/public/Message.hpp"
+#include "RTC/SCTP/public/SctpOptions.hpp"
+#include "RTC/SCTP/public/SctpTypes.hpp"
+#include "mocks/include/MockShared.hpp"
+#include "mocks/include/RTC/SCTP/association/MockAssociationListener.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <array>
+#include <span>
+#include <string_view>
+#include <vector>
+
+// NOTE: This test mirrors libwebrtc's dcsctp/socket/dcsctp_socket_test.cc. The
+// mediasoup SCTP::Association class is the equivalent of dcsctp's DcSctpSocket.
+// Instead of relying on gmock matchers (as dcsctp does) we use the inspection
+// API already exposed by SCTP::Packet and SCTP::Chunk.
+
+namespace
+{
+	// Initial value of the simulated clock (ms).
+	constexpr uint64_t InitialNowMs{ 1000000 };
+
+	// All backoff timer labels an SCTP Association may create. Used by RunTimers()
+	// to fire whichever timers have expired after advancing time, mirroring
+	// dcsctp's RunTimers() test helper.
+	constexpr std::array<std::string_view, 8> SctpTimerLabels{
+		"sctp-t1-init",          "sctp-t1-cookie",   "sctp-t2-shutdown", "sctp-t3-rtx",
+		"sctp-delayed-ack",      "sctp-heartbeat-interval", "sctp-heartbeat-timeout",
+		"sctp-re-config",
+	};
+
+	/**
+	 * Builds the default SctpOptions used in tests. Tweaked to make timers
+	 * predictable, as dcsctp's FixupOptions() does.
+	 */
+	RTC::SCTP::SctpOptions MakeSctpOptions()
+	{
+		RTC::SCTP::SctpOptions sctpOptions;
+
+		// To make the heartbeat interval more predictable in tests.
+		sctpOptions.heartbeatIntervalIncludeRtt = false;
+		sctpOptions.maxBurst                    = 4;
+
+		return sctpOptions;
+	}
+
+	/**
+	 * An SCTP Association under test, together with its simulated clock and
+	 * listener. This is the equivalent of dcsctp's SocketUnderTest.
+	 */
+	class AssociationUnderTest
+	{
+	public:
+		/**
+		 * `mayConnectOnReceivedSctpData` defaults to false so that, just like
+		 * dcsctp, the connection is only initiated by explicitly calling `Connect()`.
+		 * In production mediasoup associations auto-initiate the connection upon
+		 * receiving data (both peers are active), but for tests we want to mimic
+		 * dcsctp's asymmetric handshake (one active peer, one passive peer) so that
+		 * packet sequences and counts match.
+		 */
+		explicit AssociationUnderTest(
+		  RTC::SCTP::SctpOptions sctpOptions = MakeSctpOptions(), bool mayConnectOnReceivedSctpData = false)
+		  // NOTE: The order in which these members are initialized is **critical**.
+		  : sctpOptions(sctpOptions),
+		    shared(/*getTimeMs*/
+		           [this]()
+		           {
+			           return this->nowMs;
+		           }),
+		    association(
+		      this->sctpOptions,
+		      std::addressof(this->listener),
+		      std::addressof(this->shared),
+		      /*isDataChannel*/ true,
+		      mayConnectOnReceivedSctpData)
+		{
+		}
+
+		/**
+		 * Advances the simulated clock of this association by `incrementMs`.
+		 */
+		void AdvanceTimeMs(uint64_t incrementMs)
+		{
+			this->nowMs += incrementMs;
+		}
+
+	public:
+		uint64_t nowMs{ InitialNowMs };
+		RTC::SCTP::SctpOptions sctpOptions;
+		mocks::RTC::SCTP::MockAssociationListener listener;
+		mocks::MockShared shared;
+		RTC::SCTP::Association association;
+	};
+
+	/**
+	 * Parses a previously consumed sent packet buffer into a SCTP::Packet.
+	 */
+	std::unique_ptr<RTC::SCTP::Packet> ParsePacket(const std::vector<uint8_t>& buffer)
+	{
+		return std::unique_ptr<RTC::SCTP::Packet>(RTC::SCTP::Packet::Parse(buffer.data(), buffer.size()));
+	}
+
+	/**
+	 * Returns true if the packet contains a single chunk of the given type.
+	 */
+	template<typename ChunkType>
+	bool PacketHasSingleChunkOfType(const std::vector<uint8_t>& buffer)
+	{
+		const auto packet = ParsePacket(buffer);
+
+		return packet && packet->GetChunksCount() == 1 &&
+		       packet->GetFirstChunkOfType<ChunkType>() != nullptr;
+	}
+
+	/**
+	 * Returns true if the packet contains a DATA or I-DATA chunk.
+	 */
+	bool PacketHasDataChunk(const std::vector<uint8_t>& buffer)
+	{
+		const auto packet = ParsePacket(buffer);
+
+		return packet && (packet->GetFirstChunkOfType<RTC::SCTP::DataChunk>() != nullptr ||
+		                  packet->GetFirstChunkOfType<RTC::SCTP::IDataChunk>() != nullptr);
+	}
+
+	/**
+	 * Delivers a single sent packet from `from` to `to`. The packet must exist.
+	 */
+	void DeliverFirstSentPacket(AssociationUnderTest& from, AssociationUnderTest& to)
+	{
+		const auto packet = from.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(!packet.empty());
+
+		to.association.ReceiveSctpData(packet.data(), packet.size());
+	}
+
+	/**
+	 * Delivers all currently queued packets between `a` and `z` back and forth
+	 * until neither has anything more to send.
+	 */
+	void ExchangeMessages(AssociationUnderTest& a, AssociationUnderTest& z)
+	{
+		bool deliveredPacket{ false };
+
+		do
+		{
+			deliveredPacket = false;
+
+			auto packetFromA = a.listener.ConsumeFirstSentPacket();
+
+			if (!packetFromA.empty())
+			{
+				deliveredPacket = true;
+				z.association.ReceiveSctpData(packetFromA.data(), packetFromA.size());
+			}
+
+			auto packetFromZ = z.listener.ConsumeFirstSentPacket();
+
+			if (!packetFromZ.empty())
+			{
+				deliveredPacket = true;
+				a.association.ReceiveSctpData(packetFromZ.data(), packetFromZ.size());
+			}
+		} while (deliveredPacket);
+	}
+
+	/**
+	 * Fires every Association backoff timer that has expired, looping until none
+	 * remain expired. This is the equivalent of dcsctp's RunTimers().
+	 */
+	void RunTimers(AssociationUnderTest& s)
+	{
+		bool fired{ false };
+
+		do
+		{
+			fired = false;
+
+			for (const auto label : SctpTimerLabels)
+			{
+				auto* timer = s.shared.GetBackoffTimer(label);
+
+				// NOTE: We must check IsRunning() because MockBackoffTimerHandle's
+				// EvaluateHasExpired() only compares times: a stopped timer whose
+				// expiry time is in the past would otherwise be fired again and again.
+				if (timer && timer->IsRunning() && timer->EvaluateHasExpired())
+				{
+					fired = true;
+				}
+			}
+		} while (fired);
+	}
+
+	/**
+	 * Advances the simulated clock of both associations by `durationMs` and fires
+	 * any timer that has expired. This is the equivalent of dcsctp's AdvanceTime().
+	 */
+	void AdvanceTime(AssociationUnderTest& a, AssociationUnderTest& z, uint64_t durationMs)
+	{
+		a.AdvanceTimeMs(durationMs);
+		z.AdvanceTimeMs(durationMs);
+
+		RunTimers(a);
+		RunTimers(z);
+	}
+
+	/**
+	 * Calls Connect() on `a` (the active peer) and drives the handshake to
+	 * completion against `z` (the passive peer). This is the equivalent of
+	 * dcsctp's ConnectSockets().
+	 */
+	void ConnectAssociations(AssociationUnderTest& a, AssociationUnderTest& z)
+	{
+		a.association.Connect();
+		ExchangeMessages(a, z);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+	}
+
+	/**
+	 * Enqueues a message to be sent on the given association.
+	 */
+	RTC::SCTP::Types::SendMessageStatus SendMessage(
+	  AssociationUnderTest& s,
+	  uint16_t streamId,
+	  uint32_t ppid,
+	  std::vector<uint8_t> payload,
+	  const RTC::SCTP::SendMessageOptions& sendMessageOptions = {})
+	{
+		return s.association.SendMessage(
+		  RTC::SCTP::Message(streamId, ppid, std::move(payload)), sendMessageOptions);
+	}
+} // namespace
+
+SCENARIO("SCTP Association", "[sctp][association]")
+{
+	SECTION("establishes connection")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		a.association.Connect();
+		// Z reads INIT, produces INIT-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads INIT-ACK, produces COOKIE-ECHO.
+		DeliverFirstSentPacket(z, a);
+		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads COOKIE-ACK.
+		DeliverFirstSentPacket(z, a);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(a.listener.IsConnected() == true);
+		REQUIRE(z.listener.IsConnected() == true);
+		REQUIRE(a.listener.HasRestarted() == false);
+		REQUIRE(z.listener.HasRestarted() == false);
+	}
+
+	SECTION("establishes connection with setup collision")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		a.association.Connect();
+		z.association.Connect();
+
+		ExchangeMessages(a, z);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(a.listener.HasRestarted() == false);
+		REQUIRE(z.listener.HasRestarted() == false);
+	}
+
+	SECTION("establishes simultaneous connection")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		a.association.Connect();
+
+		// INIT isn't received by Z, as it wasn't ready yet.
+		a.listener.ConsumeFirstSentPacket();
+
+		z.association.Connect();
+
+		// A reads INIT, produces INIT-ACK.
+		DeliverFirstSentPacket(z, a);
+		// Z reads INIT-ACK, sends COOKIE-ECHO.
+		DeliverFirstSentPacket(a, z);
+		// A reads COOKIE-ECHO, establishes connection.
+		DeliverFirstSentPacket(z, a);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+
+		// Proceed with the remaining packets.
+		ExchangeMessages(a, z);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(a.listener.HasRestarted() == false);
+		REQUIRE(z.listener.HasRestarted() == false);
+	}
+
+	SECTION("establishes connection with lost COOKIE-ACK")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		a.association.Connect();
+		// Z reads INIT, produces INIT-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads INIT-ACK, produces COOKIE-ECHO.
+		DeliverFirstSentPacket(z, a);
+		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
+		DeliverFirstSentPacket(a, z);
+		// COOKIE-ACK is lost.
+		z.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTING);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+
+		// This will make A re-send the COOKIE-ECHO.
+		AdvanceTime(a, z, a.sctpOptions.t1CookieTimeoutMs);
+
+		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads COOKIE-ACK.
+		DeliverFirstSentPacket(z, a);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+	}
+
+	SECTION("resends INIT and establishes connection")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		a.association.Connect();
+
+		// INIT is never received by Z.
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::InitChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+
+		AdvanceTime(a, z, a.sctpOptions.t1InitTimeoutMs);
+
+		// Z reads INIT, produces INIT-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads INIT-ACK, produces COOKIE-ECHO.
+		DeliverFirstSentPacket(z, a);
+		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads COOKIE-ACK.
+		DeliverFirstSentPacket(z, a);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+	}
+
+	SECTION("resending INIT too many times aborts")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		a.association.Connect();
+
+		// INIT is never received by Z.
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::InitChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+
+		const auto maxInitRetransmissions = a.sctpOptions.maxInitRetransmissions.value();
+
+		for (size_t i = 0; i < maxInitRetransmissions; ++i)
+		{
+			AdvanceTime(a, z, a.sctpOptions.t1InitTimeoutMs * (1u << i));
+
+			// INIT is resent.
+			REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::InitChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+		}
+
+		// Another timeout, after the max init retransmits.
+		AdvanceTime(a, z, a.sctpOptions.t1InitTimeoutMs * (1u << maxInitRetransmissions));
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
+		REQUIRE(a.listener.HasFailed() == true);
+		REQUIRE(a.listener.GetFailedErrorKind() == RTC::SCTP::Types::ErrorKind::TOO_MANY_RETRIES);
+	}
+
+	SECTION("resends COOKIE-ECHO and establishes connection")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		a.association.Connect();
+
+		// Z reads INIT, produces INIT-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads INIT-ACK, produces COOKIE-ECHO.
+		DeliverFirstSentPacket(z, a);
+
+		// COOKIE-ECHO is never received by Z.
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::CookieEchoChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+
+		AdvanceTime(a, z, a.sctpOptions.t1CookieTimeoutMs);
+
+		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads COOKIE-ACK.
+		DeliverFirstSentPacket(z, a);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+	}
+
+	SECTION("resending COOKIE-ECHO too many times aborts")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		a.association.Connect();
+
+		// Z reads INIT, produces INIT-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads INIT-ACK, produces COOKIE-ECHO.
+		DeliverFirstSentPacket(z, a);
+
+		// COOKIE-ECHO is never received by Z.
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::CookieEchoChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+
+		const auto maxInitRetransmissions = a.sctpOptions.maxInitRetransmissions.value();
+
+		for (size_t i = 0; i < maxInitRetransmissions; ++i)
+		{
+			AdvanceTime(a, z, a.sctpOptions.t1CookieTimeoutMs * (1u << i));
+
+			// COOKIE-ECHO is resent.
+			REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::CookieEchoChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+		}
+
+		// Another timeout, after the max init retransmits.
+		AdvanceTime(a, z, a.sctpOptions.t1CookieTimeoutMs * (1u << maxInitRetransmissions));
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
+		REQUIRE(a.listener.HasFailed() == true);
+		REQUIRE(a.listener.GetFailedErrorKind() == RTC::SCTP::Types::ErrorKind::TOO_MANY_RETRIES);
+	}
+
+	SECTION("shutting down while establishing connection")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		a.association.Connect();
+
+		// Z reads INIT, produces INIT-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads INIT-ACK, produces COOKIE-ECHO.
+		DeliverFirstSentPacket(z, a);
+		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
+		DeliverFirstSentPacket(a, z);
+		// Drop COOKIE-ACK, just to more easily verify shutdown protocol.
+		z.listener.ConsumeFirstSentPacket();
+
+		// As Association A has received INIT-ACK, it has a TCB and is connected,
+		// while Association Z needs to receive COOKIE-ECHO to get there. A still
+		// has timers running at this point.
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTING);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+
+		// Association A is now shut down, which should make it stop those timers.
+		a.association.Shutdown();
+
+		// Z reads SHUTDOWN, produces SHUTDOWN-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads SHUTDOWN-ACK, produces SHUTDOWN-COMPLETE.
+		DeliverFirstSentPacket(z, a);
+		// Z reads SHUTDOWN-COMPLETE.
+		DeliverFirstSentPacket(a, z);
+
+		REQUIRE(a.listener.ConsumeFirstSentPacket().empty() == true);
+		REQUIRE(z.listener.ConsumeFirstSentPacket().empty() == true);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
+	}
+
+	SECTION("shuts down connection")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		a.association.Shutdown();
+		// Z reads SHUTDOWN, produces SHUTDOWN-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads SHUTDOWN-ACK, produces SHUTDOWN-COMPLETE.
+		DeliverFirstSentPacket(z, a);
+		// Z reads SHUTDOWN-COMPLETE.
+		DeliverFirstSentPacket(a, z);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
+		REQUIRE(a.listener.IsClosed() == true);
+		REQUIRE(z.listener.IsClosed() == true);
+	}
+
+	SECTION("shutdown timer expiring too many times closes connection")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		a.association.Shutdown();
+		// Drop the first SHUTDOWN packet.
+		a.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::SHUTTING_DOWN);
+
+		const auto maxRetransmissions = a.sctpOptions.maxRetransmissions.value();
+
+		for (size_t i = 0; i < maxRetransmissions; ++i)
+		{
+			AdvanceTime(a, z, a.sctpOptions.initialRtoMs * (1u << i));
+
+			// SHUTDOWN is resent (and dropped).
+			REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::ShutdownChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+		}
+
+		// The last expiry makes it abort the connection.
+		AdvanceTime(a, z, a.sctpOptions.initialRtoMs * (1u << maxRetransmissions));
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
+		REQUIRE(a.listener.IsClosed() == true);
+		REQUIRE(a.listener.GetClosedErrorKind() == RTC::SCTP::Types::ErrorKind::TOO_MANY_RETRIES);
+		// An ABORT chunk is sent.
+		REQUIRE(
+		  PacketHasSingleChunkOfType<RTC::SCTP::AbortAssociationChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+	}
+
+	SECTION("T2-shutdown timer expiry resends SHUTDOWN-ACK")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		z.association.Shutdown();
+
+		// A receives SHUTDOWN, sends SHUTDOWN-ACK. A is now in SHUTDOWN-ACK-SENT
+		// state.
+		DeliverFirstSentPacket(z, a);
+
+		// Consume the SHUTDOWN-ACK sent by A (drop it).
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::ShutdownAckChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::SHUTTING_DOWN);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::SHUTTING_DOWN);
+
+		// Advance time to trigger timer expiry, which makes A resend SHUTDOWN-ACK.
+		AdvanceTime(a, z, a.sctpOptions.initialRtoMs);
+
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::ShutdownAckChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+	}
+
+	SECTION("shutdown is ignored in SHUTDOWN-RECEIVED state")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		z.association.Shutdown();
+
+		// A reads SHUTDOWN, produces SHUTDOWN-ACK.
+		DeliverFirstSentPacket(z, a);
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::ShutdownAckChunk>(a.listener.ConsumeFirstSentPacket()) == true);
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::SHUTTING_DOWN);
+
+		// Second shutdown while already shutting down, must be ignored.
+		a.association.Shutdown();
+		REQUIRE(a.listener.ConsumeFirstSentPacket().empty() == true);
+	}
+
+	SECTION("shutdown is ignored in SHUTDOWN-PENDING state")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		// Send a message that will remain outstanding (unacknowledged) which
+		// transitions the association to SHUTDOWN-PENDING instead of SHUTDOWN-SENT.
+		SendMessage(a, 1, 53, { 1, 2 });
+		a.association.Shutdown();
+
+		REQUIRE(PacketHasDataChunk(a.listener.ConsumeFirstSentPacket()) == true);
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::SHUTTING_DOWN);
+
+		// Second shutdown while already shutting down, must be ignored.
+		a.association.Shutdown();
+		REQUIRE(a.listener.ConsumeFirstSentPacket().empty() == true);
+	}
+
+	SECTION("establishes connection while sending data")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		a.association.Connect();
+
+		SendMessage(a, 1, 53, { 1, 2 });
+
+		// Z reads INIT, produces INIT-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads INIT-ACK, produces COOKIE-ECHO.
+		DeliverFirstSentPacket(z, a);
+		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads COOKIE-ACK.
+		DeliverFirstSentPacket(z, a);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(z.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+
+		// Deliver the remaining packets so that the message reaches Z.
+		ExchangeMessages(a, z);
+
+		const auto message = z.listener.ConsumeFirstReceivedMessage();
+
+		REQUIRE(message.has_value() == true);
+		REQUIRE(message->GetStreamId() == 1);
+	}
+
+	SECTION("sends a message after established")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		SendMessage(a, 1, 53, { 1, 2 });
+		// Z reads the DATA chunk.
+		DeliverFirstSentPacket(a, z);
+
+		const auto message = z.listener.ConsumeFirstReceivedMessage();
+
+		REQUIRE(message.has_value() == true);
+		REQUIRE(message->GetStreamId() == 1);
+		REQUIRE(message->GetPayloadProtocolId() == 53);
+	}
+
+	SECTION("resends a packet when the T3-RTX timer expires")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		SendMessage(a, 1, 53, { 1, 2 });
+		// Drop the first DATA packet.
+		a.listener.ConsumeFirstSentPacket();
+
+		// Advance time so that the T3-RTX timer expires and the DATA is resent.
+		AdvanceTime(a, z, a.sctpOptions.initialRtoMs);
+
+		// Z reads the retransmitted DATA chunk.
+		DeliverFirstSentPacket(a, z);
+
+		const auto message = z.listener.ConsumeFirstReceivedMessage();
+
+		REQUIRE(message.has_value() == true);
+		REQUIRE(message->GetStreamId() == 1);
+	}
+
+	SECTION("sends a lot of bytes with a missed packet")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		std::vector<uint8_t> payload(a.sctpOptions.mtu * 20);
+
+		SendMessage(a, 1, 53, payload);
+
+		// Z reads the first DATA.
+		DeliverFirstSentPacket(a, z);
+		// Second DATA is lost.
+		a.listener.ConsumeFirstSentPacket();
+
+		// Retransmit and handle the rest.
+		ExchangeMessages(a, z);
+
+		const auto message = z.listener.ConsumeFirstReceivedMessage();
+
+		REQUIRE(message.has_value() == true);
+		REQUIRE(message->GetStreamId() == 1);
+		REQUIRE(message->GetPayloadLength() == payload.size());
+	}
+
+	SECTION("sends a heartbeat on idle connection")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		REQUIRE(a.listener.ConsumeFirstSentPacket().empty() == true);
+
+		// Let the heartbeat interval timer expire.
+		AdvanceTime(a, z, a.sctpOptions.heartbeatIntervalMs);
+
+		const auto buffer = a.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(buffer) == true);
+
+		// Feed it to Z and expect a HEARTBEAT-ACK that is propagated back to A.
+		z.association.ReceiveSctpData(buffer.data(), buffer.size());
+		DeliverFirstSentPacket(z, a);
+	}
+
+	SECTION("sends many messages")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		constexpr int Iterations{ 100 };
+
+		std::vector<RTC::SCTP::Message> messages;
+
+		messages.reserve(Iterations);
+
+		for (int i = 0; i < Iterations; ++i)
+		{
+			messages.emplace_back(/*streamId*/ 1, /*ppid*/ 53, std::vector<uint8_t>{ 1, 2 });
+		}
+
+		const auto statuses = a.association.SendManyMessages(messages, /*sendMessageOptions*/ {});
+
+		REQUIRE(statuses.size() == Iterations);
+
+		for (const auto status : statuses)
+		{
+			REQUIRE(status == RTC::SCTP::Types::SendMessageStatus::SUCCESS);
+		}
+
+		ExchangeMessages(a, z);
+
+		for (int i = 0; i < Iterations; ++i)
+		{
+			REQUIRE(z.listener.ConsumeFirstReceivedMessage().has_value() == true);
+		}
+
+		REQUIRE(z.listener.ConsumeFirstReceivedMessage().has_value() == false);
+	}
+
+	SECTION("initial metrics are unset")
+	{
+		AssociationUnderTest a;
+
+		REQUIRE(a.association.MakeMetrics().has_value() == false);
+	}
+
+	SECTION("message interleaving metrics are set")
+	{
+		for (const bool aEnable : { false, true })
+		{
+			for (const bool zEnable : { false, true })
+			{
+				auto aSctpOptions                      = MakeSctpOptions();
+				aSctpOptions.enableMessageInterleaving = aEnable;
+				auto zSctpOptions                      = MakeSctpOptions();
+				zSctpOptions.enableMessageInterleaving = zEnable;
+
+				AssociationUnderTest a(aSctpOptions);
+				AssociationUnderTest z(zSctpOptions);
+
+				ConnectAssociations(a, z);
+
+				REQUIRE(a.association.MakeMetrics()->usesMessageInterleaving == (aEnable && zEnable));
+			}
+		}
+	}
+
+	SECTION("rx and tx packet metrics increase")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		// A sent INIT and COOKIE-ECHO, received INIT-ACK and COOKIE-ACK.
+		REQUIRE(a.association.MakeMetrics()->txPacketsCount == 2);
+		REQUIRE(a.association.MakeMetrics()->rxPacketsCount == 2);
+		REQUIRE(a.association.MakeMetrics()->txMessagesCount == 0);
+		REQUIRE(
+		  a.association.MakeMetrics()->cwndBytes == a.sctpOptions.initialCwndMtus * a.sctpOptions.mtu);
+		REQUIRE(a.association.MakeMetrics()->unackDataCount == 0);
+
+		REQUIRE(z.association.MakeMetrics()->rxPacketsCount == 2);
+		REQUIRE(z.association.MakeMetrics()->rxMessagesCount == 0);
+
+		SendMessage(a, 1, 53, { 1, 2 });
+
+		REQUIRE(a.association.MakeMetrics()->unackDataCount == 1);
+
+		// Z reads DATA.
+		DeliverFirstSentPacket(a, z);
+		// A reads SACK.
+		DeliverFirstSentPacket(z, a);
+
+		REQUIRE(a.association.MakeMetrics()->unackDataCount == 0);
+		REQUIRE(z.listener.ConsumeFirstReceivedMessage().has_value() == true);
+
+		REQUIRE(a.association.MakeMetrics()->txPacketsCount == 3);
+		REQUIRE(a.association.MakeMetrics()->rxPacketsCount == 3);
+		REQUIRE(a.association.MakeMetrics()->txMessagesCount == 1);
+
+		REQUIRE(z.association.MakeMetrics()->rxPacketsCount == 3);
+		REQUIRE(z.association.MakeMetrics()->rxMessagesCount == 1);
+	}
+
+	SECTION("streams have initial priority")
+	{
+		auto sctpOptions                  = MakeSctpOptions();
+		sctpOptions.defaultStreamPriority = 42;
+
+		AssociationUnderTest a(sctpOptions);
+
+		REQUIRE(a.association.GetStreamPriority(1) == 42);
+
+		SendMessage(a, 2, 53, { 1, 2 });
+
+		REQUIRE(a.association.GetStreamPriority(2) == 42);
+	}
+
+	SECTION("can change stream priority")
+	{
+		auto sctpOptions                  = MakeSctpOptions();
+		sctpOptions.defaultStreamPriority = 42;
+
+		AssociationUnderTest a(sctpOptions);
+
+		a.association.SetStreamPriority(1, 43);
+		REQUIRE(a.association.GetStreamPriority(1) == 43);
+
+		SendMessage(a, 2, 53, { 1, 2 });
+
+		a.association.SetStreamPriority(2, 43);
+		REQUIRE(a.association.GetStreamPriority(2) == 43);
+	}
+
+	SECTION("respects the per-stream queue limit")
+	{
+		auto sctpOptions                    = MakeSctpOptions();
+		sctpOptions.maxSendBufferSize       = 4000;
+		sctpOptions.perStreamSendQueueLimit = 1000;
+
+		AssociationUnderTest a(sctpOptions);
+
+		REQUIRE(
+		  SendMessage(a, 1, 53, std::vector<uint8_t>(600)) == RTC::SCTP::Types::SendMessageStatus::SUCCESS);
+		REQUIRE(
+		  SendMessage(a, 1, 53, std::vector<uint8_t>(600)) == RTC::SCTP::Types::SendMessageStatus::SUCCESS);
+		REQUIRE(
+		  SendMessage(a, 1, 53, std::vector<uint8_t>(600)) ==
+		  RTC::SCTP::Types::SendMessageStatus::ERROR_RESOURCE_EXHAUSTION);
+		// The per-stream limit for stream 1 is reached, but not for stream 2.
+		REQUIRE(
+		  SendMessage(a, 2, 53, std::vector<uint8_t>(600)) == RTC::SCTP::Types::SendMessageStatus::SUCCESS);
+		REQUIRE(
+		  SendMessage(a, 2, 53, std::vector<uint8_t>(600)) == RTC::SCTP::Types::SendMessageStatus::SUCCESS);
+		REQUIRE(
+		  SendMessage(a, 2, 53, std::vector<uint8_t>(600)) ==
+		  RTC::SCTP::Types::SendMessageStatus::ERROR_RESOURCE_EXHAUSTION);
+	}
+
+	SECTION("has reasonable buffered amount values")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		REQUIRE(a.association.GetStreamBufferedAmount(1) == 0);
+
+		// Sending a small message will directly send it as a single packet, so
+		// nothing is left in the queue.
+		SendMessage(a, 1, 53, std::vector<uint8_t>(10));
+
+		REQUIRE(a.association.GetStreamBufferedAmount(1) == 0);
+
+		// Sending a large message will directly start sending a few packets, so the
+		// buffered amount is not the full message size.
+		const size_t largeSize = a.sctpOptions.mtu * 20;
+
+		SendMessage(a, 1, 53, std::vector<uint8_t>(largeSize));
+
+		REQUIRE(a.association.GetStreamBufferedAmount(1) > 0);
+		REQUIRE(a.association.GetStreamBufferedAmount(1) < largeSize);
+	}
+
+	SECTION("has a default buffered amount low threshold of zero")
+	{
+		AssociationUnderTest a;
+
+		REQUIRE(a.association.GetStreamBufferedAmountLowThreshold(1) == 0);
+	}
+
+	SECTION("triggers OnAssociationStreamBufferedAmountLow with default threshold zero")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		REQUIRE(a.listener.HasOnStreamBufferedAmountLowBeenCalledWithStreamId(1) == false);
+
+		ConnectAssociations(a, z);
+
+		SendMessage(a, 1, 53, std::vector<uint8_t>(10));
+		ExchangeMessages(a, z);
+
+		REQUIRE(a.listener.HasOnStreamBufferedAmountLowBeenCalledWithStreamId(1) == true);
+	}
+
+	SECTION("detects the peer implementation")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		// Both peers are mediasoup.
+		REQUIRE(
+		  a.association.MakeMetrics()->peerImplementation == RTC::SCTP::Types::SctpImplementation::MEDIASOUP);
+		// As A initiated the connection establishment, the passive peer Z will not
+		// receive enough information to know about A's implementation.
+		REQUIRE(
+		  z.association.MakeMetrics()->peerImplementation == RTC::SCTP::Types::SctpImplementation::UNKNOWN);
+	}
+
+	SECTION("both peers detect the peer implementation")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		a.association.Connect();
+		z.association.Connect();
+
+		ExchangeMessages(a, z);
+
+		REQUIRE(
+		  a.association.MakeMetrics()->peerImplementation == RTC::SCTP::Types::SctpImplementation::MEDIASOUP);
+		REQUIRE(
+		  z.association.MakeMetrics()->peerImplementation == RTC::SCTP::Types::SctpImplementation::MEDIASOUP);
+	}
+
+	SECTION("exposes the number of negotiated streams")
+	{
+		auto aSctpOptions                       = MakeSctpOptions();
+		aSctpOptions.announcedMaxInboundStreams = 12;
+		aSctpOptions.announcedMaxOutboundStreams = 45;
+
+		auto zSctpOptions                       = MakeSctpOptions();
+		zSctpOptions.announcedMaxInboundStreams = 23;
+		zSctpOptions.announcedMaxOutboundStreams = 34;
+
+		AssociationUnderTest a(aSctpOptions);
+		AssociationUnderTest z(zSctpOptions);
+
+		ConnectAssociations(a, z);
+
+		const auto metricsA = a.association.MakeMetrics();
+
+		REQUIRE(metricsA->negotiatedMaxInboundStreams == 12);
+		REQUIRE(metricsA->negotiatedMaxOutboundStreams == 23);
+
+		const auto metricsZ = z.association.MakeMetrics();
+
+		REQUIRE(metricsZ->negotiatedMaxInboundStreams == 23);
+		REQUIRE(metricsZ->negotiatedMaxOutboundStreams == 12);
+	}
+
+	SECTION("always sends INIT with non-zero checksum")
+	{
+		auto sctpOptions = MakeSctpOptions();
+		sctpOptions.zeroChecksumAlternateErrorDetectionMethod =
+		  RTC::SCTP::ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::SCTP_OVER_DTLS;
+
+		AssociationUnderTest a(sctpOptions);
+
+		a.association.Connect();
+
+		const auto buffer = a.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::InitChunk>(buffer) == true);
+		REQUIRE(ParsePacket(buffer)->GetChecksum() != 0);
+	}
+
+	SECTION("may send INIT-ACK with zero checksum")
+	{
+		auto sctpOptions = MakeSctpOptions();
+		sctpOptions.zeroChecksumAlternateErrorDetectionMethod =
+		  RTC::SCTP::ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::SCTP_OVER_DTLS;
+
+		AssociationUnderTest a(sctpOptions);
+		AssociationUnderTest z(sctpOptions);
+
+		a.association.Connect();
+		// Z reads INIT, produces INIT-ACK.
+		DeliverFirstSentPacket(a, z);
+
+		const auto buffer = z.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::InitAckChunk>(buffer) == true);
+		REQUIRE(ParsePacket(buffer)->GetChecksum() == 0);
+	}
+
+	SECTION("always sends COOKIE-ECHO with non-zero checksum")
+	{
+		auto sctpOptions = MakeSctpOptions();
+		sctpOptions.zeroChecksumAlternateErrorDetectionMethod =
+		  RTC::SCTP::ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::SCTP_OVER_DTLS;
+
+		AssociationUnderTest a(sctpOptions);
+		AssociationUnderTest z(sctpOptions);
+
+		a.association.Connect();
+		// Z reads INIT, produces INIT-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads INIT-ACK, produces COOKIE-ECHO.
+		DeliverFirstSentPacket(z, a);
+
+		const auto buffer = a.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::CookieEchoChunk>(buffer) == true);
+		REQUIRE(ParsePacket(buffer)->GetChecksum() != 0);
+	}
+
+	SECTION("sends COOKIE-ACK with zero checksum")
+	{
+		auto sctpOptions = MakeSctpOptions();
+		sctpOptions.zeroChecksumAlternateErrorDetectionMethod =
+		  RTC::SCTP::ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::SCTP_OVER_DTLS;
+
+		AssociationUnderTest a(sctpOptions);
+		AssociationUnderTest z(sctpOptions);
+
+		a.association.Connect();
+		// Z reads INIT, produces INIT-ACK.
+		DeliverFirstSentPacket(a, z);
+		// A reads INIT-ACK, produces COOKIE-ECHO.
+		DeliverFirstSentPacket(z, a);
+		// Z reads COOKIE-ECHO, produces COOKIE-ACK.
+		DeliverFirstSentPacket(a, z);
+
+		const auto buffer = z.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::CookieAckChunk>(buffer) == true);
+		REQUIRE(ParsePacket(buffer)->GetChecksum() == 0);
+	}
+
+	SECTION("sends DATA with zero checksum")
+	{
+		auto sctpOptions = MakeSctpOptions();
+		sctpOptions.zeroChecksumAlternateErrorDetectionMethod =
+		  RTC::SCTP::ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::SCTP_OVER_DTLS;
+
+		AssociationUnderTest a(sctpOptions);
+		AssociationUnderTest z(sctpOptions);
+
+		ConnectAssociations(a, z);
+
+		SendMessage(a, 1, 53, std::vector<uint8_t>(a.sctpOptions.mtu - 100));
+
+		const auto buffer = a.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(PacketHasDataChunk(buffer) == true);
+		REQUIRE(ParsePacket(buffer)->GetChecksum() == 0);
+	}
+
+	SECTION("both sides send heartbeats")
+	{
+		// Make them have slightly different heartbeat intervals, to validate that
+		// sending an ack by Z doesn't restart its heartbeat timer.
+		auto aSctpOptions                = MakeSctpOptions();
+		aSctpOptions.heartbeatIntervalMs = 1000;
+		auto zSctpOptions                = MakeSctpOptions();
+		zSctpOptions.heartbeatIntervalMs = 1100;
+
+		AssociationUnderTest a(aSctpOptions);
+		AssociationUnderTest z(zSctpOptions);
+
+		ConnectAssociations(a, z);
+
+		AdvanceTime(a, z, 1000);
+
+		const auto bufferA = a.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(bufferA) == true);
+		// Z receives the heartbeat and sends an ACK that is propagated back to A.
+		z.association.ReceiveSctpData(bufferA.data(), bufferA.size());
+		DeliverFirstSentPacket(z, a);
+
+		// A little while later, Z should send heartbeats to A.
+		AdvanceTime(a, z, 100);
+
+		const auto bufferZ = z.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(bufferZ) == true);
+		// A receives the heartbeat and sends an ACK that is propagated back to Z.
+		a.association.ReceiveSctpData(bufferZ.data(), bufferZ.size());
+		DeliverFirstSentPacket(a, z);
+	}
+
+	SECTION("closes connection after too many lost heartbeats")
+	{
+		AssociationUnderTest a;
+		// Disable Z's heartbeats so that it doesn't interfere.
+		auto zSctpOptions                = MakeSctpOptions();
+		zSctpOptions.heartbeatIntervalMs = 0;
+		AssociationUnderTest z(zSctpOptions);
+
+		ConnectAssociations(a, z);
+
+		REQUIRE(a.listener.ConsumeFirstSentPacket().empty() == true);
+
+		const auto maxRetransmissions = a.sctpOptions.maxRetransmissions.value();
+
+		uint64_t timeToNextHeartbeatMs = a.sctpOptions.heartbeatIntervalMs;
+
+		for (size_t i = 0; i < maxRetransmissions; ++i)
+		{
+			// Let the heartbeat interval timer expire, sending a heartbeat.
+			AdvanceTime(a, z, timeToNextHeartbeatMs);
+
+			// Drop every heartbeat.
+			REQUIRE(
+			  PacketHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(
+			    a.listener.ConsumeFirstSentPacket()) == true);
+
+			// Let the heartbeat timeout expire.
+			AdvanceTime(a, z, 1000);
+
+			timeToNextHeartbeatMs = a.sctpOptions.heartbeatIntervalMs - 1000;
+		}
+
+		// The last heartbeat.
+		AdvanceTime(a, z, timeToNextHeartbeatMs);
+
+		REQUIRE(a.listener.HasSentPackets() == true);
+		a.listener.ConsumeFirstSentPacket();
+
+		// Should suffice as exceeding RTO, which aborts the connection.
+		AdvanceTime(a, z, 1000);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CLOSED);
+		REQUIRE(a.listener.IsClosed() == true);
+		REQUIRE(a.listener.GetClosedErrorKind() == RTC::SCTP::Types::ErrorKind::TOO_MANY_RETRIES);
+	}
+
+	SECTION("recovers after a successful heartbeat ack")
+	{
+		AssociationUnderTest a;
+		// Disable Z's heartbeats so that it doesn't interfere.
+		auto zSctpOptions                = MakeSctpOptions();
+		zSctpOptions.heartbeatIntervalMs = 0;
+		AssociationUnderTest z(zSctpOptions);
+
+		ConnectAssociations(a, z);
+
+		REQUIRE(a.listener.ConsumeFirstSentPacket().empty() == true);
+
+		const auto maxRetransmissions = a.sctpOptions.maxRetransmissions.value();
+
+		uint64_t timeToNextHeartbeatMs = a.sctpOptions.heartbeatIntervalMs;
+
+		for (size_t i = 0; i < maxRetransmissions; ++i)
+		{
+			AdvanceTime(a, z, timeToNextHeartbeatMs);
+
+			// Drop every heartbeat.
+			a.listener.ConsumeFirstSentPacket();
+
+			// Let the heartbeat timeout expire.
+			AdvanceTime(a, z, 1000);
+
+			timeToNextHeartbeatMs = a.sctpOptions.heartbeatIntervalMs - 1000;
+		}
+
+		// Get the last heartbeat and ack it (round trip through Z).
+		AdvanceTime(a, z, timeToNextHeartbeatMs);
+
+		const auto buffer = a.listener.ConsumeFirstSentPacket();
+
+		REQUIRE(PacketHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(buffer) == true);
+
+		z.association.ReceiveSctpData(buffer.data(), buffer.size());
+		// A reads the HEARTBEAT-ACK, which clears the error counter.
+		DeliverFirstSentPacket(z, a);
+
+		// Should suffice as exceeding RTO, but the timer will not fire as it was
+		// stopped by the ack.
+		AdvanceTime(a, z, 1000);
+
+		REQUIRE(a.association.GetAssociationState() == RTC::SCTP::Types::AssociationState::CONNECTED);
+		REQUIRE(a.listener.IsClosed() == false);
+
+		// Verify that we get new heartbeats again.
+		AdvanceTime(a, z, timeToNextHeartbeatMs);
+
+		REQUIRE(
+		  PacketHasSingleChunkOfType<RTC::SCTP::HeartbeatRequestChunk>(
+		    a.listener.ConsumeFirstSentPacket()) == true);
+	}
+
+	SECTION("resets a stream")
+	{
+		AssociationUnderTest a;
+		AssociationUnderTest z;
+
+		ConnectAssociations(a, z);
+
+		SendMessage(a, 1, 53, { 1, 2 });
+		// Z reads the DATA chunk.
+		DeliverFirstSentPacket(a, z);
+
+		REQUIRE(z.listener.ConsumeFirstReceivedMessage().has_value() == true);
+
+		// A reads the SACK.
+		DeliverFirstSentPacket(z, a);
+
+		// Reset the outgoing stream. This will directly send a RE-CONFIG.
+		const std::vector<uint16_t> streamIds{ 1 };
+
+		REQUIRE(a.association.ResetStreams(streamIds) == RTC::SCTP::Types::ResetStreamsStatus::PERFORMED);
+
+		// Z reads the RE-CONFIG, which triggers OnAssociationInboundStreamsReset and
+		// sends a RE-CONFIG response.
+		DeliverFirstSentPacket(a, z);
+
+		REQUIRE(z.listener.HasInboundStreamsResetForStreamId(1) == true);
+
+		// A reads the response, which triggers OnAssociationStreamsResetPerformed.
+		DeliverFirstSentPacket(z, a);
+
+		REQUIRE(a.listener.HasStreamsResetPerformedForStreamId(1) == true);
+	}
+}

--- a/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
@@ -877,7 +877,7 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 	SECTION("initial metrics are unset")
 	{
-		AssociationUnderTest a;
+	 	const AssociationUnderTest a;
 
 		REQUIRE(a.association.MakeMetrics().has_value() == false);
 	}
@@ -1035,7 +1035,7 @@ SCENARIO("SCTP Association", "[sctp][association]")
 
 	SECTION("has a default buffered amount low threshold of zero")
 	{
-		AssociationUnderTest a;
+		const AssociationUnderTest a;
 
 		REQUIRE(a.association.GetStreamBufferedAmountLowThreshold(1) == 0);
 	}

--- a/worker/test/src/RTC/SCTP/association/TestPacketSender.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestPacketSender.cpp
@@ -1,0 +1,121 @@
+#include "common.hpp"
+#include "RTC/SCTP/association/PacketSender.hpp"
+#include "RTC/SCTP/packet/Packet.hpp"
+#include "RTC/SCTP/packet/chunks/CookieAckChunk.hpp"
+#include "RTC/SCTP/public/SctpOptions.hpp"
+#include "mocks/include/RTC/SCTP/association/MockAssociationListener.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+namespace
+{
+	constexpr uint32_t VerificationTag{ 123 };
+
+	/**
+	 * A PacketSender::Listener that records the last `OnPacketSenderPacketSent()`
+	 * call.
+	 */
+	class MockPacketSenderListener : public RTC::SCTP::PacketSender::Listener
+	{
+	public:
+		void OnPacketSenderPacketSent(
+		  RTC::SCTP::PacketSender* /*packetSender*/, const RTC::SCTP::Packet* /*packet*/, bool sent) override
+		{
+			++this->onPacketSentCalls;
+			this->lastSent = sent;
+		}
+
+	public:
+		size_t onPacketSentCalls{ 0 };
+		bool lastSent{ false };
+	};
+
+	/**
+	 * Builds an SCTP packet carrying a single COOKIE-ACK chunk into `buffer`
+	 * (which must outlive the returned packet).
+	 */
+	std::unique_ptr<RTC::SCTP::Packet> buildPacketWithCookieAck(std::vector<uint8_t>& buffer)
+	{
+		std::unique_ptr<RTC::SCTP::Packet> packet(
+		  RTC::SCTP::Packet::Factory(buffer.data(), buffer.size()));
+
+		packet->SetVerificationTag(VerificationTag);
+
+		auto* cookieAckChunk = packet->BuildChunkInPlace<RTC::SCTP::CookieAckChunk>();
+
+		cookieAckChunk->Consolidate();
+
+		return packet;
+	}
+} // namespace
+
+SCENARIO("SCTP PacketSender", "[sctp][packetsender]")
+{
+	const RTC::SCTP::SctpOptions sctpOptions;
+
+	MockPacketSenderListener listener;
+	mocks::RTC::SCTP::MockAssociationListener associationListener;
+	RTC::SCTP::PacketSender packetSender(std::addressof(listener), associationListener);
+
+	SECTION("sends a packet and notifies the listener")
+	{
+		std::vector<uint8_t> buffer(sctpOptions.mtu);
+		const auto packet = buildPacketWithCookieAck(buffer);
+
+		REQUIRE(packetSender.SendPacket(packet.get()) == true);
+		REQUIRE(listener.onPacketSentCalls == 1);
+		REQUIRE(listener.lastSent == true);
+		REQUIRE(associationListener.HasSentPackets() == true);
+
+		// The checksum was written.
+		const auto sentBuffer = associationListener.ConsumeFirstSentPacket();
+		std::unique_ptr<RTC::SCTP::Packet> sentPacket{ RTC::SCTP::Packet::Parse(
+			sentBuffer.data(), sentBuffer.size()) };
+
+		REQUIRE(sentPacket);
+		REQUIRE(sentPacket->ValidateCRC32cChecksum() == true);
+	}
+
+	SECTION("reports a failed send to the listener")
+	{
+		// Simulate that the transport fails to send the packet.
+		associationListener.SetSendDataResult(false);
+
+		std::vector<uint8_t> buffer(sctpOptions.mtu);
+		const auto packet = buildPacketWithCookieAck(buffer);
+
+		REQUIRE(packetSender.SendPacket(packet.get()) == false);
+		REQUIRE(listener.onPacketSentCalls == 1);
+		REQUIRE(listener.lastSent == false);
+	}
+
+	SECTION("doesn't send a packet without chunks")
+	{
+		std::vector<uint8_t> buffer(sctpOptions.mtu);
+		std::unique_ptr<RTC::SCTP::Packet> packet(
+		  RTC::SCTP::Packet::Factory(buffer.data(), buffer.size()));
+
+		packet->SetVerificationTag(VerificationTag);
+
+		REQUIRE(packetSender.SendPacket(packet.get()) == false);
+		REQUIRE(listener.onPacketSentCalls == 0);
+		REQUIRE(associationListener.HasSentPackets() == false);
+	}
+
+	SECTION("doesn't write the checksum when not requested")
+	{
+		std::vector<uint8_t> buffer(sctpOptions.mtu);
+		const auto packet = buildPacketWithCookieAck(buffer);
+
+		packet->SetChecksum(0);
+
+		REQUIRE(packetSender.SendPacket(packet.get(), /*writeChecksum*/ false) == true);
+
+		const auto sentBuffer = associationListener.ConsumeFirstSentPacket();
+		std::unique_ptr<RTC::SCTP::Packet> sentPacket{ RTC::SCTP::Packet::Parse(
+			sentBuffer.data(), sentBuffer.size()) };
+
+		REQUIRE(sentPacket);
+		REQUIRE(sentPacket->GetChecksum() == 0);
+	}
+}

--- a/worker/test/src/RTC/SCTP/association/TestPacketSender.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestPacketSender.cpp
@@ -69,7 +69,7 @@ SCENARIO("SCTP PacketSender", "[sctp][packetsender]")
 
 		// The checksum was written.
 		const auto sentBuffer = associationListener.ConsumeFirstSentPacket();
-		std::unique_ptr<RTC::SCTP::Packet> sentPacket{ RTC::SCTP::Packet::Parse(
+		const std::unique_ptr<RTC::SCTP::Packet> sentPacket{ RTC::SCTP::Packet::Parse(
 			sentBuffer.data(), sentBuffer.size()) };
 
 		REQUIRE(sentPacket);
@@ -92,7 +92,7 @@ SCENARIO("SCTP PacketSender", "[sctp][packetsender]")
 	SECTION("doesn't send a packet without chunks")
 	{
 		std::vector<uint8_t> buffer(sctpOptions.mtu);
-		std::unique_ptr<RTC::SCTP::Packet> packet(
+		const std::unique_ptr<RTC::SCTP::Packet> packet(
 		  RTC::SCTP::Packet::Factory(buffer.data(), buffer.size()));
 
 		packet->SetVerificationTag(VerificationTag);
@@ -112,7 +112,7 @@ SCENARIO("SCTP PacketSender", "[sctp][packetsender]")
 		REQUIRE(packetSender.SendPacket(packet.get(), /*writeChecksum*/ false) == true);
 
 		const auto sentBuffer = associationListener.ConsumeFirstSentPacket();
-		std::unique_ptr<RTC::SCTP::Packet> sentPacket{ RTC::SCTP::Packet::Parse(
+		const std::unique_ptr<RTC::SCTP::Packet> sentPacket{ RTC::SCTP::Packet::Parse(
 			sentBuffer.data(), sentBuffer.size()) };
 
 		REQUIRE(sentPacket);

--- a/worker/test/src/RTC/SCTP/association/TestStreamResetHandler.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestStreamResetHandler.cpp
@@ -18,8 +18,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <vector>
 
-using namespace RTC::SCTP;
-
 namespace
 {
 	constexpr uint32_t Arwnd{ 131072 };
@@ -29,8 +27,8 @@ namespace
 	constexpr uint64_t RtoMs{ 250 };
 
 	/**
-	 * A StreamResetHandler under test, together with all the (real) components it
-	 * depends on, its simulated clock and listener.
+	 * A RTC::SCTP::StreamResetHandler under test, together with all the (real)
+	 * components it depends on, its simulated clock and listener.
 	 */
 	class TestStreamResetHandler
 	{
@@ -98,11 +96,12 @@ namespace
 
 		/**
 		 * Handles a received RE-CONFIG chunk within a deferrer scope, just like
-		 * Association does before dispatching to the handler.
+		 * association does before dispatching to the handler.
 		 */
-		void HandleReceivedReConfigChunk(const ReConfigChunk* receivedReConfigChunk)
+		void HandleReceivedReConfigChunk(const RTC::SCTP::ReConfigChunk* receivedReConfigChunk)
 		{
-			const AssociationListenerDeferrer::ScopedDeferrer deferrer(this->associationListenerDeferrer);
+			const RTC::SCTP::AssociationListenerDeferrer::ScopedDeferrer deferrer(
+			  this->associationListenerDeferrer);
 
 			this->streamResetHandler.HandleReceivedReConfigChunk(receivedReConfigChunk);
 		}
@@ -122,9 +121,9 @@ namespace
 		};
 
 		/**
-		 * A no-op RetransmissionQueue listener.
+		 * A no-op RTC::SCTP::RetransmissionQueue listener.
 		 */
-		class RetransmissionQueueListener : public RetransmissionQueue::Listener
+		class RetransmissionQueueListener : public RTC::SCTP::RetransmissionQueue::Listener
 		{
 		public:
 			void OnRetransmissionQueueNewRttMs(uint64_t /*rttMs*/) override
@@ -139,32 +138,32 @@ namespace
 		// NOTE: Public members for testing.
 	public:
 		uint64_t nowMs{ InitialNowMs };
-		SctpOptions sctpOptions;
+		RTC::SCTP::SctpOptions sctpOptions;
 		BackoffTimerListener backoffTimerListener;
 		RetransmissionQueueListener retransmissionQueueListener;
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
-		AssociationListenerDeferrer associationListenerDeferrer{ std::addressof(
+		RTC::SCTP::AssociationListenerDeferrer associationListenerDeferrer{ std::addressof(
 			this->associationListener) };
 		mocks::MockShared shared;
 		mocks::RTC::SCTP::MockTransmissionControlBlockContext tcbContext;
 		const std::unique_ptr<BackoffTimerHandleInterface> delayedAckTimer;
 		const std::unique_ptr<BackoffTimerHandleInterface> t3RtxTimer;
-		RoundRobinSendQueue sendQueue;
-		DataTracker dataTracker;
-		ReassemblyQueue reassemblyQueue;
-		RetransmissionQueue retransmissionQueue;
-		StreamResetHandler streamResetHandler;
+		RTC::SCTP::RoundRobinSendQueue sendQueue;
+		RTC::SCTP::DataTracker dataTracker;
+		RTC::SCTP::ReassemblyQueue reassemblyQueue;
+		RTC::SCTP::RetransmissionQueue retransmissionQueue;
+		RTC::SCTP::StreamResetHandler streamResetHandler;
 	};
 } // namespace
 
-SCENARIO("SCTP StreamResetHandler", "[sctp][streamresethandler]")
+SCENARIO("SCTP RTC::SCTP::StreamResetHandler", "[sctp][streamresethandler]")
 {
 	SECTION("a chunk with no parameters returns an error")
 	{
 		TestStreamResetHandler test;
 
 		std::vector<uint8_t> buffer(test.sctpOptions.mtu);
-		std::unique_ptr<ReConfigChunk> reConfigChunk{ ReConfigChunk::Factory(
+		std::unique_ptr<RTC::SCTP::ReConfigChunk> reConfigChunk{ RTC::SCTP::ReConfigChunk::Factory(
 			buffer.data(), buffer.size()) };
 
 		test.HandleReceivedReConfigChunk(reConfigChunk.get());
@@ -178,13 +177,14 @@ SCENARIO("SCTP StreamResetHandler", "[sctp][streamresethandler]")
 		TestStreamResetHandler test;
 
 		std::vector<uint8_t> buffer(test.sctpOptions.mtu);
-		std::unique_ptr<ReConfigChunk> reConfigChunk{ ReConfigChunk::Factory(
+		std::unique_ptr<RTC::SCTP::ReConfigChunk> reConfigChunk{ RTC::SCTP::ReConfigChunk::Factory(
 			buffer.data(), buffer.size()) };
 
-		// Two OutgoingSsnResetRequestParameter in a RE-CONFIG is not valid.
+		// Two RTC::SCTP::OutgoingSsnResetRequestParameter in a RE-CONFIG is not valid.
 		for (const uint32_t reqSeqNbr : { 1u, 2u })
 		{
-			auto* parameter = reConfigChunk->BuildParameterInPlace<OutgoingSsnResetRequestParameter>();
+			auto* parameter =
+			  reConfigChunk->BuildParameterInPlace<RTC::SCTP::OutgoingSsnResetRequestParameter>();
 
 			parameter->SetReconfigurationRequestSequenceNumber(reqSeqNbr);
 			parameter->SetReconfigurationResponseSequenceNumber(10);
@@ -213,12 +213,12 @@ SCENARIO("SCTP StreamResetHandler", "[sctp][streamresethandler]")
 
 		test.streamResetHandler.AddStreamResetRequest(packet.get());
 
-		const auto* reConfigChunk = packet->GetFirstChunkOfType<ReConfigChunk>();
+		const auto* reConfigChunk = packet->GetFirstChunkOfType<RTC::SCTP::ReConfigChunk>();
 
 		REQUIRE(reConfigChunk);
 
 		const auto* parameter =
-		  reConfigChunk->GetFirstParameterOfType<OutgoingSsnResetRequestParameter>();
+		  reConfigChunk->GetFirstParameterOfType<RTC::SCTP::OutgoingSsnResetRequestParameter>();
 
 		REQUIRE(parameter);
 		REQUIRE(parameter->GetStreamIds() == std::vector<uint16_t>{ 42 });
@@ -238,12 +238,12 @@ SCENARIO("SCTP StreamResetHandler", "[sctp][streamresethandler]")
 
 		test.streamResetHandler.AddStreamResetRequest(packet.get());
 
-		const auto* reConfigChunk = packet->GetFirstChunkOfType<ReConfigChunk>();
+		const auto* reConfigChunk = packet->GetFirstChunkOfType<RTC::SCTP::ReConfigChunk>();
 
 		REQUIRE(reConfigChunk);
 
 		const auto* parameter =
-		  reConfigChunk->GetFirstParameterOfType<OutgoingSsnResetRequestParameter>();
+		  reConfigChunk->GetFirstParameterOfType<RTC::SCTP::OutgoingSsnResetRequestParameter>();
 
 		REQUIRE(parameter);
 
@@ -266,8 +266,9 @@ SCENARIO("SCTP StreamResetHandler", "[sctp][streamresethandler]")
 
 		test.streamResetHandler.AddStreamResetRequest(packet.get());
 
-		const auto* parameter = packet->GetFirstChunkOfType<ReConfigChunk>()
-		                          ->GetFirstParameterOfType<OutgoingSsnResetRequestParameter>();
+		const auto* parameter =
+		  packet->GetFirstChunkOfType<RTC::SCTP::ReConfigChunk>()
+		    ->GetFirstParameterOfType<RTC::SCTP::OutgoingSsnResetRequestParameter>();
 
 		REQUIRE(parameter);
 
@@ -275,13 +276,14 @@ SCENARIO("SCTP StreamResetHandler", "[sctp][streamresethandler]")
 
 		// Build a RE-CONFIG response with a successful result.
 		std::vector<uint8_t> responseBuffer(test.sctpOptions.mtu);
-		std::unique_ptr<ReConfigChunk> responseChunk{ ReConfigChunk::Factory(
+		std::unique_ptr<RTC::SCTP::ReConfigChunk> responseChunk{ RTC::SCTP::ReConfigChunk::Factory(
 			responseBuffer.data(), responseBuffer.size()) };
 
-		auto* response = responseChunk->BuildParameterInPlace<ReconfigurationResponseParameter>();
+		auto* response =
+		  responseChunk->BuildParameterInPlace<RTC::SCTP::ReconfigurationResponseParameter>();
 
 		response->SetReconfigurationResponseSequenceNumber(reqSeqNbr);
-		response->SetResult(ReconfigurationResponseParameter::Result::SUCCESS_PERFORMED);
+		response->SetResult(RTC::SCTP::ReconfigurationResponseParameter::Result::SUCCESS_PERFORMED);
 		response->Consolidate();
 
 		test.HandleReceivedReConfigChunk(responseChunk.get());
@@ -301,8 +303,9 @@ SCENARIO("SCTP StreamResetHandler", "[sctp][streamresethandler]")
 
 		test.streamResetHandler.AddStreamResetRequest(packet.get());
 
-		const auto* parameter = packet->GetFirstChunkOfType<ReConfigChunk>()
-		                          ->GetFirstParameterOfType<OutgoingSsnResetRequestParameter>();
+		const auto* parameter =
+		  packet->GetFirstChunkOfType<RTC::SCTP::ReConfigChunk>()
+		    ->GetFirstParameterOfType<RTC::SCTP::OutgoingSsnResetRequestParameter>();
 
 		REQUIRE(parameter);
 
@@ -310,13 +313,15 @@ SCENARIO("SCTP StreamResetHandler", "[sctp][streamresethandler]")
 
 		// Build a RE-CONFIG response with an error result.
 		std::vector<uint8_t> responseBuffer(test.sctpOptions.mtu);
-		std::unique_ptr<ReConfigChunk> responseChunk{ ReConfigChunk::Factory(
+		std::unique_ptr<RTC::SCTP::ReConfigChunk> responseChunk{ RTC::SCTP::ReConfigChunk::Factory(
 			responseBuffer.data(), responseBuffer.size()) };
 
-		auto* response = responseChunk->BuildParameterInPlace<ReconfigurationResponseParameter>();
+		auto* response =
+		  responseChunk->BuildParameterInPlace<RTC::SCTP::ReconfigurationResponseParameter>();
 
 		response->SetReconfigurationResponseSequenceNumber(reqSeqNbr);
-		response->SetResult(ReconfigurationResponseParameter::Result::ERROR_BAD_SEQUENCE_NUMBER);
+		response->SetResult(
+		  RTC::SCTP::ReconfigurationResponseParameter::Result::ERROR_BAD_SEQUENCE_NUMBER);
 		response->Consolidate();
 
 		test.HandleReceivedReConfigChunk(responseChunk.get());
@@ -329,10 +334,11 @@ SCENARIO("SCTP StreamResetHandler", "[sctp][streamresethandler]")
 		TestStreamResetHandler test;
 
 		std::vector<uint8_t> buffer(test.sctpOptions.mtu);
-		std::unique_ptr<ReConfigChunk> reConfigChunk{ ReConfigChunk::Factory(
+		std::unique_ptr<RTC::SCTP::ReConfigChunk> reConfigChunk{ RTC::SCTP::ReConfigChunk::Factory(
 			buffer.data(), buffer.size()) };
 
-		auto* parameter = reConfigChunk->BuildParameterInPlace<IncomingSsnResetRequestParameter>();
+		auto* parameter =
+		  reConfigChunk->BuildParameterInPlace<RTC::SCTP::IncomingSsnResetRequestParameter>();
 
 		parameter->SetReconfigurationRequestSequenceNumber(RemoteInitialTsn);
 		parameter->AddStreamId(1);
@@ -345,14 +351,17 @@ SCENARIO("SCTP StreamResetHandler", "[sctp][streamresethandler]")
 
 		REQUIRE(!sentBuffer.empty());
 
-		std::unique_ptr<Packet> sentPacket{ Packet::Parse(sentBuffer.data(), sentBuffer.size()) };
+		std::unique_ptr<RTC::SCTP::Packet> sentPacket{ RTC::SCTP::Packet::Parse(
+			sentBuffer.data(), sentBuffer.size()) };
 
 		REQUIRE(sentPacket);
 
-		const auto* response = sentPacket->GetFirstChunkOfType<ReConfigChunk>()
-		                         ->GetFirstParameterOfType<ReconfigurationResponseParameter>();
+		const auto* response = sentPacket->GetFirstChunkOfType<RTC::SCTP::ReConfigChunk>()
+		                         ->GetFirstParameterOfType<RTC::SCTP::ReconfigurationResponseParameter>();
 
 		REQUIRE(response);
-		REQUIRE(response->GetResult() == ReconfigurationResponseParameter::Result::SUCCESS_NOTHING_TO_DO);
+		REQUIRE(
+		  response->GetResult() ==
+		  RTC::SCTP::ReconfigurationResponseParameter::Result::SUCCESS_NOTHING_TO_DO);
 	}
 }

--- a/worker/test/src/RTC/SCTP/association/TestStreamResetHandler.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestStreamResetHandler.cpp
@@ -163,7 +163,8 @@ SCENARIO("SCTP RTC::SCTP::StreamResetHandler", "[sctp][streamresethandler]")
 		TestStreamResetHandler test;
 
 		std::vector<uint8_t> buffer(test.sctpOptions.mtu);
-		std::unique_ptr<RTC::SCTP::ReConfigChunk> reConfigChunk{ RTC::SCTP::ReConfigChunk::Factory(
+
+		const std::unique_ptr<RTC::SCTP::ReConfigChunk> reConfigChunk{ RTC::SCTP::ReConfigChunk::Factory(
 			buffer.data(), buffer.size()) };
 
 		test.HandleReceivedReConfigChunk(reConfigChunk.get());
@@ -177,7 +178,8 @@ SCENARIO("SCTP RTC::SCTP::StreamResetHandler", "[sctp][streamresethandler]")
 		TestStreamResetHandler test;
 
 		std::vector<uint8_t> buffer(test.sctpOptions.mtu);
-		std::unique_ptr<RTC::SCTP::ReConfigChunk> reConfigChunk{ RTC::SCTP::ReConfigChunk::Factory(
+
+		const std::unique_ptr<RTC::SCTP::ReConfigChunk> reConfigChunk{ RTC::SCTP::ReConfigChunk::Factory(
 			buffer.data(), buffer.size()) };
 
 		// Two RTC::SCTP::OutgoingSsnResetRequestParameter in a RE-CONFIG is not valid.

--- a/worker/test/src/RTC/SCTP/association/TestStreamResetHandler.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestStreamResetHandler.cpp
@@ -278,7 +278,7 @@ SCENARIO("SCTP RTC::SCTP::StreamResetHandler", "[sctp][streamresethandler]")
 
 		// Build a RE-CONFIG response with a successful result.
 		std::vector<uint8_t> responseBuffer(test.sctpOptions.mtu);
-		std::unique_ptr<RTC::SCTP::ReConfigChunk> responseChunk{ RTC::SCTP::ReConfigChunk::Factory(
+		const std::unique_ptr<RTC::SCTP::ReConfigChunk> responseChunk{ RTC::SCTP::ReConfigChunk::Factory(
 			responseBuffer.data(), responseBuffer.size()) };
 
 		auto* response =
@@ -315,7 +315,7 @@ SCENARIO("SCTP RTC::SCTP::StreamResetHandler", "[sctp][streamresethandler]")
 
 		// Build a RE-CONFIG response with an error result.
 		std::vector<uint8_t> responseBuffer(test.sctpOptions.mtu);
-		std::unique_ptr<RTC::SCTP::ReConfigChunk> responseChunk{ RTC::SCTP::ReConfigChunk::Factory(
+		const std::unique_ptr<RTC::SCTP::ReConfigChunk> responseChunk{ RTC::SCTP::ReConfigChunk::Factory(
 			responseBuffer.data(), responseBuffer.size()) };
 
 		auto* response =
@@ -336,7 +336,7 @@ SCENARIO("SCTP RTC::SCTP::StreamResetHandler", "[sctp][streamresethandler]")
 		TestStreamResetHandler test;
 
 		std::vector<uint8_t> buffer(test.sctpOptions.mtu);
-		std::unique_ptr<RTC::SCTP::ReConfigChunk> reConfigChunk{ RTC::SCTP::ReConfigChunk::Factory(
+		const std::unique_ptr<RTC::SCTP::ReConfigChunk> reConfigChunk{ RTC::SCTP::ReConfigChunk::Factory(
 			buffer.data(), buffer.size()) };
 
 		auto* parameter =
@@ -353,7 +353,7 @@ SCENARIO("SCTP RTC::SCTP::StreamResetHandler", "[sctp][streamresethandler]")
 
 		REQUIRE(!sentBuffer.empty());
 
-		std::unique_ptr<RTC::SCTP::Packet> sentPacket{ RTC::SCTP::Packet::Parse(
+		const std::unique_ptr<RTC::SCTP::Packet> sentPacket{ RTC::SCTP::Packet::Parse(
 			sentBuffer.data(), sentBuffer.size()) };
 
 		REQUIRE(sentPacket);

--- a/worker/test/src/RTC/SCTP/association/TestStreamResetHandler.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestStreamResetHandler.cpp
@@ -1,0 +1,358 @@
+#include "common.hpp"
+#include "handles/BackoffTimerHandleInterface.hpp"
+#include "RTC/SCTP/association/AssociationListenerDeferrer.hpp"
+#include "RTC/SCTP/association/StreamResetHandler.hpp"
+#include "RTC/SCTP/packet/Packet.hpp"
+#include "RTC/SCTP/packet/chunks/ReConfigChunk.hpp"
+#include "RTC/SCTP/packet/parameters/IncomingSsnResetRequestParameter.hpp"
+#include "RTC/SCTP/packet/parameters/OutgoingSsnResetRequestParameter.hpp"
+#include "RTC/SCTP/packet/parameters/ReconfigurationResponseParameter.hpp"
+#include "RTC/SCTP/public/SctpOptions.hpp"
+#include "RTC/SCTP/rx/DataTracker.hpp"
+#include "RTC/SCTP/rx/ReassemblyQueue.hpp"
+#include "RTC/SCTP/tx/RetransmissionQueue.hpp"
+#include "RTC/SCTP/tx/RoundRobinSendQueue.hpp"
+#include "mocks/include/MockShared.hpp"
+#include "mocks/include/RTC/SCTP/association/MockAssociationListener.hpp"
+#include "mocks/include/RTC/SCTP/association/MockTransmissionControlBlockContext.hpp"
+#include <catch2/catch_test_macros.hpp>
+#include <vector>
+
+using namespace RTC::SCTP;
+
+namespace
+{
+	constexpr uint32_t Arwnd{ 131072 };
+	constexpr uint32_t LocalInitialTsn{ 0 };
+	constexpr uint32_t RemoteInitialTsn{ 0 };
+	constexpr uint64_t InitialNowMs{ 10000 };
+	constexpr uint64_t RtoMs{ 250 };
+
+	/**
+	 * A StreamResetHandler under test, together with all the (real) components it
+	 * depends on, its simulated clock and listener.
+	 */
+	class TestStreamResetHandler
+	{
+	public:
+		TestStreamResetHandler()
+		  // NOTE: The order in which these members are initialized is **critical**.
+		  : shared(/*getTimeMs*/
+		           [this]()
+		           {
+			           return this->nowMs;
+		           }),
+		    tcbContext(this->associationListener, this->sctpOptions),
+		    delayedAckTimer(this->shared.CreateBackoffTimer(
+		      BackoffTimerHandleInterface::BackoffTimerHandleOptions{
+		        .listener         = std::addressof(this->backoffTimerListener),
+		        .label            = "mock-sctp-delayed-ack",
+		        .baseTimeoutMs    = this->sctpOptions.initialRtoMs,
+		        .backoffAlgorithm = BackoffTimerHandleInterface::BackoffAlgorithm::FIXED })),
+		    t3RtxTimer(this->shared.CreateBackoffTimer(
+		      BackoffTimerHandleInterface::BackoffTimerHandleOptions{
+		        .listener         = std::addressof(this->backoffTimerListener),
+		        .label            = "mock-sctp-t3-rtx",
+		        .baseTimeoutMs    = this->sctpOptions.initialRtoMs,
+		        .backoffAlgorithm = BackoffTimerHandleInterface::BackoffAlgorithm::EXPONENTIAL })),
+		    sendQueue(
+		      this->associationListener,
+		      this->sctpOptions.mtu,
+		      this->sctpOptions.defaultStreamPriority,
+		      this->sctpOptions.totalBufferedAmountLowThreshold),
+		    dataTracker(this->delayedAckTimer.get(), RemoteInitialTsn),
+		    reassemblyQueue(this->sctpOptions.maxReceiverWindowBufferSize),
+		    retransmissionQueue(
+		      std::addressof(this->retransmissionQueueListener),
+		      this->associationListener,
+		      LocalInitialTsn,
+		      Arwnd,
+		      this->sendQueue,
+		      this->t3RtxTimer.get(),
+		      this->sctpOptions,
+		      /*supportsPartialReliability*/ true,
+		      /*useMessageInterleaving*/ false),
+		    streamResetHandler(
+		      this->associationListenerDeferrer,
+		      std::addressof(this->shared),
+		      std::addressof(this->tcbContext),
+		      std::addressof(this->dataTracker),
+		      std::addressof(this->reassemblyQueue),
+		      std::addressof(this->retransmissionQueue))
+		{
+			this->tcbContext.WillGetCurrentRtoMsOnce(
+			  []()
+			  {
+				  return RtoMs;
+			  });
+		}
+
+	public:
+		/**
+		 * Advances the simulated clock by `incrementMs`.
+		 */
+		void AdvanceTimeMs(uint64_t incrementMs)
+		{
+			this->nowMs += incrementMs;
+		}
+
+		/**
+		 * Handles a received RE-CONFIG chunk within a deferrer scope, just like
+		 * Association does before dispatching to the handler.
+		 */
+		void HandleReceivedReConfigChunk(const ReConfigChunk* receivedReConfigChunk)
+		{
+			const AssociationListenerDeferrer::ScopedDeferrer deferrer(this->associationListenerDeferrer);
+
+			this->streamResetHandler.HandleReceivedReConfigChunk(receivedReConfigChunk);
+		}
+
+	private:
+		/**
+		 * A no-op BackoffTimerHandle listener for the timers owned directly by this
+		 * fixture (the ones owned by the handler are driven by the handler itself).
+		 */
+		class BackoffTimerListener : public BackoffTimerHandleInterface::Listener
+		{
+		public:
+			void OnBackoffTimer(
+			  BackoffTimerHandleInterface* /*backoffTimer*/, uint64_t& /*baseTimeoutMs*/, bool& /*stop*/) override
+			{
+			}
+		};
+
+		/**
+		 * A no-op RetransmissionQueue listener.
+		 */
+		class RetransmissionQueueListener : public RetransmissionQueue::Listener
+		{
+		public:
+			void OnRetransmissionQueueNewRttMs(uint64_t /*rttMs*/) override
+			{
+			}
+
+			void OnRetransmissionQueueClearRetransmissionCounter() override
+			{
+			}
+		};
+
+		// NOTE: Public members for testing.
+	public:
+		uint64_t nowMs{ InitialNowMs };
+		SctpOptions sctpOptions;
+		BackoffTimerListener backoffTimerListener;
+		RetransmissionQueueListener retransmissionQueueListener;
+		mocks::RTC::SCTP::MockAssociationListener associationListener;
+		AssociationListenerDeferrer associationListenerDeferrer{ std::addressof(
+			this->associationListener) };
+		mocks::MockShared shared;
+		mocks::RTC::SCTP::MockTransmissionControlBlockContext tcbContext;
+		const std::unique_ptr<BackoffTimerHandleInterface> delayedAckTimer;
+		const std::unique_ptr<BackoffTimerHandleInterface> t3RtxTimer;
+		RoundRobinSendQueue sendQueue;
+		DataTracker dataTracker;
+		ReassemblyQueue reassemblyQueue;
+		RetransmissionQueue retransmissionQueue;
+		StreamResetHandler streamResetHandler;
+	};
+} // namespace
+
+SCENARIO("SCTP StreamResetHandler", "[sctp][streamresethandler]")
+{
+	SECTION("a chunk with no parameters returns an error")
+	{
+		TestStreamResetHandler test;
+
+		std::vector<uint8_t> buffer(test.sctpOptions.mtu);
+		std::unique_ptr<ReConfigChunk> reConfigChunk{ ReConfigChunk::Factory(
+			buffer.data(), buffer.size()) };
+
+		test.HandleReceivedReConfigChunk(reConfigChunk.get());
+
+		REQUIRE(test.associationListener.HasErrored() == true);
+		REQUIRE(test.associationListener.HasSentPackets() == false);
+	}
+
+	SECTION("a chunk with invalid parameters returns an error")
+	{
+		TestStreamResetHandler test;
+
+		std::vector<uint8_t> buffer(test.sctpOptions.mtu);
+		std::unique_ptr<ReConfigChunk> reConfigChunk{ ReConfigChunk::Factory(
+			buffer.data(), buffer.size()) };
+
+		// Two OutgoingSsnResetRequestParameter in a RE-CONFIG is not valid.
+		for (const uint32_t reqSeqNbr : { 1u, 2u })
+		{
+			auto* parameter = reConfigChunk->BuildParameterInPlace<OutgoingSsnResetRequestParameter>();
+
+			parameter->SetReconfigurationRequestSequenceNumber(reqSeqNbr);
+			parameter->SetReconfigurationResponseSequenceNumber(10);
+			parameter->SetSenderLastAssignedTsn(RemoteInitialTsn);
+			parameter->AddStreamId(static_cast<uint16_t>(reqSeqNbr));
+			parameter->Consolidate();
+		}
+
+		test.HandleReceivedReConfigChunk(reConfigChunk.get());
+
+		REQUIRE(test.associationListener.HasErrored() == true);
+		REQUIRE(test.associationListener.HasSentPackets() == false);
+	}
+
+	SECTION("sends an outgoing request directly")
+	{
+		TestStreamResetHandler test;
+
+		const std::vector<uint16_t> streamIds{ 42 };
+
+		test.streamResetHandler.ResetStreams(streamIds);
+
+		REQUIRE(test.streamResetHandler.ShouldSendStreamResetRequest() == true);
+
+		const auto packet = test.tcbContext.CreatePacket();
+
+		test.streamResetHandler.AddStreamResetRequest(packet.get());
+
+		const auto* reConfigChunk = packet->GetFirstChunkOfType<ReConfigChunk>();
+
+		REQUIRE(reConfigChunk);
+
+		const auto* parameter =
+		  reConfigChunk->GetFirstParameterOfType<OutgoingSsnResetRequestParameter>();
+
+		REQUIRE(parameter);
+		REQUIRE(parameter->GetStreamIds() == std::vector<uint16_t>{ 42 });
+	}
+
+	SECTION("resets multiple streams in one request")
+	{
+		TestStreamResetHandler test;
+
+		test.streamResetHandler.ResetStreams(std::vector<uint16_t>{ 42 });
+		test.streamResetHandler.ResetStreams(std::vector<uint16_t>{ 43, 44, 41 });
+		test.streamResetHandler.ResetStreams(std::vector<uint16_t>{ 42, 40 });
+
+		REQUIRE(test.streamResetHandler.ShouldSendStreamResetRequest() == true);
+
+		const auto packet = test.tcbContext.CreatePacket();
+
+		test.streamResetHandler.AddStreamResetRequest(packet.get());
+
+		const auto* reConfigChunk = packet->GetFirstChunkOfType<ReConfigChunk>();
+
+		REQUIRE(reConfigChunk);
+
+		const auto* parameter =
+		  reConfigChunk->GetFirstParameterOfType<OutgoingSsnResetRequestParameter>();
+
+		REQUIRE(parameter);
+
+		auto streamIds = parameter->GetStreamIds();
+
+		std::ranges::sort(streamIds);
+
+		REQUIRE(streamIds == std::vector<uint16_t>{ 40, 41, 42, 43, 44 });
+	}
+
+	SECTION("commits the reset on a positive response")
+	{
+		TestStreamResetHandler test;
+
+		test.streamResetHandler.ResetStreams(std::vector<uint16_t>{ 42 });
+
+		REQUIRE(test.streamResetHandler.ShouldSendStreamResetRequest() == true);
+
+		const auto packet = test.tcbContext.CreatePacket();
+
+		test.streamResetHandler.AddStreamResetRequest(packet.get());
+
+		const auto* parameter = packet->GetFirstChunkOfType<ReConfigChunk>()
+		                          ->GetFirstParameterOfType<OutgoingSsnResetRequestParameter>();
+
+		REQUIRE(parameter);
+
+		const uint32_t reqSeqNbr = parameter->GetReconfigurationRequestSequenceNumber();
+
+		// Build a RE-CONFIG response with a successful result.
+		std::vector<uint8_t> responseBuffer(test.sctpOptions.mtu);
+		std::unique_ptr<ReConfigChunk> responseChunk{ ReConfigChunk::Factory(
+			responseBuffer.data(), responseBuffer.size()) };
+
+		auto* response = responseChunk->BuildParameterInPlace<ReconfigurationResponseParameter>();
+
+		response->SetReconfigurationResponseSequenceNumber(reqSeqNbr);
+		response->SetResult(ReconfigurationResponseParameter::Result::SUCCESS_PERFORMED);
+		response->Consolidate();
+
+		test.HandleReceivedReConfigChunk(responseChunk.get());
+
+		REQUIRE(test.associationListener.HasStreamsResetPerformedForStreamId(42) == true);
+	}
+
+	SECTION("rolls back the reset on an error response")
+	{
+		TestStreamResetHandler test;
+
+		test.streamResetHandler.ResetStreams(std::vector<uint16_t>{ 42 });
+
+		REQUIRE(test.streamResetHandler.ShouldSendStreamResetRequest() == true);
+
+		const auto packet = test.tcbContext.CreatePacket();
+
+		test.streamResetHandler.AddStreamResetRequest(packet.get());
+
+		const auto* parameter = packet->GetFirstChunkOfType<ReConfigChunk>()
+		                          ->GetFirstParameterOfType<OutgoingSsnResetRequestParameter>();
+
+		REQUIRE(parameter);
+
+		const uint32_t reqSeqNbr = parameter->GetReconfigurationRequestSequenceNumber();
+
+		// Build a RE-CONFIG response with an error result.
+		std::vector<uint8_t> responseBuffer(test.sctpOptions.mtu);
+		std::unique_ptr<ReConfigChunk> responseChunk{ ReConfigChunk::Factory(
+			responseBuffer.data(), responseBuffer.size()) };
+
+		auto* response = responseChunk->BuildParameterInPlace<ReconfigurationResponseParameter>();
+
+		response->SetReconfigurationResponseSequenceNumber(reqSeqNbr);
+		response->SetResult(ReconfigurationResponseParameter::Result::ERROR_BAD_SEQUENCE_NUMBER);
+		response->Consolidate();
+
+		test.HandleReceivedReConfigChunk(responseChunk.get());
+
+		REQUIRE(test.associationListener.HasStreamsResetFailedForStreamId(42) == true);
+	}
+
+	SECTION("an incoming stream reset request returns nothing performed")
+	{
+		TestStreamResetHandler test;
+
+		std::vector<uint8_t> buffer(test.sctpOptions.mtu);
+		std::unique_ptr<ReConfigChunk> reConfigChunk{ ReConfigChunk::Factory(
+			buffer.data(), buffer.size()) };
+
+		auto* parameter = reConfigChunk->BuildParameterInPlace<IncomingSsnResetRequestParameter>();
+
+		parameter->SetReconfigurationRequestSequenceNumber(RemoteInitialTsn);
+		parameter->AddStreamId(1);
+		parameter->Consolidate();
+
+		test.HandleReceivedReConfigChunk(reConfigChunk.get());
+
+		// A RE-CONFIG response is sent back.
+		const auto sentBuffer = test.associationListener.ConsumeFirstSentPacket();
+
+		REQUIRE(!sentBuffer.empty());
+
+		std::unique_ptr<Packet> sentPacket{ Packet::Parse(sentBuffer.data(), sentBuffer.size()) };
+
+		REQUIRE(sentPacket);
+
+		const auto* response = sentPacket->GetFirstChunkOfType<ReConfigChunk>()
+		                         ->GetFirstParameterOfType<ReconfigurationResponseParameter>();
+
+		REQUIRE(response);
+		REQUIRE(response->GetResult() == ReconfigurationResponseParameter::Result::SUCCESS_NOTHING_TO_DO);
+	}
+}

--- a/worker/test/src/RTC/SCTP/association/TestTransmissionControlBlock.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestTransmissionControlBlock.cpp
@@ -30,6 +30,14 @@ SCENARIO("SCTP TransmissionControlBlock", "[sctp][transmissioncontrolblock]")
 		}
 	};
 
+	class MockTcbContextListener : public RTC::SCTP::TransmissionControlBlockContextInterface::Listener
+	{
+	public:
+		void OnTransmissionControlBlockTooManyTxErrors() override
+		{
+		}
+	};
+
 	const RTC::SCTP::SctpOptions sctpOptions;
 
 	mocks::RTC::SCTP::MockAssociationListener associationListener;
@@ -44,6 +52,7 @@ SCENARIO("SCTP TransmissionControlBlock", "[sctp][transmissioncontrolblock]")
 	RTC::SCTP::NegotiatedCapabilities negotiatedCapabilities;
 	MockPacketSenderListener packetSenderListener;
 	RTC::SCTP::PacketSender packetSender(std::addressof(packetSenderListener), associationListener);
+	MockTcbContextListener tcbContextListener;
 
 	auto isAssociationEstablished = []()
 	{
@@ -57,6 +66,7 @@ SCENARIO("SCTP TransmissionControlBlock", "[sctp][transmissioncontrolblock]")
 		sendQueue.ExpectEnableMessageInterleavingCalledWith(false);
 
 		const RTC::SCTP::TransmissionControlBlock tcb(
+		  std::addressof(tcbContextListener),
 		  associationListenerDeferrer,
 		  sctpOptions,
 		  std::addressof(shared),
@@ -82,6 +92,7 @@ SCENARIO("SCTP TransmissionControlBlock", "[sctp][transmissioncontrolblock]")
 		sendQueue.ExpectEnableMessageInterleavingCalledWith(true);
 
 		const RTC::SCTP::TransmissionControlBlock tcb(
+		  std::addressof(tcbContextListener),
 		  associationListenerDeferrer,
 		  sctpOptions,
 		  std::addressof(shared),


### PR DESCRIPTION
# Details

- Add `TestAssociation.cpp`. Test coverage includes connection establishment, shutdown, data transfer and retransmission, heartbeats (including loss/recovery loops), stream priority ordering, per-stream and total buffered amount, metrics, zero-checksum, stream reset (RE-CONFIG), lifecycle events, raw-packet injection (unknown chunk -> ERROR, ERROR chunk -> callback, HEARTBEAT -> ACK), and limited-retransmission messages.
- Add `TestStreamResetHandler.cpp`.
- Add `TestPacketSender.cpp`.
- Fix `HeartbeatHandler`: The interval and timeout timers had their backoff algorithms swapped. The interval is now `FIXED` and the timeout `EXPONENTIAL` so idle connections no longer back off the heartbeat interval.
- Fix the association never aborting on too many transmission errors: `HasTooManyTxErrors()` was never called. Add `TransmissionControlBlockContextInterface::Listener` so the `TransmissionControlBlock` notifies on counter exhaustion and `Association` closes with `TOO_MANY_RETRIES` error kind. The t3-rtx timer, heartbeat-timeout timer and RE-CONFIG timer handlers now signal "stop" so the `TransmissionControlBlock` is torn down safely outside the timer.
- Add a `mayConnectOnReceivedSctpData` parameter to the `Association` constructor (`Transport.cpp` passes `true`) so tests can model a passive peer.
- Fix `MockBackoffTimerHandle` class: `Start()`/`Stop()` now reset the expiration count and stopped timers no longer keep firing, matching the behaviour of the real `BackoffTimerHandle` class.
- Extend `MockAssociationListener` to record and handle stream-reset callbacks (needed for tests).