### PR TITLE
Add `rust-scripts.mjs`

### DIFF
--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -51,7 +51,7 @@ jobs:
     timeout-minutes: 60
 
     env:
-      KEEP_BUILD_ARTIFACTS: '1'
+      MEDIASOUP_LOCAL_DEV: 'true'
 
     steps:
       - name: Checkout
@@ -120,7 +120,7 @@ jobs:
           check rust/types/Cargo.toml
           echo "bumped=${bumped}" >> "$GITHUB_OUTPUT"
 
-      # NOTE: No need to unset the job-level KEEP_BUILD_ARTIFACTS here:
+      # NOTE: No need to unset the job-level MEDIASOUP_LOCAL_DEV here:
       # `mediasoup-sys`'s build.rs detects the `cargo publish` verification step
       # and always cleans the Meson subprojects it extracts into the source
       # tree, avoiding the "Source directory was modified by build.rs" error.

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -9,6 +9,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
+      - 'rust-scripts.mjs'
       - '.github/workflows/mediasoup-rust.yaml'
   pull_request:
     paths:
@@ -17,6 +18,7 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
+      - 'rust-scripts.mjs'
       - '.github/workflows/mediasoup-rust.yaml'
   workflow_dispatch:
 

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -37,12 +37,17 @@ jobs:
       matrix:
         build:
           - os: ubuntu-24.04
+            run-test-in-debug-mode: true
           - os: ubuntu-24.04-arm
+            run-test-in-debug-mode: true
           - os: ubuntu-26.04
             run-cargo-fmt: true
             run-cargo-dry-run: true
+            run-test-in-debug-mode: true
           - os: ubuntu-26.04-arm
+            run-test-in-debug-mode: true
           - os: macos-15
+            run-test-in-debug-mode: true
           - os: windows-2022
           - os: windows-2025
 
@@ -74,12 +79,17 @@ jobs:
       - name: cargo clippy --all-targets -- -D warnings
         run: cargo clippy --all-targets -- -D warnings
 
-      # NOTE: In Windows this will build and test libmediasoupworker in release
-      # mode twice since build.rs doesn't allow debug mode on Windows.
-      - name: cargo test
-        run: |
-          cargo test --verbose
-          cargo test --release --verbose
+      # NOTE: On Windows build.rs builds and tests libmediasoupworker in release
+      # mode even for a debug `cargo test`, so running the debug pass there would
+      # just build and test the release library a second time. Hence the debug
+      # pass only runs where debug mode is actually different (non-Windows). The
+      # release pass always runs.
+      - if: ${{ matrix.build.run-test-in-debug-mode }}
+        name: cargo test --verbose
+        run: cargo test --verbose
+
+      - name: cargo test --release --verbose
+        run: cargo test --release --verbose
 
       - name: cargo doc --locked --all --no-deps --lib
         run: cargo doc --locked --all --no-deps --lib

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -104,7 +104,7 @@ Same as `test:node` task but it also opens a browser window with TypeScript cove
 
 ### `npm run release:check`
 
-Runs linters and tests in Node and C++ code.
+Runs linters and tests in Node and C++ code. Also verifies that `CHANGELOG.md` has an entry matching the `mediasoup` version in `package.json`.
 
 ### `npm run release`
 
@@ -112,11 +112,25 @@ Publishes a new NPM version of mediasoup. Requirements for it to work:
 
 - "version" field in `package.json` must have been incremented (and not commited to Git).
 - `CHANGELOG.md` file must have been updated with an entry matching the new version.
+- A `GITHUB_TOKEN` environment variable with permissions to create releases in GitHub is required.
 - Of course, permissions to publish in NPM registry are required.
+
+### `npm run release:rust:check`
+
+Dry-run of the Rust release. Checks which of the three Rust crate versions (`mediasoup-sys` in `worker/Cargo.toml`, `mediasoup-types` in `rust/types/Cargo.toml` and `mediasoup` in `rust/Cargo.toml`) are not yet published on crates.io, verifies that `rust/CHANGELOG.md` has an entry matching the `mediasoup` crate version (when that crate is going to be published), and reports what would be done without creating any tag/release or publishing anything.
+
+### `npm run release:rust`
+
+Publishes to crates.io (with `cargo publish --locked`, in dependency order: `mediasoup-types`, `mediasoup-sys`, `mediasoup`) every Rust crate whose version is not yet on crates.io. Additionally, when the `mediasoup` crate itself is being published, it also creates the Git tag (`rust-X.X.X`, matching its version in `rust/Cargo.toml`) and the corresponding GitHub release (see `release:rust:check` above and `doc/Rust-crates.md`). Requirements for it to work:
+
+- At least one of the three Rust crate versions must have been incremented (and commited to Git).
+- When the `mediasoup` crate version is incremented, `rust/CHANGELOG.md` must have been updated with an entry matching it.
+- A `GITHUB_TOKEN` environment variable with permissions to create releases in GitHub is required (only when the `mediasoup` crate is published).
+- Of course, permissions to publish in crates.io are required.
 
 ## Rust
 
-The only special feature in Rust case is special environment variable "KEEP_BUILD_ARTIFACTS", that when set to "1" will allow incremental recompilation of changed C++ sources during hacking on mediasoup.
+The only special feature in Rust case is special environment variable "MEDIASOUP_LOCAL_DEV", that when set to "true" will allow incremental recompilation of changed C++ sources during hacking on mediasoup.
 
 It is not necessary for normal usage of mediasoup as a dependency.
 

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -137,6 +137,8 @@ The only special feature in Rust case is special environment variable "MEDIASOUP
 
 It is not necessary for normal usage of mediasoup as a dependency.
 
