### PR TITLE
`DataProducer.send()`: Add `ignoredSubchannel` optional argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- `DataProducer.send()`: Add `ignoredSubchannel` optional argument ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 3.23.2
 
 - Handle subchannels in pipe `DataConsumers` ([PR #1875](https://github.com/versatica/mediasoup/pull/1875)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- `DataProducer.send()`: Add `ignoredSubchannel` optional argument ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- `DataProducer.send()`: Add `ignoredSubchannel` optional argument ([PR #1877](https://github.com/versatica/mediasoup/pull/1877)).
 
 ### 3.23.2
 

--- a/node/src/DataProducer.ts
+++ b/node/src/DataProducer.ts
@@ -256,7 +256,8 @@ export class DataProducerImpl<DataProducerAppData extends AppData = AppData>
 		message: string | Buffer,
 		ppid?: number,
 		subchannels?: number[],
-		requiredSubchannel?: number
+		requiredSubchannel?: number,
+		ignoredSubchannel?: number
 	): void {
 		if (typeof message !== 'string' && !Buffer.isBuffer(message)) {
 			throw new TypeError('message must be a string or a Buffer');
@@ -319,7 +320,8 @@ export class DataProducerImpl<DataProducerAppData extends AppData = AppData>
 				ppid,
 				dataOffset,
 				subchannelsOffset,
-				requiredSubchannel ?? null
+				requiredSubchannel ?? null,
+				ignoredSubchannel ?? null
 			);
 
 		this.#channel.notify(

--- a/node/src/DataProducerTypes.ts
+++ b/node/src/DataProducerTypes.ts
@@ -166,6 +166,7 @@ export interface DataProducer<
 		message: string | Buffer,
 		ppid?: number,
 		subchannels?: number[],
-		requiredSubchannel?: number
+		requiredSubchannel?: number,
+		ignoredSubchannel?: number
 	): void;
 }

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -1088,7 +1088,7 @@ test('transport.consumeData() for a pipe DataProducer succeeds with subchannels'
 	const directTransport2 = await ctx.router2!.createDirectTransport();
 	const directDataConsumer = await directTransport2.consumeData({
 		dataProducerId: directDataProducer.id,
-		subchannels: [123, 666],
+		subchannels: [123, 666, 777],
 	});
 
 	const receivedMessages: string[] = [];
@@ -1139,6 +1139,26 @@ test('transport.consumeData() for a pipe DataProducer succeeds with subchannels'
 		/* requiredSubchannel */ 666
 	);
 
+	// The `pipeDataConsumer` is subscribed to subchannel 666 so it must not
+	// allow the message to pass through.
+	directDataProducer.send(
+		'hello5',
+		/* ppid */ undefined,
+		/* subchannels */ [123],
+		/* requiredSubchannel */ undefined,
+		/* ignoredSubchannel */ 666
+	);
+
+	// The final `directDataConsumer` is subscribed to subchannel 777 so it must
+	// not receive the message.
+	directDataProducer.send(
+		'hello6',
+		/* ppid */ undefined,
+		/* subchannels */ undefined,
+		/* requiredSubchannel */ undefined,
+		/* ignoredSubchannel */ 777
+	);
+
 	// Send a message without subchannels so it's guaranteed that it will reach
 	// the final `directDataConsumer`. And wait for reception of this message so
 	// at this time we know that previous ones already reached the final
@@ -1148,15 +1168,15 @@ test('transport.consumeData() for a pipe DataProducer succeeds with subchannels'
 			const receivedMessage = message.toString('utf8');
 
 			// Resolve once the last sent message is received.
-			if (receivedMessage === 'hello5') {
+			if (receivedMessage === 'bye') {
 				resolve();
 			}
 		});
 
-		directDataProducer.send('hello5');
+		directDataProducer.send('bye');
 	});
 
