### PR TITLE
Add `NotFoundError`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@
 
 - Worker: Fix new consumer regressions ([PR #1849](https://github.com/versatica/mediasoup/pull/1849)).
 - Add `NotFoundError`, thrown when the referenced entity in the Worker doesn't exist ([PR #1852](https://github.com/versatica/mediasoup/pull/1852)).
-  - Expose mediasoup `errors`.
-  - Rename `InvalidStateError` to `WorkerClosedError`.
+  - Expose mediasoup Node `errors` via `mediasoup/errors` (in EMS).
+  - **Breaking change:** Rename `InvalidStateError` to `WorkerClosedError`.
 
 ### 3.20.10
 
@@ -161,7 +161,7 @@
 - CI: Remove `macos-13` hosts.
 - VP8: Fix keyframe detection if "extended" bit is not set ([PR #1612](https://github.com/versatica/mediasoup/pull/1612), credits to @nifigase).
 - CI: Remove `node-20` GitHub actions.
-- Require Node.js >= 22 ([PR #1614](https://github.com/versatica/mediasoup/pull/1614)).
+- Require Node >= 22 ([PR #1614](https://github.com/versatica/mediasoup/pull/1614)).
 
 ### 3.19.2
 
@@ -363,7 +363,7 @@
 ### 3.14.0
 
 - `TransportListenInfo`: Add `portRange` (deprecate worker port range) ([PR #1365](https://github.com/versatica/mediasoup/pull/1365)).
-- Require Node.js >= 18 ([PR #1365](https://github.com/versatica/mediasoup/pull/1365)).
+- Require Node >= 18 ([PR #1365](https://github.com/versatica/mediasoup/pull/1365)).
 
 ### 3.13.24
 
@@ -507,7 +507,7 @@
 
 ### 3.12.14
 
-- CI: Use Node.js version 20 ([PR #1177](https://github.com/versatica/mediasoup/pull/1177)).
+- CI: Use Node version 20 ([PR #1177](https://github.com/versatica/mediasoup/pull/1177)).
 - Use given `PYTHON` environment variable (if given) when running `worker/scripts/getmake.py` ([PR #1186](https://github.com/versatica/mediasoup/pull/1186)).
 
 ### 3.12.13
@@ -667,7 +667,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 ### 3.11.5
 
-- Require Node.js >= 16 ([PR #973](https://github.com/versatica/mediasoup/pull/973)).
+- Require Node >= 16 ([PR #973](https://github.com/versatica/mediasoup/pull/973)).
 - Fix wrong `Consumer` bandwidth estimation under `Producer` packet loss ([PR #962](https://github.com/versatica/mediasoup/pull/962) by @ggarber).
 
 ### 3.11.4
@@ -880,7 +880,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 - Worker communication optimization (aka removing netstring dependency) ([PR #644](https://github.com/versatica/mediasoup/pull/644)).
 - Move TypeScript and compiled JavaScript code to a new `node` folder.
 - Use ES6 private fields.
-- Require Node.js version >= 12.
+- Require Node version >= 12.
 
 ### 3.8.4
 
@@ -1074,7 +1074,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 ### 3.6.23
 
-- Fix yet another memory leak in Node.js layer due to `PayloadChannel` event listener not being removed.
+- Fix yet another memory leak in Node layer due to `PayloadChannel` event listener not being removed.
 
 ### 3.6.22
 
@@ -1085,7 +1085,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 ### 3.6.21
 
-- Fix memory leak in Node.js layer due to `PayloadChannel` event listener not being removed (related to #463).
+- Fix memory leak in Node layer due to `PayloadChannel` event listener not being removed (related to #463).
 
 ### 3.6.20
 
@@ -1233,7 +1233,7 @@ Migrate `npm-scripts.js` to `npm-scripts.mjs` (ES Module) ([PR #1093](https://gi
 
 - `SeqManager.cpp`: Fix a bug and improve performance.
   - Fixes issue #395 via [PR #396](https://github.com/versatica/mediasoup/pull/396) (credits to @penguinol).
-- Drop Node.js 8 support. Minimum supported Node.js version is now 10.
+- Drop Node 8 support. Minimum supported Node version is now 10.
 - Upgrade `eslint` and `jest` major versions.
 
 ### 3.5.10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### NEXT
 
 - Worker: Fix new consumer regressions ([PR #1849](https://github.com/versatica/mediasoup/pull/1849)).
-- Add `NotFoundError`, thrown when the referenced entity in the Worker doesn't exist ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Add `NotFoundError`, thrown when the referenced entity in the Worker doesn't exist ([PR #1852](https://github.com/versatica/mediasoup/pull/1852)).
   - Expose mediasoup `errors`.
   - Rename `InvalidStateError` to `WorkerClosedError`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### NEXT
 
 - Worker: Fix new consumer regressions ([PR #1849](https://github.com/versatica/mediasoup/pull/1849)).
+- Add `NotFoundError`, thrown when the referenced entity in the Worker doesn't exist ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+  - Expose mediasoup `errors`.
+  - Rename `InvalidStateError` to `WorkerClosedError`.
 
 ### 3.20.10
 

--- a/node/src/Channel.ts
+++ b/node/src/Channel.ts
@@ -4,7 +4,7 @@ import { info, warn } from 'node:console';
 import * as flatbuffers from 'flatbuffers';
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './enhancedEvents';
-import { InvalidStateError } from './errors';
+import { WorkerClosedError, NotFoundError } from './errors';
 import { Body as RequestBody, Method, Request } from './fbs/request';
 import { Response } from './fbs/response';
 import { Message, Body as MessageBody } from './fbs/message';
@@ -238,7 +238,7 @@ export class Channel extends EnhancedEventEmitter {
 		logger.debug(`notify() [event:${Event[event]}]`);
 
 		if (this.#closed) {
-			throw new InvalidStateError(
+			throw new WorkerClosedError(
 				`Channel closed, cannot send notification [event:${Event[event]}]`
 			);
 		}
@@ -306,7 +306,7 @@ export class Channel extends EnhancedEventEmitter {
 		logger.debug(`request() [method:${Method[method]}]`);
 
 		if (this.#closed) {
-			throw new InvalidStateError(
+			throw new WorkerClosedError(
 				`Channel closed, cannot send request [method:${Method[method]}]`
 			);
 		}
@@ -385,7 +385,7 @@ export class Channel extends EnhancedEventEmitter {
 				},
 				close: () => {
 					pReject(
-						new InvalidStateError(
+						new WorkerClosedError(
 							`Channel closed, pending request aborted [method:${Method[method]}, id:${id}]`
 						)
 					);
@@ -422,6 +422,12 @@ export class Channel extends EnhancedEventEmitter {
 			switch (response.error()!) {
 				case 'TypeError': {
 					sent.reject(new TypeError(response.reason()!));
+
+					break;
+				}
+
+				case 'NotFoundError': {
+					sent.reject(new NotFoundError(response.reason()!));
 
 					break;
 				}

--- a/node/src/PipeTransport.ts
+++ b/node/src/PipeTransport.ts
@@ -39,6 +39,7 @@ import {
 	serializeSrtpParameters,
 } from './srtpParametersFbsUtils';
 import type { AppData } from './types';
+import { NotFoundError } from './errors';
 import * as utils from './utils';
 import { generateUUIDv4 } from './utils';
 import { MediaKind as FbsMediaKind } from './fbs/rtp-parameters/media-kind';
@@ -237,7 +238,7 @@ export class PipeTransportImpl<PipeTransportAppData extends AppData = AppData>
 		const producer = this.getProducerById(producerId);
 
 		if (!producer) {
-			throw Error(`Producer with id "${producerId}" not found`);
+			throw new NotFoundError(`Producer with id "${producerId}" not found`);
 		}
 
 		// This may throw.

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -1,7 +1,7 @@
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './enhancedEvents';
 import * as ortc from './ortc';
-import { InvalidStateError } from './errors';
+import { NotFoundError } from './errors';
 import type { Channel } from './Channel';
 import type {
 	Router,
@@ -1102,7 +1102,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 
 				// Ensure that the producer has not been closed in the meanwhile.
 				if (producer.closed) {
-					throw new InvalidStateError('original Producer closed');
+					throw new NotFoundError('original Producer closed');
 				}
 
 				// Ensure that producer.paused has not changed in the meanwhile and, if
@@ -1160,7 +1160,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 
 				// Ensure that the dataProducer has not been closed in the meanwhile.
 				if (dataProducer.closed) {
-					throw new InvalidStateError('original DataProducer closed');
+					throw new NotFoundError('original DataProducer closed');
 				}
 
 				// Pipe events from the pipe DataConsumer to the pipe DataProducer.

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -943,7 +943,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 		} else if (producerId && dataProducerId) {
 			throw new TypeError('just producerId or dataProducerId can be given');
 		} else if (!router) {
-			throw new TypeError('Router not found');
+			throw new TypeError('missing router');
 		} else if (router === this) {
 			throw new TypeError('cannot use this Router as destination');
 		}

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -1,7 +1,6 @@
 import { Logger } from './Logger';
 import { EnhancedEventEmitter } from './enhancedEvents';
 import * as ortc from './ortc';
-import { NotFoundError } from './errors';
 import type { Channel } from './Channel';
 import type {
 	Router,
@@ -68,6 +67,7 @@ import type {
 	RouterRtpCodecCapability,
 } from './rtpParametersTypes';
 import { cryptoSuiteToFbs } from './srtpParametersFbsUtils';
+import { NotFoundError } from './errors';
 import type { AppData } from './types';
 import * as utils from './utils';
 import * as fbsUtils from './fbsUtils';
@@ -969,13 +969,13 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 			producer = this.#producers.get(producerId);
 
 			if (!producer) {
-				throw new TypeError('Producer not found');
+				throw new NotFoundError('Producer not found');
 			}
 		} else if (dataProducerId) {
 			dataProducer = this.#dataProducers.get(dataProducerId);
 
 			if (!dataProducer) {
-				throw new TypeError('DataProducer not found');
+				throw new NotFoundError('DataProducer not found');
 			}
 		}
 

--- a/node/src/RtpObserver.ts
+++ b/node/src/RtpObserver.ts
@@ -7,6 +7,7 @@ import type {
 import type { Channel } from './Channel';
 import type { RouterInternal } from './Router';
 import type { Producer } from './ProducerTypes';
+import { NotFoundError } from './errors';
 import type { AppData } from './types';
 import * as FbsRequest from './fbs/request';
 import * as FbsRouter from './fbs/router';
@@ -193,7 +194,7 @@ export abstract class RtpObserverImpl<
 		const producer = this.getProducerById(producerId);
 
 		if (!producer) {
-			throw Error(`Producer with id "${producerId}" not found`);
+			throw new NotFoundError(`Producer with id "${producerId}" not found`);
 		}
 
 		const requestOffset = new FbsRtpObserver.AddProducerRequestT(
@@ -217,7 +218,7 @@ export abstract class RtpObserverImpl<
 		const producer = this.getProducerById(producerId);
 
 		if (!producer) {
-			throw Error(`Producer with id "${producerId}" not found`);
+			throw new NotFoundError(`Producer with id "${producerId}" not found`);
 		}
 
 		const requestOffset = new FbsRtpObserver.RemoveProducerRequestT(

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -78,6 +78,7 @@ import {
 	serializeSctpStreamParameters,
 } from './sctpParametersFbsUtils';
 import type { AppData } from './types';
+import { NotFoundError } from './errors';
 import * as utils from './utils';
 import * as fbsUtils from './fbsUtils';
 import { TraceDirection as FbsTraceDirection } from './fbs/common';
@@ -612,7 +613,7 @@ export abstract class TransportImpl<
 		const producer = this.getProducerById(producerId);
 
 		if (!producer) {
-			throw Error(`Producer with id "${producerId}" not found`);
+			throw new NotFoundError(`Producer with id "${producerId}" not found`);
 		}
 
 		// If enableRtx is not given, set it to true if video and false if audio.
@@ -833,7 +834,9 @@ export abstract class TransportImpl<
 		const dataProducer = this.getDataProducerById(dataProducerId);
 
 		if (!dataProducer) {
-			throw Error(`DataProducer with id "${dataProducerId}" not found`);
+			throw new NotFoundError(
+				`DataProducer with id "${dataProducerId}" not found`
+			);
 		}
 
 		let type: DataConsumerType;

--- a/node/src/errors.ts
+++ b/node/src/errors.ts
@@ -17,17 +17,35 @@ export class UnsupportedError extends Error {
 }
 
 /**
- * Error produced when calling a method in an invalid state.
+ * Error produced when calling a method on a closed Worker.
  */
-export class InvalidStateError extends Error {
+export class WorkerClosedError extends Error {
 	constructor(message: string) {
 		super(message);
 
-		this.name = 'InvalidStateError';
+		this.name = 'WorkerClosedError';
 
 		if (Error.hasOwnProperty('captureStackTrace')) {
 			// Just in V8.
-			Error.captureStackTrace(this, InvalidStateError);
+			Error.captureStackTrace(this, WorkerClosedError);
+		} else {
+			this.stack = new Error(message).stack;
+		}
+	}
+}
+
+/**
+ * Error indicating that a referenced entity doesn't exist.
+ */
+export class NotFoundError extends Error {
+	constructor(message: string) {
+		super(message);
+
+		this.name = 'NotFoundError';
+
+		if (Error.hasOwnProperty('captureStackTrace')) {
+			// Just in V8.
+			Error.captureStackTrace(this, NotFoundError);
 		} else {
 			this.stack = new Error(message).stack;
 		}

--- a/node/src/errors.ts
+++ b/node/src/errors.ts
@@ -1,5 +1,5 @@
 /**
- * Error indicating not support for something.
+ * Error indicating that something is not supported.
  */
 export class UnsupportedError extends Error {
 	constructor(message: string) {

--- a/node/src/index.ts
+++ b/node/src/index.ts
@@ -20,6 +20,11 @@ import * as utils from './utils';
 export type * as types from './types';
 
 /**
+ * Expose all errors.
+ */
+export * as errors from './errors';
+
+/**
  * Expose mediasoup version.
  */
 // eslint-disable-next-line @typescript-eslint/no-require-imports

--- a/node/src/test/test-ActiveSpeakerObserver.ts
+++ b/node/src/test/test-ActiveSpeakerObserver.ts
@@ -1,6 +1,7 @@
 import * as mediasoup from '../';
 import { enhancedOnce } from '../enhancedEvents';
 import type { WorkerEvents, ActiveSpeakerObserverEvents } from '../types';
+import { WorkerClosedError, NotFoundError } from '../errors';
 import * as utils from '../utils';
 
 type TestContext = {
@@ -101,6 +102,8 @@ test('activeSpeakerObserver.close() succeeds', async () => {
 	dump = await ctx.router!.dump();
 
 	expect(dump.rtpObserverIds.length).toBe(0);
+
+	await expect(activeSpeakerObserver.pause()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('ActiveSpeakerObserver emits "routerclose" if Router is closed', async () => {
@@ -115,6 +118,8 @@ test('ActiveSpeakerObserver emits "routerclose" if Router is closed', async () =
 	await promise;
 
 	expect(activeSpeakerObserver.closed).toBe(true);
+
+	await expect(activeSpeakerObserver.pause()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('ActiveSpeakerObserver emits "routerclose" if Worker is closed', async () => {
@@ -129,4 +134,8 @@ test('ActiveSpeakerObserver emits "routerclose" if Worker is closed', async () =
 	await promise;
 
 	expect(activeSpeakerObserver.closed).toBe(true);
+
+	await expect(activeSpeakerObserver.pause()).rejects.toThrow(
+		WorkerClosedError
+	);
 }, 2000);

--- a/node/src/test/test-AudioLevelObserver.ts
+++ b/node/src/test/test-AudioLevelObserver.ts
@@ -1,6 +1,7 @@
 import * as mediasoup from '../';
 import { enhancedOnce } from '../enhancedEvents';
 import type { WorkerEvents, AudioLevelObserverEvents } from '../types';
+import { WorkerClosedError, NotFoundError } from '../errors';
 import * as utils from '../utils';
 
 type TestContext = {
@@ -110,6 +111,8 @@ test('audioLevelObserver.close() succeeds', async () => {
 	dump = await ctx.router!.dump();
 
 	expect(dump.rtpObserverIds.length).toBe(0);
+
+	await expect(audioLevelObserver.pause()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('AudioLevelObserver emits "routerclose" if Router is closed', async () => {
@@ -124,6 +127,8 @@ test('AudioLevelObserver emits "routerclose" if Router is closed', async () => {
 	await promise;
 
 	expect(audioLevelObserver.closed).toBe(true);
+
+	await expect(audioLevelObserver.pause()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('AudioLevelObserver emits "routerclose" if Worker is closed', async () => {
@@ -138,4 +143,6 @@ test('AudioLevelObserver emits "routerclose" if Worker is closed', async () => {
 	await promise;
 
 	expect(audioLevelObserver.closed).toBe(true);
+
+	await expect(audioLevelObserver.pause()).rejects.toThrow(WorkerClosedError);
 }, 2000);

--- a/node/src/test/test-Consumer.ts
+++ b/node/src/test/test-Consumer.ts
@@ -611,6 +611,15 @@ test('transport.consume() succeeds', async () => {
 	});
 }, 2000);
 
+test('transport.consume() with unknown producerId fails', async () => {
+	await expect(
+		ctx.webRtcTransport2!.consume({
+			producerId: '12345678',
+			rtpCapabilities: ctx.consumerDeviceCapabilities,
+		})
+	).rejects.toThrow(NotFoundError);
+}, 2000);
+
 test('transport.consume() with enableRtx succeeds', async () => {
 	const audioConsumer2 = await ctx.webRtcTransport2!.consume({
 		producerId: ctx.audioProducer!.id,

--- a/node/src/test/test-Consumer.ts
+++ b/node/src/test/test-Consumer.ts
@@ -3,7 +3,7 @@ import * as mediasoup from '../';
 import { enhancedOnce } from '../enhancedEvents';
 import type { WorkerEvents, ConsumerEvents } from '../types';
 import type { ConsumerImpl } from '../Consumer';
-import { UnsupportedError } from '../errors';
+import { UnsupportedError, NotFoundError } from '../errors';
 import * as utils from '../utils';
 import {
 	Notification,
@@ -1341,6 +1341,8 @@ test('consumer.close() succeeds', async () => {
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(audioConsumer.closed).toBe(true);
 
+	await expect(audioConsumer.dump()).rejects.toThrow(NotFoundError);
+
 	const routerDump = await ctx.router!.dump();
 
 	expect(routerDump.mapProducerIdConsumerIds).toEqual(
@@ -1370,20 +1372,20 @@ test('Consumer methods reject if closed', async () => {
 
 	audioConsumer.close();
 
-	await expect(audioConsumer.dump()).rejects.toThrow(Error);
+	await expect(audioConsumer.dump()).rejects.toThrow(NotFoundError);
 
-	await expect(audioConsumer.getStats()).rejects.toThrow(Error);
+	await expect(audioConsumer.getStats()).rejects.toThrow(NotFoundError);
 
-	await expect(audioConsumer.pause()).rejects.toThrow(Error);
+	await expect(audioConsumer.pause()).rejects.toThrow(NotFoundError);
 
-	await expect(audioConsumer.resume()).rejects.toThrow(Error);
+	await expect(audioConsumer.resume()).rejects.toThrow(NotFoundError);
 
 	// @ts-expect-error --- Testing purposes.
-	await expect(audioConsumer.setPreferredLayers({})).rejects.toThrow(Error);
+	await expect(audioConsumer.setPreferredLayers({})).rejects.toThrow(TypeError);
 
-	await expect(audioConsumer.setPriority(2)).rejects.toThrow(Error);
+	await expect(audioConsumer.setPriority(2)).rejects.toThrow(NotFoundError);
 
-	await expect(audioConsumer.requestKeyFrame()).rejects.toThrow(Error);
+	await expect(audioConsumer.requestKeyFrame()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('Consumer emits "producerclose" if Producer is closed', async () => {
@@ -1402,6 +1404,8 @@ test('Consumer emits "producerclose" if Producer is closed', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(audioConsumer.closed).toBe(true);
+
+	await expect(audioConsumer.dump()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('Consumer emits "transportclose" if Transport is closed', async () => {
@@ -1421,6 +1425,8 @@ test('Consumer emits "transportclose" if Transport is closed', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(videoConsumer.closed).toBe(true);
+
+	await expect(videoConsumer.dump()).rejects.toThrow(NotFoundError);
 
 	await expect(ctx.router!.dump()).resolves.toMatchObject({
 		mapProducerIdConsumerIds: expect.arrayContaining([

--- a/node/src/test/test-DataConsumer.ts
+++ b/node/src/test/test-DataConsumer.ts
@@ -111,6 +111,14 @@ test('transport.consumeData() succeeds', async () => {
 	});
 }, 2000);
 
+test('transport.consumeData() with unknown dataProducerId fails', async () => {
+	await expect(
+		ctx.webRtcTransport2!.consumeData({
+			dataProducerId: '12345678',
+		})
+	).rejects.toThrow(NotFoundError);
+}, 2000);
+
 test('dataConsumer.dump() succeeds', async () => {
 	const dataConsumer = await ctx.webRtcTransport2!.consumeData({
 		dataProducerId: ctx.sctpDataProducer!.id,

--- a/node/src/test/test-DataConsumer.ts
+++ b/node/src/test/test-DataConsumer.ts
@@ -1,6 +1,7 @@
 import * as mediasoup from '../';
 import { enhancedOnce } from '../enhancedEvents';
 import type { WorkerEvents, DataConsumerEvents } from '../types';
+import { NotFoundError } from '../errors';
 import * as utils from '../utils';
 
 type TestContext = {
@@ -427,6 +428,8 @@ test('dataConsumer.close() succeeds', async () => {
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(dataConsumer.closed).toBe(true);
 
+	await expect(dataConsumer.dump()).rejects.toThrow(NotFoundError);
+
 	const dump = await ctx.router!.dump();
 
 	expect(dump.mapDataProducerIdDataConsumerIds).toEqual(
@@ -449,9 +452,9 @@ test('Consumer methods reject if closed', async () => {
 
 	dataConsumer.close();
 
-	await expect(dataConsumer.dump()).rejects.toThrow(Error);
+	await expect(dataConsumer.dump()).rejects.toThrow(NotFoundError);
 
-	await expect(dataConsumer.getStats()).rejects.toThrow(Error);
+	await expect(dataConsumer.getStats()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('DataConsumer emits "dataproducerclose" if DataProducer is closed', async () => {
@@ -472,6 +475,8 @@ test('DataConsumer emits "dataproducerclose" if DataProducer is closed', async (
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(dataConsumer.closed).toBe(true);
+
+	await expect(dataConsumer.dump()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('DataConsumer emits "transportclose" if Transport is closed', async () => {
@@ -492,6 +497,8 @@ test('DataConsumer emits "transportclose" if Transport is closed', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(dataConsumer.closed).toBe(true);
+
+	await expect(dataConsumer.dump()).rejects.toThrow(NotFoundError);
 
 	await expect(ctx.router!.dump()).resolves.toMatchObject({
 		mapDataProducerIdDataConsumerIds: {},

--- a/node/src/test/test-DataProducer.ts
+++ b/node/src/test/test-DataProducer.ts
@@ -1,6 +1,7 @@
 import * as mediasoup from '../';
 import { enhancedOnce } from '../enhancedEvents';
 import type { WorkerEvents, DataProducerEvents } from '../types';
+import { NotFoundError } from '../errors';
 import * as utils from '../utils';
 
 type TestContext = {
@@ -320,6 +321,8 @@ test('dataProducer.close() succeeds', async () => {
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(dataProducer1.closed).toBe(true);
 
+	await expect(dataProducer1.dump()).rejects.toThrow(NotFoundError);
+
 	await expect(ctx.router!.dump()).resolves.toMatchObject({
 		mapDataProducerIdDataConsumerIds: {},
 		mapDataConsumerIdDataProducerId: {},
@@ -339,9 +342,9 @@ test('DataProducer methods reject if closed', async () => {
 
 	dataProducer1.close();
 
-	await expect(dataProducer1.dump()).rejects.toThrow(Error);
+	await expect(dataProducer1.dump()).rejects.toThrow(NotFoundError);
 
-	await expect(dataProducer1.getStats()).rejects.toThrow(Error);
+	await expect(dataProducer1.getStats()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('DataProducer emits "transportclose" if Transport is closed', async () => {
@@ -363,4 +366,6 @@ test('DataProducer emits "transportclose" if Transport is closed', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(dataProducer2.closed).toBe(true);
+
+	await expect(dataProducer2.dump()).rejects.toThrow(NotFoundError);
 }, 2000);

--- a/node/src/test/test-DirectTransport.ts
+++ b/node/src/test/test-DirectTransport.ts
@@ -2,6 +2,7 @@ import * as mediasoup from '../';
 import { enhancedOnce } from '../enhancedEvents';
 import type { DirectTransportEvents } from '../DirectTransportTypes';
 import type { WorkerEvents } from '../types';
+import { WorkerClosedError, NotFoundError } from '../errors';
 
 type TestContext = {
 	worker?: mediasoup.types.Worker;
@@ -379,9 +380,9 @@ test('DirectTransport methods reject if closed', async () => {
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(directTransport.closed).toBe(true);
 
-	await expect(directTransport.dump()).rejects.toThrow(Error);
+	await expect(directTransport.dump()).rejects.toThrow(NotFoundError);
 
-	await expect(directTransport.getStats()).rejects.toThrow(Error);
+	await expect(directTransport.getStats()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('DirectTransport emits "routerclose" if Router is closed', async () => {
@@ -400,6 +401,8 @@ test('DirectTransport emits "routerclose" if Router is closed', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(directTransport.closed).toBe(true);
+
+	await expect(directTransport.getStats()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('DirectTransport emits "routerclose" if Worker is closed', async () => {
@@ -418,4 +421,6 @@ test('DirectTransport emits "routerclose" if Worker is closed', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(directTransport.closed).toBe(true);
+
+	await expect(directTransport.getStats()).rejects.toThrow(WorkerClosedError);
 }, 2000);

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -7,6 +7,7 @@ import type {
 	ProducerObserverEvents,
 	DataConsumerEvents,
 } from '../types';
+import { NotFoundError } from '../errors';
 import * as utils from '../utils';
 
 type TestContext = {
@@ -872,7 +873,7 @@ test('producer.pause() and producer.resume() are transmitted to pipe Consumer', 
 
 	// We need to obtain the pipeProducer to await for its 'puase' and 'resume'
 	// events, otherwise we may get errors like this:
-	// InvalidStateError: Channel closed, pending request aborted [method:PRODUCER_PAUSE, id:8]
+	// WorkerClosedError: Channel closed, pending request aborted [method:PRODUCER_PAUSE, id:8]
 	// See related fixed issue:
 	// https://github.com/versatica/mediasoup/issues/1374
 	const { pipeProducer: pipeVideoProducer } = await ctx.router1!.pipeToRouter({
@@ -941,6 +942,8 @@ test('producer.close() is transmitted to pipe Consumer', async () => {
 	}
 
 	expect(videoConsumer.closed).toBe(true);
+
+	await expect(videoConsumer.dump()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('router.pipeToRouter() with keepId: true fails if both Routers belong to the same Worker', async () => {
@@ -1060,6 +1063,8 @@ test('dataProducer.close() is transmitted to pipe DataConsumer', async () => {
 	}
 
 	expect(dataConsumer.closed).toBe(true);
+
+	await expect(dataConsumer.dump()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('router.pipeToRouter() called twice generates a single PipeTransport pair', async () => {

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -500,6 +500,35 @@ test('router.pipeToRouter() succeeds with video', async () => {
 	expect(pipeProducer.paused).toBe(true);
 }, 2000);
 
+test('router.pipeToRouter() with unknown router, producerId or dataProducerId fails', async () => {
+	const router3 = await ctx.worker1!.createRouter({
+		mediaCodecs: ctx.mediaCodecs,
+	});
+
+	router3.close();
+
+	await expect(
+		ctx.router1!.pipeToRouter({
+			router: router3,
+			producerId: ctx.videoProducer!.id,
+		})
+	).rejects.toThrow(NotFoundError);
+
+	await expect(
+		ctx.router1!.pipeToRouter({
+			router: ctx.router2!,
+			producerId: '12345678',
+		})
+	).rejects.toThrow(NotFoundError);
+
+	await expect(
+		ctx.router1!.pipeToRouter({
+			router: ctx.router2!,
+			dataProducerId: '12345678',
+		})
+	).rejects.toThrow(NotFoundError);
+}, 2000);
+
 test('router.createPipeTransport() with wrong arguments rejects with TypeError', async () => {
 	// @ts-expect-error --- Testing purposes.
 	await expect(ctx.router1!.createPipeTransport({})).rejects.toThrow(TypeError);

--- a/node/src/test/test-PlainTransport.ts
+++ b/node/src/test/test-PlainTransport.ts
@@ -3,6 +3,7 @@ import { pickPort } from 'pick-port';
 import * as mediasoup from '../';
 import { enhancedOnce } from '../enhancedEvents';
 import type { WorkerEvents, PlainTransportEvents } from '../types';
+import { WorkerClosedError, NotFoundError } from '../errors';
 import * as utils from '../utils';
 
 const IS_WINDOWS = os.platform() === 'win32';
@@ -555,11 +556,11 @@ test('PlainTransport methods reject if closed', async () => {
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(plainTransport.closed).toBe(true);
 
-	await expect(plainTransport.dump()).rejects.toThrow(Error);
+	await expect(plainTransport.dump()).rejects.toThrow(NotFoundError);
 
-	await expect(plainTransport.getStats()).rejects.toThrow(Error);
+	await expect(plainTransport.getStats()).rejects.toThrow(NotFoundError);
 
-	await expect(plainTransport.connect({})).rejects.toThrow(Error);
+	await expect(plainTransport.connect({})).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('router.createPlainTransport() with fixed port succeeds', async () => {
@@ -594,6 +595,8 @@ test('PlainTransport emits "routerclose" if Router is closed', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(plainTransport.closed).toBe(true);
+
+	await expect(plainTransport.dump()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('PlainTransport emits "routerclose" if Worker is closed', async () => {
@@ -615,4 +618,6 @@ test('PlainTransport emits "routerclose" if Worker is closed', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(plainTransport.closed).toBe(true);
+
+	await expect(plainTransport.dump()).rejects.toThrow(WorkerClosedError);
 }, 2000);

--- a/node/src/test/test-Producer.ts
+++ b/node/src/test/test-Producer.ts
@@ -3,7 +3,7 @@ import * as mediasoup from '../';
 import { enhancedOnce } from '../enhancedEvents';
 import type { WorkerEvents, ProducerEvents } from '../types';
 import type { ProducerImpl } from '../Producer';
-import { UnsupportedError } from '../errors';
+import { UnsupportedError, NotFoundError } from '../errors';
 import * as utils from '../utils';
 import {
 	Notification,
@@ -787,6 +787,8 @@ test('producer.close() succeeds', async () => {
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(audioProducer.closed).toBe(true);
 
+	await expect(audioProducer.dump()).rejects.toThrow(NotFoundError);
+
 	await expect(ctx.router!.dump()).resolves.toMatchObject({
 		mapProducerIdConsumerIds: [],
 		mapConsumerIdProducerId: [],
@@ -806,10 +808,10 @@ test('Producer methods reject if closed', async () => {
 
 	audioProducer.close();
 
-	await expect(audioProducer.dump()).rejects.toThrow(Error);
-	await expect(audioProducer.getStats()).rejects.toThrow(Error);
-	await expect(audioProducer.pause()).rejects.toThrow(Error);
-	await expect(audioProducer.resume()).rejects.toThrow(Error);
+	await expect(audioProducer.dump()).rejects.toThrow(NotFoundError);
+	await expect(audioProducer.getStats()).rejects.toThrow(NotFoundError);
+	await expect(audioProducer.pause()).rejects.toThrow(NotFoundError);
+	await expect(audioProducer.resume()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('Producer emits "transportclose" if Transport is closed', async () => {
@@ -828,4 +830,6 @@ test('Producer emits "transportclose" if Transport is closed', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(videoProducer.closed).toBe(true);
+
+	await expect(videoProducer.dump()).rejects.toThrow(NotFoundError);
 }, 2000);

--- a/node/src/test/test-Router.ts
+++ b/node/src/test/test-Router.ts
@@ -2,7 +2,7 @@ import * as mediasoup from '../';
 import { enhancedOnce } from '../enhancedEvents';
 import type { WorkerImpl } from '../Worker';
 import type { WorkerEvents, RouterEvents } from '../types';
-import { InvalidStateError, UnsupportedError } from '../errors';
+import { WorkerClosedError, UnsupportedError, NotFoundError } from '../errors';
 import * as utils from '../utils';
 
 type TestContext = {
@@ -142,12 +142,12 @@ test('worker.createRouter() with wrong arguments rejects with TypeError', async 
 	).rejects.toThrow(TypeError);
 }, 2000);
 
-test('worker.createRouter() rejects with InvalidStateError if Worker is closed', async () => {
+test('worker.createRouter() rejects with WorkerClosedError if Worker is closed', async () => {
 	ctx.worker!.close();
 
 	await expect(
 		ctx.worker!.createRouter({ mediaCodecs: ctx.mediaCodecs })
-	).rejects.toThrow(InvalidStateError);
+	).rejects.toThrow(WorkerClosedError);
 }, 2000);
 
 test('router.rtpCapabilities getter returns cloned RTP capabilities', async () => {
@@ -198,6 +198,8 @@ test('router.close() succeeds', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(router.closed).toBe(true);
+
+	await expect(router.dump()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('Router emits "workerclose" if Worker is closed', async () => {
@@ -216,4 +218,6 @@ test('Router emits "workerclose" if Worker is closed', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(router.closed).toBe(true);
+
+	await expect(router.dump()).rejects.toThrow(WorkerClosedError);
 }, 2000);

--- a/node/src/test/test-WebRtcServer.ts
+++ b/node/src/test/test-WebRtcServer.ts
@@ -5,7 +5,7 @@ import type { WorkerImpl } from '../Worker';
 import type { WorkerEvents, WebRtcServerEvents } from '../types';
 import type { WebRtcServerImpl } from '../WebRtcServer';
 import type { RouterImpl } from '../Router';
-import { InvalidStateError } from '../errors';
+import { WorkerClosedError, NotFoundError } from '../errors';
 
 type TestContext = {
 	worker?: mediasoup.types.Worker;
@@ -312,7 +312,7 @@ test('worker.createWebRtcServer() with unavailable listenInfos rejects with Erro
 	worker2.close();
 }, 2000);
 
-test('worker.createWebRtcServer() rejects with InvalidStateError if Worker is closed', async () => {
+test('worker.createWebRtcServer() rejects with WorkerClosedError if Worker is closed', async () => {
 	ctx.worker!.close();
 
 	const port = await pickPort({
@@ -325,7 +325,7 @@ test('worker.createWebRtcServer() rejects with InvalidStateError if Worker is cl
 		ctx.worker!.createWebRtcServer({
 			listenInfos: [{ protocol: 'udp', ip: '127.0.0.1', port }],
 		})
-	).rejects.toThrow(InvalidStateError);
+	).rejects.toThrow(WorkerClosedError);
 }, 2000);
 
 test('webRtcServer.close() succeeds', async () => {
@@ -341,6 +341,8 @@ test('webRtcServer.close() succeeds', async () => {
 
 	webRtcServer.observer.once('close', onObserverClose);
 	webRtcServer.close();
+
+	await expect(webRtcServer.dump()).rejects.toThrow(NotFoundError);
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(webRtcServer.closed).toBe(true);
@@ -366,6 +368,8 @@ test('WebRtcServer emits "workerclose" if Worker is closed', async () => {
 
 	expect(onObserverClose).toHaveBeenCalledTimes(1);
 	expect(webRtcServer.closed).toBe(true);
+
+	await expect(webRtcServer.dump()).rejects.toThrow(WorkerClosedError);
 }, 2000);
 
 test('router.createWebRtcTransport() with webRtcServer succeeds and transport is closed', async () => {
@@ -405,7 +409,6 @@ test('router.createWebRtcTransport() with webRtcServer succeeds and transport is
 	);
 
 	const router = await ctx.worker!.createRouter();
-
 	const onObserverNewTransport = jest.fn();
 
 	router.observer.once('newtransport', onObserverNewTransport);

--- a/node/src/test/test-WebRtcTransport.ts
+++ b/node/src/test/test-WebRtcTransport.ts
@@ -6,6 +6,7 @@ import type { WorkerEvents, WebRtcTransportEvents } from '../types';
 import type { WebRtcTransportImpl } from '../WebRtcTransport';
 import type { TransportTuple } from '../TransportTypes';
 import { serializeProtocol } from '../Transport';
+import { WorkerClosedError, NotFoundError } from '../errors';
 import * as utils from '../utils';
 import {
 	Notification,
@@ -839,26 +840,26 @@ test('WebRtcTransport methods reject if closed', async () => {
 	expect(webRtcTransport.dtlsState).toBe('closed');
 	expect(webRtcTransport.sctpState).toBeUndefined();
 
-	await expect(webRtcTransport.dump()).rejects.toThrow(Error);
+	await expect(webRtcTransport.dump()).rejects.toThrow(NotFoundError);
 
-	await expect(webRtcTransport.getStats()).rejects.toThrow(Error);
+	await expect(webRtcTransport.getStats()).rejects.toThrow(NotFoundError);
 
 	// @ts-expect-error --- Testing purposes.
-	await expect(webRtcTransport.connect({})).rejects.toThrow(Error);
+	await expect(webRtcTransport.connect({})).rejects.toThrow(TypeError);
 
 	await expect(webRtcTransport.setMaxIncomingBitrate(200000)).rejects.toThrow(
-		Error
+		NotFoundError
 	);
 
 	await expect(webRtcTransport.setMaxOutgoingBitrate(200000)).rejects.toThrow(
-		Error
+		NotFoundError
 	);
 
 	await expect(webRtcTransport.setMinOutgoingBitrate(100000)).rejects.toThrow(
-		Error
+		NotFoundError
 	);
 
-	await expect(webRtcTransport.restartIce()).rejects.toThrow(Error);
+	await expect(webRtcTransport.restartIce()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('WebRtcTransport emits "routerclose" if Router is closed', async () => {
@@ -885,6 +886,8 @@ test('WebRtcTransport emits "routerclose" if Router is closed', async () => {
 	expect(webRtcTransport.iceSelectedTuple).toBeUndefined();
 	expect(webRtcTransport.dtlsState).toBe('closed');
 	expect(webRtcTransport.sctpState).toBe('closed');
+
+	await expect(webRtcTransport.dump()).rejects.toThrow(NotFoundError);
 }, 2000);
 
 test('WebRtcTransport emits "routerclose" if Worker is closed', async () => {
@@ -912,4 +915,6 @@ test('WebRtcTransport emits "routerclose" if Worker is closed', async () => {
 	expect(webRtcTransport.iceSelectedTuple).toBeUndefined();
 	expect(webRtcTransport.dtlsState).toBe('closed');
 	expect(webRtcTransport.sctpState).toBeUndefined();
+
+	await expect(webRtcTransport.dump()).rejects.toThrow(WorkerClosedError);
 }, 2000);

--- a/node/src/test/test-Worker.ts
+++ b/node/src/test/test-Worker.ts
@@ -4,7 +4,7 @@ import * as path from 'node:path';
 import * as mediasoup from '../';
 import { enhancedOnce } from '../enhancedEvents';
 import type { WorkerEvents } from '../types';
-import { InvalidStateError } from '../errors';
+import { WorkerClosedError } from '../errors';
 
 test('mediasoup.workerBin matches mediasoup-worker absolute path', () => {
 	const workerBin = process.env['MEDIASOUP_WORKER_BIN']
@@ -144,7 +144,7 @@ test('worker.updateSettings() with wrong settings rejects with TypeError', async
 	await enhancedOnce<WorkerEvents>(worker, 'subprocessclose');
 }, 2000);
 
-test('worker.updateSettings() rejects with InvalidStateError if closed', async () => {
+test('worker.updateSettings() rejects with WorkerClosedError if closed', async () => {
 	const worker = await mediasoup.createWorker();
 
 	worker.close();
@@ -152,7 +152,7 @@ test('worker.updateSettings() rejects with InvalidStateError if closed', async (
 	await enhancedOnce<WorkerEvents>(worker, 'subprocessclose');
 
 	await expect(worker.updateSettings({ logLevel: 'error' })).rejects.toThrow(
-		InvalidStateError
+		WorkerClosedError
 	);
 }, 2000);
 
@@ -176,14 +176,14 @@ test('worker.dump() succeeds', async () => {
 	worker.close();
 }, 2000);
 
-test('worker.dump() rejects with InvalidStateError if closed', async () => {
+test('worker.dump() rejects with WorkerClosedError if closed', async () => {
 	const worker = await mediasoup.createWorker();
 
 	worker.close();
 
 	await enhancedOnce<WorkerEvents>(worker, 'subprocessclose');
 
-	await expect(worker.dump()).rejects.toThrow(InvalidStateError);
+	await expect(worker.dump()).rejects.toThrow(WorkerClosedError);
 }, 2000);
 
 test('worker.getResourceUsage() succeeds', async () => {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,10 @@
 			"types": "./node/lib/types.d.ts",
 			"default": "./node/lib/types.js"
 		},
+		"./errors": {
+			"types": "./node/lib/errors.d.ts",
+			"default": "./node/lib/errors.js"
+		},
 		"./ortc": {
 			"types": "./node/lib/ortc.d.ts",
 			"default": "./node/lib/ortc.js"

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - Worker: Fix new consumer regressions ([PR #1849](https://github.com/versatica/mediasoup/pull/1849)).
+- Add `NotFoundError`, thrown when the referenced entity in the Worker doesn't exist ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
 
 ### 0.22.9
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### NEXT
 
 - Worker: Fix new consumer regressions ([PR #1849](https://github.com/versatica/mediasoup/pull/1849)).
-- Add `NotFoundError`, thrown when the referenced entity in the Worker doesn't exist ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Add `NotFoundError`, thrown when the referenced entity in the Worker doesn't exist ([PR #1852](https://github.com/versatica/mediasoup/pull/1852)).
 
 ### 0.22.9
 

--- a/rust/src/worker/channel.rs
+++ b/rust/src/worker/channel.rs
@@ -129,6 +129,8 @@ fn deserialize_message(bytes: &[u8]) -> ChannelReceiveMessage<'_> {
 }
 
 struct ResponseError {
+    /// Error type name ("Error", "TypeError", "NotFoundError" or "WorkerClosedError").
+    name: String,
     reason: String,
 }
 
@@ -280,6 +282,12 @@ impl Channel {
                             // Request did not succeed.
                             if let Ok(Some(reason)) = response.reason() {
                                 let _ = sender.send(Err(ResponseError {
+                                    name: response
+                                        .error()
+                                        .ok()
+                                        .flatten()
+                                        .unwrap_or("Error")
+                                        .to_string(),
                                     reason: reason.to_string(),
                                 }));
                             }
@@ -417,6 +425,7 @@ impl Channel {
         let response_result = match response_result_fut {
             Ok(response_result) => response_result,
             Err(_closed) => Err(ResponseError {
+                name: String::from("WorkerClosedError"),
                 reason: String::from("ChannelClosed"),
             }),
         };
@@ -442,14 +451,15 @@ impl Channel {
                     }
                 }
             }
-            Err(ResponseError { reason }) => {
+            Err(ResponseError { name, reason }) => {
                 debug!(
-                    "request failed [method:{:?}, id:{}]: {}",
+                    "request failed [method:{:?}, id:{}]: {} [name:{}]",
                     R::METHOD,
                     id,
-                    reason
+                    reason,
+                    name
                 );
-                if reason.contains("not found") {
+                if name == "NotFoundError" {
                     if let Some(default_response) = R::default_for_soft_error() {
                         Ok(default_response)
                     } else {

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -893,6 +893,27 @@ fn consume_succeeds() {
 }
 
 #[test]
+fn consume_with_unknown_producer_id_fails() {
+    future::block_on(async move {
+        let (_executor_guard, _worker, _router, _transport_1, transport_2) = init().await;
+
+        let unknown_producer_id: ProducerId = "12345678-1234-1234-1234-123456789012"
+            .parse()
+            .unwrap();
+
+        assert!(matches!(
+            transport_2
+                .consume(ConsumerOptions::new(
+                    unknown_producer_id,
+                    consumer_device_capabilities(),
+                ))
+                .await,
+            Err(ConsumeError::ProducerNotFound(id)) if id == unknown_producer_id
+        ));
+    });
+}
+
+#[test]
 fn consume_with_enable_rtx_succeeds() {
     future::block_on(async move {
         let (_executor_guard, _worker, _router, transport_1, transport_2) = init().await;

--- a/rust/tests/integration/consumer.rs
+++ b/rust/tests/integration/consumer.rs
@@ -897,9 +897,8 @@ fn consume_with_unknown_producer_id_fails() {
     future::block_on(async move {
         let (_executor_guard, _worker, _router, _transport_1, transport_2) = init().await;
 
-        let unknown_producer_id: ProducerId = "12345678-1234-1234-1234-123456789012"
-            .parse()
-            .unwrap();
+        let unknown_producer_id: ProducerId =
+            "12345678-1234-1234-1234-123456789012".parse().unwrap();
 
         assert!(matches!(
             transport_2

--- a/rust/tests/integration/data_consumer.rs
+++ b/rust/tests/integration/data_consumer.rs
@@ -206,9 +206,8 @@ fn consume_data_with_unknown_data_producer_id_fails() {
     future::block_on(async move {
         let (_worker, _router, webrtc_transport, _sctp_data_producer) = init().await;
 
-        let unknown_data_producer_id: DataProducerId = "12345678-1234-1234-1234-123456789012"
-            .parse()
-            .unwrap();
+        let unknown_data_producer_id: DataProducerId =
+            "12345678-1234-1234-1234-123456789012".parse().unwrap();
 
         assert!(matches!(
             webrtc_transport

--- a/rust/tests/integration/data_consumer.rs
+++ b/rust/tests/integration/data_consumer.rs
@@ -202,6 +202,24 @@ fn consume_data_succeeds() {
 }
 
 #[test]
+fn consume_data_with_unknown_data_producer_id_fails() {
+    future::block_on(async move {
+        let (_worker, _router, webrtc_transport, _sctp_data_producer) = init().await;
+
+        let unknown_data_producer_id: DataProducerId = "12345678-1234-1234-1234-123456789012"
+            .parse()
+            .unwrap();
+
+        assert!(matches!(
+            webrtc_transport
+                .consume_data(DataConsumerOptions::new_sctp(unknown_data_producer_id))
+                .await,
+            Err(ConsumeDataError::DataProducerNotFound(id)) if id == unknown_data_producer_id
+        ));
+    });
+}
+
+#[test]
 fn weak() {
     future::block_on(async move {
         let (_worker, router, _webrtc_transport, sctp_data_producer) = init().await;

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -604,6 +604,49 @@ fn pipe_to_router_succeeds_with_video() {
 }
 
 #[test]
+fn pipe_producer_to_router_with_unknown_producer_id_fails() {
+    future::block_on(async move {
+        let (_worker1, _worker2, router1, router2, _transport1, _transport2) = init().await;
+
+        let unknown_producer_id: ProducerId = "12345678-1234-1234-1234-123456789012"
+            .parse()
+            .unwrap();
+
+        assert!(matches!(
+            router1
+                .pipe_producer_to_router(
+                    unknown_producer_id,
+                    PipeToRouterOptions::new(router2.clone()),
+                )
+                .await,
+            Err(PipeProducerToRouterError::ProducerNotFound(id)) if id == unknown_producer_id
+        ));
+    });
+}
+
+#[test]
+fn pipe_data_producer_to_router_with_unknown_data_producer_id_fails() {
+    future::block_on(async move {
+        let (_worker1, _worker2, router1, router2, _transport1, _transport2) = init().await;
+
+        let unknown_data_producer_id: DataProducerId = "12345678-1234-1234-1234-123456789012"
+            .parse()
+            .unwrap();
+
+        assert!(matches!(
+            router1
+                .pipe_data_producer_to_router(
+                    unknown_data_producer_id,
+                    PipeToRouterOptions::new(router2.clone()),
+                )
+                .await,
+            Err(PipeDataProducerToRouterError::DataProducerNotFound(id))
+                if id == unknown_data_producer_id
+        ));
+    });
+}
+
+#[test]
 fn pipe_to_router_with_keep_id_true_fails_if_both_routers_belong_to_the_same_worker() {
     future::block_on(async move {
         let (worker1, _worker2, router1, _router2, transport1, _transport2) = init().await;

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -9,7 +9,6 @@ use mediasoup::router::{
     PipeDataProducerToRouterPair, PipeProducerToRouterPair, PipeToRouterOptions, Router,
     RouterOptions,
 };
-use mediasoup::transport::ProduceError;
 use mediasoup::webrtc_transport::{
     WebRtcTransport, WebRtcTransportListenInfos, WebRtcTransportOptions,
 };
@@ -666,14 +665,10 @@ fn pipe_to_router_with_keep_id_true_fails_if_both_routers_belong_to_the_same_wor
             )
             .await;
 
-        if let Err(PipeProducerToRouterError::ProduceFailed(ProduceError::Request(
-            RequestError::Response { reason },
-        ))) = result
-        {
-            assert!(reason.contains("already exists [method:transport.produce]"));
-        } else {
-            panic!("Unexpected result: {result:?}");
-        }
+        assert!(
+            matches!(result, Err(PipeProducerToRouterError::ProduceFailed(_))),
+            "Unexpected result: {result:?}"
+        );
     });
 }
 

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -608,9 +608,8 @@ fn pipe_producer_to_router_with_unknown_producer_id_fails() {
     future::block_on(async move {
         let (_worker1, _worker2, router1, router2, _transport1, _transport2) = init().await;
 
-        let unknown_producer_id: ProducerId = "12345678-1234-1234-1234-123456789012"
-            .parse()
-            .unwrap();
+        let unknown_producer_id: ProducerId =
+            "12345678-1234-1234-1234-123456789012".parse().unwrap();
 
         assert!(matches!(
             router1
@@ -629,9 +628,8 @@ fn pipe_data_producer_to_router_with_unknown_data_producer_id_fails() {
     future::block_on(async move {
         let (_worker1, _worker2, router1, router2, _transport1, _transport2) = init().await;
 
-        let unknown_data_producer_id: DataProducerId = "12345678-1234-1234-1234-123456789012"
-            .parse()
-            .unwrap();
+        let unknown_data_producer_id: DataProducerId =
+            "12345678-1234-1234-1234-123456789012".parse().unwrap();
 
         assert!(matches!(
             router1

--- a/worker/include/Channel/ChannelRequest.hpp
+++ b/worker/include/Channel/ChannelRequest.hpp
@@ -56,6 +56,8 @@ namespace Channel
 
 		void TypeError(const char* reason = nullptr);
 
+		void NotFoundError(const char* reason = nullptr);
+
 	private:
 		void Send(const uint8_t* buffer, size_t size) const;
 

--- a/worker/include/MediaSoupErrors.hpp
+++ b/worker/include/MediaSoupErrors.hpp
@@ -25,6 +25,14 @@ public:
 	}
 };
 
+class MediaSoupNotFoundError : public MediaSoupError
+{
+public:
+	explicit MediaSoupNotFoundError(const char* description) : MediaSoupError(description)
+	{
+	}
+};
+
 // clang-format off
 #define MS_THROW_ERROR(desc, ...) \
 	do \
@@ -56,6 +64,22 @@ public:
 		MS_ERROR_STD("throwing MediaSoupTypeError: " desc, ##__VA_ARGS__); \
 		std::snprintf(MediaSoupError::buffer, MediaSoupError::BufferSize, desc, ##__VA_ARGS__); \
 		throw MediaSoupTypeError(MediaSoupError::buffer); \
+	} while (false)
+
+#define MS_THROW_NOT_FOUND_ERROR(desc, ...) \
+	do \
+	{ \
+		MS_ERROR("throwing MediaSoupNotFoundError: " desc, ##__VA_ARGS__); \
+		std::snprintf(MediaSoupError::buffer, MediaSoupError::BufferSize, desc, ##__VA_ARGS__); \
+		throw MediaSoupNotFoundError(MediaSoupError::buffer); \
+	} while (false)
+
+#define MS_THROW_NOT_FOUND_ERROR_STD(desc, ...) \
+	do \
+	{ \
+		MS_ERROR_STD("throwing MediaSoupNotFoundError: " desc, ##__VA_ARGS__); \
+		std::snprintf(MediaSoupError::buffer, MediaSoupError::BufferSize, desc, ##__VA_ARGS__); \
+		throw MediaSoupNotFoundError(MediaSoupError::buffer); \
 	} while (false)
 // clang-format on
 

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -32,7 +32,7 @@ namespace RTC
 
 		public:
 			virtual RTC::WebRtcServer* OnRouterNeedWebRtcServer(
-			  RTC::Router* router, std::string& webRtcServerId) = 0;
+			  const RTC::Router* router, const std::string& webRtcServerId) = 0;
 		};
 
 	public:
@@ -48,10 +48,12 @@ namespace RTC
 		void HandleRequest(Channel::ChannelRequest* request) override;
 
 	private:
-		RTC::Transport* AssertAndGetTransportById(const std::string& transportId) const;
-		RTC::RtpObserver* AssertAndGetRtpObserverById(const std::string& rtpObserverId) const;
-		void CheckNoTransport(const std::string& transportId) const;
-		void CheckNoRtpObserver(const std::string& rtpObserverId) const;
+		RTC::Transport* AssertAndGetTransportById(
+		  const std::string& transportId, const std::string& message) const;
+		RTC::RtpObserver* AssertAndGetRtpObserverById(
+		  const std::string& rtpObserverId, const std::string& message) const;
+		void CheckNoTransport(const std::string& transportId, const std::string& message) const;
+		void CheckNoRtpObserver(const std::string& rtpObserverId, const std::string& message) const;
 
 		/* Pure virtual methods inherited from RTC::Transport::Listener. */
 	public:
@@ -100,7 +102,9 @@ namespace RTC
 		  std::vector<uint16_t>& subchannels,
 		  std::optional<uint16_t> requiredSubchannel) override;
 		void OnTransportNewDataConsumer(
-		  RTC::Transport* transport, RTC::DataConsumer* dataConsumer, std::string& dataProducerId) override;
+		  RTC::Transport* transport,
+		  RTC::DataConsumer* dataConsumer,
+		  const std::string& dataProducerId) override;
 		void OnTransportDataConsumerClosed(RTC::Transport* transport, RTC::DataConsumer* dataConsumer) override;
 		void OnTransportDataConsumerDataProducerClosed(
 		  RTC::Transport* transport, RTC::DataConsumer* dataConsumer) override;

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -110,7 +110,9 @@ namespace RTC
 			  std::vector<uint16_t>& subchannels,
 			  std::optional<uint16_t> requiredSubchannel) = 0;
 			virtual void OnTransportNewDataConsumer(
-			  RTC::Transport* transport, RTC::DataConsumer* dataConsumer, std::string& dataProducerId) = 0;
+			  RTC::Transport* transport,
+			  RTC::DataConsumer* dataConsumer,
+			  const std::string& dataProducerId) = 0;
 			virtual void OnTransportDataConsumerClosed(
 			  RTC::Transport* transport, RTC::DataConsumer* dataConsumer) = 0;
 			virtual void OnTransportDataConsumerDataProducerClosed(
@@ -198,13 +200,24 @@ namespace RTC
 		  RTC::DataConsumer* dataConsumer, RTC::SCTP::Message message, onQueuedCallback* cb = nullptr) final;
 
 	private:
-		virtual RTC::Producer* AssertAndGetProducerById(const std::string& producerId) const final;
-		virtual RTC::Consumer* AssertAndGetConsumerById(const std::string& consumerId) const final;
+		virtual RTC::Producer* AssertAndGetProducerById(
+		  const std::string& producerId, const std::string& message) const final;
+		virtual RTC::Consumer* AssertAndGetConsumerById(
+		  const std::string& consumerId, const std::string& message) const final;
 		virtual RTC::Consumer* GetConsumerByMediaSsrc(uint32_t ssrc) const final;
 		virtual RTC::Consumer* GetConsumerByRtxSsrc(uint32_t ssrc) const final;
-		virtual RTC::DataProducer* AssertAndGetDataProducerById(const std::string& dataProducerId) const final;
-		virtual RTC::DataConsumer* AssertAndGetDataConsumerById(const std::string& dataConsumerId) const final;
-		virtual RTC::DataConsumer* GetSctpDataConsumerByStreamId(uint16_t streamId) const final;
+		virtual RTC::DataProducer* AssertAndGetDataProducerById(
+		  const std::string& dataProducerId, const std::string& message) const final;
+		virtual RTC::DataConsumer* AssertAndGetDataConsumerById(
+		  const std::string& dataConsumerId, const std::string& message) const final;
+		virtual RTC::DataConsumer* AssertAndGetSctpDataConsumerByStreamId(uint16_t streamId) const final;
+		virtual void CheckNoProducer(const std::string& producerId, const std::string& message) const final;
+		virtual void CheckNoConsumer(const std::string& consumerId, const std::string& message) const final;
+		virtual void CheckNoDataProducer(
+		  const std::string& dataProducerId, const std::string& message) const final;
+		virtual void CheckNoDataConsumer(
+		  const std::string& dataConsumerId, const std::string& message) const final;
+		virtual void CheckNoSctpDataConsumer(uint16_t streamId, const std::string& message) const final;
 		virtual bool IsConnected() const = 0;
 		virtual void SendRtpPacket(
 		  RTC::Consumer* consumer, RTC::RTP::Packet* packet, const onSendCallback* cb = nullptr) = 0;
@@ -222,9 +235,6 @@ namespace RTC
 		virtual void EmitTraceEventProbationType(RTC::RTP::Packet* packet) const final;
 		virtual void EmitTraceEventBweType(
 		  RTC::TransportCongestionControlClient::Bitrates& bitrates) const final;
-		virtual void CheckNoDataProducer(const std::string& dataProducerId) const final;
-		virtual void CheckNoDataConsumer(const std::string& dataConsumerId) const final;
-		virtual void CheckNoSctpDataConsumer(uint16_t streamId) const final;
 
 		/* Pure virtual methods inherited from RTC::Producer::Listener. */
 	public:

--- a/worker/include/Worker.hpp
+++ b/worker/include/Worker.hpp
@@ -26,10 +26,11 @@ private:
 	flatbuffers::Offset<FBS::Worker::ResourceUsageResponse> FillBufferResourceUsage(
 	  flatbuffers::FlatBufferBuilder& builder) const;
 	void SetNewRouterId(std::string& routerId) const;
-	RTC::WebRtcServer* AssertAndGetWebRtcServerById(const std::string& webRtcServerId) const;
-	RTC::Router* AssertAndGetRouterById(const std::string& routerId) const;
-	void CheckNoWebRtcServer(const std::string& webRtcServerId) const;
-	void CheckNoRouter(const std::string& routerId) const;
+	RTC::WebRtcServer* AssertAndGetWebRtcServerById(
+	  const std::string& webRtcServerId, const std::string& message) const;
+	RTC::Router* AssertAndGetRouterById(const std::string& routerId, const std::string& message) const;
+	void CheckNoWebRtcServer(const std::string& webRtcServerId, const std::string& message) const;
+	void CheckNoRouter(const std::string& routerId, const std::string& message) const;
 
 	/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
 public:
@@ -46,7 +47,8 @@ public:
 
 	/* Pure virtual methods inherited from RTC::Router::Listener. */
 public:
-	RTC::WebRtcServer* OnRouterNeedWebRtcServer(RTC::Router* router, std::string& webRtcServerId) override;
+	RTC::WebRtcServer* OnRouterNeedWebRtcServer(
+	  const RTC::Router* router, const std::string& webRtcServerId) override;
 
 private:
 	// Passed by argument.

--- a/worker/src/Channel/ChannelRequest.cpp
+++ b/worker/src/Channel/ChannelRequest.cpp
@@ -160,6 +160,27 @@ namespace Channel
 		SendResponse(response);
 	}
 
+	void ChannelRequest::NotFoundError(const char* reason)
+	{
+		MS_TRACE();
+
+		MS_ASSERT(!this->replied, "request already replied");
+
+		this->replied = true;
+
+		auto& builder = ChannelRequest::bufferBuilder;
+		auto response = FBS::Response::CreateResponseDirect(
+		  builder,
+		  this->id,
+		  /*accepted*/ false,
+		  FBS::Response::Body::NONE,
+		  0,
+		  /*error*/ "NotFoundError",
+		  reason);
+
+		SendResponse(response);
+	}
+
 	void ChannelRequest::Send(const uint8_t* buffer, size_t size) const
 	{
 		this->channel->Send(buffer, size);

--- a/worker/src/Channel/ChannelSocket.cpp
+++ b/worker/src/Channel/ChannelSocket.cpp
@@ -223,6 +223,10 @@ namespace Channel
 				{
 					request->TypeError(error.what());
 				}
+				catch (const MediaSoupNotFoundError& error)
+				{
+					request->NotFoundError(error.what());
+				}
 				catch (const MediaSoupError& error)
 				{
 					request->Error(error.what());
@@ -303,6 +307,10 @@ namespace Channel
 			catch (const MediaSoupTypeError& error)
 			{
 				request->TypeError(error.what());
+			}
+			catch (const MediaSoupNotFoundError& error)
+			{
+				request->NotFoundError(error.what());
 			}
 			catch (const MediaSoupError& error)
 			{

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -726,7 +726,7 @@ namespace RTC
 
 		if (mapProducersIt == this->mapProducers.end())
 		{
-			MS_THROW_ERROR("Producer not found [producerId:%s]", producerId.c_str());
+			MS_THROW_NOT_FOUND_ERROR("Producer not found [producerId:%s]", producerId.c_str());
 		}
 
 		auto* producer              = mapProducersIt->second;
@@ -964,7 +964,7 @@ namespace RTC
 
 		if (mapDataProducersIt == this->mapDataProducers.end())
 		{
-			MS_THROW_ERROR("DataProducer not found [dataProducerId:%s]", dataProducerId.c_str());
+			MS_THROW_NOT_FOUND_ERROR("DataProducer not found [dataProducerId:%s]", dataProducerId.c_str());
 		}
 
 		auto* dataProducer                  = mapDataProducersIt->second;
@@ -1080,7 +1080,7 @@ namespace RTC
 
 		if (it == this->mapProducers.end())
 		{
-			MS_THROW_ERROR("Producer not found");
+			MS_THROW_NOT_FOUND_ERROR("Producer not found");
 		}
 
 		RTC::Producer* producer = it->second;

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -475,7 +475,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		if (this->mapTransports.find(transportId) != this->mapTransports.end())
+		if (this->mapTransports.contains(transportId))
 		{
 			MS_THROW_ERROR("a Transport with same id already exists [method:%s]", message.c_str());
 		}
@@ -485,7 +485,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		if (this->mapRtpObservers.find(rtpObserverId) != this->mapRtpObservers.end())
+		if (this->mapRtpObservers.contains(rtpObserverId))
 		{
 			MS_THROW_ERROR("an RtpObserver with same id already exists [method:%s]", message.c_str());
 		}

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -210,11 +210,10 @@ namespace RTC
 			case Channel::ChannelRequest::Method::ROUTER_CREATE_WEBRTCTRANSPORT:
 			{
 				const auto* body = request->data->body_as<FBS::Router::CreateWebRtcTransportRequest>();
-
-				auto transportId = body->transportId()->str();
+				const auto transportId = body->transportId()->str();
 
 				// This may throw.
-				CheckNoTransport(transportId);
+				CheckNoTransport(transportId, request->methodCStr);
 
 				// This may throw.
 				auto* webRtcTransport =
@@ -235,17 +234,16 @@ namespace RTC
 			case Channel::ChannelRequest::Method::ROUTER_CREATE_WEBRTCTRANSPORT_WITH_SERVER:
 			{
 				const auto* body = request->data->body_as<FBS::Router::CreateWebRtcTransportRequest>();
-				auto transportId = body->transportId()->str();
+				const auto transportId = body->transportId()->str();
 
 				// This may throw.
-				CheckNoTransport(transportId);
+				CheckNoTransport(transportId, request->methodCStr);
 
 				const auto* options    = body->options();
 				const auto* listenInfo = options->listen_as<FBS::WebRtcTransport::ListenServer>();
 
 				auto webRtcServerId = listenInfo->webRtcServerId()->str();
-
-				auto* webRtcServer = this->listener->OnRouterNeedWebRtcServer(this, webRtcServerId);
+				auto* webRtcServer  = this->listener->OnRouterNeedWebRtcServer(this, webRtcServerId);
 
 				if (!webRtcServer)
 				{
@@ -274,11 +272,11 @@ namespace RTC
 
 			case Channel::ChannelRequest::Method::ROUTER_CREATE_PLAINTRANSPORT:
 			{
-				const auto* body = request->data->body_as<FBS::Router::CreatePlainTransportRequest>();
-				auto transportId = body->transportId()->str();
+				const auto* body       = request->data->body_as<FBS::Router::CreatePlainTransportRequest>();
+				const auto transportId = body->transportId()->str();
 
 				// This may throw.
-				CheckNoTransport(transportId);
+				CheckNoTransport(transportId, request->methodCStr);
 
 				auto* plainTransport =
 				  new RTC::PlainTransport(this->shared, transportId, this, body->options());
@@ -297,11 +295,11 @@ namespace RTC
 
 			case Channel::ChannelRequest::Method::ROUTER_CREATE_PIPETRANSPORT:
 			{
-				const auto* body = request->data->body_as<FBS::Router::CreatePipeTransportRequest>();
-				auto transportId = body->transportId()->str();
+				const auto* body       = request->data->body_as<FBS::Router::CreatePipeTransportRequest>();
+				const auto transportId = body->transportId()->str();
 
 				// This may throw.
-				CheckNoTransport(transportId);
+				CheckNoTransport(transportId, request->methodCStr);
 
 				auto* pipeTransport =
 				  new RTC::PipeTransport(this->shared, transportId, this, body->options());
@@ -321,10 +319,10 @@ namespace RTC
 			case Channel::ChannelRequest::Method::ROUTER_CREATE_DIRECTTRANSPORT:
 			{
 				const auto* body = request->data->body_as<FBS::Router::CreateDirectTransportRequest>();
-				auto transportId = body->transportId()->str();
+				const auto transportId = body->transportId()->str();
 
 				// This may throw.
-				CheckNoTransport(transportId);
+				CheckNoTransport(transportId, request->methodCStr);
 
 				auto* directTransport =
 				  new RTC::DirectTransport(this->shared, transportId, this, body->options());
@@ -344,10 +342,10 @@ namespace RTC
 			case Channel::ChannelRequest::Method::ROUTER_CREATE_ACTIVESPEAKEROBSERVER:
 			{
 				const auto* body = request->data->body_as<FBS::Router::CreateActiveSpeakerObserverRequest>();
-				auto rtpObserverId = body->rtpObserverId()->str();
+				const auto rtpObserverId = body->rtpObserverId()->str();
 
 				// This may throw.
-				CheckNoRtpObserver(rtpObserverId);
+				CheckNoRtpObserver(rtpObserverId, request->methodCStr);
 
 				auto* activeSpeakerObserver =
 				  new RTC::ActiveSpeakerObserver(this->shared, rtpObserverId, this, body->options());
@@ -364,11 +362,11 @@ namespace RTC
 
 			case Channel::ChannelRequest::Method::ROUTER_CREATE_AUDIOLEVELOBSERVER:
 			{
-				const auto* body   = request->data->body_as<FBS::Router::CreateAudioLevelObserverRequest>();
-				auto rtpObserverId = body->rtpObserverId()->str();
+				const auto* body = request->data->body_as<FBS::Router::CreateAudioLevelObserverRequest>();
+				const auto rtpObserverId = body->rtpObserverId()->str();
 
 				// This may throw.
-				CheckNoRtpObserver(rtpObserverId);
+				CheckNoRtpObserver(rtpObserverId, request->methodCStr);
 
 				auto* audioLevelObserver =
 				  new RTC::AudioLevelObserver(this->shared, rtpObserverId, this, body->options());
@@ -385,11 +383,11 @@ namespace RTC
 
 			case Channel::ChannelRequest::Method::ROUTER_CLOSE_TRANSPORT:
 			{
-				const auto* body = request->data->body_as<FBS::Router::CloseTransportRequest>();
-				auto transportId = body->transportId()->str();
+				const auto* body       = request->data->body_as<FBS::Router::CloseTransportRequest>();
+				const auto transportId = body->transportId()->str();
 
 				// This may throw.
-				RTC::Transport* transport = AssertAndGetTransportById(transportId);
+				RTC::Transport* transport = AssertAndGetTransportById(transportId, request->methodCStr);
 
 				// Tell the Transport to close all its Producers and Consumers so it will
 				// notify us about their closures.
@@ -410,11 +408,10 @@ namespace RTC
 
 			case Channel::ChannelRequest::Method::ROUTER_CLOSE_RTPOBSERVER:
 			{
-				const auto* body   = request->data->body_as<FBS::Router::CloseRtpObserverRequest>();
-				auto rtpObserverId = body->rtpObserverId()->str();
-
-				// This may throw.
-				const RTC::RtpObserver* rtpObserver = AssertAndGetRtpObserverById(rtpObserverId);
+				const auto* body         = request->data->body_as<FBS::Router::CloseRtpObserverRequest>();
+				const auto rtpObserverId = body->rtpObserverId()->str();
+				const RTC::RtpObserver* rtpObserver =
+				  AssertAndGetRtpObserverById(rtpObserverId, request->methodCStr);
 
 				// Remove it from the map.
 				this->mapRtpObservers.erase(rtpObserver->id);
@@ -439,28 +436,13 @@ namespace RTC
 
 			default:
 			{
-				MS_THROW_ERROR("unknown method");
+				MS_THROW_ERROR("unknown method '%s'", request->methodCStr);
 			}
 		}
 	}
 
-	void Router::CheckNoTransport(const std::string& transportId) const
-	{
-		if (this->mapTransports.find(transportId) != this->mapTransports.end())
-		{
-			MS_THROW_ERROR("a Transport with same id already exists");
-		}
-	}
-
-	void Router::CheckNoRtpObserver(const std::string& rtpObserverId) const
-	{
-		if (this->mapRtpObservers.find(rtpObserverId) != this->mapRtpObservers.end())
-		{
-			MS_THROW_ERROR("an RtpObserver with same id already exists");
-		}
-	}
-
-	RTC::Transport* Router::AssertAndGetTransportById(const std::string& transportId) const
+	RTC::Transport* Router::AssertAndGetTransportById(
+	  const std::string& transportId, const std::string& message) const
 	{
 		MS_TRACE();
 
@@ -468,13 +450,14 @@ namespace RTC
 
 		if (this->mapTransports.find(transportId) == this->mapTransports.end())
 		{
-			MS_THROW_ERROR("Transport not found");
+			MS_THROW_NOT_FOUND_ERROR("Transport not found [method:%s]", message.c_str());
 		}
 
 		return it->second;
 	}
 
-	RTC::RtpObserver* Router::AssertAndGetRtpObserverById(const std::string& rtpObserverId) const
+	RTC::RtpObserver* Router::AssertAndGetRtpObserverById(
+	  const std::string& rtpObserverId, const std::string& message) const
 	{
 		MS_TRACE();
 
@@ -482,10 +465,30 @@ namespace RTC
 
 		if (this->mapRtpObservers.find(rtpObserverId) == this->mapRtpObservers.end())
 		{
-			MS_THROW_ERROR("RtpObserver not found");
+			MS_THROW_NOT_FOUND_ERROR("RtpObserver not found [method:%s]", message.c_str());
 		}
 
 		return it->second;
+	}
+
+	void Router::CheckNoTransport(const std::string& transportId, const std::string& message) const
+	{
+		MS_TRACE();
+
+		if (this->mapTransports.find(transportId) != this->mapTransports.end())
+		{
+			MS_THROW_ERROR("a Transport with same id already exists [method:%s]", message.c_str());
+		}
+	}
+
+	void Router::CheckNoRtpObserver(const std::string& rtpObserverId, const std::string& message) const
+	{
+		MS_TRACE();
+
+		if (this->mapRtpObservers.find(rtpObserverId) != this->mapRtpObservers.end())
+		{
+			MS_THROW_ERROR("an RtpObserver with same id already exists [method:%s]", message.c_str());
+		}
 	}
 
 	void Router::OnTransportNewProducer(RTC::Transport* /*transport*/, RTC::Producer* producer)
@@ -953,7 +956,7 @@ namespace RTC
 	}
 
 	void Router::OnTransportNewDataConsumer(
-	  RTC::Transport* /*transport*/, RTC::DataConsumer* dataConsumer, std::string& dataProducerId)
+	  RTC::Transport* /*transport*/, RTC::DataConsumer* dataConsumer, const std::string& dataProducerId)
 	{
 		MS_TRACE();
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -608,13 +608,10 @@ namespace RTC
 
 			case Channel::ChannelRequest::Method::TRANSPORT_PRODUCE:
 			{
-				const auto* body = request->data->body_as<FBS::Transport::ProduceRequest>();
-				auto producerId  = body->producerId()->str();
+				const auto* body      = request->data->body_as<FBS::Transport::ProduceRequest>();
+				const auto producerId = body->producerId()->str();
 
-				if (this->mapProducers.find(producerId) != this->mapProducers.end())
-				{
-					MS_THROW_ERROR("a Producer with same producerId already exists");
-				}
+				CheckNoProducer(producerId, request->methodCStr);
 
 				// This may throw.
 				auto* producer = new RTC::Producer(this->shared, producerId, this, body);
@@ -779,14 +776,11 @@ namespace RTC
 
 			case Channel::ChannelRequest::Method::TRANSPORT_CONSUME:
 			{
-				const auto* body             = request->data->body_as<FBS::Transport::ConsumeRequest>();
-				const std::string producerId = body->producerId()->str();
-				const std::string consumerId = body->consumerId()->str();
+				const auto* body      = request->data->body_as<FBS::Transport::ConsumeRequest>();
+				const auto producerId = body->producerId()->str();
+				const auto consumerId = body->consumerId()->str();
 
-				if (this->mapConsumers.find(consumerId) != this->mapConsumers.end())
-				{
-					MS_THROW_ERROR("a Consumer with same consumerId already exists");
-				}
+				CheckNoConsumer(consumerId, request->methodCStr);
 
 				// This may throw.
 				auto* consumer = new RTC::Consumer(this->shared, consumerId, producerId, this, body);
@@ -821,7 +815,8 @@ namespace RTC
 				  "Consumer created [consumerId:%s, producerId:%s]", consumerId.c_str(), producerId.c_str());
 
 				flatbuffers::Offset<FBS::Consumer::ConsumerLayers> preferredLayersOffset;
-				auto preferredLayers = consumer->GetPreferredLayers();
+
+				const auto preferredLayers = consumer->GetPreferredLayers();
 
 				if (preferredLayers.spatial > -1 && preferredLayers.temporal > -1)
 				{
@@ -1005,12 +1000,11 @@ namespace RTC
 					MS_THROW_ERROR("SCTP not enabled and not a direct Transport");
 				}
 
-				const auto* body = request->data->body_as<FBS::Transport::ProduceDataRequest>();
-
-				auto dataProducerId = body->dataProducerId()->str();
+				const auto* body          = request->data->body_as<FBS::Transport::ProduceDataRequest>();
+				const auto dataProducerId = body->dataProducerId()->str();
 
 				// This may throw.
-				CheckNoDataProducer(dataProducerId);
+				CheckNoDataProducer(dataProducerId, request->methodCStr);
 
 				// This may throw.
 				auto* dataProducer = new RTC::DataProducer(
@@ -1108,13 +1102,12 @@ namespace RTC
 					MS_THROW_ERROR("SCTP not enabled and not a direct Transport");
 				}
 
-				const auto* body = request->data->body_as<FBS::Transport::ConsumeDataRequest>();
-
-				auto dataProducerId = body->dataProducerId()->str();
-				auto dataConsumerId = body->dataConsumerId()->str();
+				const auto* body          = request->data->body_as<FBS::Transport::ConsumeDataRequest>();
+				const auto dataProducerId = body->dataProducerId()->str();
+				const auto dataConsumerId = body->dataConsumerId()->str();
 
 				// This may throw.
-				CheckNoDataConsumer(dataConsumerId);
+				CheckNoDataConsumer(dataConsumerId, request->methodCStr);
 
 				// This may throw.
 				auto* dataConsumer = new RTC::DataConsumer(
@@ -1137,7 +1130,8 @@ namespace RTC
 						try
 						{
 							// This may throw.
-							CheckNoSctpDataConsumer(dataConsumer->GetSctpStreamParameters().streamId);
+							CheckNoSctpDataConsumer(
+							  dataConsumer->GetSctpStreamParameters().streamId, request->methodCStr);
 						}
 						catch (const MediaSoupError& error)
 						{
@@ -1254,7 +1248,8 @@ namespace RTC
 				const auto* body = request->data->body_as<FBS::Transport::CloseProducerRequest>();
 
 				// This may throw.
-				RTC::Producer* producer = AssertAndGetProducerById(body->producerId()->str());
+				RTC::Producer* producer =
+				  AssertAndGetProducerById(body->producerId()->str(), request->methodCStr);
 
 				// Remove it from the RtpListener.
 				this->rtpListener.RemoveProducer(producer);
@@ -1293,7 +1288,8 @@ namespace RTC
 				const auto* body = request->data->body_as<FBS::Transport::CloseConsumerRequest>();
 
 				// This may throw.
-				RTC::Consumer* consumer = AssertAndGetConsumerById(body->consumerId()->str());
+				RTC::Consumer* consumer =
+				  AssertAndGetConsumerById(body->consumerId()->str(), request->methodCStr);
 
 				// Remove it from the maps.
 				this->mapConsumers.erase(consumer->id);
@@ -1344,7 +1340,8 @@ namespace RTC
 				const auto* body = request->data->body_as<FBS::Transport::CloseDataProducerRequest>();
 
 				// This may throw.
-				RTC::DataProducer* dataProducer = AssertAndGetDataProducerById(body->dataProducerId()->str());
+				RTC::DataProducer* dataProducer =
+				  AssertAndGetDataProducerById(body->dataProducerId()->str(), request->methodCStr);
 
 				if (dataProducer->GetType() == RTC::DataProducer::Type::SCTP)
 				{
@@ -1391,7 +1388,8 @@ namespace RTC
 				const auto* body = request->data->body_as<FBS::Transport::CloseDataConsumerRequest>();
 
 				// This may throw.
-				RTC::DataConsumer* dataConsumer = AssertAndGetDataConsumerById(body->dataConsumerId()->str());
+				RTC::DataConsumer* dataConsumer =
+				  AssertAndGetDataConsumerById(body->dataConsumerId()->str(), request->methodCStr);
 
 				// Remove it from the maps.
 				this->mapDataConsumers.erase(dataConsumer->id);
@@ -1761,35 +1759,8 @@ namespace RTC
 		delete cb;
 	}
 
-	void Transport::CheckNoDataProducer(const std::string& dataProducerId) const
-	{
-		if (this->mapDataProducers.find(dataProducerId) != this->mapDataProducers.end())
-		{
-			MS_THROW_ERROR("a DataProducer with same dataProducerId already exists");
-		}
-	}
-
-	void Transport::CheckNoDataConsumer(const std::string& dataConsumerId) const
-	{
-		MS_TRACE();
-
-		if (this->mapDataConsumers.find(dataConsumerId) != this->mapDataConsumers.end())
-		{
-			MS_THROW_ERROR("a DataConsumer with same dataConsumerId already exists");
-		}
-	}
-
-	void Transport::CheckNoSctpDataConsumer(uint16_t streamId) const
-	{
-		MS_TRACE();
-
-		if (this->mapSctpStreamIdDataConsumers.find(streamId) != this->mapSctpStreamIdDataConsumers.end())
-		{
-			MS_THROW_ERROR("an SCTP DataConsumer with same streamId %" PRIu16 " already exists", streamId);
-		}
-	}
-
-	RTC::Producer* Transport::AssertAndGetProducerById(const std::string& producerId) const
+	RTC::Producer* Transport::AssertAndGetProducerById(
+	  const std::string& producerId, const std::string& message) const
 	{
 		MS_TRACE();
 
@@ -1797,13 +1768,14 @@ namespace RTC
 
 		if (it == this->mapProducers.end())
 		{
-			MS_THROW_ERROR("Producer not found");
+			MS_THROW_NOT_FOUND_ERROR("Producer not found [method:%s]", message.c_str());
 		}
 
 		return it->second;
 	}
 
-	RTC::Consumer* Transport::AssertAndGetConsumerById(const std::string& consumerId) const
+	RTC::Consumer* Transport::AssertAndGetConsumerById(
+	  const std::string& consumerId, const std::string& message) const
 	{
 		MS_TRACE();
 
@@ -1811,7 +1783,7 @@ namespace RTC
 
 		if (it == this->mapConsumers.end())
 		{
-			MS_THROW_ERROR("Consumer not found");
+			MS_THROW_NOT_FOUND_ERROR("Consumer not found [method:%s]", message.c_str());
 		}
 
 		return it->second;
@@ -1849,7 +1821,8 @@ namespace RTC
 		return consumer;
 	}
 
-	RTC::DataProducer* Transport::AssertAndGetDataProducerById(const std::string& dataProducerId) const
+	RTC::DataProducer* Transport::AssertAndGetDataProducerById(
+	  const std::string& dataProducerId, const std::string& message) const
 	{
 		MS_TRACE();
 
@@ -1857,13 +1830,14 @@ namespace RTC
 
 		if (it == this->mapDataProducers.end())
 		{
-			MS_THROW_ERROR("DataProducer not found");
+			MS_THROW_NOT_FOUND_ERROR("DataProducer not found [method:%s]", message.c_str());
 		}
 
 		return it->second;
 	}
 
-	RTC::DataConsumer* Transport::AssertAndGetDataConsumerById(const std::string& dataConsumerId) const
+	RTC::DataConsumer* Transport::AssertAndGetDataConsumerById(
+	  const std::string& dataConsumerId, const std::string& message) const
 	{
 		MS_TRACE();
 
@@ -1871,13 +1845,13 @@ namespace RTC
 
 		if (it == this->mapDataConsumers.end())
 		{
-			MS_THROW_ERROR("DataConsumer not found");
+			MS_THROW_NOT_FOUND_ERROR("DataConsumer not found [method:%s]", message.c_str());
 		}
 
 		return it->second;
 	}
 
-	RTC::DataConsumer* Transport::GetSctpDataConsumerByStreamId(uint16_t streamId) const
+	RTC::DataConsumer* Transport::AssertAndGetSctpDataConsumerByStreamId(uint16_t streamId) const
 	{
 		MS_TRACE();
 
@@ -1885,10 +1859,65 @@ namespace RTC
 
 		if (it == this->mapSctpStreamIdDataConsumers.end())
 		{
-			MS_THROW_ERROR("SCTP DataConsumer with streamId %" PRIu16 " not found", streamId);
+			MS_THROW_NOT_FOUND_ERROR("SCTP DataConsumer with streamId %" PRIu16 " not found", streamId);
 		}
 
 		return it->second;
+	}
+
+	void Transport::CheckNoProducer(const std::string& producerId, const std::string& message) const
+	{
+		MS_TRACE();
+
+		if (this->mapProducers.find(producerId) != this->mapProducers.end())
+		{
+			MS_THROW_ERROR("a Producer with same producerId already exists [method:%s]", message.c_str());
+		}
+	}
+
+	void Transport::CheckNoConsumer(const std::string& dataConsumerId, const std::string& message) const
+	{
+		MS_TRACE();
+
+		if (this->mapConsumers.find(dataConsumerId) != this->mapConsumers.end())
+		{
+			MS_THROW_ERROR("a Consumer with same consumerId already exists [method:%s]", message.c_str());
+		}
+	}
+
+	void Transport::CheckNoDataProducer(const std::string& dataProducerId, const std::string& message) const
+	{
+		MS_TRACE();
+
+		if (this->mapDataProducers.find(dataProducerId) != this->mapDataProducers.end())
+		{
+			MS_THROW_ERROR(
+			  "a DataProducer with same dataProducerId already exists [method:%s]", message.c_str());
+		}
+	}
+
+	void Transport::CheckNoDataConsumer(const std::string& dataConsumerId, const std::string& message) const
+	{
+		MS_TRACE();
+
+		if (this->mapDataConsumers.find(dataConsumerId) != this->mapDataConsumers.end())
+		{
+			MS_THROW_ERROR(
+			  "a DataConsumer with same dataConsumerId already exists [method:%s]", message.c_str());
+		}
+	}
+
+	void Transport::CheckNoSctpDataConsumer(uint16_t streamId, const std::string& message) const
+	{
+		MS_TRACE();
+
+		if (this->mapSctpStreamIdDataConsumers.find(streamId) != this->mapSctpStreamIdDataConsumers.end())
+		{
+			MS_THROW_ERROR(
+			  "an SCTP DataConsumer with same streamId %" PRIu16 " already exists [method:%s]",
+			  streamId,
+			  message.c_str());
+		}
 	}
 
 	void Transport::HandleRtcpPacket(RTC::RTCP::Packet* packet)
@@ -3250,7 +3279,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		const auto* dataConsumer = GetSctpDataConsumerByStreamId(streamId);
+		const auto* dataConsumer = AssertAndGetSctpDataConsumerByStreamId(streamId);
 
 		if (!dataConsumer)
 		{

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1869,7 +1869,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		if (this->mapProducers.find(producerId) != this->mapProducers.end())
+		if (this->mapProducers.contains(producerId))
 		{
 			MS_THROW_ERROR("a Producer with same producerId already exists [method:%s]", message.c_str());
 		}
@@ -1879,7 +1879,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		if (this->mapConsumers.find(dataConsumerId) != this->mapConsumers.end())
+		if (this->mapConsumers.contains(dataConsumerId))
 		{
 			MS_THROW_ERROR("a Consumer with same consumerId already exists [method:%s]", message.c_str());
 		}
@@ -1889,7 +1889,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		if (this->mapDataProducers.find(dataProducerId) != this->mapDataProducers.end())
+		if (this->mapDataProducers.contains(dataProducerId))
 		{
 			MS_THROW_ERROR(
 			  "a DataProducer with same dataProducerId already exists [method:%s]", message.c_str());
@@ -1900,7 +1900,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		if (this->mapDataConsumers.find(dataConsumerId) != this->mapDataConsumers.end())
+		if (this->mapDataConsumers.contains(dataConsumerId))
 		{
 			MS_THROW_ERROR(
 			  "a DataConsumer with same dataConsumerId already exists [method:%s]", message.c_str());
@@ -1911,7 +1911,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		if (this->mapSctpStreamIdDataConsumers.find(streamId) != this->mapSctpStreamIdDataConsumers.end())
+		if (this->mapSctpStreamIdDataConsumers.contains(streamId))
 		{
 			MS_THROW_ERROR(
 			  "an SCTP DataConsumer with same streamId %" PRIu16 " already exists [method:%s]",

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -183,19 +183,22 @@ flatbuffers::Offset<FBS::Worker::ResourceUsageResponse> Worker::FillBufferResour
 	  uvRusage.ru_nivcsw);
 }
 
-RTC::WebRtcServer* Worker::AssertAndGetWebRtcServerById(const std::string& webRtcServerId) const
+RTC::WebRtcServer* Worker::AssertAndGetWebRtcServerById(
+  const std::string& webRtcServerId, const std::string& message) const
 {
+	MS_TRACE();
+
 	auto it = this->mapWebRtcServers.find(webRtcServerId);
 
 	if (it == this->mapWebRtcServers.end())
 	{
-		MS_THROW_ERROR("WebRtcServer not found");
+		MS_THROW_NOT_FOUND_ERROR("WebRtcServer not found [method:%s]", message.c_str());
 	}
 
 	return it->second;
 }
 
-RTC::Router* Worker::AssertAndGetRouterById(const std::string& routerId) const
+RTC::Router* Worker::AssertAndGetRouterById(const std::string& routerId, const std::string& message) const
 {
 	MS_TRACE();
 
@@ -203,25 +206,30 @@ RTC::Router* Worker::AssertAndGetRouterById(const std::string& routerId) const
 
 	if (it == this->mapRouters.end())
 	{
-		MS_THROW_ERROR("Router not found");
+		MS_THROW_NOT_FOUND_ERROR("Router not found [method:%s]", message.c_str());
 	}
 
 	return it->second;
 }
 
-void Worker::CheckNoWebRtcServer(const std::string& webRtcServerId) const
+void Worker::CheckNoWebRtcServer(const std::string& webRtcServerId, const std::string& message) const
 {
+	MS_TRACE();
+
 	if (this->mapWebRtcServers.find(webRtcServerId) != this->mapWebRtcServers.end())
 	{
-		MS_THROW_ERROR("a WebRtcServer with same webRtcServerId already exists");
+		MS_THROW_ERROR(
+		  "a WebRtcServer with same webRtcServerId already exists [method:%s]", message.c_str());
 	}
 }
 
-void Worker::CheckNoRouter(const std::string& routerId) const
+void Worker::CheckNoRouter(const std::string& routerId, const std::string& message) const
 {
+	MS_TRACE();
+
 	if (this->mapRouters.find(routerId) != this->mapRouters.end())
 	{
-		MS_THROW_ERROR("a Router with same routerId already exists");
+		MS_THROW_ERROR("a Router with same routerId already exists [method:%s]", message.c_str());
 	}
 }
 
@@ -261,50 +269,28 @@ void Worker::HandleRequest(Channel::ChannelRequest* request)
 
 		case Channel::ChannelRequest::Method::WORKER_CREATE_WEBRTCSERVER:
 		{
-			try
-			{
-				const auto* const body = request->data->body_as<FBS::Worker::CreateWebRtcServerRequest>();
+			const auto* const body    = request->data->body_as<FBS::Worker::CreateWebRtcServerRequest>();
+			const auto webRtcServerId = body->webRtcServerId()->str();
 
-				const std::string webRtcServerId = body->webRtcServerId()->str();
+			CheckNoWebRtcServer(webRtcServerId, request->methodCStr);
 
-				CheckNoWebRtcServer(webRtcServerId);
+			auto* webRtcServer = new RTC::WebRtcServer(this->shared, webRtcServerId, body->listenInfos());
 
-				auto* webRtcServer = new RTC::WebRtcServer(this->shared, webRtcServerId, body->listenInfos());
+			this->mapWebRtcServers[webRtcServerId] = webRtcServer;
 
-				this->mapWebRtcServers[webRtcServerId] = webRtcServer;
+			MS_DEBUG_DEV("WebRtcServer created [webRtcServerId:%s]", webRtcServerId.c_str());
 
-				MS_DEBUG_DEV("WebRtcServer created [webRtcServerId:%s]", webRtcServerId.c_str());
-
-				request->Accept();
-			}
-			catch (const MediaSoupTypeError& error)
-			{
-				MS_THROW_TYPE_ERROR("%s [method:%s]", error.what(), request->methodCStr);
-			}
-			catch (const MediaSoupError& error)
-			{
-				MS_THROW_ERROR("%s [method:%s]", error.what(), request->methodCStr);
-			}
+			request->Accept();
 
 			break;
 		}
 
 		case Channel::ChannelRequest::Method::WORKER_WEBRTCSERVER_CLOSE:
 		{
-			const RTC::WebRtcServer* webRtcServer{ nullptr };
-
-			const auto* body = request->data->body_as<FBS::Worker::CloseWebRtcServerRequest>();
-
-			auto webRtcServerId = body->webRtcServerId()->str();
-
-			try
-			{
-				webRtcServer = AssertAndGetWebRtcServerById(webRtcServerId);
-			}
-			catch (const MediaSoupError& error)
-			{
-				MS_THROW_ERROR("%s [method:%s]", error.what(), request->methodCStr);
-			}
+			const auto* body          = request->data->body_as<FBS::Worker::CloseWebRtcServerRequest>();
+			const auto webRtcServerId = body->webRtcServerId()->str();
+			const RTC::WebRtcServer* webRtcServer =
+			  AssertAndGetWebRtcServerById(webRtcServerId, request->methodCStr);
 
 			// Remove it from the map and delete it.
 			this->mapWebRtcServers.erase(webRtcServer->GetId());
@@ -320,18 +306,10 @@ void Worker::HandleRequest(Channel::ChannelRequest* request)
 
 		case Channel::ChannelRequest::Method::WORKER_CREATE_ROUTER:
 		{
-			const auto* body = request->data->body_as<FBS::Worker::CreateRouterRequest>();
+			const auto* body    = request->data->body_as<FBS::Worker::CreateRouterRequest>();
+			const auto routerId = body->routerId()->str();
 
-			auto routerId = body->routerId()->str();
-
-			try
-			{
-				CheckNoRouter(routerId);
-			}
-			catch (const MediaSoupError& error)
-			{
-				MS_THROW_ERROR("%s [method:%s]", error.what(), request->methodCStr);
-			}
+			CheckNoRouter(routerId, request->methodCStr);
 
 			auto* router = new RTC::Router(this->shared, routerId, this);
 
@@ -346,20 +324,9 @@ void Worker::HandleRequest(Channel::ChannelRequest* request)
 
 		case Channel::ChannelRequest::Method::WORKER_CLOSE_ROUTER:
 		{
-			const RTC::Router* router{ nullptr };
-
-			const auto* body = request->data->body_as<FBS::Worker::CloseRouterRequest>();
-
-			auto routerId = body->routerId()->str();
-
-			try
-			{
-				router = AssertAndGetRouterById(routerId);
-			}
-			catch (const MediaSoupError& error)
-			{
-				MS_THROW_ERROR("%s [method:%s]", error.what(), request->methodCStr);
-			}
+			const auto* body          = request->data->body_as<FBS::Worker::CloseRouterRequest>();
+			const auto routerId       = body->routerId()->str();
+			const RTC::Router* router = AssertAndGetRouterById(routerId, request->methodCStr);
 
 			// Remove it from the map and delete it.
 			this->mapRouters.erase(router->id);
@@ -376,26 +343,18 @@ void Worker::HandleRequest(Channel::ChannelRequest* request)
 		// Any other request must be delivered to the corresponding Router.
 		default:
 		{
-			try
-			{
-				auto* handler =
-				  this->shared->GetChannelMessageRegistrator()->GetChannelRequestHandler(request->handlerId);
+			auto* handler =
+			  this->shared->GetChannelMessageRegistrator()->GetChannelRequestHandler(request->handlerId);
 
-				if (handler == nullptr)
-				{
-					MS_THROW_ERROR("Channel request handler with ID %s not found", request->handlerId.c_str());
-				}
+			if (!handler)
+			{
+				MS_THROW_NOT_FOUND_ERROR(
+				  "Channel request handler with ID %s not found [method:%s]",
+				  request->handlerId.c_str(),
+				  request->methodCStr);
+			}
 
-				handler->HandleRequest(request);
-			}
-			catch (const MediaSoupTypeError& error)
-			{
-				MS_THROW_TYPE_ERROR("%s [method:%s]", error.what(), request->methodCStr);
-			}
-			catch (const MediaSoupError& error)
-			{
-				MS_THROW_ERROR("%s [method:%s]", error.what(), request->methodCStr);
-			}
+			handler->HandleRequest(request);
 
 			break;
 		}
@@ -426,27 +385,16 @@ void Worker::HandleNotification(Channel::ChannelNotification* notification)
 
 		default:
 		{
-			try
-			{
-				auto* handler = this->shared->GetChannelMessageRegistrator()->GetChannelNotificationHandler(
-				  notification->handlerId);
+			auto* handler = this->shared->GetChannelMessageRegistrator()->GetChannelNotificationHandler(
+			  notification->handlerId);
 
-				if (handler == nullptr)
-				{
-					MS_THROW_ERROR(
-					  "Channel notification handler with ID %s not found", notification->handlerId.c_str());
-				}
+			if (handler == nullptr)
+			{
+				MS_THROW_ERROR(
+				  "Channel notification handler with ID %s not found", notification->handlerId.c_str());
+			}
 
-				handler->HandleNotification(notification);
-			}
-			catch (const MediaSoupTypeError& error)
-			{
-				MS_THROW_TYPE_ERROR("%s [event:%s]", error.what(), notification->eventCStr);
-			}
-			catch (const MediaSoupError& error)
-			{
-				MS_THROW_ERROR("%s [event:%s]", error.what(), notification->eventCStr);
-			}
+			handler->HandleNotification(notification);
 		}
 	}
 }
@@ -494,7 +442,8 @@ void Worker::OnSignal(SignalHandle* /*signalHandle*/, int signum)
 	}
 }
 
-RTC::WebRtcServer* Worker::OnRouterNeedWebRtcServer(RTC::Router* /*router*/, std::string& webRtcServerId)
+RTC::WebRtcServer* Worker::OnRouterNeedWebRtcServer(
+  const RTC::Router* /*router*/, const std::string& webRtcServerId)
 {
 	MS_TRACE();
 

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -390,7 +390,7 @@ void Worker::HandleNotification(Channel::ChannelNotification* notification)
 
 			if (handler == nullptr)
 			{
-				MS_THROW_ERROR(
+				MS_THROW_NOT_FOUND_ERROR(
 				  "Channel notification handler with ID %s not found", notification->handlerId.c_str());
 			}
 


### PR DESCRIPTION
# Details

- Add `NotFoundError`, thrown when the referenced entity in the Worker doesn't exist.
- Expose mediasoup Node `errors` via `mediasoup/errors` (in EMS).
- **Breaking change:** Rename `InvalidStateError` to `WorkerClosedError`.

## TODO

- [x] Add "Breaking change" in CHANGELOG and PR description above.
- [x] Rust.
- [x] Document errors in the website.