### PR TITLE
Estimate the capture instant of each received RTP packet

### DIFF
--- a/worker/include/RTC/Consumer.hpp
+++ b/worker/include/RTC/Consumer.hpp
@@ -146,7 +146,10 @@ namespace RTC
 		uint32_t GetDesiredBitrate() const;
 		void SendRtpPacket(RTC::RTP::Packet* packet, RTC::RTP::SharedPacket& sharedPacket);
 		bool GetRtcp(RTC::RTCP::CompoundPacket* packet, uint64_t nowMs);
-		void NeedWorstRemoteFractionLost(uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost);
+		/**
+		 * Worst remote fraction lost among the RTP streams of this Consumer.
+		 */
+		uint8_t GetWorstRemoteFractionLost(uint32_t mappedSsrc) const;
 		void ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket);
 		void ReceiveKeyFrameRequest(RTC::RTCP::FeedbackPs::MessageType messageType, uint32_t ssrc);
 		void ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReport* report);

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -47,8 +47,20 @@ namespace RTC
 			  RTC::Producer* producer, RTC::RTP::RtpStreamRecv* rtpStream, bool first) = 0;
 			virtual void OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RTP::Packet* packet) = 0;
 			virtual void OnProducerSendRtcpPacket(RTC::Producer* producer, RTC::RTCP::Packet* packet) = 0;
-			virtual void OnProducerNeedWorstRemoteFractionLost(
-			  RTC::Producer* producer, uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost) = 0;
+			/**
+			 * Obtains the worst remote fraction lost of all the Consumers consuming the
+			 * given mapped SSRC of this Producer.
+			 */
+			virtual uint8_t OnProducerNeedWorstRemoteFractionLost(
+			  RTC::Producer* producer, uint32_t mappedSsrc) = 0;
+			/**
+			 * Capture instant of the given RTP timestamp of the given RTP stream, expressed
+			 * in our own monotonic clock.
+			 *
+			 * @returns No value while the capture instant cannot be told yet.
+			 */
+			virtual std::optional<uint64_t> OnProducerNeedLocalCaptureMs(
+			  RTC::Producer* producer, const RTC::RTP::RtpStreamRecv* rtpStream, uint32_t ts) = 0;
 		};
 
 	private:
@@ -154,7 +166,18 @@ namespace RTC
 		  const RTC::RTP::Packet* packet, const RTC::RtpCodecParameters& mediaCodec, size_t encodingIdx);
 		void NotifyNewRtpStream(RTC::RTP::RtpStreamRecv* rtpStream);
 		bool MangleRtpPacket(RTC::RTP::Packet* packet, RTC::RTP::RtpStreamRecv* rtpStream) const;
-		void PostProcessRtpPacket(RTC::RTP::Packet* packet);
+		/**
+		 * @param maxPacketTsChanged - Whether this packet became the one holding the
+		 * highest RTP timestamp of its RTP stream, which happens just for the first
+		 * arriving packet of each frame.
+		 *
+		 * @remarks
+		 * - Not "advanced": the stream also takes a packet as its new reference when its
+		 *   RTP timestamp is lower, be it the very first packet, a timestamp moving
+		 *   backwards after prolonged sender inactivity or a sequence number resync.
+		 */
+		void PostProcessRtpPacket(
+		  RTC::RTP::Packet* packet, const RTC::RTP::RtpStreamRecv* rtpStream, bool maxPacketTsChanged);
 		void EmitScore() const;
 		void EmitTraceEventRtpAndKeyFrameTypes(const RTC::RTP::Packet* packet, bool isRtx = false) const;
 		void EmitTraceEventPliType(uint32_t ssrc) const;
@@ -167,8 +190,7 @@ namespace RTC
 	public:
 		void OnRtpStreamScore(RTC::RTP::RtpStream* rtpStream, uint8_t score, uint8_t previousScore) override;
 		void OnRtpStreamSendRtcpPacket(RTC::RTP::RtpStreamRecv* rtpStream, RTC::RTCP::Packet* packet) override;