-	expect(receivedMessages).toStrictEqual(['hello1', 'hello2', 'hello5']);
+	expect(receivedMessages).toStrictEqual(['hello1', 'hello2', 'bye']);
 }, 2000);
 
 test('dataProducer.close() is transmitted to pipe DataConsumer', async () => {

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- `DirectDataProducer.send()`: Add `ignored_subchannel` optional argument ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- `DirectDataProducer.send()`: Add `ignored_subchannel` optional argument ([PR #1877](https://github.com/versatica/mediasoup/pull/1877)).
 
 ### 0.24.3
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- `DirectDataProducer.send()`: Add `ignored_subchannel` optional argument ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 0.24.3
 
 - `DataProducerOptions`: make `new_pipe_transport()` public ([PR #1876](https://github.com/versatica/mediasoup/pull/1876)).

--- a/rust/benches/direct_data.rs
+++ b/rust/benches/direct_data.rs
@@ -51,8 +51,12 @@ pub fn criterion_benchmark(c: &mut Criterion) {
                     let _ = sender.send(());
                 });
 
-                let _ =
-                    direct_data_producer.send(WebRtcMessage::Binary(Cow::from(data)), None, None);
+                let _ = direct_data_producer.send(
+                    WebRtcMessage::Binary(Cow::from(data)),
+                    None,
+                    None,
+                    None,
+                );
 
                 let _ = receiver.recv();
             })

--- a/rust/src/messages.rs
+++ b/rust/src/messages.rs
@@ -2878,6 +2878,7 @@ pub(crate) struct DataProducerSendNotification {
     pub(crate) payload: Vec<u8>,
     pub(crate) subchannels: Option<Vec<u16>>,
     pub(crate) required_subchannel: Option<u16>,
+    pub(crate) ignored_subchannel: Option<u16>,
 }
 
 impl Notification for DataProducerSendNotification {
@@ -2893,6 +2894,7 @@ impl Notification for DataProducerSendNotification {
             self.payload,
             self.subchannels,
             self.required_subchannel,
+            self.ignored_subchannel,
         );
         let notification_body =
             notification::Body::create_data_producer_send_notification(&mut builder, data);

--- a/rust/src/router/data_producer.rs
+++ b/rust/src/router/data_producer.rs
@@ -563,6 +563,7 @@ impl DirectDataProducer {
         message: WebRtcMessage<'_>,
         subchannels: Option<Vec<u16>>,
         required_subchannel: Option<u16>,
+        ignored_subchannel: Option<u16>,
     ) -> Result<(), NotificationError> {
         let (ppid, payload) = message.into_ppid_and_payload();
 
@@ -573,6 +574,7 @@ impl DirectDataProducer {
                 payload: payload.into_owned(),
                 subchannels,
                 required_subchannel,
+                ignored_subchannel,
             },
         )
     }

--- a/rust/tests/integration/direct_transport.rs
+++ b/rust/tests/integration/direct_transport.rs
@@ -287,7 +287,7 @@ fn send_succeeds() {
             };
 
             direct_data_producer
-                .send(message, None, None)
+                .send(message, None, None, None)
                 .expect("Failed to send message");
 
             if id == num_messages {
@@ -449,6 +449,7 @@ fn send_with_subchannels_succeeds() {
                 WebRtcMessage::String(Cow::Borrowed(both.as_bytes())),
                 None,
                 None,
+                None,
             )
             .expect("Failed to send message");
 
@@ -457,6 +458,7 @@ fn send_with_subchannels_succeeds() {
             .send(
                 WebRtcMessage::String(Cow::Borrowed(both.as_bytes())),
                 Some(vec![1, 2]),
+                None,
                 None,
             )
             .expect("Failed to send message");
@@ -467,6 +469,7 @@ fn send_with_subchannels_succeeds() {
                 WebRtcMessage::String(Cow::Borrowed(both.as_bytes())),
                 Some(vec![11, 22, 33]),
                 Some(666),
+                None,
             )
             .expect("Failed to send message");
 
@@ -476,6 +479,7 @@ fn send_with_subchannels_succeeds() {
                 WebRtcMessage::String(Cow::Borrowed(none.as_bytes())),
                 Some(vec![3]),
                 Some(666),
+                None,
             )
             .expect("Failed to send message");
 
@@ -485,6 +489,7 @@ fn send_with_subchannels_succeeds() {
                 WebRtcMessage::String(Cow::Borrowed(none.as_bytes())),
                 Some(vec![666]),
                 Some(3),
+                None,
             )
             .expect("Failed to send message");
 
@@ -493,6 +498,7 @@ fn send_with_subchannels_succeeds() {
             .send(
                 WebRtcMessage::String(Cow::Borrowed(dc1.as_bytes())),
                 Some(vec![1]),
+                None,
                 None,
             )
             .expect("Failed to send message");
@@ -503,6 +509,7 @@ fn send_with_subchannels_succeeds() {
                 WebRtcMessage::String(Cow::Borrowed(dc1.as_bytes())),
                 Some(vec![11]),
                 None,
+                None,
             )
             .expect("Failed to send message");
 
@@ -512,6 +519,7 @@ fn send_with_subchannels_succeeds() {
                 WebRtcMessage::String(Cow::Borrowed(dc1.as_bytes())),
                 Some(vec![666]),
                 Some(11),
+                None,
             )
             .expect("Failed to send message");
 
@@ -521,6 +529,7 @@ fn send_with_subchannels_succeeds() {
                 WebRtcMessage::String(Cow::Borrowed(dc2.as_bytes())),
                 Some(vec![666]),
                 Some(2),
+                None,
             )
             .expect("Failed to send message");
 
@@ -538,6 +547,7 @@ fn send_with_subchannels_succeeds() {
                 WebRtcMessage::String(Cow::Borrowed(both.as_bytes())),
                 Some(vec![1]),
                 Some(666),
+                None,
             )
             .expect("Failed to send message");
 

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -1323,7 +1323,7 @@ fn data_consume_for_pipe_data_producer_succeeds_with_subchannels() {
         let data_consumer = direct_transport_2
             .consume_data(DataConsumerOptions::new_direct(
                 data_producer.id(),
-                Some(vec![123, 666]),
+                Some(vec![123, 666, 777]),
             ))
             .await
             .expect("Failed to create data consumer");
@@ -1341,7 +1341,7 @@ fn data_consume_for_pipe_data_producer_succeeds_with_subchannels() {
                         panic!("Unexpected non-string message");
                     }
                 };
-                let is_last_message = text == "hello5";
+                let is_last_message = text == "bye";
 
                 received_messages.lock().push(text);
 
@@ -1367,6 +1367,7 @@ fn data_consume_for_pipe_data_producer_succeeds_with_subchannels() {
                 WebRtcMessage::String(Cow::Borrowed("hello1".as_bytes())),
                 Some(vec![123, 124]),
                 Some(666),
+                None,
             )
             .expect("Failed to send message");
 
@@ -1383,6 +1384,7 @@ fn data_consume_for_pipe_data_producer_succeeds_with_subchannels() {
                 WebRtcMessage::String(Cow::Borrowed("hello2".as_bytes())),
                 Some(vec![123]),
                 Some(666),
+                None,
             )
             .expect("Failed to send message");
 
@@ -1394,6 +1396,7 @@ fn data_consume_for_pipe_data_producer_succeeds_with_subchannels() {
                 WebRtcMessage::String(Cow::Borrowed("hello3".as_bytes())),
                 Some(vec![124]),
                 Some(666),
+                None,
             )
             .expect("Failed to send message");
 
@@ -1404,6 +1407,29 @@ fn data_consume_for_pipe_data_producer_succeeds_with_subchannels() {
                 WebRtcMessage::String(Cow::Borrowed("hello4".as_bytes())),
                 Some(vec![125]),
                 Some(666),
+                None,
+            )
+            .expect("Failed to send message");
+
+        // The pipe DataConsumer is subscribed to subchannel 666 so it must not allow the
+        // message to pass through.
+        direct_data_producer
+            .send(
+                WebRtcMessage::String(Cow::Borrowed("hello5".as_bytes())),
+                Some(vec![123]),
+                None,
+                Some(666),
+            )
+            .expect("Failed to send message");
+
+        // The final DataConsumer is subscribed to subchannel 777 so it must not receive
+        // the message.
+        direct_data_producer
+            .send(
+                WebRtcMessage::String(Cow::Borrowed("hello6".as_bytes())),
+                None,
+                None,
+                Some(777),
             )
             .expect("Failed to send message");
 
@@ -1412,7 +1438,8 @@ fn data_consume_for_pipe_data_producer_succeeds_with_subchannels() {
         // know that previous ones also arrived.
         direct_data_producer
             .send(
-                WebRtcMessage::String(Cow::Borrowed("hello5".as_bytes())),
+                WebRtcMessage::String(Cow::Borrowed("bye".as_bytes())),
+                None,
                 None,
                 None,
             )
@@ -1420,7 +1447,7 @@ fn data_consume_for_pipe_data_producer_succeeds_with_subchannels() {
 
         let received_messages = received_rx.await.expect("Failed to receive messages");
 
-        assert_eq!(received_messages, ["hello1", "hello2", "hello5"]);
+        assert_eq!(received_messages, ["hello1", "hello2", "bye"]);
     });
 }
 

--- a/worker/fbs/dataProducer.fbs
+++ b/worker/fbs/dataProducer.fbs
@@ -31,4 +31,5 @@ table SendNotification {
     data: [uint8] (required);
     subchannels: [uint16];
     required_subchannel: uint16 = null;
+    ignored_subchannel: uint16 = null;
 }

--- a/worker/include/RTC/DataConsumer.hpp
+++ b/worker/include/RTC/DataConsumer.hpp
@@ -97,6 +97,7 @@ namespace RTC
 		  RTC::SCTP::Message message,
 		  std::vector<uint16_t>& subchannels,
 		  std::optional<uint16_t> requiredSubchannel,
+		  std::optional<uint16_t> ignoredSubchannel,
 		  const onQueuedCallback* cb = nullptr);
 
 		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */

--- a/worker/include/RTC/DataProducer.hpp
+++ b/worker/include/RTC/DataProducer.hpp
@@ -27,7 +27,8 @@ namespace RTC
 			  RTC::DataProducer* dataProducer,
 			  RTC::SCTP::Message message,
 			  std::vector<uint16_t>& subchannels,
-			  std::optional<uint16_t> requiredSubchannel)                       = 0;
+			  std::optional<uint16_t> requiredSubchannel,
+			  std::optional<uint16_t> ignoredSubchannel)                        = 0;
 			virtual void OnDataProducerPaused(RTC::DataProducer* dataProducer)  = 0;
 			virtual void OnDataProducerResumed(RTC::DataProducer* dataProducer) = 0;
 		};
@@ -68,7 +69,8 @@ namespace RTC
 		void ReceiveMessage(
 		  RTC::SCTP::Message message,
 		  std::vector<uint16_t>& subchannels,
-		  std::optional<uint16_t> requiredSubchannel);
+		  std::optional<uint16_t> requiredSubchannel,
+		  std::optional<uint16_t> ignoredSubchannel);
 
 		/* Methods inherited from Channel::ChannelSocket::RequestHandler. */
 	public:

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -100,7 +100,8 @@ namespace RTC
 		  RTC::DataProducer* dataProducer,
 		  RTC::SCTP::Message message,
 		  std::vector<uint16_t>& subchannels,
