### PR TITLE
Prepare `RtpStream` classes for capture time based RTCP Sender Reports

### DIFF
--- a/worker/include/RTC/RTP/RtpStream.hpp
+++ b/worker/include/RTC/RTP/RtpStream.hpp
@@ -61,109 +61,161 @@ namespace RTC
 			};
 
 		public:
+			/**
+			 * Correspondence between wall clock and RTP timeline carried by an RTCP Sender
+			 * Report.
+			 */
+			struct SenderReportMapping
+			{
+				/**
+				 * NTP timestamp of the Sender Report (ms).
+				 */
+				uint64_t ntpMs;
+				/**
+				 * RTP timestamp the NTP timestamp above corresponds to.
+				 */
+				uint32_t ts;
+			};
+
+		public:
 			RtpStream(
 			  RTP::RtpStream::Listener* listener,
 			  SharedInterface* shared,
 			  RTP::RtpStream::Params& params,
 			  uint8_t initialScore);
+
 			virtual ~RtpStream();
 
+		public:
 			flatbuffers::Offset<FBS::RtpStream::Dump> FillBuffer(flatbuffers::FlatBufferBuilder& builder) const;
+
 			virtual flatbuffers::Offset<FBS::RtpStream::Stats> FillBufferStats(
 			  flatbuffers::FlatBufferBuilder& builder);
+
 			uint32_t GetEncodingIdx() const
 			{
 				return this->params.encodingIdx;
 			}
+
 			uint32_t GetSsrc() const
 			{
 				return this->params.ssrc;
 			}
+
 			uint8_t GetPayloadType() const
 			{
 				return this->params.payloadType;
 			}
+
 			const RTC::RtpCodecMimeType& GetMimeType() const
 			{
 				return this->params.mimeType;
 			}
+
 			uint32_t GetClockRate() const
 			{
 				return this->params.clockRate;
 			}
+
 			const std::string& GetRid() const
 			{
 				return this->params.rid;
 			}
+
 			const std::string& GetCname() const
 			{
 				return this->params.cname;
 			}
+
 			bool HasRtx() const
 			{
 				return this->rtxStream != nullptr;
 			}
+
 			virtual void SetRtx(uint8_t payloadType, uint32_t ssrc);
+
 			uint32_t GetRtxSsrc() const
 			{
 				return this->params.rtxSsrc;
 			}
+
 			uint8_t GetRtxPayloadType() const
 			{
 				return this->params.rtxPayloadType;
 			}
+
 			uint8_t GetSpatialLayers() const
 			{
 				return this->params.spatialLayers;
 			}
+
 			bool HasDtx() const
 			{
 				return this->params.useDtx;
 			}
+
 			uint8_t GetTemporalLayers() const
 			{
 				return this->params.temporalLayers;
 			}
+
 			virtual bool ReceiveStreamPacket(const RTP::Packet* packet);
-			virtual void Pause()                                                                     = 0;
-			virtual void Resume()                                                                    = 0;
-			virtual uint32_t GetBitrate(uint64_t nowMs)                                              = 0;
+
+			virtual void Pause() = 0;
+
+			virtual void Resume() = 0;
+
+			virtual uint32_t GetBitrate(uint64_t nowMs) = 0;
+
 			virtual uint32_t GetBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer) = 0;
-			virtual uint32_t GetSpatialLayerBitrate(uint64_t nowMs, uint8_t spatialLayer)            = 0;
+
+			virtual uint32_t GetSpatialLayerBitrate(uint64_t nowMs, uint8_t spatialLayer) = 0;
+
 			virtual uint32_t GetLayerBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer) = 0;
+
 			void ResetScore(uint8_t score, bool notify);
+
 			uint8_t GetFractionLost() const
 			{
 				return this->fractionLost;
 			}
+
 			float GetLossPercentage() const
 			{
 				return static_cast<float>(this->fractionLost) * 100 / 256;
 			}
+
 			float GetRtt() const
 			{
 				return this->rtt;
 			}
+
 			uint64_t GetMaxPacketMs() const
 			{
 				return this->maxPacketMs;
 			}
+
 			uint32_t GetMaxPacketTs() const
 			{
 				return this->maxPacketTs;
 			}
-			uint64_t GetSenderReportNtpMs() const
+
+			/**
+			 * Correspondence between wall clock and RTP timeline given by the last Sender
+			 * Report.
+			 *
+			 * @returns No value if there has been no Sender Report yet.
+			 */
+			std::optional<RTP::RtpStream::SenderReportMapping> GetSenderReportMapping() const
 			{
-				return this->lastSenderReportNtpMs;
+				return this->lastSenderReportMapping;
 			}
-			uint32_t GetSenderReportTs() const
-			{
-				return this->lastSenderReportTs;
-			}
+
 			uint8_t GetScore() const
 			{
 				return this->score;
 			}
