### PR TITLE
Add NPM publish CI and website publish workflows

### DIFF
--- a/.github/workflows/mediasoup-npm-publish.yaml
+++ b/.github/workflows/mediasoup-npm-publish.yaml
@@ -1,0 +1,130 @@
+name: mediasoup-npm-publish
+
+# Triggered by pushing a Node release tag (SEMVER, e.g. 3.20.8), which the
+# `release` task in npm-scripts.mjs creates. It checks version consistency,
+# creates the GitHub release from the CHANGELOG and publishes the NPM package via
+# OIDC trusted publishing.
+#
+# Only if this workflow succeeds, mediasoup-worker-prebuild.yaml runs (via its
+# workflow_run trigger) to build the mediasoup-worker prebuilt binaries and
+# upload them to the GitHub release.
+on:
+  push:
+    tags:
+      # Node release tags only (SEMVER). Rust tags (rust-X.Y.Z) don't match.
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  # Don't cancel an in-progress publish if a new run lands in the same group.
+  cancel-in-progress: false
+
+jobs:
+  check:
+    runs-on: ubuntu-26.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+
+      - name: Check version consistency
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag='${{ github.ref_name }}'
+          version=$(jq -r '.version' package.json)
+          package_lock_version=$(jq -r '.version' package-lock.json)
+          package_lock_root_version=$(jq -r '.packages[""].version' package-lock.json)
+          echo "tag=${tag} package.json=${version} package-lock.json=${package_lock_version}/${package_lock_root_version}"
+          if [ "${version}" != "${tag}" ]; then
+            echo "package.json version '${version}' does not match release tag '${tag}'"
+            exit 1
+          fi
+          if [ "${package_lock_version}" != "${version}" ] || [ "${package_lock_root_version}" != "${version}" ]; then
+            echo "package-lock.json version does not match package.json version '${version}'"
+            exit 1
+          fi
+
+      - name: Ensure mediasoup version is not already published on NPM
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(jq -r '.version' package.json)
+          published_version=$(npm view "mediasoup@${version}" version 2>/dev/null || true)
+          if [ "${published_version}" = "${version}" ]; then
+            echo "mediasoup@${version} is already published on NPM, this should not happen"
+            exit 1
+          fi
+
+  # Create the GitHub release from the matching CHANGELOG.md entry.
+  release:
+    needs: check
+    if: ${{ !cancelled() && needs.check.result == 'success' }}
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Extract the CHANGELOG.md section for this version.
+          notes=$(awk -v h="### ${TAG}" '$0==h {f=1; next} /^### / && f {exit} f {print}' CHANGELOG.md)
+          if [ -z "$(printf '%s' "${notes}" | tr -d '[:space:]')" ]; then
+            echo "No CHANGELOG.md entry found for '${TAG}'"
+            exit 1
+          fi
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "GitHub release '${TAG}' already exists, skipping creation"
+          else
+            printf '%s\n' "${notes}" | gh release create "${TAG}" --title "${TAG}" --notes-file -
+          fi
+
+  # Publish the NPM package via OIDC trusted publishing.
+  publish:
+    needs: [check, release]
+    if: ${{ !cancelled() && needs.check.result == 'success' && needs.release.result == 'success' }}
+    runs-on: ubuntu-26.04
+    permissions:
+      # Allow requesting short-lived OIDC token used for NPM trusted publishing.
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.ref_name }}
+
+      - name: Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 26
+          registry-url: 'https://registry.npmjs.org'
+
+      # Trusted publishing requires a recent npm (>= 11.5.1).
+      - name: Update npm
+        run: npm install -g npm@latest
+
+      # `--ignore-scripts` skips the package postinstall (no mediasoup-worker
+      # build/download needed here). `npm publish` below then runs the `prepare`
+      # script (flatbuffers generation and TypeScript build) to assemble the
+      # package, and publishes via OIDC with provenance.
+      - name: npm ci --ignore-scripts --foreground-scripts
+        run: npm ci --ignore-scripts --foreground-scripts
+
+      - name: npm publish
+        run: npm publish