-		  std::optional<uint16_t> requiredSubchannel) override;
+		  std::optional<uint16_t> requiredSubchannel,
+		  std::optional<uint16_t> ignoredSubchannel) override;
 		void OnTransportNewDataConsumer(
 		  RTC::Transport* transport,
 		  RTC::DataConsumer* dataConsumer,

--- a/worker/include/RTC/SubchannelsCodec.hpp
+++ b/worker/include/RTC/SubchannelsCodec.hpp
@@ -8,30 +8,34 @@
 namespace RTC
 {
 	/**
-	 * Helper to (optionally) encode/decode subchannels and required subchannel at
-	 * the beginning of an SCTP message payload so that this information travels
-	 * within the SCTP message itself.
+	 * Helper to (optionally) encode/decode subchannels, required subchannel and
+	 * ignored subchannel at the beginning of an SCTP message payload so that this
+	 * information travels within the SCTP message itself.
 	 */
 	class SubchannelsCodec
 	{
 		/**
 		 * Wire layout of the encoded header prepended to the message payload (all
-		 * fields in network byte order). `R` is the `requiredSubchannelFlag`, i.e.
-		 * the least significant bit of the Magic Token. The `requiredSubchannel`
-		 * field is only present when `R` is 1.
+		 * fields in network byte order). `R` is the `requiredSubchannelFlag` (second
+		 * least significant bit of the Magic Token) and `I` is the
+		 * `ignoredSubchannelFlag` (least significant bit of the Magic Token). The
+		 * `requiredSubchannel` field is only present when `R` is 1. The
+		 * `ignoredSubchannel` field is only present when `I` is 1.
 		 *
 		 *  0                   1                   2                   3
 		 *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
 		 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 		 * |                       Magic Token (1/2)                       |
 		 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-		 * |                      Magic Token (2/2)                      |R|
+		 * |                     Magic Token (2/2)                     |R|I|
 		 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 		 * |        subchannelsCount       |          Subchannel 0         |
 		 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 		 * |                              ...                              |
 		 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-		 * |         Subchannel N-1        |  requiredSubchannel (if R=1)  |
+		 * |         Subchannel N-2        |          Subchannel N-1       |
+		 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+		 * |  requiredSubchannel (if R=1)  |   ignoredSubchannel (if I=1)  |
 		 * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 		 */
 
@@ -41,35 +45,41 @@ namespace RTC
 		 * made of non-printable high bytes and starts with a byte that is not a valid
 		 * UTF-8 leading byte (0x80-0xBF), so a real string message (valid UTF-8) can
 		 * never begin with it and the chance of colliding with a binary message is
-		 * negligible. Its least significant bit is reserved as the
-		 * `requiredSubchannelFlag`, so it is always 0 in the token constant itself.
+		 * negligible. Its least significant bits are reserved for the
+		 * `requiredSubchannelFlag` and `ignoredSubchannelFlag`, so they are always 0
+		 * in the token constant itself.
 		 */
 		static constexpr uint64_t MagicToken{ 0xA5F09CB3D6E1F28C };
-		static constexpr uint64_t RequiredSubchannelFlagMask{ 0x1 };
+		static constexpr uint64_t RequiredSubchannelFlagMask{ 0x2 };
+		static constexpr uint64_t IgnoredSubchannelFlagMask{ 0x1 };
+		static constexpr uint64_t FlagsMask{ RequiredSubchannelFlagMask | IgnoredSubchannelFlagMask };
 
 	public:
 		/**
-		 * If `subchannels` is not empty or `requiredSubchannel` has value, encodes
-		 * them at the beginning of the given message payload.
+		 * If `subchannels` is not empty or `requiredSubchannel` or `ignoredSubchannel`
+		 * has value, encodes them at the beginning of the given message payload.
 		 *
 		 * @returns true if the message was encoded, false otherwise.
 		 */
 		static bool EncodeSubchannels(
 		  RTC::SCTP::Message& message,
 		  const std::vector<uint16_t>& subchannels,
-		  std::optional<uint16_t> requiredSubchannel);
+		  std::optional<uint16_t> requiredSubchannel,
+		  std::optional<uint16_t> ignoredSubchannel);
 
 		/**
 		 * If the given message payload starts with the Magic Token, extracts the
-		 * encoded subchannels and (optionally) the required subchannel, fills the
-		 * given arguments and removes the encoded header from the message payload.
+		 * encoded subchannels and (optionally) the required and/or ignored subchannel,
+		 * fills the given arguments and removes the encoded header from the message
+		 * payload.
 		 *
 		 * @returns true if the message was successfully decoded, false otherwise.
 		 */
 		static bool DecodeSubchannels(
 		  RTC::SCTP::Message& message,
 		  std::vector<uint16_t>& subchannels,
-		  std::optional<uint16_t>& requiredSubchannel);
+		  std::optional<uint16_t>& requiredSubchannel,
+		  std::optional<uint16_t>& ignoredSubchannel);
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -108,7 +108,8 @@ namespace RTC
 			  RTC::DataProducer* dataProducer,
 			  RTC::SCTP::Message message,
 			  std::vector<uint16_t>& subchannels,
-			  std::optional<uint16_t> requiredSubchannel) = 0;
+			  std::optional<uint16_t> requiredSubchannel,
+			  std::optional<uint16_t> ignoredSubchannel) = 0;
 			virtual void OnTransportNewDataConsumer(
 			  RTC::Transport* transport,
 			  RTC::DataConsumer* dataConsumer,
@@ -285,7 +286,8 @@ namespace RTC
 		  RTC::DataProducer* dataProducer,
 		  RTC::SCTP::Message message,
 		  std::vector<uint16_t>& subchannels,
-		  std::optional<uint16_t> requiredSubchannel) override;
+		  std::optional<uint16_t> requiredSubchannel,
+		  std::optional<uint16_t> ignoredSubchannel) override;
 		void OnDataProducerPaused(RTC::DataProducer* dataProducer) override;
 		void OnDataProducerResumed(RTC::DataProducer* dataProducer) override;
 