+
 			uint64_t GetActiveMs() const
 			{
 				return this->shared->GetTimeMs() - this->activeSinceMs;
@@ -171,9 +223,13 @@ namespace RTC
 
 		protected:
 			bool UpdateSeq(const RTP::Packet* packet);
+
 			void UpdateScore(uint8_t score);
+
 			void PacketRetransmitted(const RTP::Packet* packet);
+
 			void PacketRepaired(const RTP::Packet* packet);
+
 			uint32_t GetExpectedPackets() const
 			{
 				return (this->cycles + this->maxSeq) - this->baseSeq + 1;
@@ -221,10 +277,9 @@ namespace RTC
 			size_t repairedPriorScore{ 0u };
 			// Packets retransmitted at last interval for score calculation.
 			size_t retransmittedPriorScore{ 0u };
-			// NTP timestamp in last Sender Report (in ms).
-			uint64_t lastSenderReportNtpMs{ 0u };
-			// RTP timestamp in last Sender Report.
-			uint32_t lastSenderReportTs{ 0u };
+			// Correspondence between wall clock and RTP timeline given by the last Sender
+			// Report.
+			std::optional<RTP::RtpStream::SenderReportMapping> lastSenderReportMapping;
 			float rtt{ 0.0f };
 			// Instance of RtxStream.
 			RTP::RtxStream* rtxStream{ nullptr };

--- a/worker/include/RTC/RTP/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RTP/RtpStreamRecv.hpp
@@ -17,11 +17,29 @@ namespace RTC
 		                      public TimerHandleInterface::Listener
 		{
 		public:
+			/**
+			 * How far the RTP timestamp of a packet may be from the last received
+			 * `abs-capture-time` RTP header extension for its capture instant to still be
+			 * interpolated from it (ms).
+			 *
+			 * @remarks
+			 * - Same value libwebrtc uses in `AbsoluteCaptureTimeInterpolator`, which
+			 *   pairs with senders emitting the extension at least once per second.
+			 */
+			static constexpr uint64_t MaxAbsCaptureTimeInterpolationMs{ 5000 };
+			/**
+			 * How far the RTP timestamp of a packet may be from the last received RTCP
+			 * Sender Report for its capture instant to still be interpolated from it (ms).
+			 */
+			static constexpr uint64_t MaxSenderReportInterpolationMs{ 10000 };
+
+		public:
 			class Listener : public RTP::RtpStream::Listener
 			{
 			public:
 				virtual void OnRtpStreamSendRtcpPacket(
 				  RTP::RtpStreamRecv* rtpStream, RTC::RTCP::Packet* packet) = 0;
+
 				virtual void OnRtpStreamNeedWorstRemoteFractionLost(
 				  RTP::RtpStreamRecv* rtpStream, uint8_t& worstRemoteFractionLost) = 0;
 			};
@@ -32,16 +50,57 @@ namespace RTC
 			public:
 				TransmissionCounter(
 				  SharedInterface* shared, uint8_t spatialLayers, uint8_t temporalLayers, size_t windowSize);
+
+			public:
 				void Update(const RTP::Packet* packet);
+
 				uint32_t GetBitrate(uint64_t nowMs);
+
 				uint32_t GetBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer);
+
 				uint32_t GetSpatialLayerBitrate(uint64_t nowMs, uint8_t spatialLayer);
+
 				uint32_t GetLayerBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer);
+
 				size_t GetPacketCount() const;
+
 				size_t GetBytes() const;
 
 			private:
 				std::vector<std::vector<RTC::RtpDataCounter>> spatialLayerCounters;
+			};
+
+		private:
+			/**
+			 * Data of a received RTCP Sender Report needed to report LSR and DLSR back in a
+			 * Receiver Report.
+			 */
+			struct SenderReportTiming
+			{
+				/**
+				 * Middle 32 bits out of 64 in the NTP timestamp of the Sender Report.
+				 */
+				uint32_t compactNtp;
+				/**
+				 * Local time at which the Sender Report arrived.
+				 */
+				uint64_t receivedMs;
+			};
+
+			/**
+			 * Capture instant carried by an `abs-capture-time` RTP header extension, together
+			 * with the RTP timestamp it refers to.
+			 */
+			struct AbsCaptureTime
+			{
+				/**
+				 * RTP timestamp the capture instant below refers to.
+				 */
+				uint32_t ts;
+				/**
+				 * Capture instant in the remote sender's wall clock (ms).
+				 */
+				uint64_t ntpMs;
 			};
 
 		public:
@@ -51,36 +110,91 @@ namespace RTC
 			  RTP::RtpStream::Params& params,
 			  uint32_t sendNackDelayMs,
 			  bool useRtpInactivityCheck);
+
 			~RtpStreamRecv() override;
 
+		public:
 			flatbuffers::Offset<FBS::RtpStream::Stats> FillBufferStats(
 			  flatbuffers::FlatBufferBuilder& builder) override;
+
 			bool ReceivePacket(RTP::Packet* packet);
+
 			bool ReceiveRtxPacket(RTP::Packet* packet);
+
 			RTC::RTCP::ReceiverReport* GetRtcpReceiverReport();
+
 			RTC::RTCP::ReceiverReport* GetRtxRtcpReceiverReport();
+
 			void ReceiveRtcpSenderReport(RTC::RTCP::SenderReport* report);
+
 			void ReceiveRtxRtcpSenderReport(RTC::RTCP::SenderReport* report);
+
 			void ReceiveRtcpXrDelaySinceLastRr(RTC::RTCP::DelaySinceLastRr::SsrcInfo* ssrcInfo);
