### PR TITLE
SCTP: Add default per stream buffered amountLow threshold option

### DIFF
--- a/.github/workflows/mediasoup-worker-fuzzer.yaml
+++ b/.github/workflows/mediasoup-worker-fuzzer.yaml
@@ -5,10 +5,14 @@ on:
     branches: [v3]
     paths:
       - 'worker/**'
+      - '!worker/package.json'
+      - '!worker/package-lock.json'
       - '.github/workflows/mediasoup-worker-fuzzer.yaml'
   pull_request:
     paths:
       - 'worker/**'
+      - '!worker/scripts/package.json'
+      - '!worker/scripts/package-lock.json'
       - '.github/workflows/mediasoup-worker-fuzzer.yaml'
   workflow_dispatch:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Worker: Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY") ([PR #1867](https://github.com/versatica/mediasoup/pull/1867), credits to @alanturing881).
 - Worker: Fix OOB write in `RTP::Packet::UpdateDependencyDescriptor()` ([PR #1868](https://github.com/versatica/mediasoup/pull/1868), credits to @alanturing881).
 - Worker: Fix integer overflow in SCTP `MissingMandatoryParameterErrorCause` ([PR #1869](https://github.com/versatica/mediasoup/pull/1869), credits to @alanturing881).
+- SCTP: Add default per stream buffered amount low threshold option ([PR #1871](https://github.com/versatica/mediasoup/pull/1871)).
 
 ### 3.22.0
 

--- a/node/src/PipeTransportTypes.ts
+++ b/node/src/PipeTransportTypes.ts
@@ -59,6 +59,15 @@ export type PipeTransportOptions<
 	sctpMaxReceiverWindowBufferSize?: number;
 
 	/**
+	 * SCTP default stream buffered amount low threshold (in bytes). When the
+	 * buffered amount of a DataConsumer stream drops to or below this value, the
+	 * 'bufferedamountlow' event is emitted. It can be overridden per DataConsumer
+	 * via `dataConsumer.setBufferedAmountLowThreshold()`.
+	 * Default 1024.
+	 */
+	sctpDefaultStreamBufferedAmountLowThreshold?: number;
+
+	/**
 	 * Enable RTX and NACK for RTP retransmission. Useful if both Routers are
 	 * located in different hosts and there is packet lost in the link. For this
 	 * to work, both PipeTransports must enable this setting. Default false.

--- a/node/src/PlainTransportTypes.ts
+++ b/node/src/PlainTransportTypes.ts
@@ -71,6 +71,15 @@ export type PlainTransportOptions<
 	sctpMaxReceiverWindowBufferSize?: number;
 
 	/**
+	 * SCTP default stream buffered amount low threshold (in bytes). When the
+	 * buffered amount of a DataConsumer stream drops to or below this value, the
+	 * 'bufferedamountlow' event is emitted. It can be overridden per DataConsumer
+	 * via `dataConsumer.setBufferedAmountLowThreshold()`.
+	 * Default 1024.
+	 */
+	sctpDefaultStreamBufferedAmountLowThreshold?: number;
+
+	/**
 	 * Enable SRTP. For this to work, connect() must be called
 	 * with remote SRTP parameters. Default false.
 	 */

--- a/node/src/Router.ts
+++ b/node/src/Router.ts
@@ -306,6 +306,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 		sctpSendBufferSize = 2000000,
 		sctpPerStreamSendQueueLimit = 2000000,
 		sctpMaxReceiverWindowBufferSize = 5242880,
+		sctpDefaultStreamBufferedAmountLowThreshold = 1024,
 		iceConsentTimeout = 30,
 		appData,
 	}: WebRtcTransportOptions<WebRtcTransportAppData>): Promise<
@@ -426,6 +427,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 			sctpSendBufferSize,
 			sctpPerStreamSendQueueLimit,
 			sctpMaxReceiverWindowBufferSize,
+			sctpDefaultStreamBufferedAmountLowThreshold,
 			/* isDataChannel */ true
 		);
 
@@ -525,6 +527,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 		sctpSendBufferSize = 2000000,
 		sctpPerStreamSendQueueLimit = 2000000,
 		sctpMaxReceiverWindowBufferSize = 5242880,
+		sctpDefaultStreamBufferedAmountLowThreshold = 1024,
 		enableSrtp = false,
 		srtpCryptoSuite = 'AES_CM_128_HMAC_SHA1_80',
 		appData,
@@ -579,6 +582,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 			sctpSendBufferSize,
 			sctpPerStreamSendQueueLimit,
 			sctpMaxReceiverWindowBufferSize,
+			sctpDefaultStreamBufferedAmountLowThreshold,
 			/* isDataChannel */ false
 		);
 
@@ -689,6 +693,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 		sctpSendBufferSize = 2000000,
 		sctpPerStreamSendQueueLimit = 2000000,
 		sctpMaxReceiverWindowBufferSize = 5242880,
+		sctpDefaultStreamBufferedAmountLowThreshold = 1024,
 		enableRtx = false,
 		enableSrtp = false,
 		appData,
@@ -734,6 +739,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 			sctpSendBufferSize,
 			sctpPerStreamSendQueueLimit,
 			sctpMaxReceiverWindowBufferSize,
+			sctpDefaultStreamBufferedAmountLowThreshold,
 			/* isDataChannel */ false
 		);
 
@@ -844,6 +850,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 			/* sctpSendBufferSize */ undefined,
 			/* sctpPerStreamSendQueueLimit */ undefined,
 			/* sctpMaxReceiverWindowBufferSize */ undefined,
+			/* sctpDefaultStreamBufferedAmountLowThreshold */ undefined,
 			/* isDataChannel */ undefined
 		);
 
