### PR TITLE
Improve `SeqManager` and `NackGenerator`

### DIFF
--- a/worker/include/RTC/NackGenerator.hpp
+++ b/worker/include/RTC/NackGenerator.hpp
@@ -48,7 +48,7 @@ namespace RTC
 		};
 
 	public:
-		explicit NackGenerator(Listener* listener, SharedInterface* shared, unsigned int sendNackDelayMs);
+		explicit NackGenerator(Listener* listener, SharedInterface* shared, uint32_t sendNackDelayMs);
 		~NackGenerator() override;
 
 		bool ReceivePacket(const RTC::RTP::Packet* packet, bool isRecovered);
@@ -76,7 +76,7 @@ namespace RTC
 		// Passed by argument.
 		Listener* listener{ nullptr };
 		SharedInterface* shared{ nullptr };
-		unsigned int sendNackDelayMs{ 0u };
+		uint32_t sendNackDelayMs{ 0u };
 		// Allocated by this.
 		TimerHandleInterface* timer{ nullptr };
 		// Others.

--- a/worker/include/RTC/RTP/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RTP/RtpStreamRecv.hpp
@@ -49,7 +49,7 @@ namespace RTC
 			  RTP::RtpStreamRecv::Listener* listener,
 			  SharedInterface* shared,
 			  RTP::RtpStream::Params& params,
-			  unsigned int sendNackDelayMs,
+			  uint32_t sendNackDelayMs,
 			  bool useRtpInactivityCheck);
 			~RtpStreamRecv() override;
 
@@ -105,7 +105,7 @@ namespace RTC
 
 		private:
 			// Passed by argument.
-			unsigned int sendNackDelayMs{ 0u };
+			uint32_t sendNackDelayMs{ 0u };
 			bool useRtpInactivityCheck{ false };
 			// Others.
 			// Packets expected at last interval.

--- a/worker/src/RTC/NackGenerator.cpp
+++ b/worker/src/RTC/NackGenerator.cpp
@@ -16,7 +16,7 @@ namespace RTC
 
 	/* Instance methods. */
 
-	NackGenerator::NackGenerator(Listener* listener, SharedInterface* shared, unsigned int sendNackDelayMs)
+	NackGenerator::NackGenerator(Listener* listener, SharedInterface* shared, uint32_t sendNackDelayMs)
 	  : listener(listener),
 	    shared(shared),
 	    sendNackDelayMs(sendNackDelayMs),

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -20,7 +20,7 @@ namespace RTC
 
 	static constexpr size_t ProducerSendBufferSize{ 65536 };
 	static thread_local uint8_t ProducerSendBuffer[ProducerSendBufferSize];
-	static constexpr unsigned int SendNackDelay{ 10u }; // In ms.
+	static constexpr uint32_t SendNackDelay{ 10u }; // In ms.
 
 	/* Instance methods. */
 

--- a/worker/src/RTC/SeqManager.cpp
+++ b/worker/src/RTC/SeqManager.cpp
@@ -140,9 +140,7 @@ namespace RTC
 			}
 
 			// There are dropped inputs, calculate 'base' for this input.
-			auto droppedCount = std::distance(
-			  this->dropped.begin(),
-			  std::lower_bound(this->dropped.begin(), this->dropped.end(), input, SeqLowerThan()));
+			auto droppedCount = std::distance(this->dropped.begin(), it);
 
 			base = (this->base - droppedCount) & SeqManager::MaxValue;
 		}

--- a/worker/test/src/RTC/RTP/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/RTP/TestRtpStreamRecv.cpp
@@ -8,7 +8,7 @@
 
 // 17: 16 bit mask + the initial sequence number.
 static constexpr size_t MaxRequestedPackets{ 17 };
-static constexpr unsigned int SendNackDelay{ 0u }; // In ms.
+static constexpr uint32_t SendNackDelay{ 0u }; // In ms.
 static const bool UseRtpInactivityCheck{ false };
 
 SCENARIO("RtpStreamRecv", "[rtp][rtpstream][rtpstreamrecv]")

--- a/worker/test/src/RTC/TestNackGenerator.cpp
+++ b/worker/test/src/RTC/TestNackGenerator.cpp
@@ -9,7 +9,7 @@
 
 SCENARIO("NackGenerator generator", "[rtp][rtcp][nack]")
 {
-	constexpr unsigned int SendNackDelay{ 0u }; // In ms.
+	constexpr uint32_t SendNackDelay{ 0u }; // In ms.
 
 	struct TestNackGeneratorInput
 	{


### PR DESCRIPTION
Reuse previous `iterator` in `SeqManager::Input()`
Change the type of `sendNackDelayMs` from `unsigned int` to `uint32_t`