--- a/worker/src/RTC/DataConsumer.cpp
+++ b/worker/src/RTC/DataConsumer.cpp
@@ -313,7 +313,7 @@ namespace RTC
 				// move the message and pass its ownership to the SCTP stack.
 				RTC::SCTP::Message message(streamId, body->ppid(), std::vector<uint8_t>(data, data + len));
 
-				SendMessage(std::move(message), emptySubchannels, std::nullopt, cb);
+				SendMessage(std::move(message), emptySubchannels, std::nullopt, std::nullopt, cb);
 
 				break;
 			}
@@ -486,6 +486,7 @@ namespace RTC
 	  RTC::SCTP::Message message,
 	  std::vector<uint16_t>& subchannels,
 	  std::optional<uint16_t> requiredSubchannel,
+	  std::optional<uint16_t> ignoredSubchannel,
 	  const onQueuedCallback* cb)
 	{
 		MS_TRACE();
@@ -510,6 +511,19 @@ namespace RTC
 			// If a required subchannel is given, verify that this data consumer is
 			// subscribed to it.
 			if (requiredSubchannel.has_value() && !this->subchannels.contains(requiredSubchannel.value()))
+			{
+				if (cb)
+				{
+					(*cb)(false, false);
+					delete cb;
+				}
+
+				return false;
+			}
+
+			// If an ignored subchannel is given, verify that this data consumer is not
+			// subscribed to it, otherwise don't send this message to it.
+			if (ignoredSubchannel.has_value() && this->subchannels.contains(ignoredSubchannel.value()))
 			{
 				if (cb)
 				{
@@ -575,7 +589,10 @@ namespace RTC
 			}
 
 			RTC::SubchannelsCodec::EncodeSubchannels(
-			  message, reduceSubchannels ? reducedSubchannels : subchannels, requiredSubchannel);
+			  message,
+			  reduceSubchannels ? reducedSubchannels : subchannels,
+			  requiredSubchannel,
+			  ignoredSubchannel);
 		}
 
 		const size_t messageLen = message.GetPayloadLength();

--- a/worker/src/RTC/DataProducer.cpp
+++ b/worker/src/RTC/DataProducer.cpp
@@ -4,7 +4,6 @@
 #include "RTC/DataProducer.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
-#include "Settings.hpp"
 #include <vector>
 
 namespace RTC
@@ -229,6 +228,13 @@ namespace RTC
 					requiredSubchannel = body->requiredSubchannel();
 				}
 
+				std::optional<uint16_t> ignoredSubchannel{ std::nullopt };
+
+				if (body->ignoredSubchannel().has_value())
+				{
+					ignoredSubchannel = body->ignoredSubchannel();
+				}
+
 				const uint16_t streamId =
 				  this->type == DataProducer::Type::SCTP ? this->sctpStreamParameters.streamId : 0;
 
@@ -236,7 +242,7 @@ namespace RTC
 				// move the message and pass its ownership to the SCTP stack.
 				RTC::SCTP::Message message(streamId, body->ppid(), std::vector<uint8_t>(data, data + len));
 
-				ReceiveMessage(std::move(message), subchannels, requiredSubchannel);
+				ReceiveMessage(std::move(message), subchannels, requiredSubchannel, ignoredSubchannel);
 
 				// Increase receive transmission.
 				this->listener->OnDataProducerReceiveData(this, len);
@@ -254,7 +260,8 @@ namespace RTC
 	void DataProducer::ReceiveMessage(
 	  RTC::SCTP::Message message,
 	  std::vector<uint16_t>& subchannels,
-	  std::optional<uint16_t> requiredSubchannel)
+	  std::optional<uint16_t> requiredSubchannel,
+	  std::optional<uint16_t> ignoredSubchannel)
 	{
 		MS_TRACE();
 
@@ -268,6 +275,6 @@ namespace RTC
 		}
 
 		this->listener->OnDataProducerMessageReceived(
-		  this, std::move(message), subchannels, requiredSubchannel);
+		  this, std::move(message), subchannels, requiredSubchannel, ignoredSubchannel);
 	}
 } // namespace RTC

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -910,7 +910,8 @@ namespace RTC
 	  RTC::DataProducer* dataProducer,
 	  RTC::SCTP::Message message,
 	  std::vector<uint16_t>& subchannels,