+
+			/**
+			 * Local time at which the last RTCP Sender Report arrived.
+			 *
+			 * @returns No value if no Sender Report has arrived yet.
+			 */
+			std::optional<uint64_t> GetSenderReportReceivedMs() const
+			{
+				if (!this->lastSenderReportTiming.has_value())
+				{
+					return std::nullopt;
+				}
+
+				return this->lastSenderReportTiming.value().receivedMs;
+			}
+
+			/**
+			 * Capture instant of the given RTP timestamp, expressed in the remote sender's
+			 * wall clock, interpolated from the last received `abs-capture-time` RTP header
+			 * extension.
+			 *
+			 * @param ts - RTP timestamp whose capture instant is wanted.
+			 *
+			 * @returns No value if no such extension has been received, or if the given RTP
+			 * timestamp is too far away from the one it referred to.
+			 */
+			std::optional<uint64_t> GetRemoteCaptureMsFromAbsCaptureTime(uint32_t ts) const;
+
+			/**
+			 * Capture instant of the given RTP timestamp, expressed in the remote sender's
+			 * wall clock, interpolated from the last received RTCP Sender Report.
+			 *
+			 * @param ts - RTP timestamp whose capture instant is wanted.
+			 *
+			 * @returns No value if no Sender Report has been received, or if the given RTP
+			 * timestamp is too far away from the one it reported.
+			 */
+			std::optional<uint64_t> GetRemoteCaptureMsFromSenderReport(uint32_t ts) const;
+
 			void RequestKeyFrame();
+
 			void Pause() override;
+
 			void Resume() override;
+
 			uint32_t GetBitrate(uint64_t nowMs) override
 			{
 				return this->transmissionCounter.GetBitrate(nowMs);
 			}
+
 			uint32_t GetBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer) override
 			{
 				return this->transmissionCounter.GetBitrate(nowMs, spatialLayer, temporalLayer);
 			}
+
 			uint32_t GetSpatialLayerBitrate(uint64_t nowMs, uint8_t spatialLayer) override
 			{
 				return this->transmissionCounter.GetSpatialLayerBitrate(nowMs, spatialLayer);
 			}
+
 			uint32_t GetLayerBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer) override
 			{
 				return this->transmissionCounter.GetLayerBitrate(nowMs, spatialLayer, temporalLayer);
 			}
+
 			bool HasRtpInactivityCheckEnabled() const
 			{
 				return this->useRtpInactivityCheck;
@@ -88,7 +202,20 @@ namespace RTC
 
 		private:
 			void CalculateJitter(uint32_t rtpTimestamp);
+
 			void UpdateScore();
+
+			/**
+			 * Interpolate the capture instant of `ts` from a reference pair, all of them
+			 * expressed in the remote sender's wall clock.
+			 *
+			 * @param referenceNtpMs - Capture instant of `referenceTs`.
+			 * @param referenceTs - RTP timestamp the reference instant refers to.
+			 * @param ts - RTP timestamp whose capture instant is wanted.
+			 * @param maxDistanceMs - How far `ts` may be from `referenceTs`.
+			 */
+			std::optional<uint64_t> InterpolateRemoteCaptureMs(
+			  uint64_t referenceNtpMs, uint32_t referenceTs, uint32_t ts, uint64_t maxDistanceMs) const;
 
 			/* Pure virtual methods inherited from RTP::RtpStream. */
 		public:
@@ -101,6 +228,7 @@ namespace RTC
 			/* Pure virtual methods inherited from RTC::NackGenerator. */
 		protected:
 			void OnNackGeneratorNackRequired(const std::vector<uint16_t>& seqNumbers) override;
+
 			void OnNackGeneratorKeyFrameRequired() override;
 
 		private:
@@ -116,11 +244,10 @@ namespace RTC
 			uint32_t receivedPrior{ 0u };
 			// Packets received at last interval for score calculation.
 			uint32_t receivedPriorScore{ 0u };
-			// The middle 32 bits out of 64 in the NTP timestamp received in the most
-			// recent sender report.
-			uint32_t lastSrTimestamp{ 0u };
-			// Wallclock time representing the most recent sender report arrival.
-			uint64_t lastSrReceived{ 0u };
+			// Timing data of the most recent Sender Report received.
+			std::optional<SenderReportTiming> lastSenderReportTiming;
+			// Most recent `abs-capture-time` RTP header extension received.
+			std::optional<AbsCaptureTime> lastAbsCaptureTime;
 			// Relative transit time for prev packet.
 			int32_t transit{ 0u };
 			uint8_t firSeqNumber{ 0u };

--- a/worker/include/RTC/RTP/RtpStreamSend.hpp
+++ b/worker/include/RTC/RTP/RtpStreamSend.hpp
@@ -13,9 +13,13 @@ namespace RTC
 		class RtpStreamSend : public RTP::RtpStream
 		{
 		public:
-			// Maximum retransmission buffer size for video (ms).
+			/**
+			 * Maximum retransmission buffer size for video (ms).
+			 */
 			static constexpr uint32_t MaxRetransmissionDelayForVideoMs{ 2000 };
-			// Maximum retransmission buffer size for audio (ms).
+			/**
+			 * Maximum retransmission buffer size for audio (ms).
+			 */
 			static constexpr uint32_t MaxRetransmissionDelayForAudioMs{ 1000 };
 
 		public:
@@ -34,37 +38,73 @@ namespace RTC
 				  RTP::RtpStreamSend* rtpStream, RTP::Packet* packet) = 0;
 			};
 
