### PR TITLE
New workflow for publishing mediasoup Rust crates

### DIFF
--- a/.github/workflows/mediasoup-crate-publish.yaml
+++ b/.github/workflows/mediasoup-crate-publish.yaml
@@ -1,0 +1,228 @@
+name: mediasoup-crate-publish
+
+# Publishes a mediasoup Rust crate to crates.io. Triggered by the `release` task
+# in rust-scripts.mjs in one of two ways:
+#
+# - `mediasoup` crate: a pushed `rust-X.Y.Z` Git tag. A GitHub release is created
+#   from the matching rust/CHANGELOG.md entry and the crate is published.
+# - `mediasoup-sys` / `mediasoup-types` crates: a pushed commit on the main
+#   branch whose message is `<crate> X.Y.Z [crate-publish] [no-ci]` (no tag, no
+#   GitHub release). The "[crate-publish]" marker opts the commit in and the
+#   crate name and version are read from the start of the message.
+#
+# Publishing uses crates.io OIDC trusted publishing (no long-lived token secret),
+# mirroring the NPM trusted publishing in mediasoup-npm-publish.yaml.
+#
+# On its success, mediasoup-website-update.yaml runs (via its `workflow_run`
+# trigger) to update the mediasoup website. Pushes to the main branch that are
+# not crate-publish commits leave the `setup` job (and thus the whole run)
+# skipped, so they never trigger the website update.
+on:
+  push:
+    tags:
+      # Rust release tags (rust- + SEMVER). Node tags (X.Y.Z) don't match.
+      - 'rust-[0-9]+.[0-9]+.[0-9]+'
+    branches:
+      - v3
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.sha }}
+  # Don't cancel an in-progress publish if a new run lands in the same group.
+  cancel-in-progress: false
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  # Decide whether this push is a crate publish and, if so, for which crate and
+  # version. A `rust-X.Y.Z` tag publishes the `mediasoup` crate (with a GitHub
+  # release); a `<crate> X.Y.Z [crate-publish] [no-ci]` commit on the branch
+  # publishes that sibling crate (without a GitHub release). Any other push to the
+  # branch skips this job (the `if` below), which skips every downstream job too.
+  setup:
+    if: ${{ github.ref_type == 'tag' || contains(github.event.head_commit.message, '[crate-publish]') }}
+    runs-on: ubuntu-26.04
+    outputs:
+      crate: ${{ steps.detect.outputs.crate }}
+      version: ${{ steps.detect.outputs.version }}
+      release: ${{ steps.detect.outputs.release }}
+    steps:
+      - name: Detect crate and version
+        id: detect
+        env:
+          REF_TYPE: ${{ github.ref_type }}
+          REF_NAME: ${{ github.ref_name }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${REF_TYPE}" = "tag" ]; then
+            # `rust-X.Y.Z` tag releases the `mediasoup` crate (with a GitHub release).
+            crate=mediasoup
+            version="${REF_NAME#rust-}"
+            release=true
+          else
+            # `<crate> X.Y.Z [crate-publish] [no-ci]` commit: read crate and
+            # version from the start of the message.
+            line=$(printf '%s\n' "${COMMIT_MSG}" | head -n1)
+            crate=$(printf '%s' "${line}" | awk '{ print $1 }')
+            version=$(printf '%s' "${line}" | awk '{ print $2 }')
+            release=false
+            case "${crate}" in
+              mediasoup-sys | mediasoup-types) ;;
+              *)
+                echo "unexpected crate '${crate}' in crate-publish commit: ${line}"
+                exit 1
+                ;;
+            esac
+          fi
+          if ! printf '%s' "${version}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "invalid version '${version}'"
+            exit 1
+          fi
+          echo "crate=${crate}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          echo "release=${release}" >> "$GITHUB_OUTPUT"
+          echo "detected crate=${crate} version=${version} release=${release}"
+
+  check:
+    needs: setup
+    runs-on: ubuntu-26.04
+    env:
+      CRATE: ${{ needs.setup.outputs.crate }}
+      VERSION: ${{ needs.setup.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Check version consistency
+        shell: bash
+        run: |
+          set -euo pipefail
+          case "${CRATE}" in
+            mediasoup) manifest=rust/Cargo.toml ;;
+            mediasoup-sys) manifest=worker/Cargo.toml ;;
+            mediasoup-types) manifest=rust/types/Cargo.toml ;;
+            *) echo "unknown crate '${CRATE}'"; exit 1 ;;
+          esac
+          # First `version =` line in the manifest is the [package] one.
+          manifest_version=$(grep -m1 -E '^version *=' "${manifest}" | sed -E 's/.*"(.*)".*/\1/')
+          # Version of this crate's package (not the others) in the workspace root
+          # Cargo.lock.
+          lock_version=$(awk -v c="${CRATE}" '
+            /^\[\[package\]\]/ { name=""; ver="" }
+            /^name = / { name=$3; gsub(/"/, "", name) }
+            /^version = / { ver=$3; gsub(/"/, "", ver); if (name == c) { print ver; exit } }
+          ' Cargo.lock)
+          echo "crate=${CRATE} ${manifest}=${manifest_version} Cargo.lock=${lock_version} expected=${VERSION}"
+          if [ "${manifest_version}" != "${VERSION}" ]; then
+            echo "${manifest} version '${manifest_version}' does not match expected version '${VERSION}'"
+            exit 1
+          fi
+          if [ "${lock_version}" != "${VERSION}" ]; then
+            echo "Cargo.lock ${CRATE} version '${lock_version}' does not match expected version '${VERSION}'"
+            exit 1
+          fi
+
+      - name: Ensure crate version is not already published on crates.io
+        shell: bash
+        run: |
+          set -euo pipefail
+          status=$(curl -sS -o /dev/null -w '%{http_code}' \
+            -A 'versatica/mediasoup (https://github.com/versatica/mediasoup)' \
+            "https://crates.io/api/v1/crates/${CRATE}/${VERSION}" || echo 000)
+          echo "crates.io ${CRATE}@${VERSION} -> HTTP ${status}"
+          if [ "${status}" = "200" ]; then
+            echo "${CRATE}@${VERSION} is already published on crates.io, this should not happen"
+            exit 1
+          fi
+          if [ "${status}" != "404" ]; then
+            echo "unexpected crates.io response (HTTP ${status}), aborting"
+            exit 1
+          fi
+
+  # Create the GitHub release from the matching rust/CHANGELOG.md entry. Only for
+  # the `mediasoup` crate (tag push); the sibling crates get no GitHub release.
+  release:
+    needs: [setup, check]
+    if: ${{ !cancelled() && needs.check.result == 'success' && needs.setup.outputs.release == 'true' }}
+    runs-on: ubuntu-26.04
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ github.ref_name }}
+          VERSION: ${{ needs.setup.outputs.version }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          # rust/CHANGELOG.md headings carry the bare SEMVER (no "rust-" prefix).
+          notes=$(awk -v h="### ${VERSION}" '$0==h {f=1; next} /^### / && f {exit} f {print}' rust/CHANGELOG.md)
+          if [ -z "$(printf '%s' "${notes}" | tr -d '[:space:]')" ]; then
+            echo "No rust/CHANGELOG.md entry found for '${VERSION}'"
+            exit 1
+          fi
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            echo "GitHub release '${TAG}' already exists, skipping creation"
+          else
+            printf '%s\n' "${notes}" | gh release create "${TAG}" --title "${TAG}" --notes-file -
+          fi
+
+  # Publish the crate to crates.io via OIDC trusted publishing.
+  publish:
+    needs: [setup, check, release]
+    # Run after a passing check, and (for `mediasoup`) only once its GitHub
+    # release succeeded. The sibling crates set release=false and their `release`
+    # job is skipped, so they don't require it.
+    if: ${{ !cancelled() && needs.check.result == 'success' && (needs.setup.outputs.release != 'true' || needs.release.result == 'success') }}
+    runs-on: ubuntu-26.04
+    timeout-minutes: 60
+    permissions:
+      # Allow requesting the short-lived OIDC token used for crates.io trusted
+      # publishing.
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Configure cache
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+          key: ubuntu-26.04-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ubuntu-26.04-cargo-
+
+      # Exchange the GitHub OIDC token for a short-lived crates.io token. This
+      # mirrors the OIDC trusted publishing used for NPM in
+      # mediasoup-npm-publish.yaml (no long-lived registry token secret needed).
+      - name: Authenticate to crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
+      # Publish only the selected crate. `--locked` makes cargo abort if
+      # Cargo.lock is out of date instead of silently regenerating it.
+      #
+      # NOTE: No need to set/unset MEDIASOUP_LOCAL_DEV: `mediasoup-sys`'s build.rs
+      # detects the `cargo publish` verification build and always cleans the
+      # Meson subprojects it extracts into the source tree, avoiding the "Source
+      # directory was modified by build.rs" error.
+      - name: cargo publish --locked -p ${{ needs.setup.outputs.crate }}
+        env:
+          CRATE: ${{ needs.setup.outputs.crate }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
+        run: cargo publish --locked -p "${CRATE}"

--- a/.github/workflows/mediasoup-website-update.yaml
+++ b/.github/workflows/mediasoup-website-update.yaml
@@ -1,14 +1,15 @@
 name: mediasoup-website-update
 
-# Triggered when `mediasoup-npm-publish.yaml` finishes successfully (`workflow_run`).
-# It triggers the `update-website` workflow in versatica/mediasoup-website (via
-# `workflow_dispatch`, no inputs), which builds the website and deploys it.
+# Triggered when `mediasoup-npm-publish.yaml` or `mediasoup-crate-publish.yaml`
+# finishes successfully (`workflow_run`). It triggers the `update-website`
+# workflow in versatica/mediasoup-website (via `workflow_dispatch`, no inputs),
+# which builds the website and deploys it.
 #
 # It can also be triggered manually (`workflow_dispatch`) to re-trigger the website
 # update (for example if the previous attempt failed).
 on:
   workflow_run:
-    workflows: ['mediasoup-npm-publish']
+    workflows: ['mediasoup-npm-publish', 'mediasoup-crate-publish']
     # `workflow_run` only has 'requested', 'in_progress' and 'completed' activity
     # types (there is no 'success'/'failure' type). 'completed' fires once the
     # upstream run has fully finished, regardless of its conclusion. The actual

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 [![][github-actions-shield-mediasoup-rust]][github-actions-mediasoup-rust]
 [![][github-actions-shield-mediasoup-worker-fuzzer]][github-actions-mediasoup-worker-fuzzer]
 [![][github-actions-shield-mediasoup-npm-publish]][github-actions-mediasoup-npm-publish]
+[![][github-actions-shield-mediasoup-crate-publish]][github-actions-mediasoup-crate-publish]
 [![][github-actions-shield-mediasoup-worker-prebuild]][github-actions-mediasoup-worker-prebuild]
 [![][github-actions-shield-mediasoup-website-update]][github-actions-mediasoup-website-update]
 [![][github-actions-shield-mediasoup-demo-update]][github-actions-mediasoup-demo-update]
@@ -109,6 +110,8 @@ You can support mediasoup by [sponsoring][sponsor] it. Thanks!
 [github-actions-mediasoup-worker-prebuild]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-worker-prebuild.yaml?query=event%3Aworkflow_run
 [github-actions-shield-mediasoup-npm-publish]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-npm-publish.yaml/badge.svg?event=push
 [github-actions-mediasoup-npm-publish]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-npm-publish.yaml?query=event%3Apush
+[github-actions-shield-mediasoup-crate-publish]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-crate-publish.yaml/badge.svg?event=push
+[github-actions-mediasoup-crate-publish]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-crate-publish.yaml?query=event%3Apush
 [github-actions-shield-mediasoup-website-update]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-website-update.yaml/badge.svg?event=workflow_run
 [github-actions-mediasoup-website-update]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-website-update.yaml?query=event%3Aworkflow_run
 [github-actions-shield-mediasoup-demo-update]: https://github.com/versatica/mediasoup/actions/workflows/mediasoup-demo-update.yaml/badge.svg?event=workflow_run

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -104,15 +104,15 @@ Same as `test:node` task but it also opens a browser window with TypeScript cove
 
 ### `npm run release:check`
 
-Runs linters and tests in Node and C++ code. Also verifies that `CHANGELOG.md` has an entry matching the `mediasoup` version in `package.json`.
+Runs linters and tests in Node and C++ code. Also verifies that `CHANGELOG.md` has an entry matching the mediasoup version in `package.json`.
 
 ### `npm run release x.y.z`
 
-Prepares and triggers the release of a new NPM version "x.y.z" of mediasoup. The actual GitHub release and NPM publish are done by CI (`mediasoup-npm-publish.yaml`) once the pushed tag arrives. It:
+Prepares and triggers the release of a new version "x.y.z" of the `mediasoup` NPM package. The actual GitHub release and NPM publish are done by GitHub Actions (`mediasoup-npm-publish.yaml`) once the pushed tag arrives. It:
 
 - Performs checks (lint + test + build + publish dry-run + `CHANGELOG.md` entry check). It runs before the version bump, so the CHANGELOG check validates the previous version's entry (still in package.json), which is harmless.
 - Bumps the version to "x.y.z" in `package.json` and `package-lock.json` with `npm version x.y.z --no-git-tag-version`, and sets the top `### NEXT` heading of `CHANGELOG.md` to `### x.y.z`.
-- Commits the bump, creates the "x.y.z" tag, and pushes the branch and the tag.
+- Commits the bump (with a "release x.y.z [no-ci]" message), creates the "x.y.z" tag, and pushes the branch and the tag.
 
 Requirements for it to work:
 
@@ -123,18 +123,29 @@ Requirements for it to work:
 
 ### `npm run release:rust:check`
 
-Dry-run of the Rust release. Always runs the `cargo fmt`, `cargo clippy`, `cargo test` and `cargo doc` checks (even when there is nothing to publish). Then checks which of the three Rust crate versions (`mediasoup-sys` in `worker/Cargo.toml`, `mediasoup-types` in `rust/types/Cargo.toml` and `mediasoup` in `rust/Cargo.toml`) are not yet published on crates.io, verifies that `rust/CHANGELOG.md` has an entry matching the `mediasoup` crate version (when that crate is going to be published), and reports what would be done without creating any tag/release or publishing anything.
+Runs linters and tests in Rust code (`cargo fmt`, `cargo clippy`, `cargo test` and `cargo doc`). Also verifies that `rust/CHANGELOG.md` has an entry matching the `mediasoup` crate version in `rust/Cargo.toml`. Finally, when that version is not yet published on crates.io (i.e. it has been bumped and is about to be released), it also runs the publish dry-run (`cargo publish --dry-run` for the three crates as a group).
 
-### `npm run release:rust`
+The publish dry-run is skipped when the `mediasoup` crate version is already published, because Cargo would then resolve the dependencies among the three crates against the already-published copies on crates.io and any schema/API change made since the last release would fail verification spuriously even though nothing is being published.
 
-Runs the same checks as `release:rust:check` (including the cargo `fmt`, `clippy`, `test` and `doc` checks), then pushes local commits to GitHub (so everything that gets tagged and published is already there) and publishes to crates.io (with `cargo publish --locked`, in dependency order: `mediasoup-types`, `mediasoup-sys`, `mediasoup`) every Rust crate whose version is not yet on crates.io. Additionally, when the `mediasoup` crate itself is being published, it also creates the Git tag (`rust-X.X.X`, matching its version in `rust/Cargo.toml`) and the corresponding GitHub release (see `release:rust:check` above and `doc/Rust-crates.md`). Requirements for it to work:
+### `npm run release:rust <crate> x.y.z`
 
+Prepares and triggers the release of a new version "x.y.z" of a mediasoup Rust crate (`mediasoup`, `mediasoup-sys` or `mediasoup-types`). The actual GitHub release (if any) and crates.io publish are done by GitHub Actions (`mediasoup-crate-publish.yaml`) once the pushed commit/tag arrives. It:
+
+- Performs checks (lint + test + build + publish dry-run, plus the `rust/CHANGELOG.md` entry check when releasing the `mediasoup` crate). They run before the version bump, so the CHANGELOG check validates the previous version's entry (still in the manifest), which is harmless.
+- Bumps the crate version to "x.y.z" in its `Cargo.toml` (`rust/Cargo.toml`, `worker/Cargo.toml` or `rust/types/Cargo.toml`) and reflects it in the (workspace root) `Cargo.lock`.
+
+Then, depending on the crate:
+
+- For `mediasoup`: it also sets the top `### NEXT` heading of `rust/CHANGELOG.md` to `### x.y.z`, commits the bump (with a `release rust-x.y.z [no-ci]` message), creates the `rust-x.y.z` tag and pushes the branch and the tag. The tag triggers `mediasoup-crate-publish.yaml`, which creates the GitHub release from `rust/CHANGELOG.md` and publishes the crate.
+- For `mediasoup-sys` / `mediasoup-types`: it commits the bump with a `<crate> x.y.z [crate-publish] [no-ci]` message and pushes the branch (no tag, no CHANGELOG change). The `[crate-publish]` marker is what `mediasoup-crate-publish.yaml` detects on the branch push to publish that crate (without a GitHub release).
+
+Since `mediasoup` depends on `mediasoup-sys` and `mediasoup-types`, when several crates need a new version publish the dependencies first (`mediasoup-types` / `mediasoup-sys`) and `mediasoup` last, so each crate's dependencies are already on crates.io. Requirements for it to work:
+
+- Must be called with a crate name and a SEMVER version as the two arguments.
 - Must be in the main branch.
-- Git local repository must be clean. No pending commits or dirty status.
-- `Cargo.lock` must be in sync (run `cargo build` and commit it if needed); otherwise the release aborts before doing anything irreversible.
-- When the `mediasoup` crate version is incremented, `rust/CHANGELOG.md` must have been updated with an entry matching it.
-- A `GITHUB_TOKEN` environment variable with permissions to create releases in GitHub is required (only when the `mediasoup` crate is published).
-- Of course, permissions to publish in crates.io are required.
+- Work tree must be clean.
+- `Cargo.lock` must be in sync (run `cargo build` and commit it if needed), otherwise the release aborts before doing anything irreversible.
+- When releasing the `mediasoup` crate, the changes for the new version must be under the `### NEXT` heading in `rust/CHANGELOG.md`.
 
 ## Rust
 

--- a/doc/Rust-crates.md
+++ b/doc/Rust-crates.md
@@ -10,59 +10,30 @@ There are 3 crates: `mediasoup`, `mediasoup-sys` and `mediasoup-types`:
 
 **Important:** Adding new APIs that `mediasoup` crate has to understand to continue working normally is a breaking change because it'll start crashing/printing errors if unexpected things happen.
 
-## Steps to publish new mediasoup crates
+## Publishing crates
 
-1. Update versions in `worker/Cargo.toml` (for `mediasoup-sys` crate), `rust/types/Cargo.toml` (for `mediasoup-types` crate) and `rust/Cargo.toml` (for `mediasoup` crate). Note that in `rust/Cargo.toml` you may need to update the version of `[dependencies.mediasoup-sys]` and/or `[dependencies.mediasoup-types]` if they also changed.
-2. Update `rust/CHANGELOG.md`.
-3. Run `cargo build` to reflect changes in `Cargo.lock` and commit the updated `Cargo.lock`. Do not skip this: a stale `Cargo.lock` is harmless for crate consumers (they ignore the packaged lock) but leaves the repo and CI out of sync.
-4. Create PR and have it merged in mediasoup main branch.
-5. Upload Git tags (the new one in `rust/CHANGELOG.md`, so the new `mediasoup` crate version):
+Each crate is published through an automated flow (mirroring how the NPM package is released): `npm run release:rust <crate> X.Y.Z` bumps the version, commits and pushes, and the `mediasoup-crate-publish.yaml` workflow then publishes the crate to crates.io via OIDC trusted publishing.
 
-```sh
-git tag -a rust-X.X.X -m rust-X.X.X
-git push origin rust-X.X.X
-```
+Because `mediasoup` depends on `mediasoup-sys` and `mediasoup-types`, when more than one crate needs a new version, **publish the dependencies first** (`mediasoup-types` and/or `mediasoup-sys`) and `mediasoup` last, so each crate's dependencies are already on crates.io when it is published.
 
-6. Create a GitHub release for the new `rust-X.X.X` tag, using the matching `rust/CHANGELOG.md` entry as its body.
-7. Publish crates (you need an account and permissions and so on). Always pass `--locked` so Cargo aborts if `Cargo.lock` is out of date instead of silently regenerating it (see note below):
+You do **not** bump the crate's `[package].version` nor edit `rust/CHANGELOG.md` yourself; `npm run release:rust` does that. For each crate to publish:
+
+1. Have the crate's code changes merged on the main branch. When publishing the `mediasoup` crate, the changes for the new version must be under the `### NEXT` heading of `rust/CHANGELOG.md`.
+2. Do **not** edit the `version` of `[dependencies.mediasoup-sys]` / `[dependencies.mediasoup-types]` in `rust/Cargo.toml` just to release those crates: that requirement is what the _published_ `mediasoup` crate depends on (its `path` is only used for local builds and dropped when published), and you bump it only when releasing a `mediasoup` that must depend on the new version. Cargo keeps that requirement and the crate's actual version compatible across the workspace, so a breaking (minor/major) bump of `mediasoup-sys` / `mediasoup-types` does require updating the requirement in the same change, and is therefore published together with a new `mediasoup`.
+3. Run `cargo build` to reflect any change in `Cargo.lock` and commit the updated `Cargo.lock`. Do not skip this: a stale `Cargo.lock` is harmless for crate consumers (they ignore the packaged lock) but leaves the repo and CI out of sync, and the release aborts on it.
+4. On the main branch, with a clean work tree, run:
 
 ```sh
-cd rust/types
-cargo publish --locked
-
-cd worker
-cargo publish --locked
-
-cd rust
-cargo publish --locked
+npm run release:rust mediasoup-types X.Y.Z
+# and/or
+npm run release:rust mediasoup-sys X.Y.Z
+# and finally
+npm run release:rust mediasoup X.Y.Z
 ```
 
-## Notes
+This runs the checks, bumps the crate version in its `Cargo.toml` and in `Cargo.lock`, and then:
 
-- Depending on the state in `worker` directory you may need to run `invoke clean-all` or `make clean-all` in `worker` directory first.
-- You can have `MEDIASOUP_LOCAL_DEV=true` exported in your shell (handy to speed up regular local builds) and still publish: `mediasoup-sys`'s `build.rs` detects the `cargo publish` / `cargo package` verification step (Cargo builds the crate inside `target/package/`) and always cleans the Meson subprojects it extracts into the source tree, regardless of `MEDIASOUP_LOCAL_DEV`. This avoids the "Source directory was modified by build.rs" error.
-- `cargo publish` will create the crate package, check if all necessary dependencies are already present on [crates.io](https://crates.io/), will then compile the package (to ensure that you don't publish a broken version) and will upload it to [crates.io](https://crates.io/).
-- Never publish from random branches or local state that is not on GitHub. If you have local files modified Cargo will refuse to publish until you commit all the changes.
-- Use `cargo publish --locked`. The dirty-repo check runs _before_ the verification build, but the verification build is exactly when Cargo regenerates `Cargo.lock`, so a stale lock slips past the dirty check and gets silently updated. `--locked` makes `cargo publish` fail up front if `Cargo.lock` needs updating, forcing step 3 to have been done and committed first.
+- For `mediasoup`: sets the top `### NEXT` heading of `rust/CHANGELOG.md` to `### X.Y.Z`, commits (`release rust-X.Y.Z [no-ci]`), creates the `rust-X.Y.Z` tag and pushes the branch and the tag. The tag triggers `mediasoup-crate-publish.yaml`, which creates the GitHub release from `rust/CHANGELOG.md` and publishes the crate.
+- For `mediasoup-sys` / `mediasoup-types`: commits (`<crate> X.Y.Z [crate-publish] [no-ci]`) and pushes the branch (no tag, no GitHub release). The `[crate-publish]` marker is what `mediasoup-crate-publish.yaml` detects on the branch push to publish that crate.
 
-## Extras
-
-### Check crate without publishing
-
-- If you want to do everything except the upload itself, run `cargo publish --dry-run`, which creates the package and compiles it for verification but does not upload anything.
-- To dry-run all crates at once (recommended before bumping versions), pass them as a single group so Cargo resolves the dependencies among them against the locally packaged copies instead of [crates.io](https://crates.io/). This works even if the new versions are not published yet:
-
-```sh
-cargo publish --dry-run -p mediasoup-types -p mediasoup-sys -p mediasoup
-```
-
-- To only build the package tarball without uploading, use `cargo package`.
-- To just list the files that would be included, use `cargo package --list`.
-
-### Update required Rust version
-
-Using `rustup` command:
-
-```sh
-rustup update
-```
+See `npm run release:rust` in [Building.md](Building.md) for more details.

--- a/npm-scripts.mjs
+++ b/npm-scripts.mjs
@@ -575,7 +575,7 @@ async function checkRelease() {
 	try {
 		versionChanges = await getVersionChanges();
 	} catch (error) {
-		logError(error.message);
+		logError(`checkRelease() | ${error.message}`);
 
 		exitWithError();
 	}
@@ -697,8 +697,10 @@ async function prebuildWorker() {
 	}
 }
 
-// Returns a Promise resolving to true if a mediasoup-worker prebuilt binary
-// was downloaded and uncompressed, false otherwise.
+/**
+ * Returns a Promise resolving to true if a mediasoup-worker prebuilt binary was
+ * downloaded and uncompressed, false otherwise.
+ */
 async function downloadPrebuiltWorker() {
 	const releaseBase =
 		process.env.MEDIASOUP_WORKER_PREBUILT_DOWNLOAD_BASE_URL ||

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,6 @@
 			},
 			"devDependencies": {
 				"@eslint/js": "^10.0.1",
-				"@octokit/rest": "^22.0.1",
 				"@types/debug": "^4.1.13",
 				"@types/ini": "^4.1.1",
 				"@types/jest": "^30.0.0",
@@ -1355,172 +1354,6 @@
 			"peerDependencies": {
 				"@emnapi/core": "^1.7.1",
 				"@emnapi/runtime": "^1.7.1"
-			}
-		},
-		"node_modules/@octokit/auth-token": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-			"integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/core": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/auth-token": "^6.0.0",
-				"@octokit/graphql": "^9.0.3",
-				"@octokit/request": "^10.0.6",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
-				"before-after-hook": "^4.0.0",
-				"universal-user-agent": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/endpoint": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
-			"integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/types": "^16.0.0",
-				"universal-user-agent": "^7.0.2"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/graphql": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-			"integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/request": "^10.0.6",
-				"@octokit/types": "^16.0.0",
-				"universal-user-agent": "^7.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/openapi-types": {
-			"version": "27.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-			"integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@octokit/plugin-paginate-rest": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-			"integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/types": "^16.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			},
-			"peerDependencies": {
-				"@octokit/core": ">=6"
-			}
-		},
-		"node_modules/@octokit/plugin-request-log": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
-			"integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 20"
-			},
-			"peerDependencies": {
-				"@octokit/core": ">=6"
-			}
-		},
-		"node_modules/@octokit/plugin-rest-endpoint-methods": {
-			"version": "17.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-			"integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/types": "^16.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			},
-			"peerDependencies": {
-				"@octokit/core": ">=6"
-			}
-		},
-		"node_modules/@octokit/request": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.6.tgz",
-			"integrity": "sha512-FO+UgZCUu+pPnZAR+iKdUt64kPE7QW7ciqpldaMXaNzixz5Jld8dJ31LAUewk0cfSRkNSRKyqG438ba9c/qDlQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/endpoint": "^11.0.2",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
-				"fast-content-type-parse": "^3.0.0",
-				"universal-user-agent": "^7.0.2"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/request-error": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.2.tgz",
-			"integrity": "sha512-U8piOROoQQUyExw5c6dTkU3GKxts5/ERRThIauNL7yaRoeXW0q/5bgHWT7JfWBw1UyrbK8ERId2wVkcB32n0uQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/types": "^16.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/rest": {
-			"version": "22.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
-			"integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/core": "^7.0.6",
-				"@octokit/plugin-paginate-rest": "^14.0.0",
-				"@octokit/plugin-request-log": "^6.0.0",
-				"@octokit/plugin-rest-endpoint-methods": "^17.0.0"
-			},
-			"engines": {
-				"node": ">= 20"
-			}
-		},
-		"node_modules/@octokit/types": {
-			"version": "16.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-			"integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@octokit/openapi-types": "^27.0.0"
 			}
 		},
 		"node_modules/@oxc-parser/binding-android-arm-eabi": {
@@ -3277,13 +3110,6 @@
 				"node": ">=6.0.0"
 			}
 		},
