### PR TITLE
CI: add ubuntu-26.04

### DIFF
--- a/.github/workflows/mediasoup-codeql.yaml
+++ b/.github/workflows/mediasoup-codeql.yaml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
     timeout-minutes: 120
     permissions:
       actions: read

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -69,6 +69,36 @@ jobs:
             # takes too long.
             # See https://github.com/versatica/mediasoup/pull/1503.
             skip-test-in-debug-build-type: true
+          - os: ubuntu-26.04
+            node: 22
+            cc: gcc
+            cxx: g++
+          - os: ubuntu-26.04
+            node: 24
+            cc: gcc
+            cxx: g++
+            meson_args: '-Db_sanitize=address'
+            npm-audit: true
+            run-lint: true
+            run-publish-dry-run: true
+          - os: ubuntu-26.04
+            node: 24
+            cc: gcc
+            cxx: g++
+          - os: ubuntu-26.04
+            node: 24
+            cc: clang
+            cxx: clang++
+            meson_args: '-Db_sanitize=undefined'
+          - os: ubuntu-26.04-arm
+            node: 22
+            cc: gcc
+            cxx: g++
+          - os: ubuntu-26.04-arm
+            node: 24
+            cc: gcc
+            cxx: g++
+            meson_args: '-Db_sanitize=address'
           - os: macos-15
             node: 24
             cc: clang

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -36,18 +36,6 @@ jobs:
       matrix:
         build:
           - os: ubuntu-24.04
-            node: 22
-            cc: gcc
-            cxx: g++
-          - os: ubuntu-24.04
-            node: 24
-            cc: gcc
-            cxx: g++
-            meson_args: '-Db_sanitize=address'
-            npm-audit: true
-            run-lint: true
-            run-publish-dry-run: true
-          - os: ubuntu-24.04
             node: 24
             cc: gcc
             cxx: g++
@@ -55,7 +43,6 @@ jobs:
             node: 24
             cc: clang
             cxx: clang++
-            meson_args: '-Db_sanitize=undefined'
           - os: ubuntu-24.04-arm
             node: 22
             cc: gcc
@@ -64,7 +51,6 @@ jobs:
             node: 24
             cc: gcc
             cxx: g++
-            meson_args: '-Db_sanitize=address'
             # In Ubuntu 24.04 ARM in Debug build type with ASAN, createWorker()
             # takes too long.
             # See https://github.com/versatica/mediasoup/pull/1503.
@@ -83,17 +69,9 @@ jobs:
             run-publish-dry-run: true
           - os: ubuntu-26.04
             node: 24
-            cc: gcc
-            cxx: g++
-          - os: ubuntu-26.04
-            node: 24
             cc: clang
             cxx: clang++
             meson_args: '-Db_sanitize=undefined'
-          - os: ubuntu-26.04-arm
-            node: 22
-            cc: gcc
-            cxx: g++
           - os: ubuntu-26.04-arm
             node: 24
             cc: gcc

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -44,17 +44,9 @@ jobs:
             cc: clang
             cxx: clang++
           - os: ubuntu-24.04-arm
-            node: 22
-            cc: gcc
-            cxx: g++
-          - os: ubuntu-24.04-arm
             node: 24
             cc: gcc
             cxx: g++
-            # In Ubuntu 24.04 ARM in Debug build type with ASAN, createWorker()
-            # takes too long.
-            # See https://github.com/versatica/mediasoup/pull/1503.
-            skip-test-in-debug-build-type: true
           - os: ubuntu-26.04
             node: 22
             cc: gcc

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -52,7 +52,7 @@ jobs:
             cc: gcc
             cxx: g++
           - os: ubuntu-26.04
-            node: 24
+            node: 26
             cc: gcc
             cxx: g++
             meson_args: '-Db_sanitize=address'
@@ -60,17 +60,17 @@ jobs:
             run-lint: true
             run-publish-dry-run: true
           - os: ubuntu-26.04