-		void OnRtpStreamNeedWorstRemoteFractionLost(
-		  RTC::RTP::RtpStreamRecv* rtpStream, uint8_t& worstRemoteFractionLost) override;
+		uint8_t OnRtpStreamNeedWorstRemoteFractionLost(RTC::RTP::RtpStreamRecv* rtpStream) override;
 
 		/* Pure virtual methods inherited from RTC::KeyFrameRequestManager::Listener. */
 	public:

--- a/worker/include/RTC/RTP/RtpStream.hpp
+++ b/worker/include/RTC/RTP/RtpStream.hpp
@@ -261,6 +261,9 @@ namespace RTC
 			uint32_t maxPacketTs{ 0u };
 			// When the packet with highest timestammp was seen.
 			uint64_t maxPacketMs{ 0u };
+			// When the media in the packet with highest timestamp was captured, in our own
+			// monotonic clock.
+			std::optional<uint64_t> maxPacketCaptureMs;
 			int32_t packetsLost{ 0 };
 			uint8_t fractionLost{ 0u };
 			// Jitter in RTP timestamp units. As per spec it's kept as floating value

--- a/worker/include/RTC/RTP/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RTP/RtpStreamRecv.hpp
@@ -39,9 +39,11 @@ namespace RTC
 			public:
 				virtual void OnRtpStreamSendRtcpPacket(
 				  RTP::RtpStreamRecv* rtpStream, RTC::RTCP::Packet* packet) = 0;
-
-				virtual void OnRtpStreamNeedWorstRemoteFractionLost(
-				  RTP::RtpStreamRecv* rtpStream, uint8_t& worstRemoteFractionLost) = 0;
+				/**
+				 * Obtains the worst remote fraction lost of all the RtpStreamSend
+				 * streams consuming this RtpStreamRecv.
+				 */
+				virtual uint8_t OnRtpStreamNeedWorstRemoteFractionLost(RTP::RtpStreamRecv* rtpStream) = 0;
 			};
 
 		public:

--- a/worker/include/RTC/Router.hpp
+++ b/worker/include/RTC/Router.hpp
@@ -79,11 +79,8 @@ namespace RTC
 		  bool first) override;
 		void OnTransportProducerRtpPacketReceived(
 		  RTC::Transport* transport, RTC::Producer* producer, RTC::RTP::Packet* packet) override;
-		void OnTransportNeedWorstRemoteFractionLost(
-		  RTC::Transport* transport,
-		  RTC::Producer* producer,
-		  uint32_t mappedSsrc,
-		  uint8_t& worstRemoteFractionLost) override;
+		uint8_t OnTransportNeedWorstRemoteFractionLost(
+		  RTC::Transport* transport, RTC::Producer* producer, uint32_t mappedSsrc) override;
 		void OnTransportNewConsumer(
 		  RTC::Transport* transport, RTC::Consumer* consumer, const std::string& producerId) override;
 		void OnTransportConsumerClosed(RTC::Transport* transport, RTC::Consumer* consumer) override;

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -17,6 +17,7 @@
 #include "RTC/RTP/HeaderExtensionIds.hpp"
 #include "RTC/RTP/Packet.hpp"
 #include "RTC/RateCalculator.hpp"
+#include "RTC/RemoteCaptureTimeEstimator.hpp"
 #include "RTC/RtpListener.hpp"
 #include "RTC/SCTP/public/AssociationInterface.hpp"
 #include "RTC/SCTP/public/AssociationListenerInterface.hpp"
@@ -83,11 +84,12 @@ namespace RTC
 			  bool first) = 0;
 			virtual void OnTransportProducerRtpPacketReceived(
 			  RTC::Transport* transport, RTC::Producer* producer, RTC::RTP::Packet* packet) = 0;
-			virtual void OnTransportNeedWorstRemoteFractionLost(
-			  RTC::Transport* transport,
-			  RTC::Producer* producer,
-			  uint32_t mappedSsrc,
-			  uint8_t& worstRemoteFractionLost) = 0;
+			/**
+			 * Obtains the worst remote fraction lost of all the Consumers consuming the
+			 * given mapped SSRC of the given Producer.
+			 */
+			virtual uint8_t OnTransportNeedWorstRemoteFractionLost(
+			  RTC::Transport* transport, RTC::Producer* producer, uint32_t mappedSsrc) = 0;
 			virtual void OnTransportNewConsumer(
 			  RTC::Transport* transport, RTC::Consumer* consumer, const std::string& producerId) = 0;
 			virtual void OnTransportConsumerClosed(RTC::Transport* transport, RTC::Consumer* consumer) = 0;