--- a/.github/workflows/mediasoup-website-publish.yaml
+++ b/.github/workflows/mediasoup-website-publish.yaml
@@ -1,0 +1,50 @@
+name: mediasoup-website-publish
+
+# Triggered when mediasoup-npm-publish.yaml finishes successfully (workflow_run).
+# It triggers the `website-publish` workflow in versatica/mediasoup-website (via
+# workflow_dispatch, no inputs), which builds the website and deploys it.
+#
+# It can also be triggered manually (workflow_dispatch) to re-trigger the website
+# update (for example if the previous attempt failed).
+on:
+  workflow_run:
+    workflows: ['mediasoup-npm-publish']
+    # workflow_run only has 'requested', 'in_progress' and 'completed' activity
+    # types (there is no 'success'/'failure' type). 'completed' fires once the
+    # upstream run has fully finished, regardless of its conclusion. The actual
+    # success is gated in the job's `if` below, via
+    # github.event.workflow_run.conclusion.
+    types: [completed]
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch || github.ref_name }}
+  # Don't cancel an in-progress trigger if a new run lands in the same group.
+  cancel-in-progress: false
+
+jobs:
+  # Trigger the `website-publish` workflow in versatica/mediasoup-website.
+  trigger:
+    # Run only when triggered manually, or when the upstream mediasoup-npm-publish
+    # run finished successfully. This guarantees we never update the website for a
+    # release whose NPM publish failed.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-26.04
+    steps:
+      # Allow a short-lived installation token for the GitHub App. The App's
+      # private key (stored as a secret) does not expire but this token does, but
+      # it is generated automatically on every run, so there is nothing to renew
+      # manually.
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.WEBSITE_APP_ID }}
+          private-key: ${{ secrets.WEBSITE_APP_PRIVATE_KEY }}
+          owner: versatica
+          repositories: mediasoup-website
+
+      - name: Trigger website-publish workflow
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh workflow run website-publish.yaml --repo versatica/mediasoup-website

--- a/.github/workflows/mediasoup-worker-prebuild.yaml
+++ b/.github/workflows/mediasoup-worker-prebuild.yaml
@@ -1,16 +1,47 @@
 name: mediasoup-worker-prebuild
 
-# Only trigger on GitHub releases.
+# Triggered when mediasoup-npm-publish.yaml finishes successfully (workflow_run).
+# It builds the mediasoup-worker prebuilt binaries for all supported platforms
+# and uploads them to the GitHub release that mediasoup-npm-publish.yaml already
+# created.
+#
+# It can also be triggered manually (workflow_dispatch) to re-build and re-upload
+# the prebuilt binaries for a given release tag (for example if a platform
+# failed), by entering the release tag/version in the GitHub Actions tab.
 on:
-  release:
-    types: [published]
+  workflow_run:
+    workflows: ['mediasoup-npm-publish']
+    # workflow_run can fire on different activity types of the upstream run:
+    #   - requested: the upstream run was created/queued.
+    #   - in_progress: the upstream run started executing.
+    #   - completed: the upstream run finished, with ANY conclusion (success,
+    #     failure, cancelled, skipped, timed_out, action_required, ...).
+    # We want 'completed' because that's the only activity type that fires once
+    # the upstream run has fully finished. The conclusion is then gated in the
+    # job's `if` below, so we only build the prebuilt binaries when the NPM
+    # publish actually succeeded.
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to (re)build and upload mediasoup-worker prebuilt binaries'
+        required: true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.release_tag || github.event.workflow_run.head_branch }}
+  # Don't cancel an in-progress prebuild if a new run lands in the same group.
+  cancel-in-progress: false
 
 jobs:
-  ci:
-    # Only run for Node releases (tag X.Y.Z) and not for Rust releases (tag
-    # rust-X.Y.Z), which are created by rust-scripts.mjs and must not trigger
-    # mediasoup-worker prebuilds.
-    if: ${{ !startsWith(github.event.release.tag_name, 'rust-') }}
+  # Build the mediasoup-worker prebuilt binaries and upload them to the GH
+  # release.
+  prebuild:
+    # Run only when triggered manually, or when the upstream mediasoup-npm-publish
+    # run finished successfully. This guarantees we never build/upload binaries
+    # for a release whose NPM publish failed.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      contents: write
     strategy:
       # Here we want to see all errors, not just the first one.
       fail-fast: false
@@ -55,14 +86,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release_tag || github.event.workflow_run.head_branch }}
 
       - name: Node.js
         uses: actions/setup-node@v6
         with:
           node-version: 26
 
-      # We need to install some NPM production deps for npm-scripts.mjs to
-      # work.
+      # We need to install some NPM production deps for npm-scripts.mjs to work.
       - name: npm ci --ignore-scripts --omit=dev --foreground-scripts
         run: npm ci --ignore-scripts --omit=dev --foreground-scripts
 