-	  std::optional<uint16_t> requiredSubchannel)
+	  std::optional<uint16_t> requiredSubchannel,
+	  std::optional<uint16_t> ignoredSubchannel)
 	{
 		MS_TRACE();
 
@@ -936,7 +937,8 @@ namespace RTC
 					// NOLINTNEXTLINE(clang-analyzer-cplusplus.Move, bugprone-use-after-move, hicpp-invalid-access-moved)
 					message.SetStreamId(streamId);
 
-					dataConsumer->SendMessage(std::move(message), subchannels, requiredSubchannel);
+					dataConsumer->SendMessage(
+					  std::move(message), subchannels, requiredSubchannel, ignoredSubchannel);
 				}
 				// NOTE: Here we are cloning the message before passing it to each
 				// DataConsumer because each DataConsumer will pass std::move(message)
@@ -949,7 +951,8 @@ namespace RTC
 					// DataConsumer.
 					clonedMessage.SetStreamId(streamId);
 
-					dataConsumer->SendMessage(std::move(clonedMessage), subchannels, requiredSubchannel);
+					dataConsumer->SendMessage(
+					  std::move(clonedMessage), subchannels, requiredSubchannel, ignoredSubchannel);
 				}
 			}
 		}

--- a/worker/src/RTC/SubchannelsCodec.cpp
+++ b/worker/src/RTC/SubchannelsCodec.cpp
@@ -12,12 +12,13 @@ namespace RTC
 	bool SubchannelsCodec::EncodeSubchannels(
 	  RTC::SCTP::Message& message,
 	  const std::vector<uint16_t>& subchannels,
-	  std::optional<uint16_t> requiredSubchannel)
+	  std::optional<uint16_t> requiredSubchannel,
+	  std::optional<uint16_t> ignoredSubchannel)
 	{
 		MS_TRACE();
 
 		// Nothing to encode.
-		if (subchannels.empty() && !requiredSubchannel.has_value())
+		if (subchannels.empty() && !requiredSubchannel.has_value() && !ignoredSubchannel.has_value())
 		{
 			return false;
 		}
@@ -31,12 +32,18 @@ namespace RTC
 
 		const auto subchannelsCount       = static_cast<uint16_t>(subchannels.size());
 		const bool requiredSubchannelFlag = requiredSubchannel.has_value();
+		const bool ignoredSubchannelFlag  = ignoredSubchannel.has_value();
 
 		// Length of the header to prepend.
 		size_t headerLen =
 		  8 /* Magic Token */ + 2 /* subchannelsCount */ + (static_cast<size_t>(subchannelsCount) * 2);
 
 		if (requiredSubchannelFlag)
+		{
+			headerLen += 2;
+		}
+
+		if (ignoredSubchannelFlag)
 		{
 			headerLen += 2;
 		}
@@ -52,6 +59,11 @@ namespace RTC
 		if (requiredSubchannelFlag)
 		{
 			magicToken |= SubchannelsCodec::RequiredSubchannelFlagMask;
+		}
+
+		if (ignoredSubchannelFlag)
+		{
+			magicToken |= SubchannelsCodec::IgnoredSubchannelFlagMask;
 		}
 
 		size_t offset = 0;
@@ -74,6 +86,12 @@ namespace RTC
 			offset += 2;
 		}
 
+		if (ignoredSubchannelFlag)
+		{
+			Utils::Byte::Set2Bytes(newPayload.data(), offset, ignoredSubchannel.value());
+			offset += 2;
+		}
+
 		// Append the original payload right after the encoded header.
 		std::ranges::copy(payload, newPayload.begin() + offset);
 
@@ -85,7 +103,8 @@ namespace RTC
 	bool SubchannelsCodec::DecodeSubchannels(
 	  RTC::SCTP::Message& message,
 	  std::vector<uint16_t>& subchannels,
-	  std::optional<uint16_t>& requiredSubchannel)
+	  std::optional<uint16_t>& requiredSubchannel,
+	  std::optional<uint16_t>& ignoredSubchannel)
 	{
 		MS_TRACE();
 
@@ -102,13 +121,15 @@ namespace RTC
 		const uint64_t magicToken = Utils::Byte::Get8Bytes(payload.data(), 0);
 
 		// The message does not start with the Magic Token, so nothing to decode.
-		if ((magicToken & ~SubchannelsCodec::RequiredSubchannelFlagMask) != SubchannelsCodec::MagicToken)
+		if ((magicToken & ~SubchannelsCodec::FlagsMask) != SubchannelsCodec::MagicToken)
 		{
 			return false;
 		}
 
 		const bool requiredSubchannelFlag =
 		  (magicToken & SubchannelsCodec::RequiredSubchannelFlagMask) != 0;
+		const bool ignoredSubchannelFlag =
+		  (magicToken & SubchannelsCodec::IgnoredSubchannelFlagMask) != 0;
 
 		const uint16_t subchannelsCount = Utils::Byte::Get2Bytes(payload.data(), 8);
 
@@ -116,7 +137,7 @@ namespace RTC
 		size_t offset = 10;
 
 		// Bytes needed to hold all announced subchannels and, if present, the
-		// requiredSubchannel.
+		// requiredSubchannel and the ignoredSubchannel.
 		size_t neededLen = offset + (static_cast<size_t>(subchannelsCount) * 2);
 
 		if (requiredSubchannelFlag)
@@ -124,9 +145,14 @@ namespace RTC
 			neededLen += 2;
 		}
 
+		if (ignoredSubchannelFlag)
+		{
+			neededLen += 2;
+		}
+
 		if (len < neededLen)
 		{
-			MS_WARN_DEV("message too short to hold announced subchannels, ignoring");
+			MS_WARN_DEV("message too short to hold announced fields, ignoring");
 
 			return false;
 		}
@@ -142,6 +168,12 @@ namespace RTC
 		if (requiredSubchannelFlag)
 		{
 			requiredSubchannel = Utils::Byte::Get2Bytes(payload.data(), offset);
+			offset += 2;
+		}
+
+		if (ignoredSubchannelFlag)
+		{
+			ignoredSubchannel = Utils::Byte::Get2Bytes(payload.data(), offset);
 			offset += 2;
 		}
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2826,12 +2826,13 @@ namespace RTC
 	  RTC::DataProducer* dataProducer,
 	  RTC::SCTP::Message message,
 	  std::vector<uint16_t>& subchannels,
-	  std::optional<uint16_t> requiredSubchannel)
+	  std::optional<uint16_t> requiredSubchannel,
+	  std::optional<uint16_t> ignoredSubchannel)
 	{
 		MS_TRACE();
 
 		this->listener->OnTransportDataProducerMessageReceived(
-		  this, dataProducer, std::move(message), subchannels, requiredSubchannel);
+		  this, dataProducer, std::move(message), subchannels, requiredSubchannel, ignoredSubchannel);
 	}
 
 	void Transport::OnDataProducerPaused(RTC::DataProducer* dataProducer)