+Other than that and normal `cargo` commands, see `npm run release:rust:check` and `npm run release:rust` above.
+
 ## Python Invoke and `tasks.py` file
 
 mediasoup uses Python [Invoke](https://www.pyinvoke.org) library for managing and organizing tasks in the `worker` folder (mediasoup worker C++ subproject). `Invoke` is basically a replacemente of `make` + `Makefile` written in Python. mediasoup automatically installs `Invoke` in a local custom path during the installation process (in both Node and Rust) so the user doesn't need to worry about it.

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -110,6 +110,7 @@ Runs linters and tests in Node and C++ code. Also verifies that `CHANGELOG.md` h
 
 Publishes a new NPM version of mediasoup. Requirements for it to work:
 
+- Must be in the main branch.
 - "version" field in `package.json` must have been incremented (and not commited to Git).
 - `CHANGELOG.md` file must have been updated with an entry matching the new version.
 - A `GITHUB_TOKEN` environment variable with permissions to create releases in GitHub is required.
@@ -121,9 +122,11 @@ Dry-run of the Rust release. Always runs the `cargo fmt`, `cargo clippy`, `cargo
 
 ### `npm run release:rust`
 
-Runs the same checks as `release:rust:check` (including the cargo `fmt`, `clippy`, `test` and `doc` checks) and then publishes to crates.io (with `cargo publish --locked`, in dependency order: `mediasoup-types`, `mediasoup-sys`, `mediasoup`) every Rust crate whose version is not yet on crates.io. Additionally, when the `mediasoup` crate itself is being published, it also creates the Git tag (`rust-X.X.X`, matching its version in `rust/Cargo.toml`) and the corresponding GitHub release (see `release:rust:check` above and `doc/Rust-crates.md`). Requirements for it to work:
+Runs the same checks as `release:rust:check` (including the cargo `fmt`, `clippy`, `test` and `doc` checks), then pushes local commits to GitHub (so everything that gets tagged and published is already there) and publishes to crates.io (with `cargo publish --locked`, in dependency order: `mediasoup-types`, `mediasoup-sys`, `mediasoup`) every Rust crate whose version is not yet on crates.io. Additionally, when the `mediasoup` crate itself is being published, it also creates the Git tag (`rust-X.X.X`, matching its version in `rust/Cargo.toml`) and the corresponding GitHub release (see `release:rust:check` above and `doc/Rust-crates.md`). Requirements for it to work:
 
+- Must be in the main branch.
 - Git local repository must be clean. No pending commits or dirty status.
+- `Cargo.lock` must be in sync (run `cargo build` and commit it if needed); otherwise the release aborts before doing anything irreversible.
 - When the `mediasoup` crate version is incremented, `rust/CHANGELOG.md` must have been updated with an entry matching it.
 - A `GITHUB_TOKEN` environment variable with permissions to create releases in GitHub is required (only when the `mediasoup` crate is published).
 - Of course, permissions to publish in crates.io are required.

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -117,13 +117,13 @@ Publishes a new NPM version of mediasoup. Requirements for it to work:
 
 ### `npm run release:rust:check`
 
-Dry-run of the Rust release. Checks which of the three Rust crate versions (`mediasoup-sys` in `worker/Cargo.toml`, `mediasoup-types` in `rust/types/Cargo.toml` and `mediasoup` in `rust/Cargo.toml`) are not yet published on crates.io, verifies that `rust/CHANGELOG.md` has an entry matching the `mediasoup` crate version (when that crate is going to be published), and reports what would be done without creating any tag/release or publishing anything.
+Dry-run of the Rust release. Always runs the `cargo fmt`, `cargo clippy`, `cargo test` and `cargo doc` checks (even when there is nothing to publish). Then checks which of the three Rust crate versions (`mediasoup-sys` in `worker/Cargo.toml`, `mediasoup-types` in `rust/types/Cargo.toml` and `mediasoup` in `rust/Cargo.toml`) are not yet published on crates.io, verifies that `rust/CHANGELOG.md` has an entry matching the `mediasoup` crate version (when that crate is going to be published), and reports what would be done without creating any tag/release or publishing anything.
 
 ### `npm run release:rust`
 
-Publishes to crates.io (with `cargo publish --locked`, in dependency order: `mediasoup-types`, `mediasoup-sys`, `mediasoup`) every Rust crate whose version is not yet on crates.io. Additionally, when the `mediasoup` crate itself is being published, it also creates the Git tag (`rust-X.X.X`, matching its version in `rust/Cargo.toml`) and the corresponding GitHub release (see `release:rust:check` above and `doc/Rust-crates.md`). Requirements for it to work:
+Runs the same checks as `release:rust:check` (including the cargo `fmt`, `clippy`, `test` and `doc` checks) and then publishes to crates.io (with `cargo publish --locked`, in dependency order: `mediasoup-types`, `mediasoup-sys`, `mediasoup`) every Rust crate whose version is not yet on crates.io. Additionally, when the `mediasoup` crate itself is being published, it also creates the Git tag (`rust-X.X.X`, matching its version in `rust/Cargo.toml`) and the corresponding GitHub release (see `release:rust:check` above and `doc/Rust-crates.md`). Requirements for it to work:
 
-- At least one of the three Rust crate versions must have been incremented (and commited to Git).
+- Git local repository must be clean. No pending commits or dirty status.
 - When the `mediasoup` crate version is incremented, `rust/CHANGELOG.md` must have been updated with an entry matching it.
 - A `GITHUB_TOKEN` environment variable with permissions to create releases in GitHub is required (only when the `mediasoup` crate is published).
 - Of course, permissions to publish in crates.io are required.

--- a/doc/Rust-crates.md
+++ b/doc/Rust-crates.md
@@ -23,7 +23,8 @@ git tag -a rust-X.X.X -m rust-X.X.X
 git push origin rust-X.X.X
 ```
 
-6. Publish crates (you need an account and permissions and so on). Always pass `--locked` so Cargo aborts if `Cargo.lock` is out of date instead of silently regenerating it (see note below):
+6. Create a GitHub release for the new `rust-X.X.X` tag, using the matching `rust/CHANGELOG.md` entry as its body.
+7. Publish crates (you need an account and permissions and so on). Always pass `--locked` so Cargo aborts if `Cargo.lock` is out of date instead of silently regenerating it (see note below):
 
 ```sh
 cd rust/types
@@ -39,7 +40,7 @@ cargo publish --locked
 ## Notes
 
 - Depending on the state in `worker` directory you may need to run `invoke clean-all` or `make clean-all` in `worker` directory first.
-- You can have `KEEP_BUILD_ARTIFACTS=1` exported in your shell (handy to speed up regular local builds) and still publish: `mediasoup-sys`'s `build.rs` detects the `cargo publish` / `cargo package` verification step (Cargo builds the crate inside `target/package/`) and always cleans the Meson subprojects it extracts into the source tree, regardless of `KEEP_BUILD_ARTIFACTS`. This avoids the "Source directory was modified by build.rs" error.
+- You can have `MEDIASOUP_LOCAL_DEV=true` exported in your shell (handy to speed up regular local builds) and still publish: `mediasoup-sys`'s `build.rs` detects the `cargo publish` / `cargo package` verification step (Cargo builds the crate inside `target/package/`) and always cleans the Meson subprojects it extracts into the source tree, regardless of `MEDIASOUP_LOCAL_DEV`. This avoids the "Source directory was modified by build.rs" error.
 - `cargo publish` will create the crate package, check if all necessary dependencies are already present on [crates.io](https://crates.io/), will then compile the package (to ensure that you don't publish a broken version) and will upload it to [crates.io](https://crates.io/).
 - Never publish from random branches or local state that is not on GitHub. If you have local files modified Cargo will refuse to publish until you commit all the changes.
 - Use `cargo publish --locked`. The dirty-repo check runs _before_ the verification build, but the verification build is exactly when Cargo regenerates `Cargo.lock`, so a stale lock slips past the dirty check and gets silently updated. `--locked` makes `cargo publish` fail up front if `Cargo.lock` needs updating, forcing step 3 to have been done and committed first.

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -27,6 +27,7 @@ const ESLINT_PATHS = [
 	'knip.config.mjs',
 	'node/src',
 	'npm-scripts.mjs',
+	'rust-scripts.mjs',
 	'worker/scripts',
 ];
 
@@ -47,6 +48,7 @@ const PRETTIER_PATHS = [
 	'node/src',
 	'npm-scripts.mjs',
 	'package.json',
+	'rust-scripts.mjs',
 	'tsconfig.json',
 	'worker/scripts',
 ];
@@ -542,6 +544,18 @@ function publishDryRun() {
 async function checkRelease() {
 	logInfo('checkRelease()');
 
+	// Verify that CHANGELOG.md has an entry for the new version (and grab its
+	// changes, used as the GitHub release body) before the slow build steps.
+	let versionChanges;
+
+	try {
+		versionChanges = await getVersionChanges();
+	} catch (error) {
+		logError(error.message);
+
+		exitWithError();
+	}
+
 	installNodeDeps();
 	await flatcNode({ force: true });
 	buildTypescript({ force: true });
@@ -553,30 +567,31 @@ async function checkRelease() {
 	// Validate packaging (the `files` list in package.json) before the
 	// irreversible release steps (git push, GitHub release, npm publish).
 	publishDryRun();
+
+	return { versionChanges };
 }
 
 async function release() {
 	logInfo('release()');
 
 	let octokit;
-	let versionChanges;
 
 	try {
 		octokit = await getOctokit();
-		versionChanges = await getVersionChanges();
 	} catch (error) {
 		logError(error.message);
 
 		exitWithError();
 	}
 
-	await checkRelease();
+	const { versionChanges } = await checkRelease();
+
 	executeCmd(`git commit -am '${pkg.version}'`);
 	executeCmd(`git tag -a ${pkg.version} -m '${pkg.version}'`);
 	executeCmd(`git push origin v${MAYOR_VERSION}`);
 	executeCmd(`git push origin '${pkg.version}'`);
 
-	logInfo('creating release in GitHub');
+	logInfo(`release() | creating release '${pkg.version}' in GitHub`);
 
 	await octokit.repos.createRelease({
 		owner: GH_OWNER,
@@ -785,9 +800,26 @@ async function getVersionChanges() {
 		const entry = entries[idx];
 
 		if (entry.type === 'heading' && entry.text === pkg.version) {
-			const changes = entries[idx + 1].raw;
+			// Collect every token after the matching heading until the next heading.
+			// NOTE: We cannot just use `entries[idx + 1].raw` because `marked`
+			// inserts a `space` token between the heading and its content.
+			let changes = '';
 
-			return changes;
+			for (let next = idx + 1; next < entries.length; ++next) {
+				if (entries[next].type === 'heading') {
+					break;
+				}
+
+				changes += entries[next].raw;
+			}
+
+			changes = changes.trim();
+
+			if (changes) {
+				return changes;
+			}
+
+			break;
 		}
 	}
 
@@ -809,11 +841,11 @@ function executeCmd(command) {
 	}
 }
 
-function executeInteractiveCmd(command) {
-	logInfo(`executeInteractiveCmd(): ${command}`);
+function executeInteractiveCmd(command, { cwd } = {}) {
+	logInfo(`executeInteractiveCmd(): ${command}${cwd ? ` [cwd:${cwd}]` : ''}`);
 
 	try {
-		execSync(command, { stdio: 'inherit', env: process.env });
+		execSync(command, { cwd, stdio: 'inherit', env: process.env });
 	} catch (error) {
 		logError(`executeInteractiveCmd() failed, exiting: ${error}`);
 

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -601,9 +601,10 @@ async function release() {
 
 	const { versionChanges } = await checkRelease();
 
+	// The local repo ust be "dirty" so the script can commit now.
 	executeCmd(`git commit -am '${pkg.version}'`);
-	executeCmd(`git tag -a ${pkg.version} -m '${pkg.version}'`);
 	executeCmd(`git push origin ${MAIN_BRANCH}`);
+	executeCmd(`git tag -a ${pkg.version} -m '${pkg.version}'`);
 	executeCmd(`git push origin '${pkg.version}'`);
 
 	logInfo(`release() | creating release '${pkg.version}' in GitHub`);

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -8,7 +8,9 @@ import * as tar from 'tar';
 import pkg from './package.json' with { type: 'json' };
 
 const IS_WINDOWS = os.platform() === 'win32';
-const MAYOR_VERSION = pkg.version.split('.')[0];
+// Main Git branch is 'v' concatenated with the major SEMVER number of the
+// "version" field in package.json.
+const MAIN_BRANCH = `v${pkg.version.split('.')[0]}`;
 const PYTHON = getPython();
 const PIP_INVOKE_DIR = path.resolve('worker/pip_invoke');
 const WORKER_RELEASE_DIR = 'worker/out/Release';
@@ -574,6 +576,19 @@ async function checkRelease() {
 async function release() {
 	logInfo('release()');
 
+	// Make sure we are on the main branch.
+	const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+		encoding: 'utf-8',
+	}).trim();
+
+	if (branch !== MAIN_BRANCH) {
+		logError(
+			`release() | must be on '${MAIN_BRANCH}' branch, but it is on '${branch}' branch`
+		);
+
+		exitWithError();
+	}
+
 	let octokit;
 
 	try {
@@ -588,7 +603,7 @@ async function release() {
 
 	executeCmd(`git commit -am '${pkg.version}'`);
 	executeCmd(`git tag -a ${pkg.version} -m '${pkg.version}'`);
-	executeCmd(`git push origin v${MAYOR_VERSION}`);
+	executeCmd(`git push origin ${MAIN_BRANCH}`);
 	executeCmd(`git push origin '${pkg.version}'`);
 
 	logInfo(`release() | creating release '${pkg.version}' in GitHub`);

--- a/package.json
+++ b/package.json
@@ -98,7 +98,9 @@
 		"coverage:node": "node npm-scripts.mjs coverage:node",
 		"publish:dry-run": "node npm-scripts.mjs publish:dry-run",
 		"release:check": "node npm-scripts.mjs release:check",
-		"release": "node npm-scripts.mjs release"
+		"release": "node npm-scripts.mjs release",
+		"release:rust:check": "node rust-scripts.mjs release:check",
+		"release:rust": "node rust-scripts.mjs release"
 	},
 	"dependencies": {
 		"debug": "^4.4.3",

--- a/rust-scripts.mjs
+++ b/rust-scripts.mjs
@@ -12,7 +12,7 @@ const MAIN_BRANCH = `v${pkg.version.split('.')[0]}`;
 
 // The three Rust crates with their Cargo.toml manifest and directory (relative
 // to repo root). Listed in the order in which they must be published to
-// crates.io (dependencies first). See doc/Rust-crates.md.
+// crates.io (dependencies first).
 const CRATES = [
 	// `mediasoup-types` crate.
 	{ manifest: 'rust/types/Cargo.toml', dir: 'rust/types' },
@@ -166,7 +166,7 @@ async function release() {
 	}
 
 	// Refuse to release with a dirty working tree. `cargo publish` would refuse
-	// to publish modified local files anyway (see doc/Rust-crates.md).
+	// to publish modified local files anyway.
 	checkGitClean();
 
 	const releaseInfo = await checkRelease();
@@ -180,8 +180,8 @@ async function release() {
 		releaseInfo;
 
 	// Push local commits first so everything we tag and publish is already on
-	// GitHub (see doc/Rust-crates.md).
-	executeCmd('git push');
+	// GitHub.
+	executeCmd(`git push origin ${MAIN_BRANCH}`);
 
 	// Create the Git tag and the GitHub release only when the `mediasoup` crate
 	// itself is being published. If the tag already exists (e.g. a previous run
@@ -197,7 +197,7 @@ async function release() {
 			exitWithError();
 		}
 
-		// Create and push the annotated tag (see doc/Rust-crates.md).
+		// Create and push the annotated tag.
 		executeCmd(`git tag -a ${tag} -m ${tag}`);
 		executeCmd(`git push origin ${tag}`);
 
@@ -213,10 +213,9 @@ async function release() {
 		});
 	}
 
-	// Publish the crates to crates.io (see doc/Rust-crates.md). They are
-	// published in dependency order (the order of `CRATES`). `--locked` makes
-	// cargo abort if Cargo.lock is out of date instead of silently regenerating
-	// it.
+	// Publish the crates to crates.io. They are published in dependency order
+	// (the order of `CRATES`). `--locked` makes cargo abort if Cargo.lock is out
+	// of date instead of silently regenerating it.
 	for (const crate of cratesToPublish) {
 		executeInteractiveCmd('cargo publish --locked', { cwd: crate.dir });
 	}
@@ -348,10 +347,10 @@ async function getVersionChanges(version) {
 }
 
 /**
- * Validates packaging of the three Rust crates without uploading anything, the
- * same way doc/Rust-crates.md recommends. They are passed as a single group so
- * Cargo resolves the dependencies among them against the locally packaged copies
- * instead of crates.io (works even if the new versions are not published yet).
+ * Validates packaging of all mediasoup Rust crates without uploading anything.
+ * They are passed as a single group so cargo resolves the dependencies among
+ * them against the locally packaged copies instead of crates.io (works even if
+ * the new versions are not published yet).
  */
 function publishDryRun() {
 	logInfo('publishDryRun()');

--- a/rust-scripts.mjs
+++ b/rust-scripts.mjs
@@ -80,6 +80,11 @@ async function checkRelease() {
 	).version;
 	const tag = `rust-${mediasoupVersion}`;
 
+	// Run the cargo checks always, even if there ends up being nothing to publish.
+	lintRust();
+	testRust();
+	docRust();
+
 	// Detect which crates have a version not yet published on crates.io.
 	let cratesToPublish;
 
@@ -190,6 +195,32 @@ async function release() {
 	for (const crate of cratesToPublish) {
 		executeInteractiveCmd('cargo publish --locked', { cwd: crate.dir });
 	}
+}
+
+function lintRust() {
+	logInfo('lintRust()');
+
+	executeCmd('cargo fmt --all -- --check');
+	executeCmd('cargo clippy --all-targets -- -D warnings');
+}
+
+function testRust() {
+	logInfo('testRust()');
+
+	executeCmd('cargo test --verbose');
+	executeCmd('cargo test --release --verbose');
+}
+
+function docRust() {
+	logInfo('docRust()');
+
+	// Fail on broken/private intra-doc links, same as when building the docs for
+	// docs.rs.
+	process.env.DOCS_RS = '1';
+	process.env.RUSTDOCFLAGS =
+		'-D rustdoc::broken-intra-doc-links -D rustdoc::private_intra_doc_links';
+
+	executeCmd('cargo doc --locked --all --no-deps --lib');
 }
 
 /**

--- a/rust-scripts.mjs
+++ b/rust-scripts.mjs
@@ -2,9 +2,13 @@ import * as process from 'node:process';
 import * as fs from 'node:fs';
 import { execSync } from 'node:child_process';
 import fetch from 'node-fetch';
+import pkg from './package.json' with { type: 'json' };
 
 const GH_OWNER = 'versatica';
 const GH_REPO = 'mediasoup';
+// Main Git branch is 'v' concatenated with the major SEMVER number of the
+// "version" field in package.json.
+const MAIN_BRANCH = `v${pkg.version.split('.')[0]}`;
 
 // The three Rust crates with their Cargo.toml manifest and directory (relative
 // to repo root). Listed in the order in which they must be published to
@@ -80,6 +84,10 @@ async function checkRelease() {
 	).version;
 	const tag = `rust-${mediasoupVersion}`;
 
+	// Ensure Cargo.lock is in sync before running any cargo command that could
+	// silently regenerate it.
+	checkCargoLock();
+
 	// Run the cargo checks always, even if there ends up being nothing to publish.
 	lintRust();
 	testRust();
@@ -144,6 +152,19 @@ async function checkRelease() {
 async function release() {
 	logInfo('release()');
 
+	// Make sure we are on the main branch.
+	const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+		encoding: 'utf-8',
+	}).trim();
+
+	if (branch !== MAIN_BRANCH) {
+		logError(
+			`release() | must be on '${MAIN_BRANCH}' branch, but it is on '${branch}' branch`
+		);
+
+		exitWithError();
+	}
+
 	// Refuse to release with a dirty working tree. `cargo publish` would refuse
 	// to publish modified local files anyway (see doc/Rust-crates.md).
 	checkGitClean();
@@ -157,6 +178,10 @@ async function release() {
 
 	const { tag, releaseMediasoup, versionChanges, cratesToPublish } =
 		releaseInfo;
+
+	// Push local commits first so everything we tag and publish is already on
+	// GitHub (see doc/Rust-crates.md).
+	executeCmd('git push');
 
 	// Create the Git tag and the GitHub release only when the `mediasoup` crate
 	// itself is being published. If the tag already exists (e.g. a previous run
@@ -360,6 +385,25 @@ function checkGitClean() {
 	if (status.trim()) {
 		logError(
 			'checkGitClean() | Git working tree is not clean, commit or stash your changes first'
+		);
+
+		exitWithError();
+	}
+}
+
+function checkCargoLock() {
+	logInfo('checkCargoLock()');
+
+	// `--locked` makes cargo fail if Cargo.lock is out of date instead of
+	// regenerating it. We resolve metadata (no build) just to assert the lock is
+	// in sync, otherwise run `cargo build` and commit Cargo.lock first.
+	try {
+		execSync('cargo metadata --locked --format-version 1', {
+			stdio: ['ignore', 'ignore', process.stderr],
+		});
+	} catch (error) {
+		logError(
+			'checkCargoLock() | Cargo.lock is out of date, run `cargo build` and commit it'
 		);
 
 		exitWithError();

--- a/rust-scripts.mjs
+++ b/rust-scripts.mjs
@@ -1,0 +1,445 @@
+import * as process from 'node:process';
+import * as fs from 'node:fs';
+import { execSync } from 'node:child_process';
+import fetch from 'node-fetch';
+
+const GH_OWNER = 'versatica';
+const GH_REPO = 'mediasoup';
+
+// The three Rust crates with their Cargo.toml manifest and directory (relative
+// to repo root). Listed in the order in which they must be published to
+// crates.io (dependencies first). See doc/Rust-crates.md.
+const CRATES = [
+	// `mediasoup-types` crate.
+	{ manifest: 'rust/types/Cargo.toml', dir: 'rust/types' },
+	// `mediasoup-sys` crate.
+	{ manifest: 'worker/Cargo.toml', dir: 'worker' },
+	// `mediasoup` crate (depends on the two above).
+	{ manifest: 'rust/Cargo.toml', dir: 'rust' },
+];
+
+// The `mediasoup` crate (rust/Cargo.toml) drives both the Git tag (rust-X.X.X)
+// and the rust/CHANGELOG.md entry that the GitHub release is built from.
+const MEDIASOUP_MANIFEST = 'rust/Cargo.toml';
+const RUST_CHANGELOG = 'rust/CHANGELOG.md';
+
+const task = process.argv[2];
+
+void run();
+
+async function run() {
+	logInfo('');
+
+	switch (task) {
+		case 'release:check': {
+			await checkRelease();
+
+			break;
+		}
+
+		case 'release': {
+			await release();
+
+			break;
+		}
+
+		default: {
+			logError('unknown task');
+
+			exitWithError();
+		}
+	}
+}
+
+/**
+ * Validates that a Rust release can be made: checks which crate versions are not
+ * yet on crates.io, that rust/CHANGELOG.md has a matching entry (if the
+ * `mediasoup` crate itself is being published) and that the crates build/package.
+ * Returns the data needed to perform the release, or null if there is nothing to
+ * release.
+ */
+async function checkRelease() {
+	logInfo('checkRelease()');
+
+	// Read the current version of every Rust crate.
+	const crates = CRATES.map(crate => ({
+		...crate,
+		...readCrate(crate.manifest),
+	}));
+
+	for (const crate of crates) {
+		logInfo(
+			`checkRelease() | crate '${crate.name}' version is ${crate.version}`
+		);
+	}
+
+	// The `mediasoup` crate version is the one used for the Git tag and the
+	// CHANGELOG entry.
+	const mediasoupVersion = crates.find(
+		crate => crate.manifest === MEDIASOUP_MANIFEST
+	).version;
+	const tag = `rust-${mediasoupVersion}`;
+
+	// Detect which crates have a version not yet published on crates.io.
+	let cratesToPublish;
+
+	try {
+		cratesToPublish = await getUnpublishedCrates(crates);
+	} catch (error) {
+		logError(error.message);
+
+		exitWithError();
+	}
+
+	if (cratesToPublish.length === 0) {
+		logInfo(
+			'checkRelease() | all Rust crate versions are already published, nothing to release'
+		);
+
+		return null;
+	}
+
+	logInfo(
+		`checkRelease() | crates to publish: ${cratesToPublish
+			.map(crate => `${crate.name} (${crate.version})`)
+			.join(', ')}`
+	);
+
+	// The Git tag and GitHub release are created only when the `mediasoup` crate
+	// itself is being published (they are keyed on its version).
+	const releaseMediasoup = cratesToPublish.some(
+		crate => crate.manifest === MEDIASOUP_MANIFEST
+	);
+
+	let versionChanges;
+
+	if (releaseMediasoup) {
+		// Verify that rust/CHANGELOG.md has an entry for the `mediasoup` crate
+		// version and grab its changes (used as the GitHub release body).
+		try {
+			versionChanges = await getVersionChanges(mediasoupVersion);
+		} catch (error) {
+			logError(error.message);
+
+			exitWithError();
+		}
+	} else {
+		logInfo(
+			`checkRelease() | mediasoup ${mediasoupVersion} is already published, will not create a Git tag/release`
+		);
+	}
+
+	// Validate packaging of the crates before the irreversible release steps
+	// (git push, GitHub release, cargo publish).
+	publishDryRun();
+
+	return { tag, releaseMediasoup, versionChanges, cratesToPublish };
+}
+
+async function release() {
+	logInfo('release()');
+
+	// Refuse to release with a dirty working tree. `cargo publish` would refuse
+	// to publish modified local files anyway (see doc/Rust-crates.md).
+	checkGitClean();
+
+	const releaseInfo = await checkRelease();
+
+	// Nothing to release.
+	if (!releaseInfo) {
+		return;
+	}
+
+	const { tag, releaseMediasoup, versionChanges, cratesToPublish } =
+		releaseInfo;
+
+	// Create the Git tag and the GitHub release only when the `mediasoup` crate
+	// itself is being published. If the tag already exists (e.g. a previous run
+	// was interrupted), skip this step but still publish below.
+	if (releaseMediasoup && !gitTagExists(tag)) {
+		let octokit;
+
+		try {
+			octokit = await getOctokit();
+		} catch (error) {
+			logError(error.message);
+
+			exitWithError();
+		}
+
+		// Create and push the annotated tag (see doc/Rust-crates.md).
+		executeCmd(`git tag -a ${tag} -m ${tag}`);
+		executeCmd(`git push origin ${tag}`);
+
+		logInfo(`release() | creating release '${tag}' in GitHub`);
+
+		await octokit.repos.createRelease({
+			owner: GH_OWNER,
+			repo: GH_REPO,
+			name: tag,
+			body: versionChanges,
+			tag_name: tag,
+			draft: false,
+		});
+	}
+
+	// Publish the crates to crates.io (see doc/Rust-crates.md). They are
+	// published in dependency order (the order of `CRATES`). `--locked` makes
+	// cargo abort if Cargo.lock is out of date instead of silently regenerating
+	// it.
+	for (const crate of cratesToPublish) {
+		executeInteractiveCmd('cargo publish --locked', { cwd: crate.dir });
+	}
+}
+
+/**
+ * Returns the subset of the given crates whose exact version is not yet
+ * published on crates.io (so it has to be published).
+ */
+async function getUnpublishedCrates(crates) {
+	const unpublishedCrates = [];
+
+	for (const crate of crates) {
+		if (!(await isCratePublished(crate.name, crate.version))) {
+			unpublishedCrates.push(crate);
+		}
+	}
+
+	return unpublishedCrates;
+}
+
+/**
+ * Tells whether the given crate version is already published on crates.io by
+ * querying its API. Throws if crates.io cannot be reached or replies with an
+ * unexpected status (so we never publish or skip based on a wrong guess).
+ */
+async function isCratePublished(name, version) {
+	const url = `https://crates.io/api/v1/crates/${name}/${version}`;
+
+	let res;
+
+	try {
+		res = await fetch(url, {
+			// NOTE: crates.io requires a meaningful User-Agent.
+			headers: {
+				'User-Agent': `${GH_OWNER}/${GH_REPO} (https://github.com/${GH_OWNER}/${GH_REPO})`,
+			},
+		});
+	} catch (error) {
+		// eslint-disable-next-line preserve-caught-error
+		throw new Error(
+			`failed to reach crates.io for '${name}@${version}': ${error}`
+		);
+	}
+
+	// 200 means the version exists, 404 means it does not.
+	if (res.status === 200) {
+		return true;
+	} else if (res.status === 404) {
+		return false;
+	}
+
+	throw new Error(
+		`unexpected crates.io response for '${name}@${version}': ${res.status} ${res.statusText}`
+	);
+}
+
+/**
+ * Mimics getVersionChanges() in npm-scripts.mjs: looks up the heading matching
+ * the given version in rust/CHANGELOG.md and returns the raw markdown of its
+ * changes. Exits with error if there is no such entry.
+ */
+async function getVersionChanges(version) {
+	logInfo(`getVersionChanges() [version:${version}]`);
+
+	// NOTE: Load dep on demand since it's a devDependency.
+	const marked = await import('marked');
+
+	const changelog = fs.readFileSync(RUST_CHANGELOG, { encoding: 'utf-8' });
+	const entries = marked.lexer(changelog);
+
+	for (let idx = 0; idx < entries.length; ++idx) {
+		const entry = entries[idx];
+
+		if (entry.type === 'heading' && entry.text === version) {
+			// Collect every token after the matching heading until the next heading.
+			// NOTE: We cannot just use `entries[idx + 1].raw` because `marked`
+			// inserts a `space` token between the heading and its content.
+			let changes = '';
+
+			for (let next = idx + 1; next < entries.length; ++next) {
+				if (entries[next].type === 'heading') {
+					break;
+				}
+
+				changes += entries[next].raw;
+			}
+
+			changes = changes.trim();
+
+			if (changes) {
+				return changes;
+			}
+
+			break;
+		}
+	}
+
+	// This should not happen (unless author forgot to update the CHANGELOG).
+	throw new Error(
+		`no entry found in ${RUST_CHANGELOG} for version '${version}'`
+	);
+}
+
+/**
+ * Validates packaging of the three Rust crates without uploading anything, the
+ * same way doc/Rust-crates.md recommends. They are passed as a single group so
+ * Cargo resolves the dependencies among them against the locally packaged copies
+ * instead of crates.io (works even if the new versions are not published yet).
+ */
+function publishDryRun() {
+	logInfo('publishDryRun()');
+
+	executeCmd(
+		'cargo publish --dry-run -p mediasoup-types -p mediasoup-sys -p mediasoup'
+	);
+}
+
+async function getOctokit() {
+	if (!process.env.GITHUB_TOKEN) {
+		throw new Error('missing GITHUB_TOKEN environment variable');
+	}
+
+	// NOTE: Load dep on demand since it's a devDependency.
+	const { Octokit } = await import('@octokit/rest');
+
+	const octokit = new Octokit({
+		auth: process.env.GITHUB_TOKEN,
+	});
+
+	return octokit;
+}
+
+function checkGitClean() {
+	const status = execSync('git status --porcelain', {
+		encoding: 'utf-8',
+		stdio: ['ignore', 'pipe', 'ignore'],
+	});
+
+	if (status.trim()) {
+		logError(
+			'checkGitClean() | Git working tree is not clean, commit or stash your changes first'
+		);
+
+		exitWithError();
+	}
+}
+
+function gitTagExists(tag) {
+	try {
+		execSync(`git rev-parse --verify --quiet refs/tags/${tag}`, {
+			stdio: ['ignore', 'ignore', 'ignore'],
+		});
+
+		return true;
+	} catch (error) {
+		return false;
+	}
+}
+
+function readCrate(manifestPath) {
+	const content = fs.readFileSync(manifestPath, { encoding: 'utf-8' });
+
+	return parseManifest(content);
+}
+
+/**
+ * Extracts `name` and `version` from the `[package]` section of a Cargo.toml,
+ * ignoring the `version` keys under `[dependencies.*]` sections.
+ */
+function parseManifest(content) {
+	let inPackageSection = false;
+	let name;
+	let version;
+
+	for (const line of content.split('\n')) {
+		const trimmed = line.trim();
+
+		// A new section starts. We only care about `[package]`.
+		if (trimmed.startsWith('[')) {
+			inPackageSection = trimmed === '[package]';
+
+			continue;
+		}
+
+		if (!inPackageSection) {
+			continue;
+		}
+
+		const nameMatch = trimmed.match(/^name\s*=\s*"([^"]+)"/);
+
+		if (nameMatch) {
+			name = nameMatch[1];
+
+			continue;
+		}
+
+		const versionMatch = trimmed.match(/^version\s*=\s*"([^"]+)"/);
+
+		if (versionMatch) {
+			version = versionMatch[1];
+		}
+	}
+
+	if (!name || !version) {
+		throw new Error(
+			"failed to parse 'name'/'version' from Cargo.toml [package] section"
+		);
+	}
+
+	return { name, version };
+}
+
+function executeCmd(command) {
+	logInfo(`executeCmd(): ${command}`);
+
+	try {
+		execSync(command, { stdio: ['ignore', process.stdout, process.stderr] });
+	} catch (error) {
+		logError(`executeCmd() failed, exiting: ${error}`);
+
+		exitWithError();
+	}
+}
+
+function executeInteractiveCmd(command, { cwd } = {}) {
+	logInfo(`executeInteractiveCmd(): ${command}${cwd ? ` [cwd:${cwd}]` : ''}`);
+
+	try {
+		execSync(command, { cwd, stdio: 'inherit', env: process.env });
+	} catch (error) {
+		logError(`executeInteractiveCmd() failed, exiting: ${error}`);
+
+		exitWithError();
+	}
+}
+
+function logInfo(...args) {
+	// eslint-disable-next-line no-console
+	console.log(`rust-scripts.mjs \x1b[36m[INFO] [${task}]\x1b[0m`, ...args);
+}
+
+// eslint-disable-next-line no-unused-vars
+function logWarn(...args) {
+	// eslint-disable-next-line no-console
+	console.warn(`rust-scripts.mjs \x1b[33m[WARN] [${task}]\x1b[0m`, ...args);
+}
+
+function logError(...args) {
+	// eslint-disable-next-line no-console
+	console.error(`rust-scripts.mjs \x1b[31m[ERROR] [${task}]\x1b[0m`, ...args);
+}
+
+function exitWithError() {
+	process.exit(1);
+}

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -21,7 +21,6 @@ ENV CC="clang-21"
 ENV CXX="clang++-21"
 
 ENV MEDIASOUP_LOCAL_DEV="true"
