### PR TITLE
SCTP fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - Worker: `SeqManager`, use `std::vector` rather than `std::set` ([1807](https://github.com/versatica/mediasoup/pull/1807)).
+- SCTP: Fixes in `Association.cpp`, `StreamResetHandler.cpp` and `DataTracker.cpp` ([PR #1826](https://github.com/versatica/mediasoup/pull/1826)).
 
 ### 3.20.4
 

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -1462,7 +1462,9 @@ namespace RTC
 
 				case State::CLOSED:
 				{
-					MS_WARN_TAG(sctp, "ignoring INIT chunk received in CLOSED state)");
+					MS_WARN_TAG(sctp, "ignoring INIT chunk received in CLOSED state");
+
+					return;
 				}
 
 				// https://datatracker.ietf.org/doc/html/rfc9260#section-5.2.1
@@ -1812,7 +1814,7 @@ namespace RTC
 			else if (
 			  receivedPacket->GetVerificationTag() != this->tcb->GetLocalVerificationTag() &&
 			  cookie->GetRemoteVerificationTag() == this->tcb->GetRemoteVerificationTag() &&
-			  cookie->GetTieTag() == this->tcb->GetTieTag())
+			  cookie->GetTieTag() == 0)
 			{
 				MS_DEBUG_DEV("received COOKIE-ECHO indicating a late COOKIE-ECHO, discarding");
 

--- a/worker/src/RTC/SCTP/association/StreamResetHandler.cpp
+++ b/worker/src/RTC/SCTP/association/StreamResetHandler.cpp
@@ -376,6 +376,10 @@ namespace RTC
 				  ReconfigurationResponseParameter::Result::SUCCESS_NOTHING_TO_DO);
 
 				reconfigurationResponseParameter->Consolidate();
+
+				this->lastProcessedReqSeqNbr = requestSn;
+				this->lastProcessedReqResult =
+				  ReconfigurationResponseParameter::Result::SUCCESS_NOTHING_TO_DO;
 			}
 			else
 			{

--- a/worker/src/RTC/SCTP/rx/DataTracker.cpp
+++ b/worker/src/RTC/SCTP/rx/DataTracker.cpp
@@ -268,7 +268,9 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			UpdateAckState(AckState::IMMEDIATE, "force immediate SACK");
+			// NOTE: Assign directly instead of going through UpdateAckState() to avoid
+			// its side effect of stopping the delayed-ack timer.
+			this->ackState = AckState::IMMEDIATE;
 		}
 
 		bool DataTracker::WillIncreaseCumAckTsn(uint32_t tsn) const
@@ -359,6 +361,7 @@ namespace RTC
 				{
 					this->delayedAckTimer->Start();
 				}
+
 				this->ackState = newAckState;
 			}
 		}


### PR DESCRIPTION
# Details

- Basically fix code wrongly adapted from dcsctp.
- `Association.cpp`: Fixed COOKIE-ECHO "case C" (late cookie) detection:: compare the cookie's tie-tag against 0 instead of the TCB's tie-tag, so a late COOKIE-ECHO is correctly discarded.
- `Association.cpp`: Fixed INIT handling in CLOSED state to return instead of falling through and building an INIT-ACK with stale values.
- `StreamResetHandler.cpp`: Fixed `HandleReceivedIncomingSsnResetRequestParameter()` to update `this->lastProcessedReqSeqNbr` and `this->lastProcessedReqResult`, preventing later reconfig requests from being wrongly rejected as bad sequence numbers.
- `DataTracker.cpp`: Changed `ForceImmediateSack()` to set `this->ackState` directly instead of going through `UpdateAckState()`, avoiding stopping the delayed-ack timer.