@@ -72,11 +104,11 @@ jobs:
       - name: npm run worker:build
         run: npm run worker:build
 
-      # Publish prebuild binaries on tag.
       - name: npm run worker:prebuild
         run: npm run worker:prebuild
 
       - name: Upload mediasoup-worker prebuilt binary
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ inputs.release_tag || github.event.workflow_run.head_branch }}
           files: worker/prebuild/mediasoup-worker-*.tgz

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
 [![][github-actions-shield-mediasoup-worker-fuzzer]][github-actions-mediasoup-worker-fuzzer]
 [![][github-actions-shield-mediasoup-npm-publish]][github-actions-mediasoup-npm-publish]
 [![][github-actions-shield-mediasoup-worker-prebuild]][github-actions-mediasoup-worker-prebuild]
+[![][github-actions-shield-mediasoup-website-publish]][github-actions-mediasoup-website-publish]
 [![][github-actions-mediasoup-codeql-shield-mediasoup]][github-actions-mediasoup-codeql-mediasoup]
 
 ## Website and Documentation
@@ -107,6 +108,8 @@ You can support mediasoup by [sponsoring][sponsor] it. Thanks!
 [github-actions-mediasoup-worker-prebuild]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-prebuild.yaml?query=event%3Aworkflow_run
 [github-actions-shield-mediasoup-npm-publish]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-npm-publish.yaml/badge.svg?event=push
 [github-actions-mediasoup-npm-publish]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-npm-publish.yaml?query=event%3Apush
+[github-actions-shield-mediasoup-website-publish]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-website-publish.yaml/badge.svg?event=workflow_run
+[github-actions-mediasoup-website-publish]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-website-publish.yaml?query=event%3Aworkflow_run
 [github-actions-mediasoup-codeql-shield-mediasoup]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-codeql.yaml/badge.svg?branch=v3
 [github-actions-mediasoup-codeql-mediasoup]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-codeql.yaml?query=branch%3Av3
 [sponsor]: https://mediasoup.org/sponsor

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![][github-actions-shield-mediasoup-worker]][github-actions-mediasoup-worker]
 [![][github-actions-shield-mediasoup-rust]][github-actions-mediasoup-rust]
 [![][github-actions-shield-mediasoup-worker-fuzzer]][github-actions-mediasoup-worker-fuzzer]
+[![][github-actions-shield-mediasoup-npm-publish]][github-actions-mediasoup-npm-publish]
 [![][github-actions-shield-mediasoup-worker-prebuild]][github-actions-mediasoup-worker-prebuild]
 [![][github-actions-mediasoup-codeql-shield-mediasoup]][github-actions-mediasoup-codeql-mediasoup]
 
@@ -102,8 +103,10 @@ You can support mediasoup by [sponsoring][sponsor] it. Thanks!
 [github-actions-mediasoup-rust]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-rust.yaml?query=branch%3Av3
 [github-actions-shield-mediasoup-worker-fuzzer]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-fuzzer.yaml/badge.svg?branch=v3
 [github-actions-mediasoup-worker-fuzzer]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-fuzzer.yaml?query=branch%3Av3
-[github-actions-shield-mediasoup-worker-prebuild]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-prebuild.yaml/badge.svg?event=release
-[github-actions-mediasoup-worker-prebuild]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-prebuild.yaml?query=event%3Arelease
+[github-actions-shield-mediasoup-worker-prebuild]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-prebuild.yaml/badge.svg?event=workflow_run
+[github-actions-mediasoup-worker-prebuild]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-prebuild.yaml?query=event%3Aworkflow_run
+[github-actions-shield-mediasoup-npm-publish]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-npm-publish.yaml/badge.svg?event=push
+[github-actions-mediasoup-npm-publish]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-npm-publish.yaml?query=event%3Apush
 [github-actions-mediasoup-codeql-shield-mediasoup]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-codeql.yaml/badge.svg?branch=v3
 [github-actions-mediasoup-codeql-mediasoup]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-codeql.yaml?query=branch%3Av3
 [sponsor]: https://mediasoup.org/sponsor

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -106,15 +106,20 @@ Same as `test:node` task but it also opens a browser window with TypeScript cove
 
 Runs linters and tests in Node and C++ code. Also verifies that `CHANGELOG.md` has an entry matching the `mediasoup` version in `package.json`.
 