@@ -264,8 +266,9 @@ namespace RTC
 		  RTC::Producer* producer, RTC::RTP::RtpStreamRecv* rtpStream, bool first) override;
 		void OnProducerRtpPacketReceived(RTC::Producer* producer, RTC::RTP::Packet* packet) override;
 		void OnProducerSendRtcpPacket(RTC::Producer* producer, RTC::RTCP::Packet* packet) override;
-		void OnProducerNeedWorstRemoteFractionLost(
-		  RTC::Producer* producer, uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost) override;
+		uint8_t OnProducerNeedWorstRemoteFractionLost(RTC::Producer* producer, uint32_t mappedSsrc) override;
+		std::optional<uint64_t> OnProducerNeedLocalCaptureMs(
+		  RTC::Producer* producer, const RTC::RTP::RtpStreamRecv* rtpStream, uint32_t ts) override;
 
 		/* Pure virtual methods inherited from RTC::Consumer::Listener. */
 	public:
@@ -367,6 +370,10 @@ namespace RTC
 		ankerl::unordered_dense::map<uint16_t, RTC::DataConsumer*> mapSctpStreamIdDataConsumers;
 		ankerl::unordered_dense::map<uint32_t, RTC::Consumer*> mapSsrcConsumer;
 		ankerl::unordered_dense::map<uint32_t, RTC::Consumer*> mapRtxSsrcConsumer;
+		// Capture time estimator of each sender publishing to this Transport, keyed by
+		// its CNAME.
+		ankerl::unordered_dense::map<std::string, RTC::RemoteCaptureTimeEstimator>
+		  mapCnameRemoteCaptureTimeEstimator;
 		TimerHandleInterface* rtcpTimer{ nullptr };
 		// Allocated by this.
 		std::unique_ptr<RTC::SCTP::AssociationInterface> sctpAssociation{ nullptr };

--- a/worker/src/RTC/Consumer.cpp
+++ b/worker/src/RTC/Consumer.cpp
@@ -1414,22 +1414,25 @@ namespace RTC
 		return true;
 	}
 
-	void Consumer::NeedWorstRemoteFractionLost(uint32_t /*mappedSsrc*/, uint8_t& worstRemoteFractionLost)
+	uint8_t Consumer::GetWorstRemoteFractionLost(uint32_t /*mappedSsrc*/) const
 	{
 		MS_TRACE();
 
 		if (!IsActive())
 		{
-			return;
+			return 0;
 		}
 
-		for (auto* rtpStream : this->rtpStreams)
-		{
-			auto fractionLost = rtpStream->GetFractionLost();
+		uint8_t worstRemoteFractionLost{ 0 };
 
-			// If our fraction lost is worse than the given one, update it.
+		for (const auto* rtpStream : this->rtpStreams)
+		{
+			const auto fractionLost = rtpStream->GetFractionLost();
+
 			worstRemoteFractionLost = std::max(fractionLost, worstRemoteFractionLost);
 		}
+
+		return worstRemoteFractionLost;
 	}
 
 	void Consumer::ReceiveNack(RTC::RTCP::FeedbackRtpNackPacket* nackPacket)

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -581,7 +581,7 @@ namespace RTC
 		ReceiveRtpPacketResult result;
 		bool isRtx{ false };
 		// Highest RTP timestamp of the stream before this packet is processed, so that it
-		// can be told afterwards whether this packet made it advance.
+		// can be told afterwards whether this packet made it change.
 		const auto previousMaxPacketTs = rtpStream->GetMaxPacketTs();
 
 		// Media packet.

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -580,6 +580,9 @@ namespace RTC
 
 		ReceiveRtpPacketResult result;
 		bool isRtx{ false };
+		// Highest RTP timestamp of the stream before this packet is processed, so that it
+		// can be told afterwards whether this packet made it advance.
+		const auto previousMaxPacketTs = rtpStream->GetMaxPacketTs();
 
 		// Media packet.
 		if (packet->GetSsrc() == rtpStream->GetSsrc())
@@ -675,7 +678,10 @@ namespace RTC
 		}
 
 		// Post-process the packet.