+		private:
+			/**
+			 * Data of a received Receiver Reference Time Extended Report needed to
+			 * report LRR and DLRR back in a Delay Since Last Receiver Report Extended
+			 * Report.
+			 */
+			struct ReceiverReferenceTime
+			{
+				/**
+				 * Middle 32 bits out of 64 in the NTP timestamp of the Receiver Reference Time.
+				 */
+				uint32_t compactNtp;
+				/**
+				 * Local time at which the Receiver Reference Time arrived.
+				 */
+				uint64_t receivedMs;
+			};
+
 		public:
 			RtpStreamSend(
 			  RTP::RtpStreamSend::Listener* listener,
 			  SharedInterface* shared,
 			  RTP::RtpStream::Params& params,
 			  std::string& mid);
+
 			~RtpStreamSend() override;
 
+		public:
 			flatbuffers::Offset<FBS::RtpStream::Stats> FillBufferStats(
 			  flatbuffers::FlatBufferBuilder& builder) override;
+
 			void SetRtx(uint8_t payloadType, uint32_t ssrc) override;
+
 			ReceivePacketResult ReceivePacket(RTP::Packet* packet, const RTP::SharedPacket& sharedPacket);
+
 			void ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket);
+
 			void ReceiveKeyFrameRequest(RTC::RTCP::FeedbackPs::MessageType messageType);
+
 			void ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReport* report);
+
 			void ReceiveRtcpXrReceiverReferenceTime(RTC::RTCP::ReceiverReferenceTime* report);
+
 			RTC::RTCP::SenderReport* GetRtcpSenderReport(uint64_t nowMs);
+
 			RTC::RTCP::DelaySinceLastRr::SsrcInfo* GetRtcpXrDelaySinceLastRrSsrcInfo(uint64_t nowMs);
+
 			RTC::RTCP::SdesChunk* GetRtcpSdesChunk();
+
 			void Pause() override;
+
 			void Resume() override;
+
 			uint32_t GetBitrate(uint64_t nowMs) override
 			{
 				return this->transmissionCounter.GetBitrate(nowMs);
 			}
+
 			uint32_t GetBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer) override;
+
 			uint32_t GetSpatialLayerBitrate(uint64_t nowMs, uint8_t spatialLayer) override;
+
 			uint32_t GetLayerBitrate(uint64_t nowMs, uint8_t spatialLayer, uint8_t temporalLayer) override;
 
 		private:
 			void FillRetransmissionContainer(uint16_t seq, uint16_t bitmask);
+
 			void UpdateScore(RTC::RTCP::ReceiverReport* report);
 
 			/* Pure virtual methods inherited from RTP::RtpStream. */
@@ -80,12 +120,8 @@ namespace RTC
 			uint16_t rtxSeq{ 0u };
 			RTC::RtpDataCounter transmissionCounter;
 			RTP::RetransmissionBuffer* retransmissionBuffer{ nullptr };
-			// The middle 32 bits out of 64 in the NTP timestamp received in the most
-			// recent receiver reference timestamp.
-			uint32_t lastRrTimestamp{ 0u };
-			// Wallclock time representing the most recent receiver reference timestamp
-			// arrival.
-			uint64_t lastRrReceivedMs{ 0u };
+			// Timing data of the most recent Receiver Reference Time received.
+			std::optional<ReceiverReferenceTime> lastReceiverReferenceTime;
 		};
 	} // namespace RTP
 } // namespace RTC

--- a/worker/include/RTC/RTP/RtxStream.hpp
+++ b/worker/include/RTC/RTP/RtxStream.hpp
@@ -30,54 +30,86 @@ namespace RTC
 				std::string cname;
 			};
 
+		private:
+			/**
+			 * Data of a received RTCP Sender Report needed to report LSR and DLSR back in a
+			 * Receiver Report.
+			 */
+			struct SenderReportTiming
+			{
+				/**
+				 * Middle 32 bits out of 64 in the NTP timestamp of the Sender Report.
+				 */
+				uint32_t compactNtp;
+				/**
+				 * Local time at which the Sender Report arrived.
+				 */
+				uint64_t receivedMs;
+			};
+
 		public:
 			explicit RtxStream(SharedInterface* shared, RTP::RtxStream::Params& params);
+
 			virtual ~RtxStream();
 
+		public:
 			flatbuffers::Offset<FBS::RtxStream::RtxDump> FillBuffer(
 			  flatbuffers::FlatBufferBuilder& builder) const;
+
 			uint32_t GetSsrc() const
 			{
 				return this->params.ssrc;
 			}
+
 			uint8_t GetPayloadType() const
 			{
 				return this->params.payloadType;
 			}
+
 			const RTC::RtpCodecMimeType& GetMimeType() const
 			{
 				return this->params.mimeType;
 			}
+
 			uint32_t GetClockRate() const
 			{
 				return this->params.clockRate;
 			}
+
 			const std::string& GetRrid() const
 			{
 				return this->params.rrid;
 			}
+
 			const std::string& GetCname() const
 			{
 				return this->params.cname;
 			}
+
 			uint8_t GetFractionLost() const
 			{
 				return this->fractionLost;
 			}
+
 			float GetLossPercentage() const
 			{
 				return static_cast<float>(this->fractionLost) * 100 / 256;
 			}
+
 			size_t GetPacketsDiscarded() const
 			{
 				return this->packetsDiscarded;
 			}
+
 			bool ReceivePacket(const RTP::Packet* packet);
+
 			RTC::RTCP::ReceiverReport* GetRtcpReceiverReport();
