### PR TITLE
DataProducerOptions: make new_pipe_transport() public

### DIFF
--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- `DataProducerOptions`: make `new_pipe_transport()` public ([PR#XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 0.24.2
 
 - Handle subchannels in pipe `DataConsumers` ([PR #1875](https://github.com/versatica/mediasoup/pull/1875)).

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- `DataProducerOptions`: make `new_pipe_transport()` public ([PR#XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- `DataProducerOptions`: make `new_pipe_transport()` public ([PR #1876](https://github.com/versatica/mediasoup/pull/1876)).
 
 ### 0.24.2
 

--- a/rust/src/router/data_producer.rs
+++ b/rust/src/router/data_producer.rs
@@ -52,7 +52,8 @@ pub struct DataProducerOptions {
 
 impl DataProducerOptions {
     #[must_use]
-    pub(super) fn new_pipe_transport(
+    /// Create data producer options that will be used with Pipe transport.
+    pub fn new_pipe_transport(
         data_producer_id: DataProducerId,
         sctp_stream_parameters: SctpStreamParameters,
     ) -> Self {
@@ -66,7 +67,7 @@ impl DataProducerOptions {
         }
     }
 
-    /// Data producer options for non-Direct transport.
+    /// Create data producer options for non-Direct transport.
     #[must_use]
     pub fn new_sctp(sctp_stream_parameters: SctpStreamParameters) -> Self {
         Self {


### PR DESCRIPTION
It was missing. It must be public the same way the analogous `ProducerOptions` function is.