-### `npm run release`
+### `npm run release x.y.z`
 
-Publishes a new NPM version of mediasoup. Requirements for it to work:
+Prepares and triggers the release of a new NPM version "x.y.z" of mediasoup. The actual GitHub release and NPM publish are done by CI (`mediasoup-npm-publish.yaml`) once the pushed tag arrives. It:
 
+- Performs checks (lint + test + build + publish dry-run + `CHANGELOG.md` entry check). It runs before the version bump, so the CHANGELOG check validates the previous version's entry (still in package.json), which is harmless.
+- Bumps the version to "x.y.z" in `package.json` and `package-lock.json` with `npm version x.y.z --no-git-tag-version`, and sets the top `### NEXT` heading of `CHANGELOG.md` to `### x.y.z`.
+- Commits the bump as "version x.y.z", creates the "x.y.z" tag, and pushes the branch and the tag.
+
+Requirements for it to work:
+
+- Must be called with a SEMVER version as single argument.
 - Must be in the main branch.
-- "version" field in `package.json` must have been incremented (and not commited to Git).
-- `CHANGELOG.md` file must have been updated with an entry matching the new version.
-- A `GITHUB_TOKEN` environment variable with permissions to create releases in GitHub is required.
-- Of course, permissions to publish in NPM registry are required.
+- Work tree must be clean.
+- Changes for the new version must be under the `### NEXT` heading in `CHANGELOG.md`.
 
 ### `npm run release:rust:check`
 

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -19,8 +19,6 @@ const WORKER_RELEASE_BIN = IS_WINDOWS
 	: 'mediasoup-worker';
 const WORKER_RELEASE_BIN_PATH = `${WORKER_RELEASE_DIR}/${WORKER_RELEASE_BIN}`;
 const WORKER_PREBUILD_DIR = 'worker/prebuild';
