### PR TITLE
Worker: Fix integer overflow in SCTP `MissingMandatoryParameterErrorCause`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).
 - Worker: Update libsrtp to 3.0.0-beta-2fc078db ([PR #1860](https://github.com/versatica/mediasoup/pull/1860)).
 - Worker: Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY") ([PR #1867](https://github.com/versatica/mediasoup/pull/1867), credits to @alanturing881).
-- Worker: Fix integer overflow in SCTP `MissingMandatoryParameterErrorCause` ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX), credits to @alanturing881).
+- Worker: Fix integer overflow in SCTP `MissingMandatoryParameterErrorCause` ([PR #1869](https://github.com/versatica/mediasoup/pull/1869), credits to @alanturing881).
 
 ### 3.22.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).
 - Worker: Update libsrtp to 3.0.0-beta-2fc078db ([PR #1860](https://github.com/versatica/mediasoup/pull/1860)).
 - Worker: Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY") ([PR #1867](https://github.com/versatica/mediasoup/pull/1867), credits to @alanturing881).
+- Worker: Fix integer overflow in SCTP `MissingMandatoryParameterErrorCause` ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX), credits to @alanturing881).
 
 ### 3.22.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).
 - Worker: Update libsrtp to 3.0.0-beta-2fc078db ([PR #1860](https://github.com/versatica/mediasoup/pull/1860)).
 - Worker: Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY") ([PR #1867](https://github.com/versatica/mediasoup/pull/1867), credits to @alanturing881).
-- Worker: Fix integer overflow in SCTP `MissingMandatoryParameterErrorCause` ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX), credits to @alanturing881).
+- Worker: Fix integer overflow in SCTP `MissingMandatoryParameterErrorCause` ([PR #1869](https://github.com/versatica/mediasoup/pull/1869), credits to @alanturing881).
 
 ### 0.23.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).
 - Worker: Update libsrtp to 3.0.0-beta-2fc078db ([PR #1860](https://github.com/versatica/mediasoup/pull/1860)).
 - Worker: Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY") ([PR #1867](https://github.com/versatica/mediasoup/pull/1867), credits to @alanturing881).
+- Worker: Fix integer overflow in SCTP `MissingMandatoryParameterErrorCause` ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX), credits to @alanturing881).
 
 ### 0.23.0
 

--- a/worker/src/RTC/SCTP/packet/errorCauses/MissingMandatoryParameterErrorCause.cpp
+++ b/worker/src/RTC/SCTP/packet/errorCauses/MissingMandatoryParameterErrorCause.cpp
@@ -81,8 +81,11 @@ namespace RTC
 			  new MissingMandatoryParameterErrorCause(const_cast<uint8_t*>(buffer), bufferLength);
 
 			// In this chunk we must validate that some fields have correct values.
+			//
+			// NOTE: Must cast result to uint64_t to avoid integer overflow.
+			// See https://github.com/versatica/mediasoup/security/advisories/GHSA-p9cq-fqxc-987w
 			if (
-			  (errorCause->GetNumberOfMissingParameters() * 2) !=
+			  (static_cast<uint64_t>(errorCause->GetNumberOfMissingParameters()) * 2) !=
 			  causeLength -
 			    MissingMandatoryParameterErrorCause::MissingMandatoryParameterErrorCauseHeaderLength)
 			{

--- a/worker/test/src/RTC/SCTP/packet/errorCauses/TestMissingMandatoryParameterErrorCause.cpp
+++ b/worker/test/src/RTC/SCTP/packet/errorCauses/TestMissingMandatoryParameterErrorCause.cpp
@@ -164,6 +164,30 @@ SCENARIO("Invalid Stream Identifier Error Cause (2)", "[serializable][sctp][erro
 		// clang-format on
 
 		REQUIRE(!RTC::SCTP::MissingMandatoryParameterErrorCause::Parse(buffer3, sizeof(buffer3)));
+
+		// Security advisory.
+		// See https://github.com/versatica/mediasoup/security/advisories/GHSA-p9cq-fqxc-987w
+		//
+		// Number of missing parameters chosen so that, multiplied by 2 in 32-bit
+		// arithmetic, it wraps around to a value that would falsely match the
+		// length field. 0x80000001 (2147483649) * 2 wraps to 2, which equals
+		// Length 10 minus the 8-byte header. The check must be done in 64-bit
+		// arithmetic so this malformed cause is rejected instead of accepted
+		// (which would later drive an out-of-bounds read while iterating the
+		// bogus 2.1 billion parameter count).
+		// clang-format off
+		alignas(4) uint8_t buffer4[] =
+		{
+			// Code:2 (MISSING-MANDATORY-PARAMETER), Length: 10
+			0x00, 0x02, 0x00, 0x0A,
+			// Number of missing params: 0x80000001 (2147483649)
+			0x80, 0x00, 0x00, 0x01,
+			// A single param type (2 bytes) plus 2 bytes of padding
+			0x00, 0x05, 0x00, 0x00,
+		};
+		// clang-format on
+
+		REQUIRE(!RTC::SCTP::MissingMandatoryParameterErrorCause::Parse(buffer4, sizeof(buffer4)));
 	}
 
 	SECTION("MissingMandatoryParameterErrorCause::Factory() succeeds")


### PR DESCRIPTION
# Details

- Fixes https://github.com/versatica/mediasoup/security/advisories/GHSA-p9cq-fqxc-987w
- Credits to @alanturing881