-		"node_modules/before-after-hook": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-			"integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-			"dev": true,
-			"license": "Apache-2.0"
-		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -4193,23 +4019,6 @@
 			"engines": {
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
-		},
-		"node_modules/fast-content-type-parse": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-			"integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/fastify"
-				},
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/fastify"
-				}
-			],
-			"license": "MIT"
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
@@ -7305,13 +7114,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/universal-user-agent": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-			"integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-			"dev": true,
-			"license": "ISC"
-		},
 		"node_modules/unrs-resolver": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/unrs-resolver/-/unrs-resolver-1.11.1.tgz",
@@ -8632,122 +8434,6 @@
 				"@tybys/wasm-util": "^0.10.2"
 			}
 		},
-		"@octokit/auth-token": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-			"integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
-			"dev": true
-		},
-		"@octokit/core": {
-			"version": "7.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-			"integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
-			"dev": true,
-			"requires": {
-				"@octokit/auth-token": "^6.0.0",
-				"@octokit/graphql": "^9.0.3",
-				"@octokit/request": "^10.0.6",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
-				"before-after-hook": "^4.0.0",
-				"universal-user-agent": "^7.0.0"
-			}
-		},
-		"@octokit/endpoint": {
-			"version": "11.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.2.tgz",
-			"integrity": "sha512-4zCpzP1fWc7QlqunZ5bSEjxc6yLAlRTnDwKtgXfcI/FxxGoqedDG8V2+xJ60bV2kODqcGB+nATdtap/XYq2NZQ==",
-			"dev": true,
-			"requires": {
-				"@octokit/types": "^16.0.0",
-				"universal-user-agent": "^7.0.2"
-			}
-		},
-		"@octokit/graphql": {
-			"version": "9.0.3",
-			"resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-			"integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
-			"dev": true,
-			"requires": {
-				"@octokit/request": "^10.0.6",
-				"@octokit/types": "^16.0.0",
-				"universal-user-agent": "^7.0.0"
-			}
-		},
-		"@octokit/openapi-types": {
-			"version": "27.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-			"integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
-			"dev": true
-		},
-		"@octokit/plugin-paginate-rest": {
-			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-			"integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
-			"dev": true,
-			"requires": {
-				"@octokit/types": "^16.0.0"
-			}
-		},
-		"@octokit/plugin-request-log": {
-			"version": "6.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
-			"integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
-			"dev": true,
-			"requires": {}
-		},
-		"@octokit/plugin-rest-endpoint-methods": {
-			"version": "17.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-			"integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
-			"dev": true,
-			"requires": {
-				"@octokit/types": "^16.0.0"
-			}
-		},
-		"@octokit/request": {
-			"version": "10.0.6",
-			"resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.6.tgz",
-			"integrity": "sha512-FO+UgZCUu+pPnZAR+iKdUt64kPE7QW7ciqpldaMXaNzixz5Jld8dJ31LAUewk0cfSRkNSRKyqG438ba9c/qDlQ==",
-			"dev": true,
-			"requires": {
-				"@octokit/endpoint": "^11.0.2",
-				"@octokit/request-error": "^7.0.2",
-				"@octokit/types": "^16.0.0",
-				"fast-content-type-parse": "^3.0.0",
-				"universal-user-agent": "^7.0.2"
-			}
-		},
-		"@octokit/request-error": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.0.2.tgz",
-			"integrity": "sha512-U8piOROoQQUyExw5c6dTkU3GKxts5/ERRThIauNL7yaRoeXW0q/5bgHWT7JfWBw1UyrbK8ERId2wVkcB32n0uQ==",
-			"dev": true,
-			"requires": {
-				"@octokit/types": "^16.0.0"
-			}
-		},
-		"@octokit/rest": {
-			"version": "22.0.1",
-			"resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
-			"integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
-			"dev": true,
-			"requires": {
-				"@octokit/core": "^7.0.6",
-				"@octokit/plugin-paginate-rest": "^14.0.0",
-				"@octokit/plugin-request-log": "^6.0.0",
-				"@octokit/plugin-rest-endpoint-methods": "^17.0.0"
-			}
-		},
-		"@octokit/types": {
-			"version": "16.0.0",
-			"resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-			"integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
-			"dev": true,
-			"requires": {
-				"@octokit/openapi-types": "^27.0.0"
-			}
-		},
 		"@oxc-parser/binding-android-arm-eabi": {
 			"version": "0.137.0",
 			"resolved": "https://registry.npmjs.org/@oxc-parser/binding-android-arm-eabi/-/binding-android-arm-eabi-0.137.0.tgz",
@@ -9744,12 +9430,6 @@
 			"integrity": "sha512-girxaJ7WZssDOFhzCGZTDKoTa1gk6A1TbflaYTpykLJ4UU9Fz9kx1aREM8JCuoVHbL8X8T/mJg7w2oYSq72Oig==",
 			"dev": true
 		},
