### PR TITLE
Rust: Fix, increase worker thread stack size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+Worker: Fix, use thread_local buffer on MS_ABORT ([PR#1873](https://github.com/versatica/mediasoup/pull/1873)).
+
 ### 3.23.0
 
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-Worker: Fix, use thread_local buffer on MS_ABORT ([PR#1873](https://github.com/versatica/mediasoup/pull/1873)).
+Worker: Fix, use `thread_local` buffer on `MS_ABORT()` ([PR#1873](https://github.com/versatica/mediasoup/pull/1873)).
 
 ### 3.23.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-Worker: Fix, use thread_local buffer on MS_ABORT ([PR#1873](https://github.com/versatica/mediasoup/pull/1873)).
+Worker: Fix, use `thread_local` buffer on `MS_ABORT()` ([PR#1873](https://github.com/versatica/mediasoup/pull/1873)).
 
 ### 0.24.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-Rust: Fix, increase worker thread stack size ([PR#1873](https://github.com/versatica/mediasoup/pull/1873)).
+Worker: Fix, use thread_local buffer on MS_ABORT ([PR#1873](https://github.com/versatica/mediasoup/pull/1873)).
 
 ### 0.24.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+Rust: Fix, increase worker thread stack size ([PR#1873](https://github.com/versatica/mediasoup/pull/1873)).
+
 ### 0.24.0
 
 - Bump up Meson from 1.9.1 to 1.11.2 ([PR #1861](https://github.com/versatica/mediasoup/pull/1861)).

--- a/worker/include/Logger.hpp
+++ b/worker/include/Logger.hpp
@@ -472,9 +472,8 @@ public:
 	{ \
 		std::fprintf(stderr, "(ABORT) " _MS_LOG_STR_DESC desc _MS_LOG_SEPARATOR_CHAR_STD, _MS_LOG_ARG, ##__VA_ARGS__); \
 		std::fflush(stderr); \
-		char abortMessage[Logger::BufferSize]; \
-		std::snprintf(abortMessage, Logger::BufferSize, "(ABORT) " _MS_LOG_STR_DESC desc _MS_LOG_SEPARATOR_CHAR_STD, _MS_LOG_ARG, ##__VA_ARGS__); \
-		throw std::runtime_error(abortMessage); \
+		std::snprintf(Logger::buffer, Logger::BufferSize, "(ABORT) " _MS_LOG_STR_DESC desc _MS_LOG_SEPARATOR_CHAR_STD, _MS_LOG_ARG, ##__VA_ARGS__); \
+		throw std::runtime_error(Logger::buffer); \
 	} \
 	while (false)
 #endif

--- a/worker/include/Logger.hpp
+++ b/worker/include/Logger.hpp
@@ -470,9 +470,9 @@ public:
 #define MS_ABORT(desc, ...) \
 	do \
 	{ \
-		std::fprintf(stderr, "(ABORT) " _MS_LOG_STR_DESC desc _MS_LOG_SEPARATOR_CHAR_STD, _MS_LOG_ARG, ##__VA_ARGS__); \
-		std::fflush(stderr); \
 		std::snprintf(Logger::buffer, Logger::BufferSize, "(ABORT) " _MS_LOG_STR_DESC desc _MS_LOG_SEPARATOR_CHAR_STD, _MS_LOG_ARG, ##__VA_ARGS__); \
+		std::fprintf(stderr, "%s", Logger::buffer); \
+		std::fflush(stderr); \
 		throw std::runtime_error(Logger::buffer); \
 	} \
 	while (false)


### PR DESCRIPTION
The mediasoup worker thread was spawned with the default stack size (macOS secondary thread stack size is ~2060 KB), causing a stack overflow when a WebRtcTransport with SCTP/DataChannels connected.

Association::AssertIsConsistent() calls MS_ASSERT 38 times. Each MS_ASSERT expands to MS_ABORT, which declares a local buffer:

    char abortMessage[Logger::BufferSize];  // 50,000 bytes

    38 × 50,000 = 1,900,000 bytes ≈ 1808 KB

This was confirmed by runtime probes and disassembly:

    sub sp, sp, #0x1c3, lsl #12  ; 1,847,296 bytes
    sub sp, sp, #0xf30           ;     3,888 bytes

When triggered from the WebRtcTransport DTLS path, which already has 334 KB of frames on the stack before reaching SCTP, the total exceeds the limit:

    334 KB (DTLS base) + 1808 KB (AssertIsConsistent prologue) = 2142 KB
                                                                > 2060 KB → crash

Fix:

  Spawn the worker thread with an explicit 8 MB stack via
  std::thread::Builder::new().stack_size(8 * 1024 * 1024), giving
  6062 KB of headroom at the deepest observed call site.

Also adds Utils::PrintThreadStack() / PrintStackTrace() — a stack-depth measurement utility used to diagnose this issue.