### PR TITLE
Worker: Fix crash when an SCTP `DataConsumer` is closed and triggers buffered amount low event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Worker: Fix crash when an SCTP `DataConsumer` is closed and triggers buffered amount low event ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 3.21.1
 
 - Worker: Enable SVC for VP8 and H264 ([PR #1851](https://github.com/versatica/mediasoup/pull/1851)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Worker: Fix crash when an SCTP `DataConsumer` is closed and triggers buffered amount low event ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Worker: Fix crash when an SCTP `DataConsumer` is closed and triggers buffered amount low event ([PR #1858](https://github.com/versatica/mediasoup/pull/1858)).
 
 ### 3.21.1
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Worker: Fix crash when an SCTP `DataConsumer` is closed and triggers buffered amount low event ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 0.22.11
 
 - Worker: Enable SVC for VP8 and H264 ([PR #1851](https://github.com/versatica/mediasoup/pull/1851)).

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Worker: Fix crash when an SCTP `DataConsumer` is closed and triggers buffered amount low event ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Worker: Fix crash when an SCTP `DataConsumer` is closed and triggers buffered amount low event ([PR #1858](https://github.com/versatica/mediasoup/pull/1858)).
 
 ### 0.22.11
 

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -210,7 +210,7 @@ namespace RTC
 		  const std::string& dataProducerId, const std::string& method) const final;
 		virtual RTC::DataConsumer* AssertAndGetDataConsumerById(
 		  const std::string& dataConsumerId, const std::string& method) const final;
-		virtual RTC::DataConsumer* AssertAndGetSctpDataConsumerByStreamId(uint16_t streamId) const final;
+		virtual RTC::DataConsumer* GetSctpDataConsumerByStreamId(uint16_t streamId) const final;
 		virtual void CheckNoProducer(const std::string& producerId, const std::string& method) const final;
 		virtual void CheckNoConsumer(const std::string& consumerId, const std::string& method) const final;
 		virtual void CheckNoDataProducer(

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -446,7 +446,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		auto it = this->mapTransports.find(transportId);
+		const auto it = this->mapTransports.find(transportId);
 
 		if (this->mapTransports.find(transportId) == this->mapTransports.end())
 		{
@@ -461,7 +461,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		auto it = this->mapRtpObservers.find(rtpObserverId);
+		const auto it = this->mapRtpObservers.find(rtpObserverId);
 
 		if (this->mapRtpObservers.find(rtpObserverId) == this->mapRtpObservers.end())
 		{
@@ -566,7 +566,7 @@ namespace RTC
 			consumer->ProducerPaused();
 		}
 
-		auto it = this->mapProducerRtpObservers.find(producer);
+		const auto it = this->mapProducerRtpObservers.find(producer);
 
 		if (it != this->mapProducerRtpObservers.end())
 		{
@@ -590,7 +590,7 @@ namespace RTC
 			consumer->ProducerResumed();
 		}
 
-		auto it = this->mapProducerRtpObservers.find(producer);
+		const auto it = this->mapProducerRtpObservers.find(producer);
 
 		if (it != this->mapProducerRtpObservers.end())
 		{
@@ -688,7 +688,7 @@ namespace RTC
 			}
 		}
 
-		auto it = this->mapProducerRtpObservers.find(producer);
+		const auto it = this->mapProducerRtpObservers.find(producer);
 
 		if (it != this->mapProducerRtpObservers.end())
 		{
@@ -1076,7 +1076,7 @@ namespace RTC
 	RTC::Producer* Router::RtpObserverGetProducer(
 	  RTC::RtpObserver* /* rtpObserver */, const std::string& id)
 	{
-		auto it = this->mapProducers.find(id);
+		const auto it = this->mapProducers.find(id);
 
 		if (it == this->mapProducers.end())
 		{

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1401,6 +1401,10 @@ namespace RTC
 
 				if (this->sctpAssociation)
 				{
+					// NOTE: This must be called after removing data consumers from the maps,
+					// otherwise if `OnAssociationStreamBufferedAmountLow()` was triggered it
+					// would end up emitting an event associated to an already closed data
+					// consumer.
 					this->sctpAssociation->ResetStreams(
 					  std::array<uint16_t, 1>{ dataConsumer->GetSctpStreamParameters().streamId });
 				}
@@ -1764,7 +1768,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		auto it = this->mapProducers.find(producerId);
+		const auto it = this->mapProducers.find(producerId);
 
 		if (it == this->mapProducers.end())
 		{
@@ -1779,7 +1783,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		auto it = this->mapConsumers.find(consumerId);
+		const auto it = this->mapConsumers.find(consumerId);
 
 		if (it == this->mapConsumers.end())
 		{
@@ -1793,7 +1797,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		auto mapSsrcConsumerIt = this->mapSsrcConsumer.find(ssrc);
+		const auto mapSsrcConsumerIt = this->mapSsrcConsumer.find(ssrc);
 
 		if (mapSsrcConsumerIt == this->mapSsrcConsumer.end())
 		{
@@ -1809,7 +1813,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		auto mapRtxSsrcConsumerIt = this->mapRtxSsrcConsumer.find(ssrc);
+		const auto mapRtxSsrcConsumerIt = this->mapRtxSsrcConsumer.find(ssrc);
 
 		if (mapRtxSsrcConsumerIt == this->mapRtxSsrcConsumer.end())
 		{
@@ -1826,7 +1830,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		auto it = this->mapDataProducers.find(dataProducerId);
+		const auto it = this->mapDataProducers.find(dataProducerId);
 
 		if (it == this->mapDataProducers.end())
 		{
@@ -1841,7 +1845,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		auto it = this->mapDataConsumers.find(dataConsumerId);
+		const auto it = this->mapDataConsumers.find(dataConsumerId);
 
 		if (it == this->mapDataConsumers.end())
 		{
@@ -1851,15 +1855,15 @@ namespace RTC
 		return it->second;
 	}
 
-	RTC::DataConsumer* Transport::AssertAndGetSctpDataConsumerByStreamId(uint16_t streamId) const
+	RTC::DataConsumer* Transport::GetSctpDataConsumerByStreamId(uint16_t streamId) const
 	{
 		MS_TRACE();
 
-		auto it = this->mapSctpStreamIdDataConsumers.find(streamId);
+		const auto it = this->mapSctpStreamIdDataConsumers.find(streamId);
 
 		if (it == this->mapSctpStreamIdDataConsumers.end())
 		{
-			MS_THROW_NOT_FOUND_ERROR("SCTP DataConsumer with streamId %" PRIu16 " not found", streamId);
+			return nullptr;
 		}
 
 		return it->second;
@@ -2938,6 +2942,10 @@ namespace RTC
 			this->mapSctpStreamIdDataConsumers.erase(dataConsumer->GetSctpStreamParameters().streamId);
 		}
 
+		// NOTE: This must be called after removing the data consumer from the maps,
+		// otherwise if `OnAssociationStreamBufferedAmountLow()` was triggered it
+		// would end up emitting an event associated to an already closed data
+		// consumer.
 		if (this->sctpAssociation)
 		{
 			this->sctpAssociation->ResetStreams(
@@ -3247,8 +3255,6 @@ namespace RTC
 
 			if (!dataConsumersToClose.empty())
 			{
-				this->sctpAssociation->ResetStreams(streamsToReset);
-
 				for (auto* dataConsumer : dataConsumersToClose)
 				{
 					// Remove it from the maps.
@@ -3271,6 +3277,12 @@ namespace RTC
 					// Delete it.
 					delete dataConsumer;
 				}
+
+				// NOTE: This must be called after removing data consumers from the maps,
+				// otherwise if `OnAssociationStreamBufferedAmountLow()` was triggered it
+				// would end up emitting an event associated to an already closed data
+				// consumer.
+				this->sctpAssociation->ResetStreams(streamsToReset);
 			}
 		}
 	}
@@ -3279,7 +3291,7 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		const auto* dataConsumer = AssertAndGetSctpDataConsumerByStreamId(streamId);
+		const auto* dataConsumer = GetSctpDataConsumerByStreamId(streamId);
 
 		if (!dataConsumer)
 		{

--- a/worker/src/Worker.cpp
+++ b/worker/src/Worker.cpp
@@ -188,7 +188,7 @@ RTC::WebRtcServer* Worker::AssertAndGetWebRtcServerById(
 {
 	MS_TRACE();
 
-	auto it = this->mapWebRtcServers.find(webRtcServerId);
+	const auto it = this->mapWebRtcServers.find(webRtcServerId);
 
 	if (it == this->mapWebRtcServers.end())
 	{
@@ -202,7 +202,7 @@ RTC::Router* Worker::AssertAndGetRouterById(const std::string& routerId, const s
 {
 	MS_TRACE();
 
-	auto it = this->mapRouters.find(routerId);
+	const auto it = this->mapRouters.find(routerId);
 
 	if (it == this->mapRouters.end())
 	{


### PR DESCRIPTION
# Details

- Fixes #1857.
- Problem is that when a `DataConsumer` is closed in the worker, `Transport` ends up calling `SctpAssociation::ResetStreams([streamId])` which may trigger `Transport::OnAssociationStreamBufferedAmountLow(streamId)` and there we call `AssertAndGetSctpDataConsumerByStreamId(streamId)` which throws because the data consumer was already removed from the maps.
- The solution is:
  - Remove closed data consumers from the maps before resetting streams in the SCTP association (because we don't want to emit "buffered amount low" for already closed data consumers).
  - Replace `AssertAndGetSctpDataConsumerByStreamId()` with `GetSctpDataConsumerByStreamId()` and just return if given `streamId` is not found.