-		"before-after-hook": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-			"integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
-			"dev": true
-		},
 		"brace-expansion": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
@@ -10309,12 +9989,6 @@
 				"jest-mock": "30.4.1",
 				"jest-util": "30.4.1"
 			}
-		},
-		"fast-content-type-parse": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-3.0.0.tgz",
-			"integrity": "sha512-ZvLdcY8P+N8mGQJahJV5G4U88CSvT1rP8ApL6uETe88MBXrBHAkZlSEySdUlyztF7ccb+Znos3TFqaepHxdhBg==",
-			"dev": true
 		},
 		"fast-deep-equal": {
 			"version": "3.1.3",
@@ -12337,12 +12011,6 @@
 			"requires": {
 				"crypto-random-string": "^4.0.0"
 			}
-		},
-		"universal-user-agent": {
-			"version": "7.0.3",
-			"resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-			"integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
-			"dev": true
 		},
 		"unrs-resolver": {
 			"version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
 	},
 	"devDependencies": {
 		"@eslint/js": "^10.0.1",
-		"@octokit/rest": "^22.0.1",
 		"@types/debug": "^4.1.13",
 		"@types/ini": "^4.1.1",
 		"@types/jest": "^30.0.0",

--- a/rust-scripts.mjs
+++ b/rust-scripts.mjs
@@ -9,30 +9,27 @@ const GH_REPO = 'mediasoup';
 // Main Git branch is 'v' concatenated with the major SEMVER number of the
 // "version" field in package.json.
 const MAIN_BRANCH = `v${pkg.version.split('.')[0]}`;
-
-// The three Rust crates with their Cargo.toml manifest and directory (relative
-// to repo root). Listed in the order in which they must be published to
-// crates.io (dependencies first).
+// The three publishable mediasoup Rust crates and the Cargo.toml manifest that
+// holds each one's version. The `mediasoup` crate is special: releasing it
+// creates a `rust-X.Y.Z` Git tag and a GitHub release built from its CHANGELOG;
+// the other two are published without a tag or a GitHub release (the
+// `mediasoup-crate-publish.yaml` workflow detects them from the commit message).
 const CRATES = [
-	// `mediasoup-types` crate.
-	{ manifest: 'rust/types/Cargo.toml', dir: 'rust/types' },
-	// `mediasoup-sys` crate.
-	{ manifest: 'worker/Cargo.toml', dir: 'worker' },
-	// `mediasoup` crate (depends on the two above).
-	{ manifest: 'rust/Cargo.toml', dir: 'rust' },
+	{ name: 'mediasoup', manifest: 'rust/Cargo.toml' },
+	{ name: 'mediasoup-sys', manifest: 'worker/Cargo.toml' },
+	{ name: 'mediasoup-types', manifest: 'rust/types/Cargo.toml' },
 ];
-
-// The `mediasoup` crate (rust/Cargo.toml) drives both the Git tag (rust-X.X.X)
-// and the rust/CHANGELOG.md entry that the GitHub release is built from.
-const MEDIASOUP_MANIFEST = 'rust/Cargo.toml';
-const RUST_CHANGELOG = 'rust/CHANGELOG.md';
+// The `mediasoup` crate, whose rust/CHANGELOG.md drives the GitHub release body.
+const MEDIASOUP_CRATE = CRATES[0];
+const MEDIASOUP_CRATE_CHANGELOG = 'rust/CHANGELOG.md';
 
 const task = process.argv[2];
+const taskArgs = process.argv.slice(3).join(' ');
 
 void run();
 
 async function run() {
-	logInfo('');
+	logInfo(taskArgs ? `[args:"${taskArgs}"]` : '');
 
 	switch (task) {
 		case 'release:check': {
@@ -42,7 +39,7 @@ async function run() {
 		}
 
 		case 'release': {
-			await release();
+			await release({ args: taskArgs });
 
 			break;
 		}
@@ -55,188 +52,22 @@ async function run() {
 	}
 }
 
-/**
- * Validates that a Rust release can be made: checks which crate versions are not
- * yet on crates.io, that rust/CHANGELOG.md has a matching entry (if the
- * `mediasoup` crate itself is being published) and that the crates build/package.
- * Returns the data needed to perform the release, or null if there is nothing to
- * release.
- */
-async function checkRelease() {
-	logInfo('checkRelease()');
-
-	// Read the current version of every Rust crate.
-	const crates = CRATES.map(crate => ({
-		...crate,
-		...readCrate(crate.manifest),
-	}));
-
-	for (const crate of crates) {
-		logInfo(
-			`checkRelease() | crate '${crate.name}' version is ${crate.version}`
-		);
-	}
-
-	// The `mediasoup` crate version is the one used for the Git tag and the
-	// CHANGELOG entry.
-	const mediasoupVersion = crates.find(
-		crate => crate.manifest === MEDIASOUP_MANIFEST
-	).version;
-	const tag = `rust-${mediasoupVersion}`;
-
-	// Ensure Cargo.lock is in sync before running any cargo command that could
-	// silently regenerate it.
-	checkCargoLock();
-
-	// Run the cargo checks always, even if there ends up being nothing to publish.
-	lintRust();
-	testRust();
-	docRust();
-
-	// Detect which crates have a version not yet published on crates.io.
-	let cratesToPublish;
-
-	try {
-		cratesToPublish = await getUnpublishedCrates(crates);
-	} catch (error) {
-		logError(error.message);
-
-		exitWithError();
-	}
-
-	if (cratesToPublish.length === 0) {
-		logInfo(
-			'checkRelease() | all Rust crate versions are already published, nothing to release'
-		);
-
-		return null;
-	}
-
-	logInfo(
-		`checkRelease() | crates to publish: ${cratesToPublish
-			.map(crate => `${crate.name} (${crate.version})`)
-			.join(', ')}`
-	);
-
-	// The Git tag and GitHub release are created only when the `mediasoup` crate
-	// itself is being published (they are keyed on its version).
-	const releaseMediasoup = cratesToPublish.some(
-		crate => crate.manifest === MEDIASOUP_MANIFEST
-	);
-
-	let versionChanges;
-
-	if (releaseMediasoup) {
-		// Verify that rust/CHANGELOG.md has an entry for the `mediasoup` crate
-		// version and grab its changes (used as the GitHub release body).
-		try {
-			versionChanges = await getVersionChanges(mediasoupVersion);
-		} catch (error) {
-			logError(error.message);
-
-			exitWithError();
-		}
-	} else {
-		logInfo(
-			`checkRelease() | mediasoup ${mediasoupVersion} is already published, will not create a Git tag/release`
-		);
-	}
-
-	// Validate packaging of the crates before the irreversible release steps
-	// (git push, GitHub release, cargo publish).
-	publishDryRun();
-
-	return { tag, releaseMediasoup, versionChanges, cratesToPublish };
-}
-
-async function release() {
-	logInfo('release()');
-
-	// Make sure we are on the main branch.
-	const branch = execSync('git rev-parse --abbrev-ref HEAD', {
-		encoding: 'utf-8',
-	}).trim();
-
-	if (branch !== MAIN_BRANCH) {
-		logError(
-			`release() | must be on '${MAIN_BRANCH}' branch, but it is on '${branch}' branch`
-		);
-
-		exitWithError();
-	}
-
-	// Refuse to release with a dirty working tree. `cargo publish` would refuse
-	// to publish modified local files anyway.
-	checkGitClean();
-
-	const releaseInfo = await checkRelease();
-
-	// Nothing to release.
-	if (!releaseInfo) {
-		return;
-	}
-
-	const { tag, releaseMediasoup, versionChanges, cratesToPublish } =
-		releaseInfo;
-
-	// Push local commits first so everything we tag and publish is already on
-	// GitHub.
-	executeCmd(`git push origin ${MAIN_BRANCH}`);
-
-	// Create the Git tag and the GitHub release only when the `mediasoup` crate
-	// itself is being published. If the tag already exists (e.g. a previous run
-	// was interrupted), skip this step but still publish below.
-	if (releaseMediasoup && !gitTagExists(tag)) {
-		let octokit;
-
-		try {
-			octokit = await getOctokit();
-		} catch (error) {
-			logError(error.message);
-
-			exitWithError();
-		}
-
-		// Create and push the annotated tag.
-		executeCmd(`git tag -a ${tag} -m ${tag}`);
-		executeCmd(`git push origin ${tag}`);
-
-		logInfo(`release() | creating release '${tag}' in GitHub`);
-
-		await octokit.repos.createRelease({
-			owner: GH_OWNER,
-			repo: GH_REPO,
-			name: tag,
-			body: versionChanges,
-			tag_name: tag,
-			draft: false,
-		});
-	}
-
-	// Publish the crates to crates.io. They are published in dependency order
-	// (the order of `CRATES`). `--locked` makes cargo abort if Cargo.lock is out
-	// of date instead of silently regenerating it.
-	for (const crate of cratesToPublish) {
-		executeInteractiveCmd('cargo publish --locked', { cwd: crate.dir });
-	}
-}
-
-function lintRust() {
-	logInfo('lintRust()');
+function lint() {
+	logInfo('lint()');
 
 	executeCmd('cargo fmt --all -- --check');
 	executeCmd('cargo clippy --all-targets -- -D warnings');
 }
 
-function testRust() {
-	logInfo('testRust()');
+function test() {
+	logInfo('test()');
 
 	executeCmd('cargo test --verbose');
 	executeCmd('cargo test --release --verbose');
 }
 
-function docRust() {
-	logInfo('docRust()');
+function doc() {
+	logInfo('doc()');
 
 	// Fail on broken/private intra-doc links, same as when building the docs for
 	// docs.rs.
@@ -245,105 +76,6 @@ function docRust() {
 		'-D rustdoc::broken-intra-doc-links -D rustdoc::private_intra_doc_links';
 
 	executeCmd('cargo doc --locked --all --no-deps --lib');
-}
-
-/**
- * Returns the subset of the given crates whose exact version is not yet
- * published on crates.io (so it has to be published).
- */
-async function getUnpublishedCrates(crates) {
-	const unpublishedCrates = [];
-
-	for (const crate of crates) {
-		if (!(await isCratePublished(crate.name, crate.version))) {
-			unpublishedCrates.push(crate);
-		}
-	}
-
-	return unpublishedCrates;
-}
-
-/**
- * Tells whether the given crate version is already published on crates.io by
- * querying its API. Throws if crates.io cannot be reached or replies with an
- * unexpected status (so we never publish or skip based on a wrong guess).
- */
-async function isCratePublished(name, version) {
-	const url = `https://crates.io/api/v1/crates/${name}/${version}`;
-
-	let res;
-
-	try {
-		res = await fetch(url, {
-			// NOTE: crates.io requires a meaningful User-Agent.
-			headers: {
-				'User-Agent': `${GH_OWNER}/${GH_REPO} (https://github.com/${GH_OWNER}/${GH_REPO})`,
-			},
-		});
-	} catch (error) {
-		// eslint-disable-next-line preserve-caught-error
-		throw new Error(
-			`failed to reach crates.io for '${name}@${version}': ${error}`
-		);
-	}
-
-	// 200 means the version exists, 404 means it does not.
-	if (res.status === 200) {
-		return true;
-	} else if (res.status === 404) {
-		return false;
-	}
-
-	throw new Error(
-		`unexpected crates.io response for '${name}@${version}': ${res.status} ${res.statusText}`
-	);
-}
-
-/**
- * Mimics getVersionChanges() in npm-scripts.mjs: looks up the heading matching
- * the given version in rust/CHANGELOG.md and returns the raw markdown of its
- * changes. Exits with error if there is no such entry.
- */
-async function getVersionChanges(version) {
-	logInfo(`getVersionChanges() [version:${version}]`);
-
-	// NOTE: Load dep on demand since it's a devDependency.
-	const marked = await import('marked');
-
-	const changelog = fs.readFileSync(RUST_CHANGELOG, { encoding: 'utf-8' });
-	const entries = marked.lexer(changelog);
-
-	for (let idx = 0; idx < entries.length; ++idx) {
-		const entry = entries[idx];
-
-		if (entry.type === 'heading' && entry.text === version) {
-			// Collect every token after the matching heading until the next heading.
-			// NOTE: We cannot just use `entries[idx + 1].raw` because `marked`
-			// inserts a `space` token between the heading and its content.
-			let changes = '';
-
-			for (let next = idx + 1; next < entries.length; ++next) {
-				if (entries[next].type === 'heading') {
-					break;
-				}
-
-				changes += entries[next].raw;
-			}
-
-			changes = changes.trim();
-
-			if (changes) {
-				return changes;
-			}
-
-			break;
-		}
-	}
-
-	// This should not happen (unless author forgot to update the CHANGELOG).
-	throw new Error(
-		`no entry found in ${RUST_CHANGELOG} for version '${version}'`
-	);
 }
 
 /**
@@ -360,19 +92,150 @@ function publishDryRun() {
 	);
 }
 
-async function getOctokit() {
-	if (!process.env.GITHUB_TOKEN) {
-		throw new Error('missing GITHUB_TOKEN environment variable');
+async function checkRelease(crate = MEDIASOUP_CRATE) {
+	logInfo(`checkRelease() [crate:${crate.name}]`);
+
+	const { version } = readCrate(crate.manifest);
+
+	// rust/CHANGELOG.md tracks only the `mediasoup` crate, so the CHANGELOG entry
+	// is verified (and grabbed) only when releasing that crate, before the slow
+	// build steps.
+	let versionChanges;
+
+	if (crate.name === 'mediasoup') {
+		try {
+			versionChanges = await getVersionChanges(version);
+		} catch (error) {
+			logError(`checkRelease() | ${error.message}`);
+
+			exitWithError();
+		}
 	}
 
-	// NOTE: Load dep on demand since it's a devDependency.
-	const { Octokit } = await import('@octokit/rest');
+	// Ensure Cargo.lock is in sync before running any cargo command that could
+	// silently regenerate it.
+	checkCargoLock();
 
-	const octokit = new Octokit({
-		auth: process.env.GITHUB_TOKEN,
-	});
+	lint();
+	test();
+	doc();
 
-	return octokit;
+	// Validate packaging only when the crate version is not yet on crates.io (i.e.
+	// it has been bumped and is about to be published). Otherwise Cargo resolves
+	// the dependencies among the three crates against the already-published copies
+	// on crates.io and any schema/API change made since the last release fails
+	// verification spuriously even though nothing is being published (same gating
+	// as in `mediasoup-rust.yaml`).
+	let published;
+
+	try {
+		published = await isCratePublished(crate.name, version);
+	} catch (error) {
+		logError(`checkRelease() | ${error.message}`);
+
+		exitWithError();
+	}
+
+	if (published) {
+		logInfo(
+			`checkRelease() | ${crate.name} ${version} is already published on crates.io, skipping publish dry-run`
+		);
+	} else {
+		publishDryRun();
+	}
+
+	return { versionChanges };
+}
+
+async function release({ args = '' } = {}) {
+	logInfo('release()');
+
+	const [name, version] = args.trim().split(/\s+/);
+
+	const crate = CRATES.find(entry => entry.name === name);
+
+	if (!crate) {
+		logError(
+			`release() | first argument must be a crate name (one of: ${CRATES.map(
+				entry => `'${entry.name}'`
+			).join(', ')}), but got '${name}'`
+		);
+
+		exitWithError();
+	}
+
+	if (!version || !/^\d+\.\d+\.\d+$/.test(version)) {
+		logError(
+			`release() | a SEMVER 'x.y.z' version is required as second argument, but got '${version}'`
+		);
+
+		exitWithError();
+	}
+
+	// Must be on the main branch.
+	const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+		encoding: 'utf-8',
+	}).trim();
+
+	if (branch !== MAIN_BRANCH) {
+		logError(
+			`release() | must be on '${MAIN_BRANCH}' branch, but it is on '${branch}' branch`
+		);
+
+		exitWithError();
+	}
+
+	// Clean working tree required before bumping the version.
+	checkGitClean();
+
+	// Lint, test, doc, publish dry-run, and (for the `mediasoup` crate) verify the
+	// CHANGELOG entry. Runs before the bump (the checked version is the previous
+	// one still in the manifest, which is harmless).
+	await checkRelease(crate);
+
+	// Bump the crate version in its Cargo.toml and reflect it in the (workspace)
+	// root Cargo.lock.
+	bumpCargoVersion(crate.manifest, version);
+	syncCargoLock();
+
+	if (crate.name === 'mediasoup') {
+		// The `mediasoup` crate also bumps rust/CHANGELOG.md and is released via a
+		// `rust-X.Y.Z` Git tag, whose push triggers `mediasoup-crate-publish.yaml`
+		// to create the GitHub release and publish the crate to crates.io. On its
+		// success `mediasoup-website-update.yaml updates the website.
+		await updateChangelog(version);
+
+		const tag = `rust-${version}`;
+
+		// Commit the bump, tag it, and push both.
+		//
+		// The commit message carries a "[no-ci]" marker so the regular branch CI
+		// workflows (node, worker, rust, fuzzer, codeql) skip this commit: it only
+		// bumps version/CHANGELOG (no code change) and its parent already passed CI,
+		// and the release is driven by the tag-triggered workflows instead.
+		//
+		// NOTE: "[no-ci]" (with a hyphen) is a custom marker, NOT GitHub's native
+		// "[skip ci]"/"[no ci]" (which would also skip mediasoup-crate-publish,
+		// since the tag push shares this same commit).
+		executeCmd(`git commit -am 'release ${tag} [no-ci]'`);
+		executeCmd(`git tag -a ${tag} -m '${tag}'`);
+		executeCmd(`git push origin ${MAIN_BRANCH}`);
+		executeCmd(`git push origin '${tag}'`);
+	} else {
+		// The `mediasoup-sys` / `mediasoup-types` crates are released without a Git
+		// tag or GitHub release. The commit message
+		// `<crate> <version> [crate-publish] [no-ci]` is the signal that
+		// `mediasoup-crate-publish.yaml` parses on the branch push: the
+		// "[crate-publish]" marker opts the commit into the workflow, and the crate
+		// name and version are read from the start of the message.
+		//
+		// "[no-ci]" keeps the regular branch CI workflows (node, worker, rust,
+		// fuzzer, codeql) from running on this version-only commit.
+		executeCmd(
+			`git commit -am '${crate.name} ${version} [crate-publish] [no-ci]'`
+		);
+		executeCmd(`git push origin ${MAIN_BRANCH}`);
+	}
 }
 
 function checkGitClean() {
@@ -411,16 +274,143 @@ function checkCargoLock() {
 	}
 }
 
-function gitTagExists(tag) {
-	try {
-		execSync(`git rev-parse --verify --quiet refs/tags/${tag}`, {
-			stdio: ['ignore', 'ignore', 'ignore'],
-		});
+function syncCargoLock() {
+	logInfo('syncCargoLock()');
 
-		return true;
+	// Reflect the just-bumped crate version in the (workspace) root Cargo.lock.
+	// `cargo metadata` resolves the workspace and rewrites Cargo.lock, changing
+	// only the bumped member version while keeping every other pinned dependency
+	// intact (checkCargoLock() asserted the lock was in sync beforehand).
+	try {
+		execSync('cargo metadata --format-version 1', {
+			stdio: ['ignore', 'ignore', process.stderr],
+		});
 	} catch (error) {
-		return false;
+		logError(`syncCargoLock() failed, exiting: ${error}`);
+
+		exitWithError();
 	}
+}
+
+async function getVersionChanges(version) {
+	logInfo(`getVersionChanges() [version:${version}]`);
+
+	// NOTE: Load dep on demand since it's a devDependency.
+	const marked = await import('marked');
+
+	const changelog = fs.readFileSync(MEDIASOUP_CRATE_CHANGELOG, {
+		encoding: 'utf-8',
+	});
+	const entries = marked.lexer(changelog);
+
+	for (let idx = 0; idx < entries.length; ++idx) {
+		const entry = entries[idx];
+
+		if (entry.type === 'heading' && entry.text === version) {
+			// Collect every token after the matching heading until the next heading.
+			// NOTE: We cannot just use `entries[idx + 1].raw` because `marked`
+			// inserts a `space` token between the heading and its content.
+			let changes = '';
+
+			for (let next = idx + 1; next < entries.length; ++next) {
+				if (entries[next].type === 'heading') {
+					break;
+				}
+
+				changes += entries[next].raw;
+			}
+
+			changes = changes.trim();
+
+			if (changes) {
+				return changes;
+			}
+
+			break;
+		}
+	}
+
+	// This should not happen (unless author forgot to update the CHANGELOG).
+	throw new Error(
+		`no entry found in ${MEDIASOUP_CRATE_CHANGELOG} for version '${version}'`
+	);
+}
+
+async function updateChangelog(version) {
+	logInfo(`updateChangelog() [version:${version}]`);
+
+	// NOTE: Load dep on demand since it's a devDependency.
+	const marked = await import('marked');
+
+	const changelog = fs.readFileSync(MEDIASOUP_CRATE_CHANGELOG, {
+		encoding: 'utf-8',
+	});
+	const tokens = marked.lexer(changelog);
+
+	// Locate the top "### NEXT" heading.
+	const nextHeading = tokens.find(
+		token =>
+			token.type === 'heading' && token.depth === 3 && token.text === 'NEXT'
+	);
+
+	if (!nextHeading) {
+		throw new Error(
+			`no '### NEXT' heading found in ${MEDIASOUP_CRATE_CHANGELOG}`
+		);
+	}
+
+	// Insert "### <version>" right below "### NEXT" (keeping the empty "### NEXT"
+	// for future unreleased changes), preserving the heading's trailing newlines.
+	const updatedChangelog = changelog.replace(
+		nextHeading.raw,
+		`### NEXT\n\n### ${version}${nextHeading.raw.slice('### NEXT'.length)}`
+	);
+
+	fs.writeFileSync(MEDIASOUP_CRATE_CHANGELOG, updatedChangelog);
+}
+
+/**
+ * Rewrites the `version` key of the `[package]` section of the given Cargo.toml,
+ * leaving the `version` keys under `[dependencies.*]` sections untouched.
+ */
+function bumpCargoVersion(manifestPath, version) {
+	logInfo(`bumpCargoVersion() [manifest:${manifestPath}, version:${version}]`);
+
+	const content = fs.readFileSync(manifestPath, { encoding: 'utf-8' });
+	const lines = content.split('\n');
+
+	let inPackageSection = false;
+	let bumped = false;
+
+	for (let idx = 0; idx < lines.length; ++idx) {
+		const trimmed = lines[idx].trim();
+
+		if (trimmed.startsWith('[')) {
+			inPackageSection = trimmed === '[package]';
+
+			continue;
+		}
+
+		if (inPackageSection && /^version\s*=\s*"[^"]+"/.test(trimmed)) {
+			lines[idx] = lines[idx].replace(
+				/version\s*=\s*"[^"]+"/,
+				`version = "${version}"`
+			);
+			bumped = true;
+
+			break;
+		}
+	}
+
+	if (!bumped) {
+		logError(
+			`bumpCargoVersion() | no 'version' key found in [package] section of '${manifestPath}'`
+		);
+
+		exitWithError();
+	}
+
+	fs.writeFileSync(manifestPath, lines.join('\n'));
 }
 
 function readCrate(manifestPath) {
@@ -476,6 +466,42 @@ function parseManifest(content) {
 	return { name, version };
 }
 
+/**
+ * Tells whether the given crate version is already published on crates.io by
+ * querying its API. Throws if crates.io cannot be reached or replies with an
+ * unexpected status (so we never publish or skip based on a wrong guess).
+ */
+async function isCratePublished(name, version) {
+	const url = `https://crates.io/api/v1/crates/${name}/${version}`;
+
+	let res;
+
+	try {
+		res = await fetch(url, {
+			// NOTE: crates.io requires a meaningful User-Agent.
+			headers: {
+				'User-Agent': `${GH_OWNER}/${GH_REPO} (https://github.com/${GH_OWNER}/${GH_REPO})`,
+			},
+		});
+	} catch (error) {
+		// eslint-disable-next-line preserve-caught-error
+		throw new Error(
+			`failed to reach crates.io for '${name}@${version}': ${error}`
+		);
+	}
+
+	// 200 means the version exists, 404 means it does not.
+	if (res.status === 200) {
+		return true;
+	} else if (res.status === 404) {
+		return false;
+	}
+
+	throw new Error(
+		`unexpected crates.io response for '${name}@${version}': ${res.status} ${res.statusText}`
+	);
+}
+
 function executeCmd(command) {
 	logInfo(`executeCmd(): ${command}`);
 
@@ -488,6 +514,7 @@ function executeCmd(command) {
 	}
 }
 
+// eslint-disable-next-line no-unused-vars
 function executeInteractiveCmd(command, { cwd } = {}) {
 	logInfo(`executeInteractiveCmd(): ${command}${cwd ? ` [cwd:${cwd}]` : ''}`);
 


### PR DESCRIPTION
# Details

- Related to https://github.com/versatica/mediasoup/issues/1837.

- New behavior of the `release` task in `rust-scripts` (invoked via `npm run release:rust <crate> <version>`):
  - It bumps the crate version in its `Cargo.toml` and in the workspace `Cargo.lock`, runs the checks and pushes the result.
  - For the main `mediasoup` crate it also updates `rust/CHANGELOG.md` and pushes a `rust-X.Y.Z` Git tag.
  - For `mediasoup-sys` / `mediasoup-types` crates it pushes a commit with message `<crate> X.Y.Z [crate-publish] [no-ci]`.

- New `mediasoup-crate-publish` workflow that publishes a mediasoup Rust crate to crates.io via OIDC trusted publishing (no long-lived token).
  - A setup job inspects the event to decide which crate and version to publish and whether a GitHub release is needed (only for `mediasoup` main crate).
  - It then checks version consistency, creates the GitHub release from `rust/CHANGELOG.md` (only for `mediasoup`) and runs `cargo publish` for that crate.
  - I've created a Trusted Publisher in the `mediasoup` crate, see https://crates.io/crates/mediasoup/settings (same in `mediasoup-sys` and `mediasoup-types` crates), which is required for the `mediasoup-crate-publish` workflow to be able to publish new versions of those crates.

## Notes

- Because `mediasoup` depends on `mediasoup-sys` and `mediasoup-types`, when more than one crate needs a new version, **publish the dependencies first** (`mediasoup-types` and/or `mediasoup-sys`) and `mediasoup` last, so each crate's dependencies are already on crates.io when it is published.

- Text included in `doc/Rust-crates.md` of this PR:
  > ## Publishing crates
  >
  > Each crate is published through an automated flow (mirroring how the NPM package is released): `npm run release:rust <crate> X.Y.Z` bumps the version, commits and pushes, and the `mediasoup-crate-publish.yaml` workflow then publishes the crate to crates.io via OIDC trusted publishing.
  >
  > Because `mediasoup` depends on `mediasoup-sys` and `mediasoup-types`, when more than one crate needs a new version, **publish the dependencies first** (`mediasoup-types` and/or `mediasoup-sys`) and `mediasoup` last, so each crate's dependencies are already on crates.io when it is published.
  >
  > You do **not** bump the crate's `[package].version` nor edit `rust/CHANGELOG.md` yourself; `npm run release:rust` does that. For each crate to publish:
  >
  > 1. Have the crate's code changes merged on the main branch. When publishing the `mediasoup` crate, the changes for the new version must be under the `### NEXT` heading of `rust/CHANGELOG.md`.
  > 2. Do **not** edit the `version` of `[dependencies.mediasoup-sys]` / `[dependencies.mediasoup-types]` in `rust/Cargo.toml` just to release those crates: that requirement is what the _published_ `mediasoup` crate depends on (its `path` is only used for local builds and dropped when published), and you bump it only when releasing a `mediasoup` that must depend on the new version. Cargo keeps that requirement and the crate's actual version compatible across the workspace, so a breaking (minor/major) bump of `mediasoup-sys` / `mediasoup-types` does require updating the requirement in the same change, and is therefore published together with a new `mediasoup`.
  > 3. Run `cargo build` to reflect any change in `Cargo.lock` and commit the updated `Cargo.lock`. Do not skip this: a stale `Cargo.lock` is harmless for crate consumers (they ignore the packaged lock) but leaves the repo and CI out of sync, and the release aborts on it.
  > 4. On the main branch, with a clean work tree, run:
  >
  > ```sh
  > npm run release:rust mediasoup-types X.Y.Z
  > # and/or
  > npm run release:rust mediasoup-sys X.Y.Z
  > # and finally
  > npm run release:rust mediasoup X.Y.Z
  > ```
  >
  > This runs the checks, bumps the crate version in its `Cargo.toml` and in `Cargo.lock`, and then:
  >
  > - For `mediasoup`: sets the top `### NEXT` heading of `rust/CHANGELOG.md` to `### X.Y.Z`, commits (`release rust-X.Y.Z [no-ci]`), creates the `rust-X.Y.Z` tag and pushes the branch and the tag. The tag triggers `mediasoup-crate-publish.yaml`, which creates the GitHub release from `rust/CHANGELOG.md` and publishes the crate.
  > - For `mediasoup-sys` / `mediasoup-types`: commits (`<crate> X.Y.Z [crate-publish] [no-ci]`) and pushes the branch (no tag, no GitHub release). The `[crate-publish]` marker is what `mediasoup-crate-publish.yaml` detects on the branch push to publish that crate.