### PR TITLE
Generate RTCP Sender Reports based on the capture instant of the media rather than on the packet arrival time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received ([PR #1886](https://github.com/versatica/mediasoup/pull/1886)).
+- Generate RTCP Sender Reports based on the capture instant of the media rather than on the packet arrival time ([PR #1887](https://github.com/versatica/mediasoup/pull/1887)).
 
 ### 3.24.2
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received ([PR #1886](https://github.com/versatica/mediasoup/pull/1886)).
+- Generate RTCP Sender Reports based on the capture instant of the media rather than on the packet arrival time ([PR #1887](https://github.com/versatica/mediasoup/pull/1887)).
 
 ### 0.25.2
 

--- a/worker/include/RTC/RTP/RtpStreamSend.hpp
+++ b/worker/include/RTC/RTP/RtpStreamSend.hpp
@@ -21,6 +21,16 @@ namespace RTC
 			 * Maximum retransmission buffer size for audio (ms).
 			 */
 			static constexpr uint32_t MaxRetransmissionDelayForAudioMs{ 1000 };
+			/**
+			 * How old the last packet sent may be for a Sender Report to still be generated
+			 * (ms).
+			 *
+			 * @remarks
+			 * - Above the interval between packets of any legitimate stream, including Opus
+			 *   with a 120 ms ptime and screen sharing at 1 fps, so that it only triggers on
+			 *   a stream that has really stopped sending.
+			 */
+			static constexpr uint32_t MaxSenderReportReferenceAgeMs{ 2000 };
 
 		public:
 			enum class ReceivePacketResult : uint8_t

--- a/worker/src/RTC/RTP/RtpStreamSend.cpp
+++ b/worker/src/RTC/RTP/RtpStreamSend.cpp
@@ -336,6 +336,13 @@ namespace RTC
 				return nullptr;
 			}
 
+			// A stream that stopped sending cannot tell where its RTP timeline is now, and
+			// extrapolating would claim RTP timestamps of packets never sent.
+			if (nowMs - this->maxPacketMs > RtpStreamSend::MaxSenderReportReferenceAgeMs)
+			{
+				return nullptr;
+			}
+
 			auto ntp     = Utils::Time::TimeMs2Ntp(nowMs);
 			auto* report = new RTC::RTCP::SenderReport();
 

--- a/worker/src/RTC/RTP/RtpStreamSend.cpp
+++ b/worker/src/RTC/RTP/RtpStreamSend.cpp
@@ -339,8 +339,12 @@ namespace RTC
 			auto ntp     = Utils::Time::TimeMs2Ntp(nowMs);
 			auto* report = new RTC::RTCP::SenderReport();
 
-			// Calculate TS difference between now and maxPacketMs.
-			const uint64_t diffMs = nowMs - this->maxPacketMs;
+			// Calculate TS difference between now and the instant at which the media in the
+			// packet holding the highest RTP timestamp was captured, falling back to the
+			// instant that packet was seen while the capture instant cannot be told.
+			const uint64_t referenceMs = this->maxPacketCaptureMs.value_or(this->maxPacketMs);
+			// NOTE: The capture instant is an estimation, so it may land ahead of now.
+			const uint64_t diffMs = nowMs > referenceMs ? nowMs - referenceMs : 0;
 			const uint64_t diffTs = diffMs * GetClockRate() / 1000;
 			const auto rtpTs      = static_cast<uint32_t>(this->maxPacketTs + diffTs);
 

--- a/worker/test/src/RTC/RTP/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/RTP/TestRtpStreamSend.cpp
@@ -1155,10 +1155,10 @@ SCENARIO("RtpStreamSend", "[rtp][rtcp][nack][rtpstream][rtpstreamsend]")
 			  packet.get());
 
 			const std::unique_ptr<RTC::RTCP::SenderReport> report(
-			  stream.GetRtcpSenderReport(PacketMs + 2000));
+			  stream.GetRtcpSenderReport(PacketMs + 1000));
 
 			REQUIRE(report);
-			REQUIRE(report->GetRtpTs() == PacketTs + (2 * params.clockRate));
+			REQUIRE(report->GetRtpTs() == PacketTs + params.clockRate);
 		}
 
 		// With capture instant, the extra half second since it is accounted for.
@@ -1176,10 +1176,10 @@ SCENARIO("RtpStreamSend", "[rtp][rtcp][nack][rtpstream][rtpstreamsend]")
 			  packet.get());
 
 			const std::unique_ptr<RTC::RTCP::SenderReport> report(
-			  stream.GetRtcpSenderReport(PacketMs + 2000));
+			  stream.GetRtcpSenderReport(PacketMs + 1000));
 
 			REQUIRE(report);
-			REQUIRE(report->GetRtpTs() == PacketTs + ((2500 * params.clockRate) / 1000));
+			REQUIRE(report->GetRtpTs() == PacketTs + ((1500 * params.clockRate) / 1000));
 		}
 
 		// A capture instant ahead of now, which the estimation may yield, does not make the
@@ -1198,11 +1198,50 @@ SCENARIO("RtpStreamSend", "[rtp][rtcp][nack][rtpstream][rtpstreamsend]")
 			  packet.get());
 
 			const std::unique_ptr<RTC::RTCP::SenderReport> report(
-			  stream.GetRtcpSenderReport(PacketMs + 2000));
+			  stream.GetRtcpSenderReport(PacketMs + 1000));
 
 			REQUIRE(report);
 			REQUIRE(report->GetRtpTs() == PacketTs);
 		}