@@ -3152,15 +3153,18 @@ namespace RTC
 		{
 			std::vector<uint16_t> subchannels;
 			std::optional<uint16_t> requiredSubchannel;
+			std::optional<uint16_t> ignoredSubchannel;
 
-			// When this is a pipe transport, the subchannels and required subchannel
-			// may be encoded at the beginning of the message payload.
+			// When this is a pipe transport, the subchannels, required subchannel and
+			// ignored subchannel may be encoded at the beginning of the message payload.
 			if (this->IsPipe())
 			{
-				RTC::SubchannelsCodec::DecodeSubchannels(message, subchannels, requiredSubchannel);
+				RTC::SubchannelsCodec::DecodeSubchannels(
+				  message, subchannels, requiredSubchannel, ignoredSubchannel);
 			}
 
-			dataProducer->ReceiveMessage(std::move(message), subchannels, requiredSubchannel);
+			dataProducer->ReceiveMessage(
+			  std::move(message), subchannels, requiredSubchannel, ignoredSubchannel);
 		}
 		catch (std::exception& error)
 		{

--- a/worker/test/src/RTC/TestSubchannelsCodec.cpp
+++ b/worker/test/src/RTC/TestSubchannelsCodec.cpp
@@ -22,7 +22,7 @@ SCENARIO("SubchannelsCodec", "[subchannels]")
 	};
 
 	SECTION(
-	  "EncodeSubchannels() encodes subchannels and requiredSubchannel and DecodeSubchannels() decodes them back")
+	  "EncodeSubchannels() encodes subchannels, requiredSubchannel and ignoredSubchannel and DecodeSubchannels() decodes them back")
 	{
 		const std::vector<uint8_t> originalPayload = { 0x01, 0x02, 0x03, 0x04 };
 
@@ -30,27 +30,32 @@ SCENARIO("SubchannelsCodec", "[subchannels]")
 
 		const std::vector<uint16_t> subchannels          = { 10, 20, 300 };
 		const std::optional<uint16_t> requiredSubchannel = 5;
+		const std::optional<uint16_t> ignoredSubchannel  = 6;
 
 		REQUIRE(
-		  RTC::SubchannelsCodec::EncodeSubchannels(message, subchannels, requiredSubchannel) == true);
+		  RTC::SubchannelsCodec::EncodeSubchannels(
+		    message, subchannels, requiredSubchannel, ignoredSubchannel) == true);
 
-		// 8 (Magic Token) + 2 (subchannelsCount) + 3 * 2 (subchannels) + 2 (requiredSubchannel).
-		REQUIRE(message.GetPayloadLength() == originalPayload.size() + 8 + 2 + (3 * 2) + 2);
+		// 8 (Magic Token) + 2 (subchannelsCount) + 3 * 2 (subchannels) +
+		// 2 (requiredSubchannel) + 2 (ignoredSubchannel).
+		REQUIRE(message.GetPayloadLength() == originalPayload.size() + 8 + 2 + (3 * 2) + 2 + 2);
 
 		std::vector<uint16_t> decodedSubchannels;
 		std::optional<uint16_t> decodedRequiredSubchannel;
+		std::optional<uint16_t> decodedIgnoredSubchannel;
 
 		REQUIRE(
 		  RTC::SubchannelsCodec::DecodeSubchannels(
-		    message, decodedSubchannels, decodedRequiredSubchannel) == true);
+		    message, decodedSubchannels, decodedRequiredSubchannel, decodedIgnoredSubchannel) == true);
 
 		REQUIRE(decodedSubchannels == subchannels);
 		REQUIRE(decodedRequiredSubchannel == requiredSubchannel);
+		REQUIRE(decodedIgnoredSubchannel == ignoredSubchannel);
 		// The header must have been removed, leaving the original payload.
 		REQUIRE(payloadToVector(message) == originalPayload);
 	}
 
-	SECTION("EncodeSubchannels() encodes subchannels without requiredSubchannel")
+	SECTION("EncodeSubchannels() encodes subchannels without requiredSubchannel nor ignoredSubchannel")
 	{
 		const std::vector<uint8_t> originalPayload = { 0xAA, 0xBB };
 
@@ -58,20 +63,24 @@ SCENARIO("SubchannelsCodec", "[subchannels]")
 
 		const std::vector<uint16_t> subchannels = { 1, 2 };
 
-		REQUIRE(RTC::SubchannelsCodec::EncodeSubchannels(message, subchannels, std::nullopt) == true);
+		REQUIRE(
+		  RTC::SubchannelsCodec::EncodeSubchannels(message, subchannels, std::nullopt, std::nullopt) ==
+		  true);
 
 		// 8 (Magic Token) + 2 (subchannelsCount) + 2 * 2 (subchannels).
 		REQUIRE(message.GetPayloadLength() == originalPayload.size() + 8 + 2 + (2 * 2));
 
 		std::vector<uint16_t> decodedSubchannels;
 		std::optional<uint16_t> decodedRequiredSubchannel;
+		std::optional<uint16_t> decodedIgnoredSubchannel;
 
 		REQUIRE(
 		  RTC::SubchannelsCodec::DecodeSubchannels(
-		    message, decodedSubchannels, decodedRequiredSubchannel) == true);
+		    message, decodedSubchannels, decodedRequiredSubchannel, decodedIgnoredSubchannel) == true);
 
 		REQUIRE(decodedSubchannels == subchannels);
 		REQUIRE(decodedRequiredSubchannel.has_value() == false);
+		REQUIRE(decodedIgnoredSubchannel.has_value() == false);
 		REQUIRE(payloadToVector(message) == originalPayload);
 	}
 
@@ -83,20 +92,82 @@ SCENARIO("SubchannelsCodec", "[subchannels]")
 
 		const std::optional<uint16_t> requiredSubchannel = 4321;
 
-		REQUIRE(RTC::SubchannelsCodec::EncodeSubchannels(message, {}, requiredSubchannel) == true);
+		REQUIRE(
+		  RTC::SubchannelsCodec::EncodeSubchannels(message, {}, requiredSubchannel, std::nullopt) == true);
 
 		// 8 (Magic Token) + 2 (subchannelsCount) + 2 (requiredSubchannel).
 		REQUIRE(message.GetPayloadLength() == originalPayload.size() + 8 + 2 + 2);
 
 		std::vector<uint16_t> decodedSubchannels;
 		std::optional<uint16_t> decodedRequiredSubchannel;
