### PR TITLE
Worker: Fix OOB write in Packet::UpdateDependencyDescriptor() (GHSA-jhm4-v227-4375)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).
 - Worker: Update libsrtp to 3.0.0-beta-2fc078db ([PR #1860](https://github.com/versatica/mediasoup/pull/1860)).
-- Worker: Fix OOB write in `Packet::UpdateDependencyDescriptor()` [PR #1868](https://github.com/versatica/mediasoup/pull/1868)
+- Worker: Fix OOB write in `RTP::Packet::UpdateDependencyDescriptor()` ([PR #1868](https://github.com/versatica/mediasoup/pull/1868), credits to @alanturing881).
 
 ### 3.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).
 - Worker: Update libsrtp to 3.0.0-beta-2fc078db ([PR #1860](https://github.com/versatica/mediasoup/pull/1860)).
+- Worker: Fix OOB write in `Packet::UpdateDependencyDescriptor()` []()
 
 ### 3.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).
 - Worker: Update libsrtp to 3.0.0-beta-2fc078db ([PR #1860](https://github.com/versatica/mediasoup/pull/1860)).
-- Worker: Fix OOB write in `Packet::UpdateDependencyDescriptor()` []()
+- Worker: Fix OOB write in `Packet::UpdateDependencyDescriptor()` [PR #1868](https://github.com/versatica/mediasoup/pull/1868)
 
 ### 3.22.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).
 - Worker: Update libsrtp to 3.0.0-beta-2fc078db ([PR #1860](https://github.com/versatica/mediasoup/pull/1860)).
+- Worker: Fix OOB write in `RTP::Packet::UpdateDependencyDescriptor()` ([PR #1868](https://github.com/versatica/mediasoup/pull/1868), credits to @alanturing881).
 
 ### 0.23.0
 

--- a/worker/fuzzer/src/RTC/RTP/FuzzerPacket.cpp
+++ b/worker/fuzzer/src/RTC/RTP/FuzzerPacket.cpp
@@ -256,7 +256,7 @@ void FuzzerRtcRtcPacket::Fuzz(const uint8_t* data, size_t len)
 	packet->RemovePayload();
 
 	// Regression test for GHSA-jhm4-v227-4375 (CWE-787 OOB write in
-	// UpdateDependencyDescriptor). Build a fresh packet with a tightly-sized
+	// UpdateDependencyDescriptor()). Build a fresh packet with a tightly-sized
 	// DEPENDENCY_DESCRIPTOR value and attempt to update it with the raw fuzzer
 	// input as the new descriptor bytes. When the new length exceeds the original
 	// the fixed code must return false without writing out of bounds; when it
@@ -291,7 +291,7 @@ void FuzzerRtcRtcPacket::Fuzz(const uint8_t* data, size_t len)
 
 		packet->SetExtensions(RTC::RTP::Packet::ExtensionsType::OneByte, extensions);
 
-		// Call UpdateDependencyDescriptor with the full fuzzer input as
+		// Call UpdateDependencyDescriptor() with the full fuzzer input as
 		// the replacement bytes. This covers:
 		//   len > slotLen  → no OOB write (was the bug).
 		//   len <= slotLen → in-place update.

--- a/worker/fuzzer/src/RTC/RTP/FuzzerPacket.cpp
+++ b/worker/fuzzer/src/RTC/RTP/FuzzerPacket.cpp
@@ -254,4 +254,48 @@ void FuzzerRtcRtcPacket::Fuzz(const uint8_t* data, size_t len)
 	packet->RemoveHeaderExtension();
 	packet->SetPayloadLength(sizeof(payload) - 2);
 	packet->RemovePayload();
+
+	// Regression test for GHSA-jhm4-v227-4375 (CWE-787 OOB write in
+	// UpdateDependencyDescriptor). Build a fresh packet with a tightly-sized
+	// DEPENDENCY_DESCRIPTOR value and attempt to update it with the raw fuzzer
+	// input as the new descriptor bytes. When the new length exceeds the original
+	// the fixed code must return false without writing out of bounds; when it
+	// fits it must succeed. AddressSanitizer will catch any regression here.
+	{
+		constexpr size_t BufferLenght{ 512 };
+		static thread_local uint8_t buffer[BufferLenght];
+
+		std::unique_ptr<RTC::RTP::Packet> packet{ RTC::RTP::Packet::Factory(buffer, BufferLenght) };
+
+		if (!packet)
+		{
+			return;
+		}
+
+		// Use the first byte of the fuzzer input to pick the slot size
+		// (1..15 is the valid One-Byte extension range).
+		const uint8_t extenLen = (data[0] % 15u) + 1u;
+
+		static thread_local uint8_t extenValue[15];
+
+		// clang-format off
+		const std::vector<RTC::RTP::Packet::Extension> extensions {
+			{
+				RTC::RtpHeaderExtensionUri::Type::DEPENDENCY_DESCRIPTOR,
+				static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::DEPENDENCY_DESCRIPTOR),
+				extenLen,
+				extenValue
+			}
+		};
+		// clang-format off
+
+		packet->SetExtensions(RTC::RTP::Packet::ExtensionsType::OneByte, extensions);
+
+		// Call UpdateDependencyDescriptor with the full fuzzer input as
+		// the replacement bytes. This covers:
+		//   len > slotLen  → no OOB write (was the bug).
+		//   len <= slotLen → in-place update.
+		//   len == 0       → must not crash.
+		packet->UpdateDependencyDescriptor(data, len);
+	}
 }

--- a/worker/src/RTC/RTP/Packet.cpp
+++ b/worker/src/RTC/RTP/Packet.cpp
@@ -1083,6 +1083,17 @@ namespace RTC
 				return false;
 			}
 
+			if (len > extenLen)
+			{
+				MS_WARN_TAG(
+				  rtp,
+				  "no enough space for updated dependency descriptor [needed:%zu, available:%" PRIu8 "]",
+				  len,
+				  extenLen);
+
+				return false;
+			}
+
 			std::memcpy(extenValue, data, len);
 
 			SetExtensionLength(this->headerExtensionIds.dependencyDescriptor, len);


### PR DESCRIPTION
Fixes vulnerability [GHSA-jhm4-v227-4375](https://github.com/versatica/mediasoup/security/advisories/GHSA-wq22-prq7-m8pc).
Credits to @alanturing881.

Add a bounds check before the memcpy in UpdateDependencyDescriptor() to reject updates whose re-serialized length exceeds the original extension
 size, mirroring the existing guard in UpdateMid().