+	}
+
+	SECTION("no Sender Report is generated once the stream has stopped sending")
+	{
+		// Instant reported by the mocked clock, and hence the one at which packets are seen.
+		constexpr uint64_t PacketMs{ 1000 };
+		constexpr uint32_t PacketTs{ 1533790901 };
+
+		TestRtpStreamListener testRtpStreamListener;
+
+		RTC::RTP::RtpStream::Params params;
+
+		params.ssrc          = 1111;
+		params.clockRate     = 90000;
+		params.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
+
+		std::string mid;
+
+		RTC::RTP::RtpStreamSend stream(
+		  std::addressof(testRtpStreamListener), std::addressof(shared), params, mid);
+		auto packet(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, PacketTs));
+
+		sendRtpPacket(
+		  {
+		    { std::addressof(stream), params.ssrc }
+    },
+		  packet.get());
+
+		// Right at the limit the Sender Report is still generated.
+		const std::unique_ptr<RTC::RTCP::SenderReport> report(
+		  stream.GetRtcpSenderReport(PacketMs + RTC::RTP::RtpStreamSend::MaxSenderReportReferenceAgeMs));
+
+		REQUIRE(report);
+
+		// Past the limit it is not.
+		const std::unique_ptr<RTC::RTCP::SenderReport> staleReport(stream.GetRtcpSenderReport(
+		  PacketMs + RTC::RTP::RtpStreamSend::MaxSenderReportReferenceAgeMs + 1));
+
+		REQUIRE_FALSE(staleReport);
 	}
 
 #ifdef PERFORMANCE_TEST

--- a/worker/test/src/RTC/RTP/TestRtpStreamSend.cpp
+++ b/worker/test/src/RTC/RTP/TestRtpStreamSend.cpp
@@ -1,5 +1,6 @@
 #include "common.hpp"
 #include "RTC/RTCP/FeedbackRtpNack.hpp"
+#include "RTC/RTCP/SenderReport.hpp"
 #include "RTC/RTP/Codecs/AV1.hpp"
 #include "RTC/RTP/Codecs/PayloadDescriptorHandler.hpp"
 #include "RTC/RTP/Codecs/VP8.hpp"
@@ -1123,6 +1124,85 @@ SCENARIO("RtpStreamSend", "[rtp][rtcp][nack][rtpstream][rtpstreamsend]")
 		result = stream->ReceivePacket(packet.get(), sharedPacket);
 
 		REQUIRE(result == RTC::RTP::RtpStreamSend::ReceivePacketResult::DISCARDED);