+		std::optional<uint16_t> decodedIgnoredSubchannel;
 
 		REQUIRE(
 		  RTC::SubchannelsCodec::DecodeSubchannels(
-		    message, decodedSubchannels, decodedRequiredSubchannel) == true);
+		    message, decodedSubchannels, decodedRequiredSubchannel, decodedIgnoredSubchannel) == true);
 
 		REQUIRE(decodedSubchannels.empty() == true);
 		REQUIRE(decodedRequiredSubchannel == requiredSubchannel);
+		REQUIRE(decodedIgnoredSubchannel.has_value() == false);
+		REQUIRE(payloadToVector(message) == originalPayload);
+	}
+
+	SECTION("EncodeSubchannels() encodes ignoredSubchannel without subchannels")
+	{
+		const std::vector<uint8_t> originalPayload = { 0xAA, 0xBB, 0xCC };
+
+		auto message = makeMessage(originalPayload);
+
+		const std::optional<uint16_t> ignoredSubchannel = 1234;
+
+		REQUIRE(
+		  RTC::SubchannelsCodec::EncodeSubchannels(message, {}, std::nullopt, ignoredSubchannel) == true);
+
+		// 8 (Magic Token) + 2 (subchannelsCount) + 2 (ignoredSubchannel).
+		REQUIRE(message.GetPayloadLength() == originalPayload.size() + 8 + 2 + 2);
+
+		std::vector<uint16_t> decodedSubchannels;
+		std::optional<uint16_t> decodedRequiredSubchannel;
+		std::optional<uint16_t> decodedIgnoredSubchannel;
+
+		REQUIRE(
+		  RTC::SubchannelsCodec::DecodeSubchannels(
+		    message, decodedSubchannels, decodedRequiredSubchannel, decodedIgnoredSubchannel) == true);
+
+		REQUIRE(decodedSubchannels.empty() == true);
+		REQUIRE(decodedRequiredSubchannel.has_value() == false);
+		REQUIRE(decodedIgnoredSubchannel == ignoredSubchannel);
+		REQUIRE(payloadToVector(message) == originalPayload);
+	}
+
+	SECTION("EncodeSubchannels() encodes subchannels and ignoredSubchannel without requiredSubchannel")
+	{
+		const std::vector<uint8_t> originalPayload = { 0x11 };
+
+		auto message = makeMessage(originalPayload);
+
+		const std::vector<uint16_t> subchannels         = { 100, 200 };
+		const std::optional<uint16_t> ignoredSubchannel = 200;
+
+		REQUIRE(
+		  RTC::SubchannelsCodec::EncodeSubchannels(
+		    message, subchannels, std::nullopt, ignoredSubchannel) == true);
+
+		// 8 (Magic Token) + 2 (subchannelsCount) + 2 * 2 (subchannels) +
+		// 2 (ignoredSubchannel).
+		REQUIRE(message.GetPayloadLength() == originalPayload.size() + 8 + 2 + (2 * 2) + 2);
+
+		std::vector<uint16_t> decodedSubchannels;
+		std::optional<uint16_t> decodedRequiredSubchannel;
+		std::optional<uint16_t> decodedIgnoredSubchannel;
+
+		REQUIRE(
+		  RTC::SubchannelsCodec::DecodeSubchannels(
+		    message, decodedSubchannels, decodedRequiredSubchannel, decodedIgnoredSubchannel) == true);
+
+		REQUIRE(decodedSubchannels == subchannels);
+		REQUIRE(decodedRequiredSubchannel.has_value() == false);
+		REQUIRE(decodedIgnoredSubchannel == ignoredSubchannel);
 		REQUIRE(payloadToVector(message) == originalPayload);
 	}
 
@@ -106,7 +177,8 @@ SCENARIO("SubchannelsCodec", "[subchannels]")
 
 		auto message = makeMessage(originalPayload);
 
-		REQUIRE(RTC::SubchannelsCodec::EncodeSubchannels(message, {}, std::nullopt) == false);
+		REQUIRE(
+		  RTC::SubchannelsCodec::EncodeSubchannels(message, {}, std::nullopt, std::nullopt) == false);
 
 		// The message must remain untouched.
 		REQUIRE(payloadToVector(message) == originalPayload);
@@ -120,13 +192,15 @@ SCENARIO("SubchannelsCodec", "[subchannels]")
 
 		std::vector<uint16_t> decodedSubchannels;
 		std::optional<uint16_t> decodedRequiredSubchannel;
+		std::optional<uint16_t> decodedIgnoredSubchannel;
 
 		REQUIRE(
 		  RTC::SubchannelsCodec::DecodeSubchannels(
-		    message, decodedSubchannels, decodedRequiredSubchannel) == false);
+		    message, decodedSubchannels, decodedRequiredSubchannel, decodedIgnoredSubchannel) == false);
 
 		REQUIRE(decodedSubchannels.empty() == true);
 		REQUIRE(decodedRequiredSubchannel.has_value() == false);
+		REQUIRE(decodedIgnoredSubchannel.has_value() == false);
 		REQUIRE(payloadToVector(message) == originalPayload);
 	}
 
@@ -138,21 +212,23 @@ SCENARIO("SubchannelsCodec", "[subchannels]")
 
 		std::vector<uint16_t> decodedSubchannels;
 		std::optional<uint16_t> decodedRequiredSubchannel;
+		std::optional<uint16_t> decodedIgnoredSubchannel;
 
 		REQUIRE(
 		  RTC::SubchannelsCodec::DecodeSubchannels(
-		    message, decodedSubchannels, decodedRequiredSubchannel) == false);
+		    message, decodedSubchannels, decodedRequiredSubchannel, decodedIgnoredSubchannel) == false);
 
 		REQUIRE(decodedSubchannels.empty() == true);
 		REQUIRE(decodedRequiredSubchannel.has_value() == false);
+		REQUIRE(decodedIgnoredSubchannel.has_value() == false);
 		REQUIRE(payloadToVector(message) == originalPayload);
 	}
 
 	SECTION(
 	  "DecodeSubchannels() ignores a truncated message that announces more subchannels than present")
 	{
-		// Craft a payload with the Magic Token (no requiredSubchannelFlag) that
-		// announces 3 subchannels but does not carry their bytes.
+		// Craft a payload with the Magic Token (no flags set) that announces 3
+		// subchannels but does not carry their bytes.
 		std::vector<uint8_t> originalPayload(10);
 
 		Utils::Byte::Set8Bytes(originalPayload.data(), 0, RTC::SubchannelsCodec::MagicToken);
@@ -162,13 +238,15 @@ SCENARIO("SubchannelsCodec", "[subchannels]")
 
 		std::vector<uint16_t> decodedSubchannels;
 		std::optional<uint16_t> decodedRequiredSubchannel;
+		std::optional<uint16_t> decodedIgnoredSubchannel;
 
 		REQUIRE(
 		  RTC::SubchannelsCodec::DecodeSubchannels(
-		    message, decodedSubchannels, decodedRequiredSubchannel) == false);
+		    message, decodedSubchannels, decodedRequiredSubchannel, decodedIgnoredSubchannel) == false);
 
 		REQUIRE(decodedSubchannels.empty() == true);
 		REQUIRE(decodedRequiredSubchannel.has_value() == false);