-		PostProcessRtpPacket(packet);
+		PostProcessRtpPacket(
+		  packet,
+		  rtpStream,
+		  /*maxPacketTsChanged*/ rtpStream->GetMaxPacketTs() != previousMaxPacketTs);
 
 		this->listener->OnProducerRtpPacketReceived(this, packet);
 
@@ -1409,9 +1415,23 @@ namespace RTC
 		return true;
 	}
 
-	inline void Producer::PostProcessRtpPacket(RTC::RTP::Packet* packet)
+	inline void Producer::PostProcessRtpPacket(
+	  RTC::RTP::Packet* packet, const RTC::RTP::RtpStreamRecv* rtpStream, bool maxPacketTsChanged)
 	{
 		MS_TRACE();
+
+		// Store the capture instant of the packet holding the highest RTP timestamp of its
+		// stream, which is the only one the Sender Reports we send are built upon.
+		if (maxPacketTsChanged)
+		{
+			const auto captureMs =
+			  this->listener->OnProducerNeedLocalCaptureMs(this, rtpStream, packet->GetTimestamp());
+
+			if (captureMs.has_value())
+			{
+				packet->SetCaptureMs(captureMs.value());
+			}
+		}
 
 		if (this->kind == RTC::Media::Kind::VIDEO)
 		{
@@ -1697,15 +1717,14 @@ namespace RTC
 		this->listener->OnProducerSendRtcpPacket(this, packet);
 	}
 
-	inline void Producer::OnRtpStreamNeedWorstRemoteFractionLost(
-	  RTC::RTP::RtpStreamRecv* rtpStream, uint8_t& worstRemoteFractionLost)
+	inline uint8_t Producer::OnRtpStreamNeedWorstRemoteFractionLost(RTC::RTP::RtpStreamRecv* rtpStream)
 	{
 		MS_TRACE();
 
-		auto mappedSsrc = this->mapRtpStreamMappedSsrc.at(rtpStream);
+		const auto mappedSsrc = this->mapRtpStreamMappedSsrc.at(rtpStream);
 
 		// Notify the listener.
-		this->listener->OnProducerNeedWorstRemoteFractionLost(this, mappedSsrc, worstRemoteFractionLost);
+		return this->listener->OnProducerNeedWorstRemoteFractionLost(this, mappedSsrc);
 	}
 
 	inline void Producer::OnKeyFrameNeeded(

--- a/worker/src/RTC/RTP/RtpStream.cpp
+++ b/worker/src/RTC/RTP/RtpStream.cpp
@@ -137,10 +137,11 @@ namespace RTC
 			{
 				InitSeq(seq);
 
-				this->started     = true;
-				this->maxSeq      = seq - 1;
-				this->maxPacketTs = packet->GetTimestamp();
-				this->maxPacketMs = this->shared->GetTimeMs();
+				this->started            = true;
+				this->maxSeq             = seq - 1;
+				this->maxPacketTs        = packet->GetTimestamp();
+				this->maxPacketMs        = this->shared->GetTimeMs();
+				this->maxPacketCaptureMs = packet->GetCaptureMs();
 			}
 
 			// If not a valid packet ignore it.
@@ -158,8 +159,9 @@ namespace RTC
 			// Update highest seen RTP timestamp.
 			if (Utils::Number::IsHigherThan<uint32_t>(packet->GetTimestamp(), this->maxPacketTs))
 			{
-				this->maxPacketTs = packet->GetTimestamp();
-				this->maxPacketMs = this->shared->GetTimeMs();
+				this->maxPacketTs        = packet->GetTimestamp();
+				this->maxPacketMs        = this->shared->GetTimeMs();
+				this->maxPacketCaptureMs = packet->GetCaptureMs();
 			}
 
 			return true;
@@ -226,8 +228,9 @@ namespace RTC
 					  this->maxPacketTs,
 					  packet->GetTimestamp());
 
-					this->maxPacketTs = packet->GetTimestamp();
-					this->maxPacketMs = this->shared->GetTimeMs();
+					this->maxPacketTs        = packet->GetTimestamp();
+					this->maxPacketMs        = this->shared->GetTimeMs();
+					this->maxPacketCaptureMs = packet->GetCaptureMs();
 				}
 			}
 			// Too old packet received (older than the allowed misorder).
