### PR TITLE
SCTP: Validate CRC32c checksum in received packets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - Unify all consumer classes into a single one ([1731](https://github.com/versatica/mediasoup/pull/1731)).
+- SCTP: Validate CRC32c checksum in received packets ([XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
 
 ### 3.20.5
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### NEXT
 
 - Unify all consumer classes into a single one ([1731](https://github.com/versatica/mediasoup/pull/1731)).
-- SCTP: Validate CRC32c checksum in received packets ([XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- SCTP: Validate CRC32c checksum in received packets ([1828](https://github.com/versatica/mediasoup/pull/1828)).
 
 ### 3.20.5
 

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -1057,6 +1057,16 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			if (!receivedPacket->ValidateCRC32cChecksum())
+			{
+				MS_WARN_TAG(sctp, "invalid CRC32c cheksum, packet discarded");
+
+				this->associationListenerDeferrer.OnAssociationError(
+				  Types::ErrorKind::PARSE_FAILED, "invalid CRC32c cheksum");
+
+				return false;
+			}
+
 			const uint32_t localVerificationTag = this->tcb ? this->tcb->GetLocalVerificationTag() : 0;
 
 			// https://datatracker.ietf.org/doc/html/rfc9260#section-8.5.1

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -1057,14 +1057,30 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			if (!receivedPacket->ValidateCRC32cChecksum())
+			// https://datatracker.ietf.org/doc/html/rfc9653#section-5.3
+			//
+			// "If an endpoint has sent the Zero Checksum Acceptable Chunk Parameter
+			// indicating the support of an alternate error detection method in an INIT
+			// or INIT ACK chunk, in addition to SCTP packets containing the correct
+			// CRC32c checksum value it MUST accept SCTP packets that have an incorrect
+			// checksum value of zero [...]"
+			const bool acceptsZeroChecksum =
+			  this->sctpOptions.zeroChecksumAlternateErrorDetectionMethod !=
+			  ZeroChecksumAcceptableParameter::AlternateErrorDetectionMethod::NONE;
+
+			// Validate the CRC32c checksum unless this is a zero checksum packet that we
+			// announced we are willing to accept.
+			if (!acceptsZeroChecksum || receivedPacket->GetChecksum() != 0)
 			{
-				MS_WARN_TAG(sctp, "invalid CRC32c cheksum, packet discarded");
+				if (!receivedPacket->ValidateCRC32cChecksum())
+				{
+					MS_WARN_TAG(sctp, "invalid CRC32c checksum, packet discarded");
 
-				this->associationListenerDeferrer.OnAssociationError(
-				  Types::ErrorKind::PARSE_FAILED, "invalid CRC32c cheksum");
+					this->associationListenerDeferrer.OnAssociationError(
+					  Types::ErrorKind::PARSE_FAILED, "invalid CRC32c checksum");
 
-				return false;
+					return false;
+				}
 			}
 
 			const uint32_t localVerificationTag = this->tcb ? this->tcb->GetLocalVerificationTag() : 0;


### PR DESCRIPTION
# Details

- This validation was just missing despite `SCTP::Packet::ValidateCRC32cChecksum()` does exists.