### PR TITLE
Avoid error logs when TCP peer sends a RST right after the TCP handshake completes

### DIFF
--- a/worker/include/handles/TcpConnectionHandle.hpp
+++ b/worker/include/handles/TcpConnectionHandle.hpp
@@ -64,7 +64,7 @@ public:
 	{
 		return this->uvHandle;
 	}
-	void Start();
+	bool Start() noexcept;
 	void Write(
 	  const uint8_t* data1,
 	  size_t len1,
@@ -90,7 +90,7 @@ public:
 	}
 	const struct sockaddr* GetPeerAddress() const
 	{
-		return reinterpret_cast<const struct sockaddr*>(&this->peerAddr);
+		return reinterpret_cast<const struct sockaddr*>(std::addressof(this->peerAddr));
 	}
 	const std::string& GetPeerIp() const
 	{

--- a/worker/include/handles/TcpServerHandle.hpp
+++ b/worker/include/handles/TcpServerHandle.hpp
@@ -20,11 +20,11 @@ public:
 	void Dump(int indentation = 0) const;
 	const struct sockaddr* GetLocalAddress() const
 	{
-		return reinterpret_cast<const struct sockaddr*>(&this->localAddr);
+		return reinterpret_cast<const struct sockaddr*>(std::addressof(this->localAddr));
 	}
 	int GetLocalFamily() const
 	{
-		return reinterpret_cast<const struct sockaddr*>(&this->localAddr)->sa_family;
+		return reinterpret_cast<const struct sockaddr*>(std::addressof(this->localAddr))->sa_family;
 	}
 	const std::string& GetLocalIp() const
 	{

--- a/worker/include/handles/UdpSocketHandle.hpp
+++ b/worker/include/handles/UdpSocketHandle.hpp
@@ -51,11 +51,11 @@ public:
 	  const uint8_t* data, size_t len, const struct sockaddr* addr, UdpSocketHandle::onSendCallback* cb);
 	const struct sockaddr* GetLocalAddress() const
 	{
-		return reinterpret_cast<const struct sockaddr*>(&this->localAddr);
+		return reinterpret_cast<const struct sockaddr*>(std::addressof(this->localAddr));
 	}
 	int GetLocalFamily() const
 	{
-		return reinterpret_cast<const struct sockaddr*>(&this->localAddr)->sa_family;
+		return reinterpret_cast<const struct sockaddr*>(std::addressof(this->localAddr))->sa_family;
 	}
 	const std::string& GetLocalIp() const
 	{

--- a/worker/src/handles/TcpConnectionHandle.cpp
+++ b/worker/src/handles/TcpConnectionHandle.cpp
@@ -138,13 +138,13 @@ void TcpConnectionHandle::Setup(
 	this->localPort = localPort;
 }
 
-void TcpConnectionHandle::Start()
+bool TcpConnectionHandle::Start() noexcept
 {
 	MS_TRACE();
 
 	if (this->closed)
 	{
-		return;
+		return false;
 	}
 
 	// NOLINTNEXTLINE(misc-const-correctness)
@@ -155,14 +155,18 @@ void TcpConnectionHandle::Start()
 
 	if (err != 0)
 	{
-		MS_THROW_ERROR("uv_read_start() failed: %s", uv_strerror(err));
+		MS_ERROR("uv_read_start() failed: %s", uv_strerror(err));
+
+		return false;
 	}
 
 	// Get the peer address.
 	if (!SetPeerAddress())
 	{
-		MS_THROW_ERROR("error setting peer IP and port");
+		return false;
 	}
+
+	return true;
 }
 
 void TcpConnectionHandle::Write(
@@ -364,11 +368,18 @@ bool TcpConnectionHandle::SetPeerAddress()
 	int err;
 	int len = sizeof(this->peerAddr);
 
-	err = uv_tcp_getpeername(this->uvHandle, reinterpret_cast<struct sockaddr*>(&this->peerAddr), &len);
+	// NOTE: `uv_tcp_getpeername()` fails if the socket is not connected. This is
+	// a legitimate scenario since at the time `uv_accept()` was called it may
+	// happen that the peer sent a TCP RST already. In fact, this is the proper
+	// and only way to check whether the socket remains connected now.
+	err = uv_tcp_getpeername(
+	  this->uvHandle,
+	  reinterpret_cast<struct sockaddr*>(std::addressof(this->peerAddr)),
+	  std::addressof(len));
 
 	if (err != 0)
 	{
-		MS_ERROR("uv_tcp_getpeername() failed: %s", uv_strerror(err));
+		MS_DEBUG_DEV("uv_tcp_getpeername() failed: %s", uv_strerror(err));
 
 		return false;
 	}
@@ -376,7 +387,10 @@ bool TcpConnectionHandle::SetPeerAddress()
 	int family;
 
 	Utils::IP::GetAddressInfo(
-	  reinterpret_cast<const struct sockaddr*>(&this->peerAddr), family, this->peerIp, this->peerPort);
+	  reinterpret_cast<const struct sockaddr*>(std::addressof(this->peerAddr)),
+	  family,
+	  this->peerIp,
+	  this->peerPort);
 
 	return true;
 }

--- a/worker/src/handles/TcpServerHandle.cpp
+++ b/worker/src/handles/TcpServerHandle.cpp
@@ -159,7 +159,7 @@ void TcpServerHandle::AcceptTcpConnection(TcpConnectionHandle* connection)
 
 	try
 	{
-		connection->Setup(this, &(this->localAddr), this->localIp, this->localPort);
+		connection->Setup(this, std::addressof(this->localAddr), this->localIp, this->localPort);
 	}
 	catch (const MediaSoupError& error)
 	{
@@ -179,12 +179,7 @@ void TcpServerHandle::AcceptTcpConnection(TcpConnectionHandle* connection)
 	}
 
 	// Start receiving data.
-	try
-	{
-		// NOTE: This may throw.
-		connection->Start();
-	}
-	catch (const MediaSoupError& error)
+	if (!connection->Start())
 	{
 		delete connection;
 
@@ -226,8 +221,10 @@ bool TcpServerHandle::SetLocalAddress()
 	int err;
 	int len = sizeof(this->localAddr);
 
-	err =
-	  uv_tcp_getsockname(this->uvHandle, reinterpret_cast<struct sockaddr*>(&this->localAddr), &len);
+	err = uv_tcp_getsockname(
+	  this->uvHandle,
+	  reinterpret_cast<struct sockaddr*>(std::addressof(this->localAddr)),
+	  std::addressof(len));
 
 	if (err != 0)
 	{
@@ -239,7 +236,10 @@ bool TcpServerHandle::SetLocalAddress()
 	int family;
 
 	Utils::IP::GetAddressInfo(
-	  reinterpret_cast<const struct sockaddr*>(&this->localAddr), family, this->localIp, this->localPort);
+	  reinterpret_cast<const struct sockaddr*>(std::addressof(this->localAddr)),
+	  family,
+	  this->localIp,
+	  this->localPort);
 
 	return true;
 }

--- a/worker/src/handles/UdpSocketHandle.cpp
+++ b/worker/src/handles/UdpSocketHandle.cpp
@@ -146,7 +146,7 @@ void UdpSocketHandle::Send(
 	// then build a uv_req_t and use uv_udp_send().
 
 	uv_buf_t buffer = uv_buf_init(reinterpret_cast<char*>(const_cast<uint8_t*>(data)), len);
-	const int sent  = uv_udp_try_send(this->uvHandle, &buffer, 1, addr);
+	const int sent  = uv_udp_try_send(this->uvHandle, std::addressof(buffer), 1, addr);
 
 	// Entire datagram was sent. Done.
 	if (sent == static_cast<int>(len))
@@ -192,7 +192,12 @@ void UdpSocketHandle::Send(
 	buffer = uv_buf_init(reinterpret_cast<char*>(sendData->store), len);
 
 	const int err = uv_udp_send(
-	  &sendData->req, this->uvHandle, &buffer, 1, addr, static_cast<uv_udp_send_cb>(onSend));
+	  std::addressof(sendData->req),
+	  this->uvHandle,
+	  std::addressof(buffer),
+	  1,
+	  addr,
+	  static_cast<uv_udp_send_cb>(onSend));
 
 	if (err != 0)
 	{
@@ -319,8 +324,10 @@ bool UdpSocketHandle::SetLocalAddress()
 	int err;
 	int len = sizeof(this->localAddr);
 
-	err =
-	  uv_udp_getsockname(this->uvHandle, reinterpret_cast<struct sockaddr*>(&this->localAddr), &len);
+	err = uv_udp_getsockname(
+	  this->uvHandle,
+	  reinterpret_cast<struct sockaddr*>(std::addressof(this->localAddr)),
+	  std::addressof(len));
 
 	if (err != 0)
 	{
@@ -332,7 +339,10 @@ bool UdpSocketHandle::SetLocalAddress()
 	int family;
 
 	Utils::IP::GetAddressInfo(
-	  reinterpret_cast<const struct sockaddr*>(&this->localAddr), family, this->localIp, this->localPort);
+	  reinterpret_cast<const struct sockaddr*>(std::addressof(this->localAddr)),
+	  family,
+	  this->localIp,
+	  this->localPort);
 
 	return true;
 }

--- a/worker/src/handles/UnixStreamSocketHandle.cpp
+++ b/worker/src/handles/UnixStreamSocketHandle.cpp
@@ -211,7 +211,8 @@ void UnixStreamSocketHandle::Write(const uint8_t* data, size_t len)
 	// then build a uv_req_t and use uv_write().
 
 	uv_buf_t buffer = uv_buf_init(reinterpret_cast<char*>(const_cast<uint8_t*>(data)), len);
-	int written     = uv_try_write(reinterpret_cast<uv_stream_t*>(this->uvHandle), &buffer, 1);
+	int written =
+	  uv_try_write(reinterpret_cast<uv_stream_t*>(this->uvHandle), std::addressof(buffer), 1);
 
 	// All the data was written. Done.
 	if (written == static_cast<int>(len))
@@ -242,9 +243,9 @@ void UnixStreamSocketHandle::Write(const uint8_t* data, size_t len)
 	buffer = uv_buf_init(reinterpret_cast<char*>(writeData->store), pendingLen);
 
 	const int err = uv_write(
-	  &writeData->req,
+	  std::addressof(writeData->req),
 	  reinterpret_cast<uv_stream_t*>(this->uvHandle),
-	  &buffer,
+	  std::addressof(buffer),
 	  1,
 	  static_cast<uv_write_cb>(onWrite));
 


### PR DESCRIPTION
# Details

- Some logs like these happen:
  ```
  [mediasoup:mediasoup:ERROR:Channel] [pid:68] TcpConnectionHandle::SetPeerAddress() | uv_tcp_getpeername() failed: socket is not connected
  [mediasoup:mediasoup:ERROR:Channel] [pid:68] TcpConnectionHandle::Start() | throwing MediaSoupError: error setting peer IP and port
  ```
-  Actually this is a legitimate scenario: `uv_accept()` just pulls an already-handshaked connection's `fd` off the kernel's accept queue. If the peer sends a RST in the gap between the kernel completing the handshake and the event loop calling `uv_accept()`, the kernel tears down the connection but the `fd` stays valid in the queue. So `uv_accept()` still succeeds and returns a live `fd` pointing at a dead socket, hence `getpeername()` (and thus `uv_tcp_getpeername()` and `TcpConnectionHandle::SetPeerAddress()`) fails with `ENOTCONN`.
- So let's redo it a bit to avoid those false alarms.