@@ -248,8 +251,9 @@ namespace RTC
 
 					InitSeq(seq);
 
-					this->maxPacketTs = packet->GetTimestamp();
-					this->maxPacketMs = this->shared->GetTimeMs();
+					this->maxPacketTs        = packet->GetTimestamp();
+					this->maxPacketMs        = this->shared->GetTimeMs();
+					this->maxPacketCaptureMs = packet->GetCaptureMs();
 
 					// Notify the subclass about it.
 					UserOnSequenceNumberReset();

--- a/worker/src/RTC/RTP/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RTP/RtpStreamRecv.cpp
@@ -475,18 +475,15 @@ namespace RTC
 		{
 			MS_TRACE();
 
-			uint8_t worstRemoteFractionLost{ 0 };
+			// Ask the listener for the worst remote fraction lost.
+			const uint8_t worstRemoteFractionLost =
+			  this->params.useInBandFec ? static_cast<RTP::RtpStreamRecv::Listener*>(this->listener)
+			                                ->OnRtpStreamNeedWorstRemoteFractionLost(this)
+			                            : 0;
 
-			if (this->params.useInBandFec)
+			if (worstRemoteFractionLost > 0)
 			{
-				// Notify the listener so we'll get the worst remote fraction lost.
-				static_cast<RTP::RtpStreamRecv::Listener*>(this->listener)
-				  ->OnRtpStreamNeedWorstRemoteFractionLost(this, worstRemoteFractionLost);
-
-				if (worstRemoteFractionLost > 0)
-				{
-					MS_DEBUG_TAG(rtcp, "using worst remote fraction lost:%" PRIu8, worstRemoteFractionLost);
-				}
+				MS_DEBUG_TAG(rtcp, "using worst remote fraction lost:%" PRIu8, worstRemoteFractionLost);
 			}
 
 			auto* report = new RTC::RTCP::ReceiverReport();

--- a/worker/src/RTC/Router.cpp
+++ b/worker/src/RTC/Router.cpp
@@ -701,20 +701,22 @@ namespace RTC
 		}
 	}
 
