### PR TITLE
Rust: Fix `connect()` method in `PlainTransport` when comedia mode and SRTP mode are enabled

### DIFF
--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -87,6 +87,39 @@ jobs:
           DOCS_RS: '1'
           RUSTDOCFLAGS: '-D rustdoc::broken-intra-doc-links -D rustdoc::private_intra_doc_links'
 
+      # NOTE: Only run the publish dry-run when at least one of the three crates
+      # has a version not yet on crates.io (i.e. it's been bumped and is about to
+      # be published). Otherwise Cargo resolves the dependencies among them
+      # against the already-published copies on crates.io, and any schema/API
+      # change made since the last release fails verification spuriously even
+      # though nothing is being published.
+      - if: ${{ matrix.build.run-cargo-dry-run }}
+        id: check-versions
+        name: Check whether any Rust crate version was bumped
+        shell: bash
+        run: |
+          set -euo pipefail
+          bumped=false
+          check() {
+            local manifest="$1" name version status
+            name=$(grep -m1 -E '^name *=' "$manifest" | sed -E 's/.*"(.*)".*/\1/')
+            version=$(grep -m1 -E '^version *=' "$manifest" | sed -E 's/.*"(.*)".*/\1/')
+            status=$(curl -sS -o /dev/null -w '%{http_code}' \
+              -A 'mediasoup-ci (https://github.com/versatica/mediasoup)' \
+              "https://crates.io/api/v1/crates/${name}/${version}" || echo 000)
+            echo "${name} ${version} -> HTTP ${status}"
+            if [ "${status}" = "200" ]; then
+              echo "  already published, no bump"
+            else
+              echo "  not published (or unreachable), treating as bumped"
+              bumped=true
+            fi
+          }
+          check worker/Cargo.toml
+          check rust/Cargo.toml
+          check rust/types/Cargo.toml
+          echo "bumped=${bumped}" >> "$GITHUB_OUTPUT"
+
       # NOTE: No need to unset the job-level KEEP_BUILD_ARTIFACTS here:
       # `mediasoup-sys`'s build.rs detects the `cargo publish` verification step
       # and always cleans the Meson subprojects it extracts into the source
@@ -97,6 +130,6 @@ jobs:
       # of crates.io. This way `mediasoup` verifies fine even when the versions
       # of `mediasoup-sys` / `mediasoup-types` it depends on have been bumped but
       # not yet published.
-      - if: ${{ matrix.build.run-cargo-dry-run }}
+      - if: ${{ matrix.build.run-cargo-dry-run && steps.check-versions.outputs.bumped == 'true' }}
         name: cargo publish --dry-run -p mediasoup-types -p mediasoup-sys -p mediasoup
         run: cargo publish --dry-run -p mediasoup-types -p mediasoup-sys -p mediasoup

--- a/node/src/test/test-PlainTransport.ts
+++ b/node/src/test/test-PlainTransport.ts
@@ -326,6 +326,47 @@ test('router.createPlainTransport() with enableSrtp succeeds', async () => {
 	expect(plainTransport.srtpParameters?.keyBase64.length).toBe(60);
 }, 2000);
 