+	}
+
+	SECTION("Sender Report RTP timestamp is based on the capture instant when known")
+	{
+		// Instant reported by the mocked clock, and hence the one at which packets are seen.
+		constexpr uint64_t PacketMs{ 1000 };
+		constexpr uint32_t PacketTs{ 1533790901 };
+
+		TestRtpStreamListener testRtpStreamListener;
+
+		RTC::RTP::RtpStream::Params params;
+
+		params.ssrc          = 1111;
+		params.clockRate     = 90000;
+		params.mimeType.type = RTC::RtpCodecMimeType::Type::VIDEO;
+
+		std::string mid;
+
+		// Without capture instant, the instant at which the packet was seen is used.
+		{
+			RTC::RTP::RtpStreamSend stream(
+			  std::addressof(testRtpStreamListener), std::addressof(shared), params, mid);
+			auto packet(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, PacketTs));
+
+			sendRtpPacket(
+			  {
+			    { std::addressof(stream), params.ssrc }
+      },
+			  packet.get());
+
+			const std::unique_ptr<RTC::RTCP::SenderReport> report(
+			  stream.GetRtcpSenderReport(PacketMs + 2000));
+
+			REQUIRE(report);
+			REQUIRE(report->GetRtpTs() == PacketTs + (2 * params.clockRate));
+		}
+
+		// With capture instant, the extra half second since it is accounted for.
+		{
+			RTC::RTP::RtpStreamSend stream(
+			  std::addressof(testRtpStreamListener), std::addressof(shared), params, mid);
+			auto packet(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, PacketTs));
+
+			packet->SetCaptureMs(PacketMs - 500);
+
+			sendRtpPacket(
+			  {
+			    { std::addressof(stream), params.ssrc }
+      },
+			  packet.get());
+
+			const std::unique_ptr<RTC::RTCP::SenderReport> report(
+			  stream.GetRtcpSenderReport(PacketMs + 2000));
+
+			REQUIRE(report);
+			REQUIRE(report->GetRtpTs() == PacketTs + ((2500 * params.clockRate) / 1000));
+		}
+
+		// A capture instant ahead of now, which the estimation may yield, does not make the
+		// difference wrap around.
+		{
+			RTC::RTP::RtpStreamSend stream(
+			  std::addressof(testRtpStreamListener), std::addressof(shared), params, mid);
+			auto packet(createRtpPacket(rtpBuffer1, sizeof(rtpBuffer1), 21006, PacketTs));
+
+			packet->SetCaptureMs(PacketMs + 3000);
+
+			sendRtpPacket(
+			  {
+			    { std::addressof(stream), params.ssrc }
+      },
+			  packet.get());
+
+			const std::unique_ptr<RTC::RTCP::SenderReport> report(
+			  stream.GetRtcpSenderReport(PacketMs + 2000));
+
+			REQUIRE(report);
+			REQUIRE(report->GetRtpTs() == PacketTs);
+		}
 	}
 
 #ifdef PERFORMANCE_TEST


### PR DESCRIPTION
# Details

- Related to #1881.
- `RtpStreamSend::GetRtcpSenderReport()` now extrapolates from the instant at which the media was captured instead of the instant the packet reached mediasoup, so a sender's uplink delay is no longer reported as part of the content timing. Streams with no capture instant available, and senders that send no RTCP at all, keep the previous behaviour.
- No Sender Report is generated for a stream that has not sent anything for more than `MaxSenderReportReferenceAgeMs` (2000 ms), since extrapolating from a stale reference claims RTP timestamps of packets that were never sent.
- Receivers will start applying a relative offset between the audio and video (typical scenario) of a same sender where they previously applied none, which is the point of the change and which increases audio latency by that offset (in case the video stream reaches mediasoup with more delay due to congestion on the sender's uplink).

## Behavior changes

- Receivers now get the real timing relation between the audio and the video of a same sender, so lip sync is correct even when that sender's uplink delays its video much more than its audio.
- The mapping we report does not move with network conditions any more. So if a receiver gets misaligned during congestion, there is something correct for it to converge back to once the network recovers (so no permanent lip-sync in some well-known RTP endpoints).
- A frozen or idle stream no longer claims RTP timestamps of packets that were never sent.

**Not so good changes (but not bad):**

- While a stream sends nothing for more than 2 seconds there is no sync information and no RTT for it. Screen sharing at very low framerate and audio with DTX are examples. But if they are not sending real media then there is nothing to sync in the receiver side so it's not that bad.
- Nothing improves for senders that send no RTCP at all, such as typical Node based RTP senders created on `DirectTransports` or terrible FFMpeg scripts that d not send RTCP. This is same as before, no changes.
- During the first seconds and assuming that a client enables audio and video at the same time, while the video already has a capture instant and the audio does not yet (because clients usually send RTCP Sender Reports every 1 second for video and every 5 seconds for audio), receivers see a small skew of the order of the audio delay (= time it takes for audio packets to reach mediasoup once sent from the sender). It corrects itself when the audio Sender Report arrives to mediasoup. However this is not that true. Chrome for example sends the first RTCP Sender Report for audio only ~1.2 seconds later than the first SR for video. So no real problem here.