### PR TITLE
Handle subchannels in pipe `DataConsumers`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### 3.23.1
 
-Worker: Fix, use `thread_local` buffer on `MS_ABORT()` ([PR#1873](https://github.com/versatica/mediasoup/pull/1873)).
+- Worker: Fix, use `thread_local` buffer on `MS_ABORT()` ([PR#1873](https://github.com/versatica/mediasoup/pull/1873)).
+- Handle subchannels in pipe `DataConsumers` ([PR#XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
 
 ### 3.23.0
 

--- a/node/src/DataConsumerTypes.ts
+++ b/node/src/DataConsumerTypes.ts
@@ -40,8 +40,6 @@ export type DataConsumerOptions<DataConsumerAppData extends AppData = AppData> =
 
 		/**
 		 * Subchannels this data consumer initially subscribes to.
-		 * Only used in case this data consumer receives messages from a local data
-		 * producer that specifies subchannel(s) when calling send().
 		 */
 		subchannels?: number[];
 

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -1140,8 +1140,9 @@ test('transport.consumeData() for a pipe DataProducer succeeds with subchannels'
 	);
 
 	// Send a message without subchannels so it's guaranteed that it will reach
-	// the final `directDataConsumer`. And wait for reception of tis message so
-	// at this time we know that previous ones also arrived.
+	// the final `directDataConsumer`. And wait for reception of this message so
+	// at this time we know that previous ones already reached the final
+	// `directDataConsumer`.
 	await new Promise<void>(resolve => {
 		directDataConsumer.on('message', message => {
 			const receivedMessage = message.toString('utf8');

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -1080,7 +1080,7 @@ test('transport.consumeData() for a pipe DataProducer succeeds with subchannels'
 		protocol: 'bar',
 	});
 
-	await ctx.router1!.pipeToRouter({
+	const { pipeDataConsumer } = await ctx.router1!.pipeToRouter({
 		dataProducerId: directDataProducer.id,
 		router: ctx.router2!,
 	});
@@ -1091,25 +1091,71 @@ test('transport.consumeData() for a pipe DataProducer succeeds with subchannels'
 		subchannels: [123, 666],
 	});
 
-	await new Promise<void>((resolve, reject) => {
-		directDataConsumer.on('message', (message, ppid) => {
-			try {
-				expect(message.toString('utf8')).toBe('hello');
-				expect(ppid).toBe(51);
+	const receivedMessages: string[] = [];
 
+	directDataConsumer.on('message', message => {
+		const receivedMessage = message.toString('utf8');
+
+		receivedMessages.push(receivedMessage);
+	});
+
+	// The `pipeDataConsumer` is not subscribed to any subchannel, so it must allow
+	// the message to pass through and reach the final `directDataConsumer`.
+	directDataProducer.send(
+		'hello1',
+		/* ppid */ undefined,
+		/* subchannels */ [123, 124],
+		/* requiredSubchannel */ 666
+	);
+
+	// Subscribe `pipeDataConsumer` to subchannels 123, 124 and 666.
+	await pipeDataConsumer!.setSubchannels([123, 124, 666]);
+
+	// The `pipeDataConsumer` is subscribed to subchannels 123 and 666 so it must
+	// allow the message to pass through and reach the final `directDataConsumer`.
+	directDataProducer.send(
+		'hello2',
+		/* ppid */ undefined,
+		/* subchannels */ [123],
+		/* requiredSubchannel */ 666
+	);
+
+	// The `pipeDataConsumer` is subscribed to subchannels 124 and 666 so it must
+	// allow the message to pass through, however the final `directDataConsumer`
+	// is not subscribed to subchannel 124 so the message must not reach it.
+	directDataProducer.send(
+		'hello3',
+		/* ppid */ undefined,
+		/* subchannels */ [124],
+		/* requiredSubchannel */ 666
+	);
+
+	// The `pipeDataConsumer` is not subscribed to subchannel 125 so it must not
+	// allow the message to pass through.
+	directDataProducer.send(
+		'hello4',
+		/* ppid */ undefined,
+		/* subchannels */ [125],
+		/* requiredSubchannel */ 666
+	);
+
+	// Send a message without subchannels so it's guaranteed that it will reach
+	// the final `directDataConsumer`. And wait for reception of tis message so
+	// at this time we know that previous ones also arrived.
+	await new Promise<void>(resolve => {
+		directDataConsumer.on('message', message => {
+			const receivedMessage = message.toString('utf8');
+
+			// Resolve once the last sent message is received.
+			if (receivedMessage === 'hello5') {
 				resolve();
-			} catch (error) {
-				reject(error as Error);
 			}
 		});
 
-		directDataProducer.send(
-			'hello',
-			/* ppid */ undefined,
-			/* subchannels */ [123, 124],
-			/* requiredSubchannel */ 666
-		);
+		directDataProducer.send('hello5');
 	});
+
+	expect(receivedMessages).toStrictEqual(['hello1', 'hello2', 'hello5']);
 }, 2000);
 
 test('dataProducer.close() is transmitted to pipe DataConsumer', async () => {

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### 0.24.1
 
-Worker: Fix, use `thread_local` buffer on `MS_ABORT()` ([PR#1873](https://github.com/versatica/mediasoup/pull/1873)).
+- Worker: Fix, use `thread_local` buffer on `MS_ABORT()` ([PR#1873](https://github.com/versatica/mediasoup/pull/1873)).
+- Handle subchannels in pipe `DataConsumers` ([PR#XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
 
 ### 0.24.0
 

--- a/rust/src/router/data_consumer.rs
+++ b/rust/src/router/data_consumer.rs
@@ -59,8 +59,6 @@ pub struct DataConsumerOptions {
     /// Whether the DataConsumer must start in paused mode. Default false.
     pub paused: bool,
     /// Subchannels this DataConsumer initially subscribes to.
-    /// Only used in case this DataConsumer receives messages from a local DataProducer
-    /// that specifies subchannel(s) when calling send().
     pub subchannels: Option<Vec<u16>>,
     /// Custom application data.
     pub app_data: AppData,

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -1304,7 +1304,10 @@ fn data_consume_for_pipe_data_producer_succeeds_with_subchannels() {
             .await
             .expect("Failed to produce data");
 
-        router1
+        let PipeDataProducerToRouterPair {
+            pipe_data_producer: _pipe_data_producer,
+            pipe_data_consumer,
+        } = router1
             .pipe_data_producer_to_router(
                 data_producer.id(),
                 PipeToRouterOptions::new(router2.clone()),
@@ -1325,9 +1328,11 @@ fn data_consume_for_pipe_data_producer_succeeds_with_subchannels() {
             .await
             .expect("Failed to create data consumer");
 
-        let (received_tx, received_rx) = async_oneshot::oneshot::<String>();
+        // Resolved with all received messages once the last sent one is received.
+        let (received_tx, received_rx) = async_oneshot::oneshot::<Vec<String>>();
         let _handler = data_consumer.on_message({
             let received_tx = Mutex::new(Some(received_tx));
+            let received_messages = Mutex::new(Vec::<String>::new());
 
             move |message| {
                 let text = match message {
@@ -1336,9 +1341,14 @@ fn data_consume_for_pipe_data_producer_succeeds_with_subchannels() {
                         panic!("Unexpected non-string message");
                     }
                 };
+                let is_last_message = text == "hello5";
 
-                if let Some(mut received_tx) = received_tx.lock().take() {
-                    let _ = received_tx.send(text);
+                received_messages.lock().push(text);
+
+                if is_last_message {
+                    if let Some(mut received_tx) = received_tx.lock().take() {
+                        let _ = received_tx.send(received_messages.lock().clone());
+                    }
                 }
             }
         });
@@ -1350,17 +1360,67 @@ fn data_consume_for_pipe_data_producer_succeeds_with_subchannels() {
             }
         };
 
+        // The pipe DataConsumer is not subscribed to any subchannel, so it must allow the
+        // message to pass through and reach the final DataConsumer.
         direct_data_producer
             .send(
-                WebRtcMessage::String(Cow::Borrowed("hello".as_bytes())),
+                WebRtcMessage::String(Cow::Borrowed("hello1".as_bytes())),
                 Some(vec![123, 124]),
                 Some(666),
             )
             .expect("Failed to send message");
 
-        let received_message = received_rx.await.expect("Failed to receive message");
+        // Subscribe the pipe DataConsumer to subchannels 123, 124 and 666.
+        pipe_data_consumer
+            .set_subchannels(vec![123, 124, 666])
+            .await
+            .expect("Failed to set data consumer subchannels");
 
-        assert_eq!(received_message, "hello");
+        // The pipe DataConsumer is subscribed to subchannels 123 and 666 so it must allow
+        // the message to pass through and reach the final DataConsumer.
+        direct_data_producer
+            .send(
+                WebRtcMessage::String(Cow::Borrowed("hello2".as_bytes())),
+                Some(vec![123]),
+                Some(666),
+            )
+            .expect("Failed to send message");
+
+        // The pipe DataConsumer is subscribed to subchannels 124 and 666 so it must allow
+        // the message to pass through, however the final DataConsumer is not subscribed to
+        // subchannel 124 so the message must not reach it.
+        direct_data_producer
+            .send(
+                WebRtcMessage::String(Cow::Borrowed("hello3".as_bytes())),
+                Some(vec![124]),
+                Some(666),
+            )
+            .expect("Failed to send message");
+
+        // The pipe DataConsumer is not subscribed to subchannel 125 so it must not allow
+        // the message to pass through.
+        direct_data_producer
+            .send(
+                WebRtcMessage::String(Cow::Borrowed("hello4".as_bytes())),
+                Some(vec![125]),
+                Some(666),
+            )
+            .expect("Failed to send message");
+
+        // Send a message without subchannels so it's guaranteed that it will reach the
+        // final DataConsumer. And wait for reception of this message so at this time we
+        // know that previous ones also arrived.
+        direct_data_producer
+            .send(
+                WebRtcMessage::String(Cow::Borrowed("hello5".as_bytes())),
+                None,
+                None,
+            )
+            .expect("Failed to send message");
+
+        let received_messages = received_rx.await.expect("Failed to receive messages");
+
+        assert_eq!(received_messages, ["hello1", "hello2", "hello5"]);
     });
 }
 

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -5,6 +5,7 @@
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
 #include "RTC/SubchannelsCodec.hpp"
+#include <vector>
 
 namespace RTC
 {
@@ -500,7 +501,11 @@ namespace RTC
 			return false;
 		}
 
-		if (!this->pipe)
+		// Only verify subchannels if this is not a piped DataConsumer or if this is
+		// a piped DataConsumer and it's subscribed to at least one subchannel.
+		const bool verifySubchannels = !this->pipe || !this->subchannels.empty();
+
+		if (verifySubchannels)
 		{
 			// If a required subchannel is given, verify that this data consumer is
 			// subscribed to it.
@@ -543,13 +548,33 @@ namespace RTC
 				}
 			}
 		}
-		// This is a piped DataConsumer, so instead of verifying subchannels locally,
-		// encode the subchannels and required subchannel at the beginning of the
-		// message payload so the receiving PipeTransport can decode them and apply
-		// them to its own DataConsumers.
-		else
+
+		// If this is a piped DataConsumer, encode given subchannels and required
+		// subchannel at the beginning of the message payload so the receiving
+		// PipeTransport can decode them and apply them to its own DataConsumers.
+		if (this->pipe)
 		{
-			RTC::SubchannelsCodec::EncodeSubchannels(message, subchannels, requiredSubchannel);
+			// If subchannels were verified, encode just those this DataConsumer is
+			// subscribed to. Otherwise the receiving Router would deliver the message to
+			// DataConsumers subscribed to subchannels that this pipe does not carry.
+			const bool reduceSubchannels = verifySubchannels && !subchannels.empty();
+			std::vector<uint16_t> reducedSubchannels;
+
+			if (reduceSubchannels)
+			{
+				reducedSubchannels.reserve(subchannels.size());
+
+				for (const auto subchannel : subchannels)
+				{
+					if (this->subchannels.contains(subchannel))
+					{
+						reducedSubchannels.push_back(subchannel);
+					}
+				}
+			}
+
+			RTC::SubchannelsCodec::EncodeSubchannels(
+			  message, reduceSubchannels ? reducedSubchannels : subchannels, requiredSubchannel);
 		}
 
 		const size_t messageLen = message.GetPayloadLength();

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -558,6 +558,7 @@ namespace RTC
 			// subscribed to. Otherwise the receiving Router would deliver the message to
 			// DataConsumers subscribed to subchannels that this pipe does not carry.
 			const bool reduceSubchannels = verifySubchannels && !subchannels.empty();
+
 			std::vector<uint16_t> reducedSubchannels;
 
 			if (reduceSubchannels)


### PR DESCRIPTION
# Details

- Fixes #1874.
- Verify/check given subchannels and/or required subchannels in messages received by piped data consumers (`DataConsumers` created on `PipeTransports`).
- However the behavior is different than in data consumers created in **non** `PipeTransports`: If the piped data consumer is not subscribed to **any** subchannel then it lets all messages pass through despite the message comes with subchannels.