### PR TITLE
rust-scripts: sync sibling crate version requirement on release

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -132,7 +132,7 @@ The publish dry-run is skipped when the `mediasoup` crate version is already pub
 Prepares and triggers the release of a new version "x.y.z" of a mediasoup Rust crate (`mediasoup`, `mediasoup-sys` or `mediasoup-types`). The actual GitHub release (if any) and crates.io publish are done by GitHub Actions (`mediasoup-crate-publish.yaml`) once the pushed commit/tag arrives. It:
 
 - Performs checks (lint + test + build + publish dry-run, plus the `rust/CHANGELOG.md` entry check when releasing the `mediasoup` crate). They run before the version bump, so the CHANGELOG check validates the previous version's entry (still in the manifest), which is harmless.
-- Bumps the crate version to "x.y.z" in its `Cargo.toml` (`rust/Cargo.toml`, `worker/Cargo.toml` or `rust/types/Cargo.toml`) and reflects it in the (workspace root) `Cargo.lock`.
+- Bumps the crate version to "x.y.z" in its `Cargo.toml` (`rust/Cargo.toml`, `worker/Cargo.toml` or `rust/types/Cargo.toml`) and reflects it in the (workspace root) `Cargo.lock`. When releasing `mediasoup-sys` / `mediasoup-types`, it also bumps the matching `version` requirement of that dependency in the `mediasoup` crate's `rust/Cargo.toml` (committed together with the release), so the `mediasoup` crate keeps depending on the just-released version.
 
 Then, depending on the crate:
 

--- a/doc/Rust-crates.md
+++ b/doc/Rust-crates.md
@@ -14,24 +14,24 @@ There are 3 crates: `mediasoup`, `mediasoup-sys` and `mediasoup-types`:
 
 Each crate is published through an automated flow (mirroring how the NPM package is released): `npm run release:rust <crate> X.Y.Z` bumps the version, commits and pushes, and the `mediasoup-crate-publish.yaml` workflow then publishes the crate to crates.io via OIDC trusted publishing.
 