+
 			void ReceiveRtcpSenderReport(RTC::RTCP::SenderReport* report);
 
 		protected:
 			bool UpdateSeq(const RTP::Packet* packet);
+
 			uint32_t GetExpectedPackets() const
 			{
 				return (this->cycles + this->maxSeq) - this->baseSeq + 1;
@@ -109,8 +141,8 @@ namespace RTC
 			// Fields for generating Receiver Reports.
 			uint32_t expectedPrior{ 0u };
 			uint32_t receivedPrior{ 0u };
-			uint32_t lastSrTimestamp{ 0u };
-			uint64_t lastSrReceived{ 0u };
+			// Timing data of the most recent Sender Report received.
+			std::optional<SenderReportTiming> lastSenderReportTiming;
 			int32_t reportedPacketsLost{ 0 };
 		};
 	} // namespace RTP

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -691,7 +691,7 @@ namespace RTC
 		if (it != this->mapSsrcRtpStream.end())
 		{
 			auto* rtpStream  = it->second;
-			const bool first = rtpStream->GetSenderReportNtpMs() == 0;
+			const bool first = !rtpStream->GetSenderReportMapping().has_value();
 
 			rtpStream->ReceiveRtcpSenderReport(report);
 

--- a/worker/src/RTC/RTP/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RTP/RtpStreamRecv.cpp
@@ -299,6 +299,28 @@ namespace RTC
 			// Calculate jitter.
 			CalculateJitter(packet->GetTimestamp());
 
+			// Store the capture instant if the packet carries it.
+			{
+				uint64_t absCaptureTimestamp{ 0 };
+				int64_t estimatedCaptureClockOffset{ 0 };
+
+				if (packet->ReadAbsCaptureTime(absCaptureTimestamp, estimatedCaptureClockOffset))
+				{
+					Utils::Time::Ntp ntp{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+
+					ntp.seconds   = static_cast<uint32_t>(absCaptureTimestamp >> 32);
+					ntp.fractions = static_cast<uint32_t>(absCaptureTimestamp);
+
+					// NOTE: The estimated capture clock offset is ignored on purpose. All the
+					// streams of a same sender share its clock, which is all that inter stream
+					// synchronization needs.
+					this->lastAbsCaptureTime = AbsCaptureTime{
+						.ts    = packet->GetTimestamp(),
+						.ntpMs = Utils::Time::Ntp2TimeMs(ntp),
+					};
+				}
+			}
+
 			// Increase transmission counter.
 			this->transmissionCounter.Update(packet);
 
@@ -528,17 +550,19 @@ namespace RTC
 			report->SetLastSeq(static_cast<uint32_t>(this->maxSeq) + this->cycles);
 			report->SetJitter(this->jitter);
 
-			if (this->lastSrReceived != 0)
+			if (this->lastSenderReportTiming.has_value())
 			{
+				const auto& senderReportTiming = this->lastSenderReportTiming.value();
 				// Get delay in milliseconds.
-				auto delayMs = static_cast<uint32_t>(this->shared->GetTimeMs() - this->lastSrReceived);
+				auto delayMs =
+				  static_cast<uint32_t>(this->shared->GetTimeMs() - senderReportTiming.receivedMs);
 				// Express delay in units of 1/65536 seconds.
 				uint32_t dlsr = (delayMs / 1000) << 16;
 
 				dlsr |= uint32_t{ (delayMs % 1000) * 65536 / 1000 };
 
 				report->SetDelaySinceLastSenderReport(dlsr);
-				report->SetLastSenderReport(this->lastSrTimestamp);
+				report->SetLastSenderReport(senderReportTiming.compactNtp);
 			}
 			else
 			{
@@ -565,9 +589,14 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			this->lastSrReceived  = this->shared->GetTimeMs();
-			this->lastSrTimestamp = report->GetNtpSec() << 16;
-			this->lastSrTimestamp += report->GetNtpFrac() >> 16;
+			uint32_t compactNtp = report->GetNtpSec() << 16;
+
+			compactNtp += report->GetNtpFrac() >> 16;
+
+			this->lastSenderReportTiming = SenderReportTiming{
+				.compactNtp = compactNtp,
+				.receivedMs = this->shared->GetTimeMs(),
+			};
 
 			// Update info about last Sender Report.
 			Utils::Time::Ntp ntp{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
@@ -575,8 +604,10 @@ namespace RTC
 			ntp.seconds   = report->GetNtpSec();
 			ntp.fractions = report->GetNtpFrac();
 
-			this->lastSenderReportNtpMs = Utils::Time::Ntp2TimeMs(ntp);
-			this->lastSenderReportTs    = report->GetRtpTs();
+			this->lastSenderReportMapping = RTP::RtpStream::SenderReportMapping{
+				.ntpMs = Utils::Time::Ntp2TimeMs(ntp),
+				.ts    = report->GetRtpTs(),
+			};
 
 			// Update the score with the current RR.
 			UpdateScore();
@@ -632,6 +663,68 @@ namespace RTC
 			{
 				this->nackGenerator->UpdateRtt(static_cast<uint32_t>(this->rtt));
 			}
+		}
+
+		std::optional<uint64_t> RtpStreamRecv::GetRemoteCaptureMsFromAbsCaptureTime(uint32_t ts) const
+		{
+			MS_TRACE();
+
+			if (!this->lastAbsCaptureTime.has_value())
+			{
+				return std::nullopt;
+			}
+
+			const auto& absCaptureTime = this->lastAbsCaptureTime.value();
+
+			return InterpolateRemoteCaptureMs(
+			  absCaptureTime.ntpMs, absCaptureTime.ts, ts, RtpStreamRecv::MaxAbsCaptureTimeInterpolationMs);
+		}
+
+		std::optional<uint64_t> RtpStreamRecv::GetRemoteCaptureMsFromSenderReport(uint32_t ts) const
+		{
+			MS_TRACE();
+
+			if (!this->lastSenderReportMapping.has_value())
+			{
+				return std::nullopt;
+			}
+
+			const auto& senderReportMapping = this->lastSenderReportMapping.value();
+
+			return InterpolateRemoteCaptureMs(
+			  senderReportMapping.ntpMs,
+			  senderReportMapping.ts,
+			  ts,
+			  RtpStreamRecv::MaxSenderReportInterpolationMs);
+		}
+
+		std::optional<uint64_t> RtpStreamRecv::InterpolateRemoteCaptureMs(
+		  uint64_t referenceNtpMs, uint32_t referenceTs, uint32_t ts, uint64_t maxDistanceMs) const
+		{
+			MS_TRACE();
+
+			// Distance in RTP timestamp units, taking wrap around into account.
+			const auto distanceTs    = static_cast<int64_t>(static_cast<int32_t>(ts - referenceTs));
+			const int64_t distanceMs = (distanceTs * 1000) / static_cast<int64_t>(GetClockRate());
+
+			if (distanceMs > static_cast<int64_t>(maxDistanceMs) || distanceMs < -static_cast<int64_t>(maxDistanceMs))
+			{
+				return std::nullopt;
+			}
+
+			const int64_t captureMs = static_cast<int64_t>(referenceNtpMs) + distanceMs;
+
+			// The reference does not map into a valid capture instant, so the remote
+			// endpoint is reporting nonsense.
+			if (captureMs < 0)
+			{
+				MS_WARN_2TAGS(
+				  rtp, rtcp, "invalid interpolated capture instant [distanceMs:%" PRIi64 "]", distanceMs);
+
+				return std::nullopt;
+			}
+
+			return static_cast<uint64_t>(captureMs);
 		}
 
 		void RtpStreamRecv::RequestKeyFrame()

--- a/worker/src/RTC/RTP/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RTP/RtpStreamRecv.cpp
@@ -304,7 +304,8 @@ namespace RTC
 				uint64_t absCaptureTimestamp{ 0 };
 				int64_t estimatedCaptureClockOffset{ 0 };
 
-				if (packet->ReadAbsCaptureTime(absCaptureTimestamp, estimatedCaptureClockOffset))
+				// NOTE: A zeroed capture timestamp gives no capture instant to store.
+				if (packet->ReadAbsCaptureTime(absCaptureTimestamp, estimatedCaptureClockOffset) && absCaptureTimestamp != 0)
 				{
 					Utils::Time::Ntp ntp{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
@@ -589,25 +590,31 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			uint32_t compactNtp = report->GetNtpSec() << 16;
-
-			compactNtp += report->GetNtpFrac() >> 16;
-
-			this->lastSenderReportTiming = SenderReportTiming{
-				.compactNtp = compactNtp,
-				.receivedMs = this->shared->GetTimeMs(),
-			};
-
 			// Update info about last Sender Report.
-			Utils::Time::Ntp ntp{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+			//
+			// NOTE: A sender with no wall clock may report a zeroed NTP timestamp, which
+			// gives nothing to store.
+			if (report->GetNtpSec() != 0 || report->GetNtpFrac() != 0)
+			{
+				uint32_t compactNtp = report->GetNtpSec() << 16;
 
-			ntp.seconds   = report->GetNtpSec();
-			ntp.fractions = report->GetNtpFrac();
+				compactNtp += report->GetNtpFrac() >> 16;
 
-			this->lastSenderReportMapping = RTP::RtpStream::SenderReportMapping{
-				.ntpMs = Utils::Time::Ntp2TimeMs(ntp),
-				.ts    = report->GetRtpTs(),
-			};
+				this->lastSenderReportTiming = SenderReportTiming{
+					.compactNtp = compactNtp,
+					.receivedMs = this->shared->GetTimeMs(),
+				};
+
+				Utils::Time::Ntp ntp{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+
+				ntp.seconds   = report->GetNtpSec();
+				ntp.fractions = report->GetNtpFrac();
+
+				this->lastSenderReportMapping = RTP::RtpStream::SenderReportMapping{
+					.ntpMs = Utils::Time::Ntp2TimeMs(ntp),
+					.ts    = report->GetRtpTs(),
+				};
+			}
 
 			// Update the score with the current RR.
 			UpdateScore();
@@ -703,9 +710,16 @@ namespace RTC
 		{
 			MS_TRACE();
 
+			const auto clockRate = GetClockRate();
+
+			if (clockRate == 0)
+			{
+				return std::nullopt;
+			}
+
 			// Distance in RTP timestamp units, taking wrap around into account.
 			const auto distanceTs    = static_cast<int64_t>(static_cast<int32_t>(ts - referenceTs));
-			const int64_t distanceMs = (distanceTs * 1000) / static_cast<int64_t>(GetClockRate());
+			const int64_t distanceMs = (distanceTs * 1000) / static_cast<int64_t>(clockRate);
 			// NOTE: The negation is safe since `distanceMs` comes from a 32 bits
 			// distance scaled down by the clock rate.
 			const auto absDistanceMs = static_cast<uint64_t>(distanceMs < 0 ? -distanceMs : distanceMs);

--- a/worker/src/RTC/RTP/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RTP/RtpStreamRecv.cpp
@@ -706,8 +706,11 @@ namespace RTC
 			// Distance in RTP timestamp units, taking wrap around into account.
 			const auto distanceTs    = static_cast<int64_t>(static_cast<int32_t>(ts - referenceTs));
 			const int64_t distanceMs = (distanceTs * 1000) / static_cast<int64_t>(GetClockRate());
+			// NOTE: The negation is safe since `distanceMs` comes from a 32 bits
+			// distance scaled down by the clock rate.
+			const auto absDistanceMs = static_cast<uint64_t>(distanceMs < 0 ? -distanceMs : distanceMs);
 
-			if (distanceMs > static_cast<int64_t>(maxDistanceMs) || distanceMs < -static_cast<int64_t>(maxDistanceMs))
+			if (absDistanceMs > maxDistanceMs)
 			{
 				return std::nullopt;
 			}

--- a/worker/src/RTC/RTP/RtpStreamSend.cpp
+++ b/worker/src/RTC/RTP/RtpStreamSend.cpp
@@ -317,9 +317,14 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			this->lastRrReceivedMs = this->shared->GetTimeMs();
-			this->lastRrTimestamp  = report->GetNtpSec() << 16;
-			this->lastRrTimestamp += report->GetNtpFrac() >> 16;
+			uint32_t compactNtp = report->GetNtpSec() << 16;
+
+			compactNtp += report->GetNtpFrac() >> 16;
+
+			this->lastReceiverReferenceTime = ReceiverReferenceTime{
+				.compactNtp = compactNtp,
+				.receivedMs = this->shared->GetTimeMs(),
+			};
 		}
 
 		RTC::RTCP::SenderReport* RtpStreamSend::GetRtcpSenderReport(uint64_t nowMs)
@@ -335,19 +340,22 @@ namespace RTC
 			auto* report = new RTC::RTCP::SenderReport();
 
 			// Calculate TS difference between now and maxPacketMs.
-			auto diffMs = nowMs - this->maxPacketMs;
-			auto diffTs = diffMs * GetClockRate() / 1000;
+			const uint64_t diffMs = nowMs - this->maxPacketMs;
+			const uint64_t diffTs = diffMs * GetClockRate() / 1000;
+			const auto rtpTs      = static_cast<uint32_t>(this->maxPacketTs + diffTs);
 
 			report->SetSsrc(GetSsrc());
 			report->SetPacketCount(this->transmissionCounter.GetPacketCount());
 			report->SetOctetCount(this->transmissionCounter.GetBytes());
 			report->SetNtpSec(ntp.seconds);
 			report->SetNtpFrac(ntp.fractions);
-			report->SetRtpTs(this->maxPacketTs + diffTs);
+			report->SetRtpTs(rtpTs);
 
 			// Update info about last Sender Report.
-			this->lastSenderReportNtpMs = nowMs;
-			this->lastSenderReportTs    = this->maxPacketTs + diffTs;
+			this->lastSenderReportMapping = RTP::RtpStream::SenderReportMapping{
+				.ntpMs = nowMs,
+				.ts    = rtpTs,
+			};
 
 			return report;
 		}
@@ -356,13 +364,14 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			if (this->lastRrReceivedMs == 0u)
+			if (!this->lastReceiverReferenceTime.has_value())
 			{
 				return nullptr;
 			}
 
+			const auto& receiverReferenceTime = this->lastReceiverReferenceTime.value();
 			// Get delay in milliseconds.
-			auto delayMs = static_cast<uint32_t>(nowMs - this->lastRrReceivedMs);
+			auto delayMs = static_cast<uint32_t>(nowMs - receiverReferenceTime.receivedMs);
 			// Express delay in units of 1/65536 seconds.
 			uint32_t dlrr = (delayMs / 1000) << 16;
 
@@ -372,7 +381,7 @@ namespace RTC
 
 			ssrcInfo->SetSsrc(GetSsrc());
 			ssrcInfo->SetDelaySinceLastReceiverReport(dlrr);
-			ssrcInfo->SetLastReceiverReport(this->lastRrTimestamp);
+			ssrcInfo->SetLastReceiverReport(receiverReferenceTime.compactNtp);
 
 			return ssrcInfo;
 		}

--- a/worker/src/RTC/RTP/RtxStream.cpp
+++ b/worker/src/RTC/RTP/RtxStream.cpp
@@ -138,17 +138,18 @@ namespace RTC
 			// NOTE: Do not calculate any jitter.
 			report->SetJitter(0);
 
-			if (this->lastSrReceived != 0)
+			if (this->lastSenderReportTiming.has_value())
 			{
+				const auto& senderReportTiming = this->lastSenderReportTiming.value();
 				// Get delay in milliseconds.
-				const uint32_t delayMs = this->shared->GetTimeMs() - this->lastSrReceived;
+				const uint32_t delayMs = this->shared->GetTimeMs() - senderReportTiming.receivedMs;
 				// Express delay in units of 1/65536 seconds.
 				uint32_t dlsr = (delayMs / 1000) << 16;
 
 				dlsr |= uint32_t{ (delayMs % 1000) * 65536 / 1000 };
 
 				report->SetDelaySinceLastSenderReport(dlsr);
-				report->SetLastSenderReport(this->lastSrTimestamp);
+				report->SetLastSenderReport(senderReportTiming.compactNtp);
 			}
 			else
 			{
@@ -163,9 +164,14 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			this->lastSrReceived  = this->shared->GetTimeMs();
-			this->lastSrTimestamp = report->GetNtpSec() << 16;
-			this->lastSrTimestamp += report->GetNtpFrac() >> 16;
+			uint32_t compactNtp = report->GetNtpSec() << 16;
+
+			compactNtp += report->GetNtpFrac() >> 16;
+
+			this->lastSenderReportTiming = SenderReportTiming{
+				.compactNtp = compactNtp,
+				.receivedMs = this->shared->GetTimeMs(),
+			};
 		}
 
 		bool RtxStream::UpdateSeq(const RTP::Packet* packet)

--- a/worker/src/RTC/SimulcastProducerStreamManager.cpp
+++ b/worker/src/RTC/SimulcastProducerStreamManager.cpp
@@ -176,7 +176,7 @@ namespace RTC
 		// since we know we won't be able to switch.
 		auto* producerTsReferenceRtpStream = GetProducerTsReferenceRtpStream();
 
-		if (!producerTsReferenceRtpStream || !producerTsReferenceRtpStream->GetSenderReportNtpMs())
+		if (!producerTsReferenceRtpStream || !producerTsReferenceRtpStream->GetSenderReportMapping().has_value())
 		{
 			return;
 		}
@@ -596,19 +596,19 @@ namespace RTC
 				auto* producerTsReferenceRtpStream = GetProducerTsReferenceRtpStream();
 				auto* producerTargetRtpStream      = GetProducerTargetRtpStream();
 
+				const auto tsReferenceMapping = producerTsReferenceRtpStream->GetSenderReportMapping();
+				const auto targetMapping      = producerTargetRtpStream->GetSenderReportMapping();
+
 				// NOTE: If we are here is because we have Sender Reports for both the
 				// TS reference stream and the target one.
-				MS_ASSERT(
-				  producerTsReferenceRtpStream->GetSenderReportNtpMs(),
-				  "no Sender Report for TS reference RTP stream");
-				MS_ASSERT(
-				  producerTargetRtpStream->GetSenderReportNtpMs(), "no Sender Report for current RTP stream");
+				MS_ASSERT(tsReferenceMapping.has_value(), "no Sender Report for TS reference RTP stream");
+				MS_ASSERT(targetMapping.has_value(), "no Sender Report for current RTP stream");
 
 				// Calculate NTP and TS stuff.
-				auto ntpMs1 = producerTsReferenceRtpStream->GetSenderReportNtpMs();
-				auto ts1    = producerTsReferenceRtpStream->GetSenderReportTs();
-				auto ntpMs2 = producerTargetRtpStream->GetSenderReportNtpMs();
-				auto ts2    = producerTargetRtpStream->GetSenderReportTs();
+				auto ntpMs1 = tsReferenceMapping.value().ntpMs;
+				auto ts1    = tsReferenceMapping.value().ts;
+				auto ntpMs2 = targetMapping.value().ntpMs;
+				auto ts2    = targetMapping.value().ts;
 				int64_t diffMs;
 
 				if (ntpMs2 >= ntpMs1)
@@ -857,8 +857,9 @@ namespace RTC
 
 		// If we don't have yet a RTP timestamp reference, set it now.
 		if (
-		  newTargetSpatialLayer != -1 && (this->tsReferenceSpatialLayer == -1 ||
-		                                  !GetProducerTsReferenceRtpStream()->GetSenderReportNtpMs()))
+		  newTargetSpatialLayer != -1 &&
+		  (this->tsReferenceSpatialLayer == -1 ||
+		   !GetProducerTsReferenceRtpStream()->GetSenderReportMapping().has_value()))
 		{
 			MS_DEBUG_TAG(
 			  simulcast, "using spatial layer %" PRIi16 " as RTP timestamp reference", newTargetSpatialLayer);
@@ -1050,7 +1051,7 @@ namespace RTC
 
 		return (
 		  this->tsReferenceSpatialLayer == -1 || spatialLayer == this->tsReferenceSpatialLayer ||
-		  this->producerRtpStreams.at(spatialLayer)->GetSenderReportNtpMs());
+		  this->producerRtpStreams.at(spatialLayer)->GetSenderReportMapping().has_value());
 	}
 
 	RTC::RTP::RtpStreamRecv* SimulcastProducerStreamManager::GetProducerTsReferenceRtpStream() const


### PR DESCRIPTION
# Details

- Related to #1881.
- No functional change. Preparation for making the RTCP Sender Reports mediasoup sends to `Consumers` report the real capture instant of the media rather than the time each packet reached mediasoup.
- Gives `RtpStreamRecv` class the two sources for the capture instant of an RTP timestamp: the `abs-capture-time` RTP extension when the packets carry it, and interpolation from the last Sender Report otherwise.
- Groups the timestamp pairs that used 0 to mean "no data yet" into `std::optional` structs, since they are only meaningful together.
- Cosmetic changes for consistency with new C++ style applied to recent code.