+		REQUIRE(decodedIgnoredSubchannel.has_value() == false);
 		REQUIRE(payloadToVector(message) == originalPayload);
 	}
 
@@ -190,13 +268,73 @@ SCENARIO("SubchannelsCodec", "[subchannels]")
 
 		std::vector<uint16_t> decodedSubchannels;
 		std::optional<uint16_t> decodedRequiredSubchannel;
+		std::optional<uint16_t> decodedIgnoredSubchannel;
 
 		REQUIRE(
 		  RTC::SubchannelsCodec::DecodeSubchannels(
-		    message, decodedSubchannels, decodedRequiredSubchannel) == false);
+		    message, decodedSubchannels, decodedRequiredSubchannel, decodedIgnoredSubchannel) == false);
 
 		REQUIRE(decodedSubchannels.empty() == true);
 		REQUIRE(decodedRequiredSubchannel.has_value() == false);
+		REQUIRE(decodedIgnoredSubchannel.has_value() == false);
+		REQUIRE(payloadToVector(message) == originalPayload);
+	}
+
+	SECTION(
+	  "DecodeSubchannels() ignores a message whose ignoredSubchannelFlag is set but has no room for the ignoredSubchannel field")
+	{
+		// Craft a payload with the Magic Token and ignoredSubchannelFlag set,
+		// announcing 1 subchannel (present) but without the ignoredSubchannel bytes.
+		std::vector<uint8_t> originalPayload(12);
+
+		Utils::Byte::Set8Bytes(
+		  originalPayload.data(),
+		  0,
+		  RTC::SubchannelsCodec::MagicToken | RTC::SubchannelsCodec::IgnoredSubchannelFlagMask);
+		Utils::Byte::Set2Bytes(originalPayload.data(), 8, /*subchannelsCount*/ 1);
+		Utils::Byte::Set2Bytes(originalPayload.data(), 10, /*subchannel*/ 42);
+
+		auto message = makeMessage(originalPayload);
+
+		std::vector<uint16_t> decodedSubchannels;
+		std::optional<uint16_t> decodedRequiredSubchannel;
+		std::optional<uint16_t> decodedIgnoredSubchannel;
+
+		REQUIRE(
+		  RTC::SubchannelsCodec::DecodeSubchannels(
+		    message, decodedSubchannels, decodedRequiredSubchannel, decodedIgnoredSubchannel) == false);
+
+		REQUIRE(decodedSubchannels.empty() == true);
+		REQUIRE(decodedRequiredSubchannel.has_value() == false);
+		REQUIRE(decodedIgnoredSubchannel.has_value() == false);
+		REQUIRE(payloadToVector(message) == originalPayload);
+	}
+
+	SECTION(
+	  "DecodeSubchannels() ignores a message with both flags set but room for just one of the fields")
+	{
+		// Craft a payload with the Magic Token and both flags set, announcing no
+		// subchannels but carrying just 2 bytes after the header.
+		std::vector<uint8_t> originalPayload(12);
+
+		Utils::Byte::Set8Bytes(
+		  originalPayload.data(), 0, RTC::SubchannelsCodec::MagicToken | RTC::SubchannelsCodec::FlagsMask);
+		Utils::Byte::Set2Bytes(originalPayload.data(), 8, /*subchannelsCount*/ 0);
+		Utils::Byte::Set2Bytes(originalPayload.data(), 10, /*requiredSubchannel*/ 42);
+
+		auto message = makeMessage(originalPayload);
+
+		std::vector<uint16_t> decodedSubchannels;
+		std::optional<uint16_t> decodedRequiredSubchannel;
+		std::optional<uint16_t> decodedIgnoredSubchannel;
+
+		REQUIRE(
+		  RTC::SubchannelsCodec::DecodeSubchannels(
+		    message, decodedSubchannels, decodedRequiredSubchannel, decodedIgnoredSubchannel) == false);
+
+		REQUIRE(decodedSubchannels.empty() == true);
+		REQUIRE(decodedRequiredSubchannel.has_value() == false);
+		REQUIRE(decodedIgnoredSubchannel.has_value() == false);
 		REQUIRE(payloadToVector(message) == originalPayload);
 	}
 
@@ -206,19 +344,23 @@ SCENARIO("SubchannelsCodec", "[subchannels]")
 
 		const std::vector<uint16_t> subchannels          = { 7 };
 		const std::optional<uint16_t> requiredSubchannel = 7;
+		const std::optional<uint16_t> ignoredSubchannel  = 8;
 
 		REQUIRE(
-		  RTC::SubchannelsCodec::EncodeSubchannels(message, subchannels, requiredSubchannel) == true);
+		  RTC::SubchannelsCodec::EncodeSubchannels(
+		    message, subchannels, requiredSubchannel, ignoredSubchannel) == true);
 
 		std::vector<uint16_t> decodedSubchannels;
 		std::optional<uint16_t> decodedRequiredSubchannel;
+		std::optional<uint16_t> decodedIgnoredSubchannel;
 
 		REQUIRE(
 		  RTC::SubchannelsCodec::DecodeSubchannels(
-		    message, decodedSubchannels, decodedRequiredSubchannel) == true);
+		    message, decodedSubchannels, decodedRequiredSubchannel, decodedIgnoredSubchannel) == true);
 
 		REQUIRE(decodedSubchannels == subchannels);
 		REQUIRE(decodedRequiredSubchannel == requiredSubchannel);
+		REQUIRE(decodedIgnoredSubchannel == ignoredSubchannel);
 		REQUIRE(message.GetPayloadLength() == 0);
 	}
 }


### PR DESCRIPTION
# Details

- New optional argument `ignoredSubchannel` in `DataProducer.send()` method.
- If given, `DataConsumers` subscribed to that subchannel will drop the message.

## TODO

- [x] Doc in the website.