### PR TITLE
Fix abs-capture-time extension read failure

### DIFF
--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -696,6 +696,14 @@ namespace RTC
 					  producerRtpHeaderExtensionIds.dependencyDescriptor;
 				}
 
+				// NOTE: Not transport related, but needed here so that received packets carry
+				// its id and `RtpStreamRecv` can read the extension off them.
+				if (producerRtpHeaderExtensionIds.absCaptureTime != 0)
+				{
+					this->recvRtpHeaderExtensionIds.absCaptureTime =
+					  producerRtpHeaderExtensionIds.absCaptureTime;
+				}
+
 				// Create status response.
 				auto responseOffset = FBS::Transport::CreateProduceResponse(
 				  request->GetBufferBuilder(), FBS::RtpParameters::Type(producer->GetType()));


### PR DESCRIPTION
# Details

- Fixes a bug introduced in PR #1883.
- It needs to be added in `Transport`'s `recvRtpHeaderExtensionIds` map so they are later assigned to the received RTP `Packet` can can be read from `RtpStreamRecv`.