-            node: 24
+            node: 26
             cc: clang
             cxx: clang++
             meson_args: '-Db_sanitize=undefined'
           - os: ubuntu-26.04-arm
-            node: 24
+            node: 26
             cc: gcc
             cxx: g++
             meson_args: '-Db_sanitize=address'
           - os: macos-15
-            node: 24
+            node: 26
             cc: clang
             cxx: clang++
           - os: windows-2022
@@ -78,7 +78,7 @@ jobs:
             cc: cl
             cxx: cl
           - os: windows-2025
-            node: 24
+            node: 26
             cc: cl
             cxx: cl
         build-type:

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -37,9 +37,11 @@ jobs:
       matrix:
         build:
           - os: ubuntu-24.04
+          - os: ubuntu-24.04-arm
+          - os: ubuntu-26.04
             run-cargo-fmt: true
             run-cargo-dry-run: true
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-26.04-arm
           - os: macos-15
           - os: windows-2022
           - os: windows-2025

--- a/.github/workflows/mediasoup-worker-clang-tidy.yaml
+++ b/.github/workflows/mediasoup-worker-clang-tidy.yaml
@@ -23,7 +23,7 @@ concurrency:
 
 jobs:
   clang-tidy:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -27,7 +27,11 @@ jobs:
             cc: clang
             cxx: clang++
             pip-break-system-packages: true
-          - os: ubuntu-24.04-arm
+          - os: ubuntu-26.04
+            cc: clang
+            cxx: clang++
+            pip-break-system-packages: true
+          - os: ubuntu-26.04-arm
             cc: clang
             cxx: clang++
             pip-break-system-packages: true

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         build:
-          # Worker prebuild for Linux with kernel version 6 Ubuntu (22.04).
+          # Worker prebuild for Linux with kernel version 6 Ubuntu 22.04.
           # Let's use Ubuntu 22.04 instead of 24.04 so that it builds the
           # mediasoup-worker binary using an old version of GLib that will work
           # on Linux hosts running more modern GLib versions.
@@ -21,6 +21,13 @@ jobs:
             cc: gcc
             cxx: g++
           - os: ubuntu-22.04-arm
+            cc: gcc
+            cxx: g++
+          # Linux with kernel version 7 Ubuntu 26.04.
+          - os: ubuntu-26.04
+            cc: gcc
+            cxx: g++
+          - os: ubuntu-26.04-arm
             cc: gcc
             cxx: g++
           - os: macos-15

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 26
 
       # We need to install some NPM production deps for npm-scripts.mjs to
       # work.

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -208,18 +208,18 @@ jobs:
         name: pip3 install --break-system-packages invoke
         run: pip3 install --break-system-packages invoke
 
-      # Fail if run-lint is set for non macos.
-      - if: ${{ matrix.build.run-lint && !startsWith(matrix.build.os, 'macos') }}
-        name: fail if run-lint is set for non macos
-        run: |
-          echo "run-lint set for non macos"
-          exit 1
-
       # Install clang-format on macos.
       - if: ${{ matrix.build.run-lint && startsWith(matrix.build.os, 'macos') }}
         name: brew install clang-format@22
         run: |
           brew install clang-format@22
+
+      # Install clang-format on ubuntu.
+      - if: ${{ matrix.build.run-lint && startsWith(matrix.build.os, 'ubuntu') }}
+        name: apt install clang-format-22
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes clang-format-22
 
       # We need to install npm deps of worker/scripts/package.json.
       - if: ${{ matrix.build.run-lint }}

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -63,9 +63,6 @@ jobs:
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
-            # Compile with all Meson option flags enabled once with gcc in
-            # Release mode.
-            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true'
           - os: ubuntu-24.04
             cc: gcc
             cxx: g++
@@ -75,21 +72,6 @@ jobs:
             run-test: true
             run-test-asan-address: false
             run-test-asan-undefined: false