-const GH_OWNER = 'versatica';
-const GH_REPO = 'mediasoup';
 
 // Paths for ESLint to check.
 const ESLINT_PATHS = [
@@ -576,7 +574,17 @@ async function checkRelease() {
 async function release() {
 	logInfo('release()');
 
-	// Make sure we are on the main branch.
+	const version = taskArgs.trim();
+
+	if (!/^\d+\.\d+\.\d+$/.test(version)) {
+		logError(
+			`release() | a SEMVER 'x.y.z' argument is required, but got '${version}'`
+		);
+
+		exitWithError();
+	}
+
+	// Must be on the main branch.
 	const branch = execSync('git rev-parse --abbrev-ref HEAD', {
 		encoding: 'utf-8',
 	}).trim();
@@ -589,36 +597,25 @@ async function release() {
 		exitWithError();
 	}
 
-	let octokit;
+	// Clean working tree required before bumping the version.
+	checkGitClean();
 
-	try {
-		octokit = await getOctokit();
-	} catch (error) {
-		logError(error.message);
+	// Lint, test, build, publish dry-run, and verify the CHANGELOG entry (of the
+	// previous version still in package.json, which is harmless).
+	await checkRelease();
 
-		exitWithError();
-	}
+	// Bump the version in package.json + package-lock.json and in CHANGELOG.md.
+	executeCmd(`npm version ${version} --no-git-tag-version`);
+	await updateChangelog(version);
 
-	const { versionChanges } = await checkRelease();
-
-	// The local repo ust be "dirty" so the script can commit now.
-	executeCmd(`git commit -am '${pkg.version}'`);
+	// Commit the bump, tag it, and push both. The pushed tag triggers
+	// mediasoup-npm-publish.yaml, which checks, creates the GitHub release and
+	// publishes to NPM; on its success mediasoup-worker-prebuild.yaml builds and
+	// uploads the prebuilt binaries.
+	executeCmd(`git commit -am 'version ${version}'`);
+	executeCmd(`git tag -a ${version} -m '${version}'`);
 	executeCmd(`git push origin ${MAIN_BRANCH}`);
-	executeCmd(`git tag -a ${pkg.version} -m '${pkg.version}'`);
-	executeCmd(`git push origin '${pkg.version}'`);
-
-	logInfo(`release() | creating release '${pkg.version}' in GitHub`);
-
-	await octokit.repos.createRelease({
-		owner: GH_OWNER,
-		repo: GH_REPO,
-		name: pkg.version,
-		body: versionChanges,
-		tag_name: pkg.version,
-		draft: false,
-	});
-
-	executeInteractiveCmd('npm publish');
+	executeCmd(`git push origin '${version}'`);
 }
 
 function ensureDir(dir) {
@@ -788,19 +785,21 @@ async function downloadPrebuiltWorker() {
 	});
 }
 
-async function getOctokit() {
-	if (!process.env.GITHUB_TOKEN) {
-		throw new Error('missing GITHUB_TOKEN environment variable');
-	}
+function checkGitClean() {
+	logInfo('checkGitClean()');
 
-	// NOTE: Load dep on demand since it's a devDependency.
-	const { Octokit } = await import('@octokit/rest');
-
-	const octokit = new Octokit({
-		auth: process.env.GITHUB_TOKEN,
+	const status = execSync('git status --porcelain', {
+		encoding: 'utf-8',
+		stdio: ['ignore', 'pipe', 'ignore'],
 	});
 
-	return octokit;
+	if (status.trim()) {
+		logError(
+			'checkGitClean() | Git working tree is not clean, commit or stash your changes first'
+		);
+
+		exitWithError();
+	}
 }
 
 async function getVersionChanges() {
@@ -845,6 +844,35 @@ async function getVersionChanges() {
 	);
 }
 
+async function updateChangelog(version) {
+	logInfo(`updateChangelog() [version:${version}]`);
+
+	// NOTE: Load dep on demand since it's a devDependency.
+	const marked = await import('marked');
+
+	const changelog = fs.readFileSync('./CHANGELOG.md', { encoding: 'utf-8' });
+	const tokens = marked.lexer(changelog);
+
+	// Locate the top "### NEXT" heading.
+	const nextHeading = tokens.find(
+		token =>
+			token.type === 'heading' && token.depth === 3 && token.text === 'NEXT'
+	);
+
+	if (!nextHeading) {
+		throw new Error("no '### NEXT' heading found in CHANGELOG.md");
+	}
+
+	// Insert "### <version>" right below "### NEXT" (keeping the empty "### NEXT"
+	// for future unreleased changes), preserving the heading's trailing newlines.
+	const updatedChangelog = changelog.replace(
+		nextHeading.raw,
+		`### NEXT\n\n### ${version}${nextHeading.raw.slice('### NEXT'.length)}`
+	);
+
+	fs.writeFileSync('./CHANGELOG.md', updatedChangelog);
+}
+
 function executeCmd(command) {
 	logInfo(`executeCmd(): ${command}`);
 
@@ -857,6 +885,7 @@ function executeCmd(command) {
 	}
 }
 
+// eslint-disable-next-line no-unused-vars
 function executeInteractiveCmd(command, { cwd } = {}) {
 	logInfo(`executeInteractiveCmd(): ${command}${cwd ? ` [cwd:${cwd}]` : ''}`);
 

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -139,13 +139,13 @@ async function run() {
 		}
 
 		case 'typescript:build': {
-			buildTypescript({ force: true });
+			buildTypescript({ force: true, args: taskArgs });
 
 			break;
 		}
 
 		case 'typescript:watch': {
-			watchTypescript();
+			watchTypescript({ args: taskArgs });
 
 			break;
 		}
@@ -217,7 +217,7 @@ async function run() {
 		}
 
 		case 'test:node': {
-			testNode();
+			testNode({ args: taskArgs });
 
 			break;
 		}
@@ -229,7 +229,7 @@ async function run() {
 		}
 
 		case 'coverage:node': {
-			coverageNode();
+			coverageNode({ args: taskArgs });
 
 			break;
 		}
@@ -247,7 +247,7 @@ async function run() {
 		}
 
 		case 'release': {
-			await release();
+			await release({ args: taskArgs });
 
 			break;
 		}
@@ -319,7 +319,7 @@ function deleteNodeLib() {
 	fs.rmSync('node/lib', { recursive: true, force: true });
 }
 
-function buildTypescript({ force }) {
+function buildTypescript({ force, args = '' }) {
 	// Skip JavaScript code generation if the output already exists, unless forced.
 	if (!force && fs.existsSync('node/lib')) {
 		return;
@@ -329,15 +329,15 @@ function buildTypescript({ force }) {
 
 	deleteNodeLib();
 
-	executeCmd(`tsc ${taskArgs}`);
+	executeCmd(`tsc ${args}`);
 }
 
-function watchTypescript() {
+function watchTypescript({ args = '' } = {}) {
 	logInfo('watchTypescript()');
 
 	deleteNodeLib();
 
-	executeCmd(`tsc --watch ${taskArgs}`);
+	executeCmd(`tsc --watch ${args}`);
 }
 
 function buildWorker() {
@@ -489,10 +489,10 @@ function flatcWorker() {
 	executeCmd(`"${PYTHON}" -m invoke -r worker flatc`);
 }
 
-function testNode() {
+function testNode({ args = '' } = {}) {
 	logInfo('testNode()');
 
-	executeCmd(`jest --silent false --detectOpenHandles ${taskArgs}`);
+	executeCmd(`jest --silent false --detectOpenHandles ${args}`);
 }
 
 function testWorker() {
@@ -503,10 +503,10 @@ function testWorker() {
 	executeCmd(`"${PYTHON}" -m invoke -r worker test`);
 }
 
-function coverageNode() {
+function coverageNode({ args = '' } = {}) {
 	logInfo('coverageNode()');
 
-	executeCmd(`jest --coverage ${taskArgs}`);
+	executeCmd(`jest --coverage ${args}`);
 	executeCmd('open-cli coverage/lcov-report/index.html');
 }
 
@@ -571,10 +571,10 @@ async function checkRelease() {
 	return { versionChanges };
 }
 
-async function release() {
+async function release({ args = '' } = {}) {
 	logInfo('release()');
 
-	const version = taskArgs.trim();
+	const version = args.trim();
 
 	if (!/^\d+\.\d+\.\d+$/.test(version)) {
 		logError(

--- a/rust-scripts.mjs
+++ b/rust-scripts.mjs
@@ -376,6 +376,8 @@ async function getOctokit() {
 }
 
 function checkGitClean() {
+	logInfo('checkGitClean()');
+
 	const status = execSync('git status --porcelain', {
 		encoding: 'utf-8',
 		stdio: ['ignore', 'pipe', 'ignore'],


### PR DESCRIPTION
# Details

- As proposed in https://github.com/versatica/mediasoup/issues/1837#issuecomment-4742773466.
- I've created a "Trusted Publisher" in the mediasoup NPM package settings (see https://www.npmjs.com/package/mediasoup/access), needed for the flow below.

## mediasoup NPM release publish and website build/publish trigger flows

1. Run `npm run release X.Y.Z` locally, where "X.Y.Z" is the desired new version.
   - Work tree must be clean and the new "X.Y.Z" version MUST NOT be already in `package.json`.
   - Changes for the new version must be under the `### NEXT` heading in `CHANGELOG.md`.
   - It performs all checks.
   - It bumps version in `package.json` and `package-lock.json` and `CHANGELOG.md`.
   - It commits the changes and pushes them.
   - It creates and pushes the "X.Y.Z" Git tag.
2. The new `mediasoup-npm-publish.yaml` workflow reacts on the new Git tag and publishes a new GitHub release and a new mediasoup NPM release.
3. The `mediasoup-worker-prebuild.yaml` workflow reacts once `mediasoup-npm-publish.yaml` workflow finishes successfully and builds the worker binaries and publishes them in the GitHub release as usual.
4. The `mediasoup-website-publish.yaml` workflow reacts once `mediasoup-npm-publish.yaml` workflow finishes successfully and triggers the `website-publish` workflow in `mediasoup-website` project, which builds and deploys the website.

## GitHub App "mediasoup-website-dispatcher"

A **GitHub App** has been created to allow `mediasoup` CI trigger website build and publication in the `mediasoup-website` repository. It's been created this way:

1. In https://github.com/organizations/versatica/settings/apps/new:
   - Name: "mediasoup-website-dispatcher"
   - Description: "Allows `mediasoup` CI to trigger the `website-publish` workflow in the `mediasoup-website` repository after a release."
   - Homepage URL (irrelevant): "https://github.com/versatica/mediasoup"
   - Webhook: disabled
   - Permissions: In "Repository permissions" - "Actions": read and write
   - Where can this GitHub App be installed?: "Only on this account" (versatica)
2. Then save and "Generate a private key". A PEM file is downloaded. And we get "App ID" (a number) which will be the `WEBSITE_APP_ID` secret in the workflow while the content of the PEM file will be the `WEBSITE_APP_PRIVATE_KEY` secret.
3. Then install the app in `mediasoup-website` by clicking on "Install App" and choosing "versatica" and `mediasoup-website` repository.
4. Then add the secrets in the `mediasoup` repository settings as repository secrets.