-ENV KEEP_BUILD_ARTIFACTS="1"
 
 WORKDIR "/foo bar/mediasoup"
 

--- a/worker/Dockerfile.386
+++ b/worker/Dockerfile.386
@@ -18,7 +18,6 @@ RUN set -x \
 ENV LANG="C.UTF-8"
 
 ENV MEDIASOUP_LOCAL_DEV="true"
-ENV KEEP_BUILD_ARTIFACTS="1"
 
 WORKDIR "/foo bar/mediasoup"
 

--- a/worker/Dockerfile.alpine
+++ b/worker/Dockerfile.alpine
@@ -10,7 +10,6 @@ ENV CC="gcc"
 ENV CXX="g++"
 
 ENV MEDIASOUP_LOCAL_DEV="true"
-ENV KEEP_BUILD_ARTIFACTS="1"
 
 WORKDIR "/foo bar/mediasoup"
 

--- a/worker/build.rs
+++ b/worker/build.rs
@@ -209,13 +209,19 @@ fn main() {
     // source tree must be left untouched, otherwise Cargo fails with "Source
     // directory was modified by build.rs". Meson extracts the wrap subprojects
     // into the source tree, so we must always clean them here regardless of
-    // `KEEP_BUILD_ARTIFACTS` (which a developer may have exported to speed up
+    // `MEDIASOUP_LOCAL_DEV` (which a developer may have exported to speed up
     // their regular local builds).
     let is_publish_verification = env::var("CARGO_MANIFEST_DIR")
         .map(|dir| dir.replace('\\', "/").contains("/target/package/"))
         .unwrap_or(false);
 
-    if is_publish_verification || env::var("KEEP_BUILD_ARTIFACTS") != Ok("1".to_string()) {
+    // `MEDIASOUP_LOCAL_DEV` is considered enabled when set to any non-empty value
+    // (matching how npm-scripts.mjs treats it).
+    let is_local_dev = env::var("MEDIASOUP_LOCAL_DEV")
+        .map(|value| !value.is_empty())
+        .unwrap_or(false);
+
+    if is_publish_verification || !is_local_dev {
         // Clean
         if !Command::new(python)
             .arg("-m")


### PR DESCRIPTION
# Details

- Add `rust-scripts.mjs` script which "release:check" and "release" actions.
- They are controlled via `npm` scripts:: `npm run release:rust:check` and `npm run release:rust`.
- They are similar to the ones in `npm-scripts.mjs` and run lint, test, doc, changelog file, etc.
- The "release" one also publishes the modified crates.
- The "release" script creates not only a `rust-x.x.x` tag in GitHub but also a `rust-x.x.x` release.

## Bonus tracks

- Rename `KEEP_BUILD_ARTIFACTS` env (using when building mediasoup Rust) to `MEDIASOUP_LOCAL_DEV` so both Node and Rust use the same env to avoid rebuilding everything from scratch when in local development.
- `npm-scripts.mjs`: Make "release:check" **also** verify that `CHANGELOG.md` is in sync with version in `package.json`.
