### PR TITLE
CI: Do not run workflows when publishing a release

### DIFF
--- a/.github/workflows/mediasoup-codeql.yaml
+++ b/.github/workflows/mediasoup-codeql.yaml
@@ -23,6 +23,11 @@ concurrency:
 jobs:
   analyze:
     name: Analyze
+    # Skip the release commit pushed by `npm run release` (its message carries a
+    # "[no-ci]" marker): it only bumps version/CHANGELOG and the release is
+    # driven by the tag-triggered workflows. On pull_request there is no
+    # head_commit, so the guard is a no-op and the job runs.
+    if: ${{ !contains(github.event.head_commit.message, '[no-ci]') }}
     runs-on: ubuntu-26.04
     timeout-minutes: 120
     permissions:

--- a/.github/workflows/mediasoup-node.yaml
+++ b/.github/workflows/mediasoup-node.yaml
@@ -30,6 +30,11 @@ concurrency:
 
 jobs:
   ci:
+    # Skip the release commit pushed by `npm run release` (its message carries a
+    # "[no-ci]" marker): it only bumps version/CHANGELOG and the release is
+    # driven by the tag-triggered workflows. On pull_request there is no
+    # head_commit, so the guard is a no-op and the job runs.
+    if: ${{ !contains(github.event.head_commit.message, '[no-ci]') }}
     strategy:
       # Here we want to see all errors, not just the first one.
       fail-fast: false

--- a/.github/workflows/mediasoup-rust.yaml
+++ b/.github/workflows/mediasoup-rust.yaml
@@ -33,6 +33,11 @@ env:
 
 jobs:
   ci:
+    # Skip the release commit pushed by `npm run release` (its message carries a
+    # "[no-ci]" marker): it only bumps version/CHANGELOG and the release is
+    # driven by the tag-triggered workflows. On pull_request there is no
+    # head_commit, so the guard is a no-op and the job runs.
+    if: ${{ !contains(github.event.head_commit.message, '[no-ci]') }}
     strategy:
       # Here we want to see all errors, not just the first one.
       fail-fast: false

--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -20,6 +20,11 @@ concurrency:
 
 jobs:
   ci:
+    # Skip the release commit pushed by `npm run release` (its message carries a
+    # "[no-ci]" marker): it only bumps version/CHANGELOG and the release is
+    # driven by the tag-triggered workflows. On pull_request there is no
+    # head_commit, so the guard is a no-op and the job runs.
+    if: ${{ !contains(github.event.head_commit.message, '[no-ci]') }}
     strategy:
       matrix:
         build:

--- a/.github/workflows/mediasoup-worker.yaml
+++ b/.github/workflows/mediasoup-worker.yaml
@@ -24,6 +24,11 @@ concurrency:
 
 jobs:
   ci:
+    # Skip the release commit pushed by `npm run release` (its message carries a
+    # "[no-ci]" marker): it only bumps version/CHANGELOG and the release is
+    # driven by the tag-triggered workflows. On pull_request there is no
+    # head_commit, so the guard is a no-op and the job runs.
+    if: ${{ !contains(github.event.head_commit.message, '[no-ci]') }}
     strategy:
       # Here we want to see all errors, not just the first one.
       fail-fast: false

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -612,7 +612,16 @@ async function release({ args = '' } = {}) {
 	// mediasoup-npm-publish.yaml, which checks, creates the GitHub release and
 	// publishes to NPM; on its success mediasoup-worker-prebuild.yaml builds and
 	// uploads the prebuilt binaries.
-	executeCmd(`git commit -am 'release ${version}'`);
+	//
+	// The commit message carries a "[no-ci]" marker so the regular branch CI
+	// workflows (node, worker, rust, fuzzer, codeql) skip this commit: it only
+	// bumps version/CHANGELOG (no code change) and its parent already passed CI,
+	// and the release is driven by the tag-triggered workflows instead.
+	//
+	// NOTE: "[no-ci]" (with a hyphen) is a custom marker, NOT GitHub's native
+	// "[skip ci]"/"[no ci]" (which would also skip mediasoup-npm-publish, since
+	// the tag push shares this same commit).
+	executeCmd(`git commit -am 'release ${version} [no-ci]'`);
 	executeCmd(`git tag -a ${version} -m '${version}'`);
 	executeCmd(`git push origin ${MAIN_BRANCH}`);
 	executeCmd(`git push origin '${version}'`);


### PR DESCRIPTION
# Details

- `release()` in `npm-scripts.mjs` bumps version in `package.json` and `CHANGELOG.md`, commits and pushes it, and then it creates and pushes a tag X.Y.Z.
- The push of the tag will trigger `mediasoup-npm-publish` workflow.
- But we don't want to re-run the other workflows (node, worker, rust, fuzzer, codeql) because of the above tiny/cosmetic commit/push.
- So in the commit we include a message "release X.Y.Z [no-ci]" and inspect it in workflows to prevent them from running.