### PR TITLE
Handle new STUN "NOMINATION" attribute `0x0030`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Worker: Handle new STUN "NOMINATION`" attribute `0x0030` ([XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Worker: Handle new STUN "NOMINATION" attribute `0x0030` ([1846](https://github.com/versatica/mediasoup/pull/1846)).
 
 ### 3.20.9
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Worker: Handle new STUN "NOMINATION`" attribute `0x0030` ([XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 3.20.9
 
 - Worker: Replace `uint64_t` hash with `TupleKey` in `TransportTuple` to avoid hash collisions ([1823](https://github.com/versatica/mediasoup/pull/1823)).

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Worker: Replace `uint64_t` hash with `TupleKey` in `TransportTuple` to avoid hash collisions ([1823](https://github.com/versatica/mediasoup/pull/1823)).
 - Worker: Fix `SeqManager::GetMaxOutput()` ([1840](https://github.com/versatica/mediasoup/pull/1840)).
+- Worker: Handle new STUN "NOMINATION`" attribute `0x0030` ([XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
 
 ### 0.22.8
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Worker: Replace `uint64_t` hash with `TupleKey` in `TransportTuple` to avoid hash collisions ([1823](https://github.com/versatica/mediasoup/pull/1823)).
 - Worker: Fix `SeqManager::GetMaxOutput()` ([1840](https://github.com/versatica/mediasoup/pull/1840)).
-- Worker: Handle new STUN "NOMINATION`" attribute `0x0030` ([XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Worker: Handle new STUN "NOMINATION" attribute `0x0030` ([1846](https://github.com/versatica/mediasoup/pull/1846)).
 
 ### 0.22.8
 

--- a/worker/include/RTC/ICE/StunPacket.hpp
+++ b/worker/include/RTC/ICE/StunPacket.hpp
@@ -113,7 +113,21 @@ namespace RTC
 				FINGERPRINT        = 0x8028,
 				ICE_CONTROLLED     = 0x8029,
 				ICE_CONTROLLING    = 0x802A,
-				NOMINATION         = 0xC001
+				/**
+				 * In libwebrtc native code, STUN_ATTR_NOMINATION is defined as 0xC001.
+				 * However that value is not defined in any RFC/draft, not even in the
+				 * draft that defines the NOMINATION attribute.
+				 *
+				 * @see https://datatracker.ietf.org/doc/html/draft-thatcher-ice-renomination
+				 * @see https://issues.webrtc.org/issues/496629058
+				 */
+				NOMINATION_OLD = 0xC001,
+				/**
+				 * Value of the NOMINATION attribute in the new specification.
+				 *
+				 * @see https://juberti.github.io/draft-renomination/draft-thatcher-tsvwg-renomination.html
+				 */
+				NOMINATION = 0x0030
 			};
 
 			// Authentication result.
@@ -290,7 +304,12 @@ namespace RTC
 
 			uint32_t GetNomination() const
 			{
-				const auto* attribute = GetAttribute(StunPacket::AttributeType::NOMINATION);
+				auto* attribute = GetAttribute(StunPacket::AttributeType::NOMINATION);
+
+				if (!attribute)
+				{
+					attribute = GetAttribute(StunPacket::AttributeType::NOMINATION_OLD);
+				}
 
 				if (!attribute)
 				{

--- a/worker/src/RTC/ICE/IceServer.cpp
+++ b/worker/src/RTC/ICE/IceServer.cpp
@@ -523,7 +523,8 @@ namespace RTC
 			HandleTuple(
 			  tuple,
 			  request->HasAttribute(StunPacket::AttributeType::USE_CANDIDATE),
-			  request->HasAttribute(StunPacket::AttributeType::NOMINATION),
+			  request->HasAttribute(StunPacket::AttributeType::NOMINATION) ||
+			    request->HasAttribute(StunPacket::AttributeType::NOMINATION_OLD),
 			  request->GetNomination());
 
 			// If state is 'connected' or 'completed' after handling the tuple, then

--- a/worker/src/RTC/ICE/StunPacket.cpp
+++ b/worker/src/RTC/ICE/StunPacket.cpp
@@ -250,6 +250,11 @@ namespace RTC
 				MS_DUMP_CLEAN(indentation + 1, "  nomination: %" PRIu32, GetNomination());
 			}
 
+			if (HasAttribute(StunPacket::AttributeType::NOMINATION_OLD))
+			{
+				MS_DUMP_CLEAN(indentation + 1, "  nomination (old): %" PRIu32, GetNomination());
+			}
+
 			if (HasAttribute(StunPacket::AttributeType::SOFTWARE))
 			{
 				const auto software = GetSoftware();
@@ -404,6 +409,8 @@ namespace RTC
 
 			StoreNewAttribute(
 			  StunPacket::AttributeType::NOMINATION, AttributeFactoryBuffer, sizeof(nomination));
+			StoreNewAttribute(
+			  StunPacket::AttributeType::NOMINATION_OLD, AttributeFactoryBuffer, sizeof(nomination));
 		}
 
 		void StunPacket::AddSoftware(const std::string_view software)
@@ -1058,6 +1065,7 @@ namespace RTC
 					}
 
 					case StunPacket::AttributeType::NOMINATION:
+					case StunPacket::AttributeType::NOMINATION_OLD:
 					{
 						if (attrLen != 4)
 						{

--- a/worker/test/src/RTC/ICE/TestStunPacket.cpp
+++ b/worker/test/src/RTC/ICE/TestStunPacket.cpp
@@ -508,7 +508,9 @@ SCENARIO("ICE StunPacket", "[serializable][ice][stunpacket]")
 		// Byte length: 8.
 		uint64_t iceControlling = 15697499370457501716u;
 		// Byte length of USE_CANDIDATE: 0.
-		// // Byte length: 4.
+		// NOTE: `AddNomination()` adds the "NOMINATION" attribute with both the old
+		// and the new value, so it will insert 2 attributes instead of one.
+		// Byte length: 4 x 2.
 		uint32_t nomination = 12345678u;
 		// Byte length: 18 (2 byte of padding needed).
 		std::string software = "mediasoup x.y.z :)";
@@ -518,7 +520,7 @@ SCENARIO("ICE StunPacket", "[serializable][ice][stunpacket]")
 
 		// Total length of the attributes.
 		size_t attributesLen =
-		  (4 + 27 + 1) + (4 + 4) + (4 + 8) + (4) + (4 + 4) + (4 + 18 + 2) + (4 + 4 + 23 + 1);
+		  (4 + 27 + 1) + (4 + 4) + (4 + 8) + (4) + ((4 + 4) * 2) + (4 + 18 + 2) + (4 + 4 + 23 + 1);
 
 		request->AddUsername(username);
 		request->AddPriority(priority);
@@ -533,6 +535,8 @@ SCENARIO("ICE StunPacket", "[serializable][ice][stunpacket]")
 		REQUIRE_THROWS_AS(request->AddPriority(priority), MediaSoupError);
 		REQUIRE_THROWS_AS(request->AddIceControlling(iceControlling), MediaSoupError);
 		REQUIRE_THROWS_AS(request->AddUseCandidate(), MediaSoupError);
+		// NOTE: `AddNomination()` adds the "NOMINATION" attribute with both the old
+		// and the new value, so it will insert 2 attributes instead of one.
 		REQUIRE_THROWS_AS(request->AddNomination(nomination), MediaSoupError);
 		REQUIRE_THROWS_AS(request->AddSoftware(software), MediaSoupError);
 		REQUIRE_THROWS_AS(request->AddErrorCode(errorCode, errorReasonPhrase), MediaSoupError);


### PR DESCRIPTION
# Details

- The STUN "NOMINATION" attribute is not yet a standard specification. In libwebrtc native code, `STUN_ATTR_NOMINATION` is defined as `0xC001`. However that value is not defined in any RFC/draft, not even in the draft that defines the NOMINATION attribute. See the old draft https://datatracker.ietf.org/doc/html/draft-thatcher-ice-renomination.
- So there is an ongoing effort to standardize it (see https://issues.webrtc.org/issues/496629058 and the ongoing draft https://juberti.github.io/draft-renomination/draft-thatcher-tsvwg-renomination.html).
- The ongoing draft defines the "NOMINATION" attribute with value `0x0030`.
- In this PR we make `IceServer` handle both, the old value `0xC001` and the new one `0x0030`.
- Fixes #1766 