-Because `mediasoup` depends on `mediasoup-sys` and `mediasoup-types`, when more than one crate needs a new version, **publish the dependencies first** (`mediasoup-types` and/or `mediasoup-sys`) and `mediasoup` last, so each crate's dependencies are already on crates.io when it is published.
+Because `mediasoup` depends on `mediasoup-sys` and `mediasoup-types`, when more than one crate needs a new version, **publish the dependencies first** (`mediasoup-types` and/or `mediasoup-sys`) and `mediasoup` last, so each crate's dependencies are already on crates.io when it is published. Each release updates only the released crate's own resolved version in `Cargo.lock` (within that crate's release commit), so releasing a dependency is what refreshes its `Cargo.lock` entry, and the later `mediasoup` release only touches `mediasoup`'s own entry.
 
-You do **not** bump the crate's `[package].version` nor edit `rust/CHANGELOG.md` yourself; `npm run release:rust` does that. For each crate to publish:
+You do **not** bump the crate's `[package].version`, edit `rust/CHANGELOG.md`, nor edit the sibling `version` requirements in `rust/Cargo.toml` yourself; `npm run release:rust` does all that. For each crate to publish:
 
 1. Have the crate's code changes merged on the main branch. When publishing the `mediasoup` crate, the changes for the new version must be under the `### NEXT` heading of `rust/CHANGELOG.md`.
-2. Do **not** edit the `version` of `[dependencies.mediasoup-sys]` / `[dependencies.mediasoup-types]` in `rust/Cargo.toml` just to release those crates: that requirement is what the _published_ `mediasoup` crate depends on (its `path` is only used for local builds and dropped when published), and you bump it only when releasing a `mediasoup` that must depend on the new version. Cargo keeps that requirement and the crate's actual version compatible across the workspace, so a breaking (minor/major) bump of `mediasoup-sys` / `mediasoup-types` does require updating the requirement in the same change, and is therefore published together with a new `mediasoup`.
-3. Run `cargo build` to reflect any change in `Cargo.lock` and commit the updated `Cargo.lock`. Do not skip this: a stale `Cargo.lock` is harmless for crate consumers (they ignore the packaged lock) but leaves the repo and CI out of sync, and the release aborts on it.
+2. You do **not** edit the `version` of `[dependencies.mediasoup-sys]` / `[dependencies.mediasoup-types]` in `rust/Cargo.toml` yourself: that requirement is what the _published_ `mediasoup` crate depends on (its `path` is only used for local builds and is dropped when published). Releasing `mediasoup-sys` / `mediasoup-types` automatically bumps that requirement to the just-released version and commits it together with the release, so the `mediasoup` crate always depends on the latest version of its siblings (and the workspace stays buildable after a breaking minor/major bump, where the requirement must keep accepting the sibling's actual version).
+3. Make sure `Cargo.lock` is already in sync with the merged code, committing it if an earlier change to third-party dependencies left it stale (run `cargo build`). This is only about pre-existing code changes, **not** the version bump: `npm run release:rust` regenerates `Cargo.lock` for the bumped version itself and commits it within the crate's own release commit. A stale `Cargo.lock` is harmless for crate consumers (they ignore the packaged lock) but leaves the repo out of sync and breaks the `--locked` GitHub Actions workflows, and the release aborts on it.
 4. On the main branch, with a clean work tree, run:
 
 ```sh
 npm run release:rust mediasoup-types X.Y.Z
 # and/or
 npm run release:rust mediasoup-sys X.Y.Z
-# and finally
+# and finally, when a new mediasoup must depend on the version(s) just released
 npm run release:rust mediasoup X.Y.Z
 ```
 
-This runs the checks, bumps the crate version in its `Cargo.toml` and in `Cargo.lock`, and then:
+This runs the checks, bumps the crate version in its `Cargo.toml` (and, for `mediasoup-sys` / `mediasoup-types`, the matching `version` requirement in the `mediasoup` crate's `rust/Cargo.toml`) and in `Cargo.lock`, and then:
 
 - For `mediasoup`: sets the top `### NEXT` heading of `rust/CHANGELOG.md` to `### X.Y.Z`, commits (`release rust-X.Y.Z [no-ci]`), creates the `rust-X.Y.Z` tag and pushes the branch and the tag. The tag triggers `mediasoup-crate-publish.yaml`, which creates the GitHub release from `rust/CHANGELOG.md` and publishes the crate.
 - For `mediasoup-sys` / `mediasoup-types`: commits (`<crate> X.Y.Z [crate-publish] [no-ci]`) and pushes the branch (no tag, no GitHub release). The `[crate-publish]` marker is what `mediasoup-crate-publish.yaml` detects on the branch push to publish that crate.

--- a/rust-scripts.mjs
+++ b/rust-scripts.mjs
@@ -9,15 +9,26 @@ const GH_REPO = 'mediasoup';
 // Main Git branch is 'v' concatenated with the major SEMVER number of the
 // "version" field in package.json.
 const MAIN_BRANCH = `v${pkg.version.split('.')[0]}`;
-// The three publishable mediasoup Rust crates and the Cargo.toml manifest that
-// holds each one's version. The `mediasoup` crate is special: releasing it
-// creates a `rust-X.Y.Z` Git tag and a GitHub release built from its CHANGELOG;
-// the other two are published without a tag or a GitHub release (the
-// `mediasoup-crate-publish.yaml` workflow detects them from the commit message).
+// The three publishable mediasoup Rust crates. For each one: `manifest` is the
+// Cargo.toml that holds its `[package].version`, and `dependents` lists the
+// workspace manifests that declare it as a dependency (whose `version`
+// requirement is bumped to the released version too). The `mediasoup` crate is
+// special: releasing it creates a `rust-X.Y.Z` Git tag and a GitHub release
+// built from its CHANGELOG; the other two are published without a tag or a
+// GitHub release (the `mediasoup-crate-publish.yaml` workflow detects them from
+// the commit message).
 const CRATES = [
 	{ name: 'mediasoup', manifest: 'rust/Cargo.toml' },
-	{ name: 'mediasoup-sys', manifest: 'worker/Cargo.toml' },
-	{ name: 'mediasoup-types', manifest: 'rust/types/Cargo.toml' },
+	{
+		name: 'mediasoup-sys',
+		manifest: 'worker/Cargo.toml',
+		dependents: ['rust/Cargo.toml'],
+	},
+	{
+		name: 'mediasoup-types',
+		manifest: 'rust/types/Cargo.toml',
+		dependents: ['rust/Cargo.toml'],
+	},
 ];
 // The `mediasoup` crate, whose rust/CHANGELOG.md drives the GitHub release body.
 const MEDIASOUP_CRATE = CRATES[0];
@@ -196,6 +207,19 @@ async function release({ args = '' } = {}) {
 	// Bump the crate version in its Cargo.toml and reflect it in the (workspace)
 	// root Cargo.lock.
 	bumpCargoVersion(crate.manifest, version);
+
+	// Keep every workspace manifest that depends on this crate pointing at the
+	// just-released version (the `mediasoup` crate's `version` requirement on
+	// `mediasoup-sys` / `mediasoup-types` in rust/Cargo.toml). These are
+	// `path` + `version` dependencies, so the requirement must keep accepting the
+	// sibling's actual version (otherwise a breaking bump would fail the
+	// `cargo metadata` in syncCargoLock()); bumping it here also makes the next
+	// `mediasoup` release depend on the new version, and it is committed together
+	// with this release commit.
+	for (const dependent of crate.dependents ?? []) {
+		updateDependencyVersion(dependent, crate.name, version);
+	}
+
 	syncCargoLock();
 
 	if (crate.name === 'mediasoup') {
@@ -405,6 +429,56 @@ function bumpCargoVersion(manifestPath, version) {
 	if (!bumped) {
 		logError(
 			`bumpCargoVersion() | no 'version' key found in [package] section of '${manifestPath}'`
+		);
+
+		exitWithError();
+	}
+
+	fs.writeFileSync(manifestPath, lines.join('\n'));
+}
+
+/**
+ * Rewrites the `version` key of the `[dependencies.<depName>]` table of the
+ * given Cargo.toml (the table form used across the workspace, e.g.
+ * `[dependencies.mediasoup-sys]`), leaving its `path` and any other keys
+ * untouched. Used to keep the `mediasoup` crate's requirement on a sibling crate
+ * in sync when that sibling is released.
+ */
+function updateDependencyVersion(manifestPath, depName, version) {
+	logInfo(
+		`updateDependencyVersion() [manifest:${manifestPath}, dep:${depName}, version:${version}]`
+	);
+
+	const content = fs.readFileSync(manifestPath, { encoding: 'utf-8' });
+	const lines = content.split('\n');
+	const sectionHeader = `[dependencies.${depName}]`;
+
+	let inDepSection = false;
+	let bumped = false;
+
+	for (let idx = 0; idx < lines.length; ++idx) {
+		const trimmed = lines[idx].trim();
+
+		if (trimmed.startsWith('[')) {
+			inDepSection = trimmed === sectionHeader;
+
+			continue;
+		}
+
+		if (inDepSection && /^version\s*=\s*"[^"]+"/.test(trimmed)) {
+			lines[idx] = lines[idx].replace(
+				/version\s*=\s*"[^"]+"/,
+				`version = "${version}"`
+			);
+			bumped = true;
+
+			break;
+		}
+	}
+
+	if (!bumped) {
+		logError(
+			`updateDependencyVersion() | no 'version' key found in '${sectionHeader}' section of '${manifestPath}'`
 		);
 
 		exitWithError();


### PR DESCRIPTION
# Details

- When releasing `mediasoup-sys` or `mediasoup-types`, the release script now also bumps the matching `version` requirement of that dependency in the `mediasoup` crate's `rust/Cargo.toml`, committed together with the release. Previously only the crate's own `[package].version` was bumped, leaving the sibling requirement stale.
- This keeps the workspace buildable after a breaking (minor/major) bump: since these are `path` + `version` dependencies, Cargo requires the requirement to keep accepting the sibling's actual version, otherwise `cargo metadata` in syncCargoLock() would fail.