-	void Router::OnTransportNeedWorstRemoteFractionLost(
-	  RTC::Transport* /*transport*/,
-	  RTC::Producer* producer,
-	  uint32_t mappedSsrc,
-	  uint8_t& worstRemoteFractionLost)
+	uint8_t Router::OnTransportNeedWorstRemoteFractionLost(
+	  RTC::Transport* /*transport*/, RTC::Producer* producer, uint32_t mappedSsrc)
 	{
 		MS_TRACE();
 
-		auto& consumers = this->mapProducerConsumers.at(producer);
+		const auto& consumers = this->mapProducerConsumers.at(producer);
 
-		for (auto* consumer : consumers)
+		uint8_t worstRemoteFractionLost{ 0 };
+
+		for (const auto* consumer : consumers)
 		{
-			consumer->NeedWorstRemoteFractionLost(mappedSsrc, worstRemoteFractionLost);
+			worstRemoteFractionLost =
+			  std::max(consumer->GetWorstRemoteFractionLost(mappedSsrc), worstRemoteFractionLost);
 		}
+
+		return worstRemoteFractionLost;
 	}
 
 	void Router::OnTransportNewConsumer(

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1268,7 +1268,7 @@ namespace RTC
 
 					const bool cnameStillInUse = std::ranges::any_of(
 					  this->mapProducers,
-					  [&cname](const auto& kv) -> bool
+					  [&cname](const auto& kv)
 					  {
 						  const auto* otherProducer = kv.second;
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -640,6 +640,22 @@ namespace RTC
 				// Insert into the map.
 				this->mapProducers[producerId] = producer;
 
+				// Take this Producer into account for the capture time estimation of its
+				// sender.
+				//
+				// NOTE: A Producer with no CNAME cannot be grouped with the other Producers
+				// of its sender, and sharing a single estimator among all the CNAME less
+				// Producers of a PipeTransport would mix the clocks of different senders.
+				{
+					const auto& cname = producer->GetRtpParameters().rtcp.cname;
+
+					if (!cname.empty())
+					{
+						this->mapCnameRemoteCaptureTimeEstimator[cname].UpdateSource(
+						  producer->GetRtpHeaderExtensionIds().absCaptureTime != 0);
+					}
+				}
+
 				MS_DEBUG_DEV("Producer created [producerId:%s]", producerId.c_str());
 
 				// Take the transport related RTP header extensions of the Producer and
@@ -1244,6 +1260,26 @@ namespace RTC
 
 				// Remove it from the map.
 				this->mapProducers.erase(producer->id);
+
+				// Remove the capture time estimator of its sender once its last Producer
+				// is gone.
+				{
+					const auto& cname = producer->GetRtpParameters().rtcp.cname;
+
+					const bool cnameStillInUse = std::ranges::any_of(
+					  this->mapProducers,
+					  [&cname](const auto& kv) -> bool
+					  {
+						  const auto* otherProducer = kv.second;
+
+						  return otherProducer->GetRtpParameters().rtcp.cname == cname;
+					  });
+
+					if (!cnameStillInUse)
+					{
+						this->mapCnameRemoteCaptureTimeEstimator.erase(cname);
+					}
+				}
 
 				// Tell the child class to clear associated SSRCs.
 				for (const auto& kv : producer->GetRtpStreams())
@@ -2538,6 +2574,17 @@ namespace RTC
 	{
 		MS_TRACE();
 
+		// Feed the capture time estimator of the sender of this Producer.
+		const auto it =
+		  this->mapCnameRemoteCaptureTimeEstimator.find(producer->GetRtpParameters().rtcp.cname);
+
+		if (it != this->mapCnameRemoteCaptureTimeEstimator.end())
+		{
+			auto& remoteCaptureTimeEstimator = it->second;
+
+			remoteCaptureTimeEstimator.SenderReportReceived(rtpStream);
+		}
+
 		this->listener->OnTransportProducerRtcpSenderReport(this, producer, rtpStream, first);
 	}
 
@@ -2555,13 +2602,29 @@ namespace RTC
 		SendRtcpPacket(packet);
 	}
 
-	void Transport::OnProducerNeedWorstRemoteFractionLost(
-	  RTC::Producer* producer, uint32_t mappedSsrc, uint8_t& worstRemoteFractionLost)
+	uint8_t Transport::OnProducerNeedWorstRemoteFractionLost(RTC::Producer* producer, uint32_t mappedSsrc)
 	{
 		MS_TRACE();
 
-		this->listener->OnTransportNeedWorstRemoteFractionLost(
-		  this, producer, mappedSsrc, worstRemoteFractionLost);
+		return this->listener->OnTransportNeedWorstRemoteFractionLost(this, producer, mappedSsrc);
+	}
+
+	std::optional<uint64_t> Transport::OnProducerNeedLocalCaptureMs(
+	  RTC::Producer* producer, const RTC::RTP::RtpStreamRecv* rtpStream, uint32_t ts)
+	{
+		MS_TRACE();
+
+		const auto it =
+		  this->mapCnameRemoteCaptureTimeEstimator.find(producer->GetRtpParameters().rtcp.cname);
+
+		if (it == this->mapCnameRemoteCaptureTimeEstimator.end())
+		{
+			return std::nullopt;
+		}
+
+		const auto& remoteCaptureTimeEstimator = it->second;
+
+		return remoteCaptureTimeEstimator.GetLocalCaptureMs(rtpStream, ts);
 	}
 
 	void Transport::OnConsumerSendRtpPacket(RTC::Consumer* consumer, RTC::RTP::Packet* packet)

--- a/worker/test/src/RTC/RTP/TestRtpStreamRecv.cpp
+++ b/worker/test/src/RTC/RTP/TestRtpStreamRecv.cpp
@@ -106,9 +106,9 @@ SCENARIO("RtpStreamRecv", "[rtp][rtpstream][rtpstreamrecv]")
 			}
 		}
 