+test('plainTransport.connect() with srtpParameters and comedia enabled succeeds', async () => {
+	// In comedia mode the remote endpoint is not known until the first packet is
+	// received, so the worker's connect response carries no tuple. `connect()`
+	// (called with just `srtpParameters`, as documented for comedia + SRTP) must
+	// still succeed.
+	const plainTransport = await ctx.router!.createPlainTransport({
+		listenInfo: { protocol: 'udp', ip: '127.0.0.1' },
+		enableSrtp: true,
+		comedia: true,
+	});
+
+	// Default cryptoSuite: 'AES_CM_128_HMAC_SHA1_80'.
+	expect(plainTransport.srtpParameters?.cryptoSuite).toBe(
+		'AES_CM_128_HMAC_SHA1_80'
+	);
+	expect(plainTransport.srtpParameters?.keyBase64.length).toBe(40);
+
+	// The tuple only carries local information until comedia latches a remote.
+	expect(plainTransport.tuple.localAddress).toBe('127.0.0.1');
+	expect(plainTransport.tuple.protocol).toBe('udp');
+	expect(plainTransport.tuple.remoteIp).toBeUndefined();
+
+	// Valid srtpParameters. And no need for ip and port since comedia is enabled.
+	await expect(
+		plainTransport.connect({
+			srtpParameters: {
+				cryptoSuite: 'AEAD_AES_256_GCM',
+				keyBase64:
+					'YTdjcDBvY2JoMGY5YXNlNDc0eDJsdGgwaWRvNnJsamRrdG16aWVpZHphdHo=',
+			},
+		})
+	).resolves.toBeUndefined();
+
+	// The remote SRTP crypto suite has been applied.
+	expect(plainTransport.srtpParameters?.cryptoSuite).toBe('AEAD_AES_256_GCM');
+	expect(plainTransport.srtpParameters?.keyBase64.length).toBe(60);
+
+	// The tuple is still local only. Comedia will latch the remote later.
+	expect(plainTransport.tuple.remoteIp).toBeUndefined();
+}, 2000);
+
 test('router.createPlainTransport() with non bindable IP rejects with Error', async () => {
 	await expect(
 		ctx.router!.createPlainTransport({ listenIp: '8.8.8.8' })

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Fix `connect()` method in `PlainTransport` when comedia mode and SRTP mode are enabled (PR #1831).
+
 ### 0.22.5
 
 - Unify all consumer classes into a single one (PR #1731).

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -1515,7 +1515,7 @@ impl Request for PipeTransportConnectRequest {
 
 #[derive(Debug)]
 pub(crate) struct PlainTransportConnectResponse {
-    pub(crate) tuple: TransportTuple,
+    pub(crate) tuple: Option<TransportTuple>,
     pub(crate) rtcp_tuple: Option<TransportTuple>,
     pub(crate) srtp_parameters: Option<SrtpParameters>,
 }
@@ -1567,7 +1567,9 @@ impl Request for TransportConnectPlainRequest {
         let data = plain_transport::ConnectResponse::try_from(data)?;
 
         Ok(PlainTransportConnectResponse {
-            tuple: TransportTuple::from_fbs(data.tuple.as_ref()),
+            tuple: data
+                .tuple
+                .map(|tuple| TransportTuple::from_fbs(tuple.as_ref())),
             rtcp_tuple: data
                 .rtcp_tuple
                 .map(|tuple| TransportTuple::from_fbs(tuple.as_ref())),

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -949,7 +949,9 @@ impl PlainTransport {
             )
             .await?;
 
-        *self.inner.data.tuple.lock() = response.tuple;
+        if let Some(tuple) = response.tuple {
+            *self.inner.data.tuple.lock() = tuple;
+        }
 
         if let Some(rtcp_tuple) = response.rtcp_tuple {
             self.inner.data.rtcp_tuple.lock().replace(rtcp_tuple);

--- a/rust/tests/integration/plain_transport.rs
+++ b/rust/tests/integration/plain_transport.rs
@@ -428,6 +428,76 @@ fn create_enable_srtp_succeeds() {
 }
 
 #[test]
+fn connect_enable_srtp_comedia_succeeds() {
+    future::block_on(async move {
+        let (_worker, router) = init().await;
+
+        let transport = router
+            .create_plain_transport({
+                let mut plain_transport_options = PlainTransportOptions::new(ListenInfo {
+                    protocol: Protocol::Udp,
+                    ip: IpAddr::V4(Ipv4Addr::LOCALHOST),
+                    announced_address: None,
+                    expose_internal_ip: false,
+                    port: None,
+                    port_range: None,
+                    flags: None,
+                    send_buffer_size: None,
+                    recv_buffer_size: None,
+                });
+                plain_transport_options.enable_srtp = true;
+                plain_transport_options.comedia = true;
+
+                plain_transport_options
+            })
+            .await
+            .expect("Failed to create Plain transport");
+
+        // Use default cryptoSuite: 'AES_CM_128_HMAC_SHA1_80'.
+        assert_eq!(
+            transport.srtp_parameters().unwrap().crypto_suite,
+            SrtpCryptoSuite::AesCm128HmacSha180,
+        );
+
+        // In comedia mode the remote endpoint is not known until the first
+        // packet is received, so the tuple has no remote info yet.
+        assert!(matches!(
+            transport.tuple(),
+            TransportTuple::LocalOnly { .. }
+        ));
+
+        // connect() with just srtp_parameters (no ip/port) must succeed even
+        // though the worker's connect response carries no tuple.
+        transport
+            .connect(PlainTransportRemoteParameters {
+                ip: None,
+                port: None,
+                rtcp_port: None,
+                srtp_parameters: Some(SrtpParameters {
+                    crypto_suite: SrtpCryptoSuite::AeadAes256Gcm,
+                    key_base64: "YTdjcDBvY2JoMGY5YXNlNDc0eDJsdGgwaWRvNnJsamRrdG16aWVpZHphdHo="
+                        .to_string(),
+                }),
+            })
+            .await
+            .expect("Failed to establish Plain transport connection");
+
+        // The remote SRTP crypto suite has been applied.
+        assert_eq!(
+            transport.srtp_parameters().unwrap().crypto_suite,
+            SrtpCryptoSuite::AeadAes256Gcm,
+        );
+        assert_eq!(transport.srtp_parameters().unwrap().key_base64.len(), 60);
+
+        // The tuple is still local-only; comedia will latch the remote later.
+        assert!(matches!(
+            transport.tuple(),
+            TransportTuple::LocalOnly { .. }
+        ));
+    });
+}
+
+#[test]
 fn create_non_bindable_ip() {
     future::block_on(async move {
         let (_worker, router) = init().await;

--- a/worker/fbs/plainTransport.fbs
+++ b/worker/fbs/plainTransport.fbs
@@ -22,7 +22,7 @@ table ConnectRequest {
 }
 
 table ConnectResponse {
-    tuple: FBS.Transport.Tuple (required);
+    tuple: FBS.Transport.Tuple;
     rtcp_tuple: FBS.Transport.Tuple;
     srtp_parameters: FBS.SrtpParameters.SrtpParameters;
 }


### PR DESCRIPTION
# Details

- Fixes #1827
- bonus track: Only run the `publish dry-run` check when at least one of the three crates has a version not yet on crates.io (i.e. it's been bumped and is about to be published). Otherwise Cargo resolves the dependencies among them against the already-published copies on crates.io, and any schema/API change made since the last release fails verification spuriously even though nothing is being published.