-            # Compile with all Meson option flags enabled once with gcc in
-            # Debug mode.
-            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_disable_liburing=true'
-          - os: ubuntu-24.04
-            cc: clang
-            cxx: clang++
-            build-type: Release
-            pip-break-system-packages: true
-            run-lint: false
-            run-test: true
-            run-test-asan-address: true
-            run-test-asan-undefined: true
-            # Let's just compile with all Meson option flags enabled once with
-            # clang.
-            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true'
           - os: ubuntu-24.04-arm
             cc: gcc
             cxx: g++
@@ -101,6 +83,50 @@ jobs:
             run-test-asan-address: false
             run-test-asan-undefined: false
           - os: ubuntu-24.04-arm
+            cc: clang
+            cxx: clang++
+            build-type: Release
+            pip-break-system-packages: true
+            # No clang-format for ARM.
+            run-lint: false
+            run-test: true
+            run-test-asan-address: false
+            run-test-asan-undefined: false
+          - os: ubuntu-26.04
+            cc: gcc
+            cxx: g++
+            build-type: Debug
+            pip-break-system-packages: true
+            run-lint: false
+            run-test: true
+            run-test-asan-address: false
+            run-test-asan-undefined: false
+            # Compile with all Meson option flags enabled once with gcc in
+            # Debug mode.
+            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true -Dms_disable_liburing=true'
+          - os: ubuntu-26.04
+            cc: clang
+            cxx: clang++
+            build-type: Release
+            pip-break-system-packages: true
+            run-lint: false
+            run-test: true
+            run-test-asan-address: true
+            run-test-asan-undefined: true
+            # Let's just compile with all Meson option flags enabled once with
+            # clang.
+            meson_args: '-Dms_log_trace=true -Dms_log_file_line=true -Dms_rtc_logger_rtp=true -Dms_dump_rtp_payload_descriptor=true -Dms_dump_rtp_shared_packet_memory_usage=true'
+          - os: ubuntu-26.04-arm
+            cc: gcc
+            cxx: g++
+            build-type: Release
+            pip-break-system-packages: true
+            # No clang-format for ARM.
+            run-lint: false
+            run-test: true
+            run-test-asan-address: false
+            run-test-asan-undefined: false
+          - os: ubuntu-26.04-arm
             cc: clang
             cxx: clang++
             build-type: Release

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -109,7 +109,7 @@ jobs:
             cxx: clang++
             build-type: Release
             pip-break-system-packages: true
-            run-lint: false
+            run-lint: true
             run-test: true
             run-test-asan-address: true
             run-test-asan-undefined: true
@@ -141,7 +141,6 @@ jobs:
             cxx: clang++
             build-type: Release
             pip-break-system-packages: true
-            # Run lint for the latest macos.
             run-lint: true
             run-test: true
             run-test-asan-address: false

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -187,7 +187,7 @@ jobs:
       - name: Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: 24
+          node-version: 26
 
       - name: Configure cache
         uses: actions/cache@v5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- CI: Add `ubuntu-26.04` hosts ([1830](https://github.com/versatica/mediasoup/pull/1830)).
+
 ### 3.20.6
 
 - Unify all consumer classes into a single one ([1731](https://github.com/versatica/mediasoup/pull/1731)).

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -660,6 +660,8 @@ namespace RTC
 
 			const auto prevState = this->state;
 
+			// Notice that, contrary to what happens in dcsctp, here the association
+			// never transitions back to NEW state.
 			SetState(State::CLOSED, message);
 
 			if (prevState == State::COOKIE_WAIT || prevState == State::COOKIE_ECHOED)


### PR DESCRIPTION
# Details

- Add `ubuntu-26.04` hosts.
- Also in `mediasoup-worker-prebuild.yaml` so it generates worker prebuilt images for Linux kernel 7.
- And use Node 26.