### PR TITLE
Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY")

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).
 - Worker: Update libsrtp to 3.0.0-beta-2fc078db ([PR #1860](https://github.com/versatica/mediasoup/pull/1860)).
+- Worker: Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY") ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX), credits to @alanturing881).
 
 ### 3.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).
 - Worker: Update libsrtp to 3.0.0-beta-2fc078db ([PR #1860](https://github.com/versatica/mediasoup/pull/1860)).
-- Worker: Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY") ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX), credits to @alanturing881).
+- Worker: Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY") ([PR #1867](https://github.com/versatica/mediasoup/pull/1867), credits to @alanturing881).
 
 ### 3.22.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).
 - Worker: Update libsrtp to 3.0.0-beta-2fc078db ([PR #1860](https://github.com/versatica/mediasoup/pull/1860)).
+- Worker: Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY") ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX), credits to @alanturing881).
 
 ### 0.23.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).
 - Worker: Update libsrtp to 3.0.0-beta-2fc078db ([PR #1860](https://github.com/versatica/mediasoup/pull/1860)).
-- Worker: Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY") ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX), credits to @alanturing881).
+- Worker: Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY") ([PR #1867](https://github.com/versatica/mediasoup/pull/1867), credits to @alanturing881).
 
 ### 0.23.0
 

--- a/worker/src/RTC/ICE/StunPacket.cpp
+++ b/worker/src/RTC/ICE/StunPacket.cpp
@@ -4,8 +4,9 @@
 #include "RTC/ICE/StunPacket.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
+#include <openssl/crypto.h>
 #include <cstdio>  // std::snprintf()
-#include <cstring> // std::memcmp(), std::memcpy(), std::memset()
+#include <cstring> // std::memcpy(), std::memset()
 #include <string>
 
 namespace RTC
@@ -744,7 +745,10 @@ namespace RTC
 
 			// Compare the computed HMAC-SHA1 with the MESSAGE-INTEGRITY in the STUN
 			// packet.
-			if (std::memcmp(messageIntegrity, computedMessageIntegrity, StunPacket::FixedHeaderLength) == 0)
+			//
+			// NOTE: Use `CRYPTO_memcmp()` to have constant time memory comparison.
+			// See https://github.com/versatica/mediasoup/security/advisories/GHSA-xvjj-6cm4-ppgq
+			if (CRYPTO_memcmp(messageIntegrity, computedMessageIntegrity, StunPacket::FixedHeaderLength) == 0)
 			{
 				result = StunPacket::AuthenticationResult::OK;
 			}

--- a/worker/src/RTC/SCTP/association/StateCookie.cpp
+++ b/worker/src/RTC/SCTP/association/StateCookie.cpp
@@ -4,7 +4,8 @@
 #include "RTC/SCTP/association/StateCookie.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
-#include <cstring> // std::memcpy(), std::memcmp()
+#include <openssl/crypto.h>
+#include <cstring> // std::memcpy()
 #include <string_view>
 
 namespace RTC
@@ -179,7 +180,9 @@ namespace RTC
 			const uint8_t* expectedMac = Utils::Crypto::GetHmacSha1(
 			  reinterpret_cast<const char*>(macKey), macKeyLength, buffer, StateCookie::MacOffset);
 
-			return std::memcmp(buffer + StateCookie::MacOffset, expectedMac, StateCookie::MacLength) == 0;
+			// NOTE: Use `CRYPTO_memcmp()` to have constant time memory comparison.
+			// See https://github.com/versatica/mediasoup/security/advisories/GHSA-xvjj-6cm4-ppgq
+			return CRYPTO_memcmp(buffer + StateCookie::MacOffset, expectedMac, StateCookie::MacLength) == 0;
 		}
 
 		Types::SctpImplementation StateCookie::DetermineSctpImplementation(


### PR DESCRIPTION
# Details

- Fixes vulnerability https://github.com/versatica/mediasoup/security/advisories/GHSA-xvjj-6cm4-ppgq.
- Credits to @alanturing881.