### PR TITLE
Worker: Enable SVC for VP8 and H264

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+Worker: Enable SVC for VP8 and H264 ([PR #1851](https://github.com/versatica/mediasoup/pull/1851)).
+
 ### 3.20.10
 
 - Worker: Handle new STUN "NOMINATION" attribute `0x0030` ([PR #1846](https://github.com/versatica/mediasoup/pull/1846)).

--- a/node/src/test/test-Consumer.ts
+++ b/node/src/test/test-Consumer.ts
@@ -1163,6 +1163,132 @@ test('transport.consume() for a simulcast producer honors preferredLayers', asyn
 	});
 }, 2000);
 
+test('transport.consume() from a single-encoding no temporal layer producer is of type simple', async () => {
+	const router = await ctx.worker!.createRouter({
+		mediaCodecs: ctx.vpxMediaCodecs,
+	});
+	const transport1 = await router.createWebRtcTransport({
+		listenIps: ['127.0.0.1'],
+	});
+	const transport2 = await router.createWebRtcTransport({
+		listenIps: ['127.0.0.1'],
+	});
+
+	const producer = await transport1.produce({
+		kind: 'video',
+		rtpParameters: {
+			codecs: [
+				{
+					mimeType: 'video/VP8',
+					payloadType: 96,
+					clockRate: 90000,
+					rtcpFeedback: [
+						{ type: 'nack', parameter: '' },
+						{ type: 'nack', parameter: 'pli' },
+					],
+				},
+			],
+			headerExtensions: [],
+			encodings: [{ ssrc: 11111111 }],
+			rtcp: { cname: 'test' },
+		},
+	});
+
+	expect(producer.type).toBe('simple');
+
+	const consumer = await transport2.consume({
+		producerId: producer.id,
+		rtpCapabilities: ctx.vpxConsumerDeviceCapabilities,
+	});
+
+	expect(consumer.type).toBe('simple');
+}, 2000);
+
+test('transport.consume() from a single-encoding multiple temporal layer producer is of type svc', async () => {
+	const router = await ctx.worker!.createRouter({
+		mediaCodecs: ctx.vpxMediaCodecs,
+	});
+	const transport1 = await router.createWebRtcTransport({
+		listenIps: ['127.0.0.1'],
+	});
+	const transport2 = await router.createWebRtcTransport({
+		listenIps: ['127.0.0.1'],
+	});
+
+	const producer = await transport1.produce({
+		kind: 'video',
+		rtpParameters: {
+			codecs: [
+				{
+					mimeType: 'video/VP8',
+					payloadType: 96,
+					clockRate: 90000,
+					rtcpFeedback: [
+						{ type: 'nack', parameter: '' },
+						{ type: 'nack', parameter: 'pli' },
+					],
+				},
+			],
+			headerExtensions: [],
+			encodings: [{ ssrc: 55555555, scalabilityMode: 'L1T3' }],
+			rtcp: { cname: 'test' },
+		},
+	});
+
+	expect(producer.type).toBe('svc');
+
+	const consumer = await transport2.consume({
+		producerId: producer.id,
+		rtpCapabilities: ctx.vpxConsumerDeviceCapabilities,
+	});
+
+	expect(consumer.type).toBe('svc');
+}, 2000);
+
+test('transport.consume() from a multiple-encoding producer is of type simulcast', async () => {
+	const router = await ctx.worker!.createRouter({
+		mediaCodecs: ctx.vpxMediaCodecs,
+	});
+	const transport1 = await router.createWebRtcTransport({
+		listenIps: ['127.0.0.1'],
+	});
+	const transport2 = await router.createWebRtcTransport({
+		listenIps: ['127.0.0.1'],
+	});
+
+	const producer = await transport1.produce({
+		kind: 'video',
+		rtpParameters: {
+			codecs: [
+				{
+					mimeType: 'video/VP8',
+					payloadType: 96,
+					clockRate: 90000,
+					rtcpFeedback: [
+						{ type: 'nack', parameter: '' },
+						{ type: 'nack', parameter: 'pli' },
+					],
+				},
+			],
+			headerExtensions: [],
+			encodings: [
+				{ ssrc: 11111111, scalabilityMode: 'L1T3' },
+				{ ssrc: 22222222, scalabilityMode: 'L1T3' },
+			],
+			rtcp: { cname: 'test' },
+		},
+	});
+
+	expect(producer.type).toBe('simulcast');
+
+	const consumer = await transport2.consume({
+		producerId: producer.id,
+		rtpCapabilities: ctx.vpxConsumerDeviceCapabilities,
+	});
+
+	expect(consumer.type).toBe('simulcast');
+}, 2000);
+
 test('consumer.setPriority() succeed', async () => {
 	const videoConsumer = await ctx.webRtcTransport2!.consume({
 		producerId: ctx.videoProducer!.id,

--- a/node/src/test/test-Producer.ts
+++ b/node/src/test/test-Producer.ts
@@ -487,6 +487,66 @@ test('transport.produce() with no MID and with single encoding without RID or SS
 	).rejects.toThrow(Error);
 }, 2000);
 
+test('transport.produce() with single encoding and no temporal layers is of type simple', async () => {
+	const producer = await ctx.webRtcTransport1!.produce({
+		kind: 'video',
+		rtpParameters: {
+			codecs: [
+				{
+					mimeType: 'video/VP8',
+					payloadType: 96,
+					clockRate: 90000,
+				},
+			],
+			encodings: [{ ssrc: 11111111 }],
+			rtcp: { cname: 'test' },
+		},
+	});
+
+	expect(producer.type).toBe('simple');
+}, 2000);
+
+test('transport.produce() with single encoding and temporal layers is of type svc', async () => {
+	const producer = await ctx.webRtcTransport1!.produce({
+		kind: 'video',
+		rtpParameters: {
+			codecs: [
+				{
+					mimeType: 'video/VP8',
+					payloadType: 96,
+					clockRate: 90000,
+				},
+			],
+			encodings: [{ ssrc: 11111111, scalabilityMode: 'L1T3' }],
+			rtcp: { cname: 'test' },
+		},
+	});
+
+	expect(producer.type).toBe('svc');
+}, 2000);
+
+test('transport.produce() with multiple encodings is of type simulcast', async () => {
+	const producer = await ctx.webRtcTransport1!.produce({
+		kind: 'video',
+		rtpParameters: {
+			codecs: [
+				{
+					mimeType: 'video/VP8',
+					payloadType: 96,
+					clockRate: 90000,
+				},
+			],
+			encodings: [
+				{ ssrc: 11111111, scalabilityMode: 'L1T3' },
+				{ ssrc: 22222222, scalabilityMode: 'L1T3' },
+			],
+			rtcp: { cname: 'test' },
+		},
+	});
+
+	expect(producer.type).toBe('simulcast');
+}, 2000);
+
 test('producer.dump() succeeds', async () => {
 	const audioProducer = await ctx.webRtcTransport1!.produce(
 		ctx.audioProducerOptions

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,11 +2,12 @@
 
 ### NEXT
 
+- Worker: Enable SVC for VP8 and H264 ([PR #1851](https://github.com/versatica/mediasoup/pull/1851)).
+
 ### 0.22.10
 
 - Worker: Fix new consumer regressions ([PR #1849](https://github.com/versatica/mediasoup/pull/1849)).
 - Add `NotFoundError`, thrown when the referenced entity in the Worker doesn't exist ([PR #1852](https://github.com/versatica/mediasoup/pull/1852)).
-- Worker: Enable SVC for VP8 and H264 ([PR #1851](https://github.com/versatica/mediasoup/pull/1851)).
 
 ### 0.22.9
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+Worker: Enable SVC for VP8 and H264 ([PR #1851](https://github.com/versatica/mediasoup/pull/1851)).
+
 ### 0.22.9
 
 - Worker: Replace `uint64_t` hash with `TupleKey` in `TransportTuple` to avoid hash collisions ([PR #1823](https://github.com/versatica/mediasoup/pull/1823)).

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -1717,6 +1717,151 @@ fn consume_simulcast_honors_preferred_layers() {
 }
 
 #[test]
+fn consume_single_encoding_no_temporal_is_simple() {
+    future::block_on(async move {
+        let (_executor_guard, _worker, router, transport_1, transport_2) =
+            init_with_media_codecs(media_codecs_vpx()).await;
+
+        let device_capabilities = consumer_device_capabilities_vpx();
+
+        let producer = transport_1
+            .produce(ProducerOptions::new(
+                MediaKind::Video,
+                RtpParameters {
+                    mid: None,
+                    codecs: vec![RtpCodecParameters::Video {
+                        mime_type: MimeTypeVideo::Vp8,
+                        payload_type: 96,
+                        clock_rate: NonZeroU32::new(90000).unwrap(),
+                        parameters: RtpCodecParametersParameters::default(),
+                        rtcp_feedback: vec![RtcpFeedback::Nack, RtcpFeedback::NackPli],
+                    }],
+                    header_extensions: vec![],
+                    encodings: vec![RtpEncodingParameters {
+                        ssrc: Some(11111111),
+                        ..RtpEncodingParameters::default()
+                    }],
+                    rtcp: RtcpParameters {
+                        cname: Some("test".to_string()),
+                        ..RtcpParameters::default()
+                    },
+                    msid: None,
+                },
+            ))
+            .await
+            .expect("Failed to produce single-encoding no temporal video");
+
+        assert!(router.can_consume(&producer.id(), &device_capabilities));
+
+        let consumer = transport_2
+            .consume(ConsumerOptions::new(producer.id(), device_capabilities))
+            .await
+            .expect("Failed to consume single-encoding no temporal video");
+
+        assert_eq!(consumer.r#type(), ConsumerType::Simple);
+    });
+}
+
+#[test]
+fn consume_single_encoding_temporal_is_svc() {
+    future::block_on(async move {
+        let (_executor_guard, _worker, router, transport_1, transport_2) =
+            init_with_media_codecs(media_codecs_vpx()).await;
+
+        let device_capabilities = consumer_device_capabilities_vpx();
+
+        let producer = transport_1
+            .produce(ProducerOptions::new(
+                MediaKind::Video,
+                RtpParameters {
+                    mid: None,
+                    codecs: vec![RtpCodecParameters::Video {
+                        mime_type: MimeTypeVideo::Vp8,
+                        payload_type: 96,
+                        clock_rate: NonZeroU32::new(90000).unwrap(),
+                        parameters: RtpCodecParametersParameters::default(),
+                        rtcp_feedback: vec![RtcpFeedback::Nack, RtcpFeedback::NackPli],
+                    }],
+                    header_extensions: vec![],
+                    encodings: vec![RtpEncodingParameters {
+                        ssrc: Some(11111111),
+                        scalability_mode: "L1T3".parse().unwrap(),
+                        ..RtpEncodingParameters::default()
+                    }],
+                    rtcp: RtcpParameters {
+                        cname: Some("test".to_string()),
+                        ..RtcpParameters::default()
+                    },
+                    msid: None,
+                },
+            ))
+            .await
+            .expect("Failed to produce single-encoding temporal video");
+
+        assert!(router.can_consume(&producer.id(), &device_capabilities));
+
+        let consumer = transport_2
+            .consume(ConsumerOptions::new(producer.id(), device_capabilities))
+            .await
+            .expect("Failed to consume single-encoding temporal video");
+
+        assert_eq!(consumer.r#type(), ConsumerType::Svc);
+    });
+}
+
+#[test]
+fn consume_multiple_encoding_is_simulcast() {
+    future::block_on(async move {
+        let (_executor_guard, _worker, router, transport_1, transport_2) =
+            init_with_media_codecs(media_codecs_vpx()).await;
+
+        let device_capabilities = consumer_device_capabilities_vpx();
+
+        let producer = transport_1
+            .produce(ProducerOptions::new(
+                MediaKind::Video,
+                RtpParameters {
+                    mid: None,
+                    codecs: vec![RtpCodecParameters::Video {
+                        mime_type: MimeTypeVideo::Vp8,
+                        payload_type: 96,
+                        clock_rate: NonZeroU32::new(90000).unwrap(),
+                        parameters: RtpCodecParametersParameters::default(),
+                        rtcp_feedback: vec![RtcpFeedback::Nack, RtcpFeedback::NackPli],
+                    }],
+                    header_extensions: vec![],
+                    encodings: vec![
+                        RtpEncodingParameters {
+                            ssrc: Some(11111111),
+                            ..RtpEncodingParameters::default()
+                        },
+                        RtpEncodingParameters {
+                            ssrc: Some(22222222),
+                            ..RtpEncodingParameters::default()
+                        },
+                    ],
+                    rtcp: RtcpParameters {
+                        cname: Some("test".to_string()),
+                        ..RtcpParameters::default()
+                    },
+                    msid: None,
+                },
+            ))
+            .await
+            .expect("Failed to produce multiple-encoding video");
+
+        assert!(router.can_consume(&producer.id(), &device_capabilities));
+
+        let consumer = transport_2
+            .consume(ConsumerOptions::new(producer.id(), device_capabilities))
+            .await
+            .expect("Failed to consume multiple-encoding video");
+
+        assert_eq!(consumer.r#type(), ConsumerType::Simulcast);
+    });
+}
+
+#[test]
 fn set_unset_priority_succeeds() {
     future::block_on(async move {
         let (_executor_guard, _worker, _router, transport_1, transport_2) = init().await;

--- a/rust/tests/integration/producer.rs
+++ b/rust/tests/integration/producer.rs
@@ -691,6 +691,121 @@ fn produce_no_mid_single_encoding_without_rid_or_ssrc() {
 }
 
 #[test]
+fn produce_single_encoding_no_temporal_is_simple() {
+    future::block_on(async move {
+        let (_worker, _router, transport_1, _transport_2) = init().await;
+
+        let producer = transport_1
+            .produce(ProducerOptions::new(
+                MediaKind::Video,
+                RtpParameters {
+                    mid: None,
+                    codecs: vec![RtpCodecParameters::Video {
+                        mime_type: MimeTypeVideo::Vp8,
+                        payload_type: 96,
+                        clock_rate: NonZeroU32::new(90000).unwrap(),
+                        parameters: RtpCodecParametersParameters::default(),
+                        rtcp_feedback: vec![RtcpFeedback::Nack, RtcpFeedback::NackPli],
+                    }],
+                    header_extensions: vec![],
+                    encodings: vec![RtpEncodingParameters {
+                        ssrc: Some(11111111),
+                        ..RtpEncodingParameters::default()
+                    }],
+                    rtcp: RtcpParameters {
+                        cname: Some("test".to_string()),
+                        ..RtcpParameters::default()
+                    },
+                    msid: None,
+                },
+            ))
+            .await
+            .expect("Failed to produce single-encoding no temporal video");
+
+        assert_eq!(producer.r#type(), ProducerType::Simple);
+    });
+}
+
+#[test]
+fn produce_single_encoding_temporal_is_svc() {
+    future::block_on(async move {
+        let (_worker, _router, transport_1, _transport_2) = init().await;
+
+        let producer = transport_1
+            .produce(ProducerOptions::new(
+                MediaKind::Video,
+                RtpParameters {
+                    mid: None,
+                    codecs: vec![RtpCodecParameters::Video {
+                        mime_type: MimeTypeVideo::Vp8,
+                        payload_type: 96,
+                        clock_rate: NonZeroU32::new(90000).unwrap(),
+                        parameters: RtpCodecParametersParameters::default(),
+                        rtcp_feedback: vec![RtcpFeedback::Nack, RtcpFeedback::NackPli],
+                    }],
+                    header_extensions: vec![],
+                    encodings: vec![RtpEncodingParameters {
+                        ssrc: Some(11111111),
+                        scalability_mode: "L1T3".parse().unwrap(),
+                        ..RtpEncodingParameters::default()
+                    }],
+                    rtcp: RtcpParameters {
+                        cname: Some("test".to_string()),
+                        ..RtcpParameters::default()
+                    },
+                    msid: None,
+                },
+            ))
+            .await
+            .expect("Failed to produce single-encoding temporal video");
+
+        assert_eq!(producer.r#type(), ProducerType::Svc);
+    });
+}
+
+#[test]
+fn produce_multiple_encodings_is_simulcast() {
+    future::block_on(async move {
+        let (_worker, _router, transport_1, _transport_2) = init().await;
+
+        let producer = transport_1
+            .produce(ProducerOptions::new(
+                MediaKind::Video,
+                RtpParameters {
+                    mid: None,
+                    codecs: vec![RtpCodecParameters::Video {
+                        mime_type: MimeTypeVideo::Vp8,
+                        payload_type: 96,
+                        clock_rate: NonZeroU32::new(90000).unwrap(),
+                        parameters: RtpCodecParametersParameters::default(),
+                        rtcp_feedback: vec![RtcpFeedback::Nack, RtcpFeedback::NackPli],
+                    }],
+                    header_extensions: vec![],
+                    encodings: vec![
+                        RtpEncodingParameters {
+                            ssrc: Some(11111111),
+                            ..RtpEncodingParameters::default()
+                        },
+                        RtpEncodingParameters {
+                            ssrc: Some(22222222),
+                            ..RtpEncodingParameters::default()
+                        },
+                    ],
+                    rtcp: RtcpParameters {
+                        cname: Some("test".to_string()),
+                        ..RtcpParameters::default()
+                    },
+                    msid: None,
+                },
+            ))
+            .await
+            .expect("Failed to produce multiple-encoding video");
+
+        assert_eq!(producer.r#type(), ProducerType::Simulcast);
+    });
+}
+
+#[test]
 fn dump_succeeds() {
     future::block_on(async move {
         let (_worker, _router, transport_1, transport_2) = init().await;

--- a/worker/include/RTC/RTP/Codecs/Tools.hpp
+++ b/worker/include/RTC/RTP/Codecs/Tools.hpp
@@ -159,7 +159,9 @@ namespace RTC
 								{
 									switch (mimeType.subtype)
 									{
+										case RTC::RtpCodecMimeType::Subtype::VP8:
 										case RTC::RtpCodecMimeType::Subtype::VP9:
+										case RTC::RtpCodecMimeType::Subtype::H264:
 										case RTC::RtpCodecMimeType::Subtype::AV1:
 										{
 											return true;

--- a/worker/src/RTC/Consumer.cpp
+++ b/worker/src/RTC/Consumer.cpp
@@ -33,12 +33,11 @@ namespace RTC
 	    producerId(producerId),
 	    shared(shared),
 	    listener(listener),
-	    kind(RTC::Media::Kind(data->kind())),
-	    type(RTC::RtpParameters::Type(data->type()))
+	    kind(RTC::Media::Kind(data->kind()))
 	{
 		MS_TRACE();
 
-		this->pipe = this->type == RTC::RtpParameters::Type::PIPE;
+		this->pipe = data->type() == FBS::RtpParameters::Type::PIPE;
 
 		// This may throw.
 		this->rtpParameters = RTC::RtpParameters(data->rtpParameters());
@@ -85,7 +84,7 @@ namespace RTC
 		}
 
 		// Ensure there are as many encodings as consumable encodings for pipe.
-		if (pipe && this->rtpParameters.encodings.size() != this->consumableRtpEncodings.size())
+		if (this->pipe && this->rtpParameters.encodings.size() != this->consumableRtpEncodings.size())
 		{
 			MS_THROW_TYPE_ERROR("number of rtpParameters.encodings and consumableRtpEncodings do not match");
 		}
@@ -202,6 +201,25 @@ namespace RTC
 
 		// Build preferred layers from FBS data.
 		RTC::ConsumerTypes::VideoLayers preferredLayers;
+
+		// Derive the stream type from consumableRtpEncodings.
+		if (this->pipe)
+		{
+			this->type = RTC::RtpParameters::Type::PIPE;
+		}
+		else if (this->consumableRtpEncodings.size() > 1u)
+		{
+			this->type = RTC::RtpParameters::Type::SIMULCAST;
+		}
+		else if (this->consumableRtpEncodings[0].spatialLayers > 1u || this->consumableRtpEncodings[0].temporalLayers > 1u)
+		{
+			// Single encoding with multiple layers is always SVC.
+			this->type = RTC::RtpParameters::Type::SVC;
+		}
+		else
+		{
+			this->type = RTC::RtpParameters::Type::SIMPLE;
+		}
 
 		// Create the appropriate ProducerStreamManager subclass based on type.
 		switch (this->type)

--- a/worker/src/RTC/RTP/Codecs/H264.cpp
+++ b/worker/src/RTC/RTP/Codecs/H264.cpp
@@ -178,6 +178,9 @@ namespace RTC
 					return false;
 				}
 
+				// H264 always has a single spatial layer (0).
+				context->SetCurrentSpatialLayer(0);
+
 				// Update/fix current temporal layer.
 				if (this->payloadDescriptor->temporalLayer > context->GetCurrentTemporalLayer())
 				{

--- a/worker/src/RTC/RTP/Codecs/VP8.cpp
+++ b/worker/src/RTC/RTP/Codecs/VP8.cpp
@@ -348,6 +348,9 @@ namespace RTC
 					return false;
 				}
 
+				// VP8 always has a single spatial layer (0).
+				context->SetCurrentSpatialLayer(0);
+
 				// Update/fix current temporal layer.
 				if (this->payloadDescriptor->hasTlIndex && this->payloadDescriptor->tlIndex == context->GetTargetTemporalLayer())
 				{

--- a/worker/src/RTC/SvcProducerStreamManager.cpp
+++ b/worker/src/RTC/SvcProducerStreamManager.cpp
@@ -447,7 +447,10 @@ namespace RTC
 
 		auto previousLayers = this->encodingContext->GetCurrentLayers();
 
-		bool marker{ false };
+		// Preserve the original marker bit. ProcessPayload may update it (VP9/AV1
+		// overwrite it based on spatial-layer end-of-frame; VP8/H264 do not, so the
+		// original packet marker must survive).
+		bool marker{ packet->HasMarker() };
 
 		if (!packet->ProcessPayload(this->encodingContext.get(), marker))
 		{


### PR DESCRIPTION
Related to #1359

Rather than relying on Producer's type, do calculate the type based on `consumableRtpEncodings`.

Adapted VP8 and H264 codecs accordingly.


### How to test it with mediasoup-demo:

1. **&forceVP8=true&numWebcamSimulcastStreams=1&webcamScalabilityMode=L1T3**
   This will create a single encoding with L1T3. It will use SVC.
2. **&forceVP8=true&numWebcamSimulcastStreams=3&webcamScalabilityMode=L1T3**
   This will create three encodings with L1T3. It will use Simulcast.


NOTE: this PR does not pretend to handle #1359 entirely but just what indicates. It uses no SVC for VP8 and H264 when there is a single stream with temporal layers.