@@ -924,6 +931,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 		sctpSendBufferSize = 2000000,
 		sctpPerStreamSendQueueLimit = 2000000,
 		sctpMaxReceiverWindowBufferSize = 5242880,
+		sctpDefaultStreamBufferedAmountLowThreshold = 1024,
 		enableRtx = false,
 		enableSrtp = false,
 	}: PipeToRouterOptions): Promise<PipeToRouterResult> {
@@ -1001,6 +1009,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 						sctpSendBufferSize,
 						sctpPerStreamSendQueueLimit,
 						sctpMaxReceiverWindowBufferSize,
+						sctpDefaultStreamBufferedAmountLowThreshold,
 						enableRtx,
 						enableSrtp,
 					}),
@@ -1012,6 +1021,7 @@ export class RouterImpl<RouterAppData extends AppData = AppData>
 						sctpSendBufferSize,
 						sctpPerStreamSendQueueLimit,
 						sctpMaxReceiverWindowBufferSize,
+						sctpDefaultStreamBufferedAmountLowThreshold,
 						enableRtx,
 						enableSrtp,
 					}),

--- a/node/src/RouterTypes.ts
+++ b/node/src/RouterTypes.ts
@@ -112,6 +112,15 @@ export type PipeToRouterOptions = {
 	sctpMaxReceiverWindowBufferSize?: number;
 
 	/**
+	 * SCTP default stream buffered amount low threshold (in bytes). When the
+	 * buffered amount of a DataConsumer stream drops to or below this value, the
+	 * 'bufferedamountlow' event is emitted. It can be overridden per DataConsumer
+	 * via `dataConsumer.setBufferedAmountLowThreshold()`.
+	 * Default 1024.
+	 */
+	sctpDefaultStreamBufferedAmountLowThreshold?: number;
+
+	/**
 	 * Enable RTX and NACK for RTP retransmission.
 	 */
 	enableRtx?: boolean;

--- a/node/src/WebRtcTransportTypes.ts
+++ b/node/src/WebRtcTransportTypes.ts
@@ -91,6 +91,15 @@ type WebRtcTransportOptionsBase<WebRtcTransportAppData> = {
 	sctpMaxReceiverWindowBufferSize?: number;
 
 	/**
+	 * SCTP default stream buffered amount low threshold (in bytes). When the
+	 * buffered amount of a DataConsumer stream drops to or below this value, the
+	 * 'bufferedamountlow' event is emitted. It can be overridden per DataConsumer
+	 * via `dataConsumer.setBufferedAmountLowThreshold()`.
+	 * Default 1024.
+	 */
+	sctpDefaultStreamBufferedAmountLowThreshold?: number;
+
+	/**
 	 * Custom application data.
 	 */
 	appData?: WebRtcTransportAppData;

--- a/node/src/test/test-DataConsumer.ts
+++ b/node/src/test/test-DataConsumer.ts
@@ -148,6 +148,9 @@ test('dataConsumer.dump() succeeds', async () => {
 	expect(dump.subchannels).toEqual(
 		expect.arrayContaining([0, 1, 2, 100, 65535])
 	);
+	expect(dump.bufferedAmount).toBe(0);
+	// Default per stream buffered amount threshold is 1024.
+	expect(dump.bufferedAmountLowThreshold).toBe(1024);
 }, 2000);
 
 test('dataConsumer.getStats() succeeds', async () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -672,16 +672,16 @@
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@eslint/config-array/node_modules/minimatch": {
@@ -2477,16 +2477,16 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
@@ -3808,16 +3808,16 @@
 			}
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/eslint/node_modules/eslint-visitor-keys": {
@@ -7931,9 +7931,9 @@
 					"dev": true
 				},
 				"brace-expansion": {
-					"version": "5.0.7",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-					"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+					"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 					"dev": true,
 					"requires": {
 						"balanced-match": "^4.0.2"
@@ -9022,9 +9022,9 @@
 					"dev": true
 				},
 				"brace-expansion": {
-					"version": "5.0.7",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-					"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+					"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 					"dev": true,
 					"requires": {
 						"balanced-match": "^4.0.2"
@@ -9776,9 +9776,9 @@
 					"dev": true
 				},
 				"brace-expansion": {
-					"version": "5.0.7",
-					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-					"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+					"version": "5.0.8",
+					"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+					"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 					"dev": true,
 					"requires": {
 						"balanced-match": "^4.0.2"

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Worker: Use constant-time memory comparison in MAC/credential verification (SCTP State Cookie MAC and STUN "MESSAGE-INTEGRITY") ([PR #1867](https://github.com/versatica/mediasoup/pull/1867), credits to @alanturing881).
 - Worker: Fix OOB write in `RTP::Packet::UpdateDependencyDescriptor()` ([PR #1868](https://github.com/versatica/mediasoup/pull/1868), credits to @alanturing881).
 - Worker: Fix integer overflow in SCTP `MissingMandatoryParameterErrorCause` ([PR #1869](https://github.com/versatica/mediasoup/pull/1869), credits to @alanturing881).
+- SCTP: Add default per stream buffered amount low threshold option ([PR #1871](https://github.com/versatica/mediasoup/pull/1871)).
 
 ### 0.23.0
 

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -565,6 +565,7 @@ impl ToFbs for RouterCreateDirectTransportData {
                 sctp_send_buffer_size: 0,
                 sctp_per_stream_send_queue_limit: 0,
                 sctp_max_receiver_window_buffer_size: 0,
+                sctp_default_stream_buffered_amount_low_threshold: 0,
                 enable_sctp: false,
                 is_data_channel: false,
             }),
@@ -663,6 +664,7 @@ pub(crate) struct RouterCreateWebrtcTransportData {
     sctp_send_buffer_size: u32,
     sctp_per_stream_send_queue_limit: u32,
     sctp_max_receiver_window_buffer_size: u32,
+    sctp_default_stream_buffered_amount_low_threshold: u32,
     is_data_channel: bool,
 }
 
@@ -700,6 +702,8 @@ impl RouterCreateWebrtcTransportData {
                 .sctp_per_stream_send_queue_limit,
             sctp_max_receiver_window_buffer_size: webrtc_transport_options
                 .sctp_max_receiver_window_buffer_size,
+            sctp_default_stream_buffered_amount_low_threshold: webrtc_transport_options
+                .sctp_default_stream_buffered_amount_low_threshold,
             is_data_channel: true,
         }
     }
@@ -719,6 +723,8 @@ impl ToFbs for RouterCreateWebrtcTransportData {
                 sctp_send_buffer_size: self.sctp_send_buffer_size,
                 sctp_per_stream_send_queue_limit: self.sctp_per_stream_send_queue_limit,
                 sctp_max_receiver_window_buffer_size: self.sctp_max_receiver_window_buffer_size,
+                sctp_default_stream_buffered_amount_low_threshold: self
+                    .sctp_default_stream_buffered_amount_low_threshold,
                 is_data_channel: true,
             }),
             listen: self.listen.to_fbs(),
@@ -896,6 +902,7 @@ pub(crate) struct RouterCreatePlainTransportData {
     sctp_send_buffer_size: u32,
     sctp_per_stream_send_queue_limit: u32,
     sctp_max_receiver_window_buffer_size: u32,
+    sctp_default_stream_buffered_amount_low_threshold: u32,
     is_data_channel: bool,
     enable_srtp: bool,
     srtp_crypto_suite: SrtpCryptoSuite,
@@ -920,6 +927,8 @@ impl RouterCreatePlainTransportData {
                 .sctp_per_stream_send_queue_limit,
             sctp_max_receiver_window_buffer_size: plain_transport_options
                 .sctp_max_receiver_window_buffer_size,
+            sctp_default_stream_buffered_amount_low_threshold: plain_transport_options
+                .sctp_default_stream_buffered_amount_low_threshold,
             is_data_channel: false,
             enable_srtp: plain_transport_options.enable_srtp,
             srtp_crypto_suite: plain_transport_options.srtp_crypto_suite,
@@ -941,6 +950,8 @@ impl ToFbs for RouterCreatePlainTransportData {
                 sctp_send_buffer_size: self.sctp_send_buffer_size,
                 sctp_per_stream_send_queue_limit: self.sctp_per_stream_send_queue_limit,
                 sctp_max_receiver_window_buffer_size: self.sctp_max_receiver_window_buffer_size,
+                sctp_default_stream_buffered_amount_low_threshold: self
+                    .sctp_default_stream_buffered_amount_low_threshold,
                 is_data_channel: self.is_data_channel,
             }),
             listen_info: Box::new(self.listen_info.clone().to_fbs()),
@@ -1038,6 +1049,7 @@ pub(crate) struct RouterCreatePipeTransportData {
     sctp_send_buffer_size: u32,
     sctp_per_stream_send_queue_limit: u32,
     sctp_max_receiver_window_buffer_size: u32,
+    sctp_default_stream_buffered_amount_low_threshold: u32,
     is_data_channel: bool,
     enable_rtx: bool,
     enable_srtp: bool,
@@ -1059,6 +1071,8 @@ impl RouterCreatePipeTransportData {
                 .sctp_per_stream_send_queue_limit,
             sctp_max_receiver_window_buffer_size: pipe_transport_options
                 .sctp_max_receiver_window_buffer_size,
+            sctp_default_stream_buffered_amount_low_threshold: pipe_transport_options
+                .sctp_default_stream_buffered_amount_low_threshold,
             is_data_channel: false,
             enable_rtx: pipe_transport_options.enable_rtx,
             enable_srtp: pipe_transport_options.enable_srtp,
@@ -1080,6 +1094,8 @@ impl ToFbs for RouterCreatePipeTransportData {
                 sctp_send_buffer_size: self.sctp_send_buffer_size,
                 sctp_per_stream_send_queue_limit: self.sctp_per_stream_send_queue_limit,
                 sctp_max_receiver_window_buffer_size: self.sctp_max_receiver_window_buffer_size,
+                sctp_default_stream_buffered_amount_low_threshold: self
+                    .sctp_default_stream_buffered_amount_low_threshold,
                 is_data_channel: self.is_data_channel,
             }),
             listen_info: Box::new(self.listen_info.clone().to_fbs()),

--- a/rust/src/router.rs
+++ b/rust/src/router.rs
@@ -150,6 +150,12 @@ pub struct PipeToRouterOptions {
     /// than the largest sized message you want to be able to receive.
     /// Default 5_242_880.
     pub sctp_max_receiver_window_buffer_size: u32,
+    /// SCTP default stream buffered amount low threshold (in bytes). When the
+    /// buffered amount of a DataConsumer stream drops to or below this value, the
+    /// buffered amount low event is emitted. It can be overridden per DataConsumer
+    /// via DataConsumer::set_buffered_amount_low_threshold().
+    /// Default 1024.
+    pub sctp_default_stream_buffered_amount_low_threshold: u32,
     /// Enable RTX and NACK for RTP retransmission.
     ///
     /// Default `false`.
@@ -184,6 +190,7 @@ impl PipeToRouterOptions {
             sctp_send_buffer_size: 2_000_000,
             sctp_per_stream_send_queue_limit: 2_000_000,
             sctp_max_receiver_window_buffer_size: 5_242_880,
+            sctp_default_stream_buffered_amount_low_threshold: 1024,
             enable_rtx: false,
             enable_srtp: false,
         }
@@ -1565,6 +1572,7 @@ impl Router {
             sctp_send_buffer_size,
             sctp_per_stream_send_queue_limit,
             sctp_max_receiver_window_buffer_size,
+            sctp_default_stream_buffered_amount_low_threshold,
             enable_rtx,
             enable_srtp,
         } = pipe_to_router_options;
@@ -1578,6 +1586,7 @@ impl Router {
             sctp_send_buffer_size,
             sctp_per_stream_send_queue_limit,
             sctp_max_receiver_window_buffer_size,
+            sctp_default_stream_buffered_amount_low_threshold,
             enable_rtx,
             enable_srtp,
             app_data: AppData::default(),

--- a/rust/src/router/pipe_transport.rs
+++ b/rust/src/router/pipe_transport.rs
@@ -58,6 +58,12 @@ pub struct PipeTransportOptions {
     /// than the largest sized message you want to be able to receive.
     /// Default 5_242_880.
     pub sctp_max_receiver_window_buffer_size: u32,
+    /// SCTP default stream buffered amount low threshold (in bytes). When the
+    /// buffered amount of a DataConsumer stream drops to or below this value, the
+    /// buffered amount low event is emitted. It can be overridden per DataConsumer
+    /// via DataConsumer::set_buffered_amount_low_threshold().
+    /// Default 1024.
+    pub sctp_default_stream_buffered_amount_low_threshold: u32,
     /// Enable RTX and NACK for RTP retransmission. Useful if both Routers are located in different
     /// hosts and there is packet lost in the link. For this to work, both PipeTransports must
     /// enable this setting.
@@ -83,6 +89,7 @@ impl PipeTransportOptions {
             sctp_send_buffer_size: 2_000_000,
             sctp_per_stream_send_queue_limit: 2_000_000,
             sctp_max_receiver_window_buffer_size: 5_242_880,
+            sctp_default_stream_buffered_amount_low_threshold: 1024,
             enable_rtx: false,
             enable_srtp: false,
             app_data: AppData::default(),

--- a/rust/src/router/plain_transport.rs
+++ b/rust/src/router/plain_transport.rs
@@ -77,6 +77,12 @@ pub struct PlainTransportOptions {
     /// than the largest sized message you want to be able to receive.
     /// Default 5_242_880.
     pub sctp_max_receiver_window_buffer_size: u32,
+    /// SCTP default stream buffered amount low threshold (in bytes). When the
+    /// buffered amount of a DataConsumer stream drops to or below this value, the
+    /// buffered amount low event is emitted. It can be overridden per DataConsumer
+    /// via DataConsumer::set_buffered_amount_low_threshold().
+    /// Default 1024.
+    pub sctp_default_stream_buffered_amount_low_threshold: u32,
     /// Enable SRTP. For this to work, connect() must be called with remote SRTP parameters.
     /// Default false.
     pub enable_srtp: bool,
@@ -102,6 +108,7 @@ impl PlainTransportOptions {
             sctp_send_buffer_size: 2_000_000,
             sctp_per_stream_send_queue_limit: 2_000_000,
             sctp_max_receiver_window_buffer_size: 5_242_880,
+            sctp_default_stream_buffered_amount_low_threshold: 1024,
             enable_srtp: false,
             srtp_crypto_suite: SrtpCryptoSuite::default(),
             app_data: AppData::default(),

--- a/rust/src/router/webrtc_transport.rs
+++ b/rust/src/router/webrtc_transport.rs
@@ -153,6 +153,12 @@ pub struct WebRtcTransportOptions {
     /// than the largest sized message you want to be able to receive.
     /// Default 5_242_880.
     pub sctp_max_receiver_window_buffer_size: u32,
+    /// SCTP default stream buffered amount low threshold (in bytes). When the
+    /// buffered amount of a DataConsumer stream drops to or below this value, the
+    /// buffered amount low event is emitted. It can be overridden per DataConsumer
+    /// via DataConsumer::set_buffered_amount_low_threshold().
+    /// Default 1024.
+    pub sctp_default_stream_buffered_amount_low_threshold: u32,
     /// Custom application data.
     pub app_data: AppData,
 }
@@ -175,6 +181,7 @@ impl WebRtcTransportOptions {
             sctp_send_buffer_size: 2_000_000,
             sctp_per_stream_send_queue_limit: 2_000_000,
             sctp_max_receiver_window_buffer_size: 5_242_880,
+            sctp_default_stream_buffered_amount_low_threshold: 1024,
             app_data: AppData::default(),
         }
     }
@@ -195,6 +202,7 @@ impl WebRtcTransportOptions {
             sctp_send_buffer_size: 2_000_000,
             sctp_per_stream_send_queue_limit: 2_000_000,
             sctp_max_receiver_window_buffer_size: 5_242_880,
+            sctp_default_stream_buffered_amount_low_threshold: 1024,
             app_data: AppData::default(),
         }
     }

--- a/rust/tests/integration/data_consumer.rs
+++ b/rust/tests/integration/data_consumer.rs
@@ -305,6 +305,9 @@ fn dump_succeeds() {
         }
         assert_eq!(dump.label.as_str(), "foo");
         assert_eq!(dump.protocol.as_str(), "bar");
+        assert_eq!(dump.buffered_amount, 0);
+        // Default per stream buffered amount threshold is 1024.
+        assert_eq!(dump.buffered_amount_low_threshold, 1024);
     });
 }
 

--- a/worker/fbs/transport.fbs
+++ b/worker/fbs/transport.fbs
@@ -130,6 +130,7 @@ table Options {
     sctp_send_buffer_size: uint32;
     sctp_per_stream_send_queue_limit: uint32;
     sctp_max_receiver_window_buffer_size: uint32;
+    sctp_default_stream_buffered_amount_low_threshold: uint32;
     is_data_channel: bool = false;
 }
 

--- a/worker/include/RTC/SCTP/public/SctpOptions.hpp
+++ b/worker/include/RTC/SCTP/public/SctpOptions.hpp
@@ -84,6 +84,13 @@ namespace RTC
 			size_t maxReceiverWindowBufferSize{ 5 * 1024 * 1024 };
 
 			/**
+			 * The default threshold that, when the amount of data in a stream send
+			 * buffer goes below this value, will trigger
+			 * `Association::OnAssociationStreamBufferedAmountLow()`.
+			 */
+			size_t defaultStreamBufferedAmountLowThreshold{ 0 };
+
+			/**
 			 * A threshold that, when the amount of data in the send buffer goes below
 			 * this value, will trigger `Association::OnAssociationTotalBufferedAmountLow()`.
 			 */

--- a/worker/include/RTC/SCTP/tx/RoundRobinSendQueue.hpp
+++ b/worker/include/RTC/SCTP/tx/RoundRobinSendQueue.hpp
@@ -275,6 +275,7 @@ namespace RTC
 			  AssociationListenerInterface& associationListener,
 			  size_t mtu,
 			  uint16_t defaultPriority,
+			  size_t defaultStreamBufferedAmountLowThreshold,
 			  size_t totalBufferedAmountLowThreshold);
 
 			~RoundRobinSendQueue() override;
@@ -343,6 +344,7 @@ namespace RTC
 		private:
 			AssociationListenerInterface& associationListener;
 			const uint16_t defaultPriority;
+			const size_t defaultStreamBufferedAmountLowThreshold;
 			StreamScheduler scheduler;
 			// The total amount of buffer data, for all streams.
 			ThresholdWatcher totalBufferedAmountThresholdWatcher;

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -394,11 +394,6 @@ namespace RTC
 		// For SCTP capable transports and for direct transport.
 		size_t maxSendMessageSize{ 0u };
 		size_t maxReceiveMessageSize{ 0u };
-		// For SCTP capable transports.
-		size_t sctpSendBufferSize{ 0u };
-		size_t sctpPerStreamSendQueueLimit{ 0u };
-		size_t sctpMaxReceiverWindowBufferSize{ 0u };
-
 		struct TraceEventTypes traceEventTypes;
 	};
 } // namespace RTC

--- a/worker/scripts/package-lock.json
+++ b/worker/scripts/package-lock.json
@@ -21,15 +21,15 @@
 			}
 		},
 		"node_modules/brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"license": "MIT",
 			"dependencies": {
 				"balanced-match": "^4.0.2"
 			},
 			"engines": {
-				"node": "18 || 20 || >=22"
+				"node": "20 || >=22"
 			}
 		},
 		"node_modules/glob": {
@@ -105,9 +105,9 @@
 			"integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="
 		},
 		"brace-expansion": {
-			"version": "5.0.7",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-			"integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+			"version": "5.0.8",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+			"integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
 			"requires": {
 				"balanced-match": "^4.0.2"
 			}

--- a/worker/src/RTC/SCTP/association/Association.cpp
+++ b/worker/src/RTC/SCTP/association/Association.cpp
@@ -54,6 +54,7 @@ namespace RTC
 		      this->associationListenerDeferrer,
 		      sctpOptions.mtu,
 		      sctpOptions.defaultStreamPriority,
+		      sctpOptions.defaultStreamBufferedAmountLowThreshold,
 		      sctpOptions.totalBufferedAmountLowThreshold),
 		    t1InitTimer(this->shared->CreateBackoffTimer(
 		      BackoffTimerHandleInterface::BackoffTimerHandleOptions{

--- a/worker/src/RTC/SCTP/tx/RoundRobinSendQueue.cpp
+++ b/worker/src/RTC/SCTP/tx/RoundRobinSendQueue.cpp
@@ -20,9 +20,11 @@ namespace RTC
 		  AssociationListenerInterface& associationListener,
 		  size_t mtu,
 		  uint16_t defaultPriority,
+		  size_t defaultStreamBufferedAmountLowThreshold,
 		  size_t totalBufferedAmountLowThreshold)
 		  : associationListener(associationListener),
 		    defaultPriority(defaultPriority),
+		    defaultStreamBufferedAmountLowThreshold(defaultStreamBufferedAmountLowThreshold),
 		    scheduler(mtu),
 		    totalBufferedAmountThresholdWatcher(
 		      [this]()
@@ -256,7 +258,9 @@ namespace RTC
 
 			if (it == this->streams.end())
 			{
-				return 0;
+				// The stream is created lazily (on first send or when its threshold is
+				// explicitly set), so report the default that it will be created with.
+				return this->defaultStreamBufferedAmountLowThreshold;
 			}
 
 			const auto& stream = it->second;
@@ -297,7 +301,11 @@ namespace RTC
 				    this->associationListener.OnAssociationStreamBufferedAmountLow(streamId);
 			    }));
 
-			return it2->second;
+			auto& stream = it2->second;
+
+			stream.GetBufferedAmount().SetLowThreshold(this->defaultStreamBufferedAmountLowThreshold);
+
+			return stream;
 		}
 
 		void RoundRobinSendQueue::AssertIsConsistent() const

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -49,19 +49,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		this->direct                = options->direct();
 		this->maxSendMessageSize    = options->maxSendMessageSize();
 		this->maxReceiveMessageSize = options->maxReceiveMessageSize();
-
-		if (options->direct())
-		{
-			this->direct = true;
-		}
-		else
-		{
-			this->sctpSendBufferSize              = options->sctpSendBufferSize();
-			this->sctpPerStreamSendQueueLimit     = options->sctpPerStreamSendQueueLimit();
-			this->sctpMaxReceiverWindowBufferSize = options->sctpMaxReceiverWindowBufferSize();
-		}
 
 		if (
 		  auto initialAvailableOutgoingBitrate = options->initialAvailableOutgoingBitrate();
@@ -80,11 +70,13 @@ namespace RTC
 			const RTC::SCTP::SctpOptions sctpOptions = {
 				.mtu                         = RTC::Consts::MaxSafeMtuSizeForSctp,
 				.maxSendMessageSize          = this->maxSendMessageSize,
-				.maxSendBufferSize           = this->sctpSendBufferSize,
-				.perStreamSendQueueLimit     = this->sctpPerStreamSendQueueLimit,
+				.maxSendBufferSize           = options->sctpSendBufferSize(),
+				.perStreamSendQueueLimit     = options->sctpPerStreamSendQueueLimit(),
 				.maxReceiveMessageSize       = this->maxReceiveMessageSize,
-				.maxReceiverWindowBufferSize = this->sctpMaxReceiverWindowBufferSize,
-				.requireAuthenticatedCookie  = requireSctpStateCookieAuthentication
+				.maxReceiverWindowBufferSize = options->sctpMaxReceiverWindowBufferSize(),
+				.defaultStreamBufferedAmountLowThreshold =
+				  options->sctpDefaultStreamBufferedAmountLowThreshold(),
+				.requireAuthenticatedCookie = requireSctpStateCookieAuthentication
 			};
 
 			this->sctpAssociation = std::make_unique<RTC::SCTP::Association>(

--- a/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestAssociation.cpp
@@ -1057,6 +1057,40 @@ SCENARIO("SCTP Association", "[sctp][association]")
 		REQUIRE(a.listener.HasOnStreamBufferedAmountLowBeenCalledWithStreamId(1) == true);
 	}
 
+	SECTION("applies the configured default buffered amount low threshold to new streams")
+	{
+		auto sctpOptions = makeSctpOptions();
+
+		sctpOptions.defaultStreamBufferedAmountLowThreshold = 1024;
+
+		AssociationUnderTest a(sctpOptions);
+
+		// Sending a message creates the outgoing stream, which must inherit the
+		// configured default buffered amount low threshold.
+		sendMessage(a, 1, 53, std::vector<uint8_t>(10));
+
+		REQUIRE(a.association.GetStreamBufferedAmountLowThreshold(1) == 1024);
+	}
+
+	SECTION("does not trigger buffered amount low until crossing a non-zero default threshold")
+	{
+		auto sctpOptions = makeSctpOptions();
+
+		sctpOptions.defaultStreamBufferedAmountLowThreshold = 1024;
+
+		AssociationUnderTest a(sctpOptions);
+		AssociationUnderTest z;
+
+		connectAssociations(a, z);
+
+		// A small message never takes the buffered amount above the threshold, so
+		// draining it must not trigger the event.
+		sendMessage(a, 1, 53, std::vector<uint8_t>(10));
+		exchangeMessages(a, z);
+
+		REQUIRE(a.listener.HasOnStreamBufferedAmountLowBeenCalledWithStreamId(1) == false);
+	}
+
 	SECTION("detects the peer implementation")
 	{
 		AssociationUnderTest a;

--- a/worker/test/src/RTC/SCTP/association/TestStreamResetHandler.cpp
+++ b/worker/test/src/RTC/SCTP/association/TestStreamResetHandler.cpp
@@ -57,6 +57,7 @@ namespace
 		      this->associationListener,
 		      this->sctpOptions.mtu,
 		      this->sctpOptions.defaultStreamPriority,
+		      this->sctpOptions.defaultStreamBufferedAmountLowThreshold,
 		      this->sctpOptions.totalBufferedAmountLowThreshold),
 		    dataTracker(this->delayedAckTimer.get(), RemoteInitialTsn),
 		    reassemblyQueue(this->sctpOptions.maxReceiverWindowBufferSize),

--- a/worker/test/src/RTC/SCTP/tx/TestRoundRobinSendQueue.cpp
+++ b/worker/test/src/RTC/SCTP/tx/TestRoundRobinSendQueue.cpp
@@ -14,7 +14,8 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	constexpr uint16_t StreamId{ 1 };
 	constexpr uint32_t Ppid{ 53 };
 	constexpr uint16_t DefaultPriority{ 10 };
-	constexpr size_t BufferedAmountLowThreshold{ 500 };
+	constexpr size_t DefaultStreamBufferedAmountLowThreshold{ 0 };
+	constexpr size_t TotalBufferedAmountLowThreshold{ 500 };
 	constexpr size_t OneFragmentPacketLength{ 100 };
 	constexpr size_t TwoFragmentPacketLength{ 101 };
 
@@ -22,7 +23,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		REQUIRE(q.IsEmpty());
 		REQUIRE(q.Produce(NowMs, OneFragmentPacketLength).has_value() == false);
@@ -32,7 +37,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		q.AddMessage(NowMs, RTC::SCTP::Message(StreamId, Ppid, { 1, 2, 4, 5, 6 }));
 
@@ -49,7 +58,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(60);
 
@@ -80,7 +93,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(60);
 
@@ -108,7 +125,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(600);
 
@@ -157,7 +178,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(20);
 
@@ -184,7 +209,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(20);
 
@@ -235,7 +264,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(120);
 
@@ -273,7 +306,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		q.AddMessage(NowMs, RTC::SCTP::Message(StreamId, Ppid, { 1, 2, 3 }));
 		q.AddMessage(NowMs, RTC::SCTP::Message(2, 54, { 1, 2, 3, 4, 5 }));
@@ -300,7 +337,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(120);
 
@@ -323,7 +364,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(50);
 
@@ -362,7 +407,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const size_t payloadLength  = 100;
 		const size_t fragmentLength = 50;
@@ -397,7 +446,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(50);
 
@@ -437,7 +490,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(50);
 
@@ -479,7 +536,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(50);
 
@@ -527,7 +588,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(50);
 
@@ -565,7 +630,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(200);
 
@@ -597,7 +666,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(TwoFragmentPacketLength);
 
@@ -635,7 +708,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		q.AddMessage(NowMs, RTC::SCTP::Message(1, Ppid, std::vector<uint8_t>(1)));
 		q.AddMessage(NowMs, RTC::SCTP::Message(1, Ppid, std::vector<uint8_t>(2)));
@@ -699,7 +776,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		q.SetStreamBufferedAmountLowThreshold(1, 0);
 
@@ -710,7 +791,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		q.AddMessage(NowMs, RTC::SCTP::Message(1, Ppid, std::vector<uint8_t>(1)));
 
@@ -731,7 +816,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		q.AddMessage(NowMs, RTC::SCTP::Message(1, Ppid, std::vector<uint8_t>(1)));
 
@@ -761,7 +850,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		q.SetStreamBufferedAmountLowThreshold(1, 1000);
 
@@ -797,7 +890,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		q.SetStreamBufferedAmountLowThreshold(1, 700);
 
@@ -842,7 +939,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		q.SetStreamBufferedAmountLowThreshold(1, 700);
 
@@ -876,7 +977,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		q.AddMessage(NowMs, RTC::SCTP::Message(StreamId, Ppid, std::vector<uint8_t>(100)));
 
@@ -913,9 +1018,13 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
-		const std::vector<uint8_t> payload(BufferedAmountLowThreshold - 1);
+		const std::vector<uint8_t> payload(TotalBufferedAmountLowThreshold - 1);
 
 		q.AddMessage(NowMs, RTC::SCTP::Message(StreamId, Ppid, payload));
 
@@ -933,9 +1042,13 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
-		const std::vector<uint8_t> payload(BufferedAmountLowThreshold);
+		const std::vector<uint8_t> payload(TotalBufferedAmountLowThreshold);
 
 		q.AddMessage(NowMs, RTC::SCTP::Message(StreamId, Ppid, payload));
 
@@ -950,14 +1063,18 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 		REQUIRE(associationListener.CountOnTotalBufferedAmountLowCalls() == 1);
 
 		REQUIRE(dataToSendTwo.has_value());
-		REQUIRE(q.GetTotalBufferedAmount() < BufferedAmountLowThreshold);
+		REQUIRE(q.GetTotalBufferedAmount() < TotalBufferedAmountLowThreshold);
 	}
 
 	SECTION("will stay in a stream as long as that message is sending")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		constexpr size_t OneFragmentPacketSize = OneFragmentPacketLength;
 
@@ -1002,7 +1119,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		REQUIRE(q.GetStreamPriority(1) == DefaultPriority);
 
@@ -1015,7 +1136,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		q.SetStreamPriority(1, 42);
 
@@ -1031,7 +1156,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		q.EnableMessageInterleaving(true);
 
@@ -1060,7 +1189,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(OneFragmentPacketLength);
 
@@ -1082,7 +1215,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(120);
 
@@ -1109,7 +1246,11 @@ SCENARIO("SCTP RoundRobinSendQueue", "[sctp][roundrobinsendqueue]")
 	{
 		mocks::RTC::SCTP::MockAssociationListener associationListener;
 		RTC::SCTP::RoundRobinSendQueue q(
-		  associationListener, Mtu, DefaultPriority, BufferedAmountLowThreshold);
+		  associationListener,
+		  Mtu,
+		  DefaultPriority,
+		  DefaultStreamBufferedAmountLowThreshold,
+		  TotalBufferedAmountLowThreshold);
 
 		const std::vector<uint8_t> payload(OneFragmentPacketLength + 20);
 


### PR DESCRIPTION
# Default

- Fixes #1866
- Worker: Added a new `SctpOptions.defaultStreamBufferedAmountLowThreshold` field.
- Node and Rust: Added a new `sctpDefaultStreamBufferedAmountLowThreshold` option in `router.createXxxxTransport()`. It defaults to 1024 bytes instead of 0.

## TODO

- [x] Website API documentation.