### PR TITLE
Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received ([PR #1886](https://github.com/versatica/mediasoup/pull/1886)).
+
 ### 3.24.2
 
 - Worker: Verify `DataConsumer` subchannels before cloning the message ([PR #1880](https://github.com/versatica/mediasoup/pull/1880)).

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received ([PR #1886](https://github.com/versatica/mediasoup/pull/1886)).
+
 ### 0.25.2
 
 - Worker: Verify `DataConsumer` subchannels before cloning the message ([PR #1880](https://github.com/versatica/mediasoup/pull/1880)).

--- a/worker/src/RTC/RTP/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RTP/RtpStreamRecv.cpp
@@ -895,6 +895,15 @@ namespace RTC
 				return;
 			}
 
+			// We expected packets but received none of them, so there is nothing to
+			// compute (and ratios below would divide by zero).
+			if (received == 0)
+			{
+				RTP::RtpStream::UpdateScore(0);
+
+				return;
+			}
+
 			lost = std::min(lost, received);
 
 			if (repaired > lost)


### PR DESCRIPTION
# Details

- Fixes https://github.com/versatica/mediasoup/actions/runs/31715636811/job/94499741000.
- `RtpStreamRecv::UpdateScore()` divides by the number of packets received in the interval without checking if it was zero. When a Sender Report or Receiver Report is processed before the first RTP packet has been received, `expected` is 1 (so the existing `expected == 0` early return doesn't apply) while `received` is 0, so `repairedRatio` and `deliveredRatio` become NaN and casting NaN to an integer type is undefined behavior (reported by UBSan).
- Now, if packets were expected but none was received, the worst score (0) is applied and the computation is skipped.