-		void OnRtpStreamNeedWorstRemoteFractionLost(
-		  RTC::RTP::RtpStreamRecv* /*rtpStream*/, uint8_t& /*worstRemoteFractionLost*/) override
+		uint8_t OnRtpStreamNeedWorstRemoteFractionLost(RTC::RTP::RtpStreamRecv* /*rtpStream*/) override
 		{
+			return 0;
 		}
 
 	public:

--- a/worker/test/src/RTC/TestConsumer.cpp
+++ b/worker/test/src/RTC/TestConsumer.cpp
@@ -33,9 +33,9 @@ namespace
 		{
 		}
 
-		void OnRtpStreamNeedWorstRemoteFractionLost(
-		  RTC::RTP::RtpStreamRecv* /*rtpStream*/, uint8_t& /*worstRemoteFractionLost*/) override
+		uint8_t OnRtpStreamNeedWorstRemoteFractionLost(RTC::RTP::RtpStreamRecv* /*rtpStream*/) override
 		{
+			return 0;
 		}
 	};
 

--- a/worker/test/src/RTC/TestRemoteCaptureTimeEstimator.cpp
+++ b/worker/test/src/RTC/TestRemoteCaptureTimeEstimator.cpp
@@ -30,9 +30,9 @@ SCENARIO("RemoteCaptureTimeEstimator", "[rtp][rtcp][remotecapturetimeestimator]"
 		{
 		}
 
-		void OnRtpStreamNeedWorstRemoteFractionLost(
-		  RTC::RTP::RtpStreamRecv* /*rtpStream*/, uint8_t& /*worstRemoteFractionLost*/) override
+		uint8_t OnRtpStreamNeedWorstRemoteFractionLost(RTC::RTP::RtpStreamRecv* /*rtpStream*/) override
 		{
+			return 0;
 		}
 	};
 

--- a/worker/test/src/RTC/TestSimpleProducerStreamManager.cpp
+++ b/worker/test/src/RTC/TestSimpleProducerStreamManager.cpp
@@ -61,9 +61,9 @@ namespace
 		{
 		}
 
-		void OnRtpStreamNeedWorstRemoteFractionLost(
-		  RTC::RTP::RtpStreamRecv* /*rtpStream*/, uint8_t& /*worstRemoteFractionLost*/) override
+		uint8_t OnRtpStreamNeedWorstRemoteFractionLost(RTC::RTP::RtpStreamRecv* /*rtpStream*/) override
 		{
+			return 0;
 		}
 	};
 

--- a/worker/test/src/RTC/TestSimulcastProducerStreamManager.cpp
+++ b/worker/test/src/RTC/TestSimulcastProducerStreamManager.cpp
@@ -70,9 +70,9 @@ namespace
 		{
 		}
 
-		void OnRtpStreamNeedWorstRemoteFractionLost(
-		  RTC::RTP::RtpStreamRecv* /*rtpStream*/, uint8_t& /*worstRemoteFractionLost*/) override
+		uint8_t OnRtpStreamNeedWorstRemoteFractionLost(RTC::RTP::RtpStreamRecv* /*rtpStream*/) override
 		{
+			return 0;
 		}
 	};
 

--- a/worker/test/src/RTC/TestSvcProducerStreamManager.cpp
+++ b/worker/test/src/RTC/TestSvcProducerStreamManager.cpp
@@ -66,9 +66,9 @@ namespace
 		{
 		}
 
-		void OnRtpStreamNeedWorstRemoteFractionLost(
-		  RTC::RTP::RtpStreamRecv* /*rtpStream*/, uint8_t& /*worstRemoteFractionLost*/) override
+		uint8_t OnRtpStreamNeedWorstRemoteFractionLost(RTC::RTP::RtpStreamRecv* /*rtpStream*/) override
 		{
+			return 0;
 		}
 	};
 


### PR DESCRIPTION
# Details

- Related to #1881.
- No functional change. The RTCP Sender Reports mediasoup sends are still built from the packet arrival time.
- `Transport` now keeps a `RemoteCaptureTimeEstimator` instance per sender, keyed by CNAME, and feeds it with every Sender Report received. `Producer` asks it for the capture instant of each packet that becomes the highest RTP timestamp of its stream and stores it in the packet, and `RtpStream` records it alongside that highest RTP timestamp. Nothing reads these things yet.