### PR TITLE
`SimulcastProducerStreamManager`: Apply new capture time logic and fix 'abs-capture-time' rewriting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,13 @@
 ### NEXT
 
 - Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received ([PR #1886](https://github.com/versatica/mediasoup/pull/1886)).
-- Generate RTCP Sender Reports based on the capture instant of the media rather than on the packet arrival time ([PR #1887](https://github.com/versatica/mediasoup/pull/1887)).
+- Do not make generated RTCP Sender Reports depend on RTP packet arrival time ([issue #1881](https://github.com/versatica/mediasoup/issues/1881)):
+  - `RemoteClockOffsetEstimator` class ([PR #1882](https://github.com/versatica/mediasoup/pull/1882)).
+  - Prepare `RtpStream` classes for capture time based RTCP Sender Reports ([PR #1883](https://github.com/versatica/mediasoup/pull/1883), [PR #1888](https://github.com/versatica/mediasoup/pull/1888)).
+  - `RemoteCaptureTimeEstimator` class ([PR #1884](https://github.com/versatica/mediasoup/pull/1884)).
+  - Estimate the capture instant of each received RTP packet ([PR #1885](https://github.com/versatica/mediasoup/pull/1885)).
+  - Generate RTCP Sender Reports based on the capture instant of the media rather than on the packet arrival time ([PR #1887](https://github.com/versatica/mediasoup/pull/1887)).
+  - `SimulcastProducerStreamManager`: Apply new capture time logic and fix 'abs-capture-time' rewriting ([PR #1889](https://github.com/versatica/mediasoup/pull/1889)).
 
 ### 3.24.2
 

--- a/node/src/Transport.ts
+++ b/node/src/Transport.ts
@@ -508,6 +508,13 @@ export abstract class TransportImpl<
 			clonedRtpParameters.rtcp = clonedRtpParameters.rtcp ?? {};
 			clonedRtpParameters.rtcp.cname = this.#cnameForProducers;
 		}
+		// In a PipeTransport, give a random CNAME to a Producer that comes without one.
+		// Its own one, since a CNAME shared with the other Producers without CNAME would
+		// tell the worker that they all come from a same sender and share its clock.
+		else if (!clonedRtpParameters.rtcp?.cname) {
+			clonedRtpParameters.rtcp = clonedRtpParameters.rtcp ?? {};
+			clonedRtpParameters.rtcp.cname = utils.generateUUIDv4().substr(0, 8);
+		}
 
 		const routerRtpCapabilities = this.#getRouterRtpCapabilities();
 

--- a/node/src/ortc.ts
+++ b/node/src/ortc.ts
@@ -514,6 +514,19 @@ export function getConsumableRtpParameters(
 			continue;
 		}
 
+		// 'abs-capture-time' RTP extension is just proxied from the packets of this
+		// Producer, so don't announce it to Consumers unless this Producer negotiated
+		// it. Otherwise a Producer created out of a pipe Consumer would announce it
+		// and the worker would wait forever for an extension that is never going to
+		// arrive.
+		if (
+			capExt.uri ===
+				'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time' &&
+			!params.headerExtensions!.some(ext => ext.uri === capExt.uri)
+		) {
+			continue;
+		}
+
 		const consumableExt = {
 			uri: capExt.uri,
 			id: capExt.preferredId,

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -274,12 +274,6 @@ test('router.pipeToRouter() succeeds with audio', async () => {
 			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
 		},
 		{
-			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
-			id: 10,
-			encrypt: false,
-			parameters: {},
-		},
-		{
 			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay',
 			id: 11,
 			encrypt: false,
@@ -332,12 +326,6 @@ test('router.pipeToRouter() succeeds with audio', async () => {
 			id: 7,
 			parameters: {},
 			uri: 'https://aomediacodec.github.io/av1-rtp-spec/#dependency-descriptor-rtp-header-extension',
-		},
-		{
-			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
-			id: 10,
-			encrypt: false,
-			parameters: {},
 		},
 		{
 			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay',
@@ -413,12 +401,6 @@ test('router.pipeToRouter() succeeds with video', async () => {
 			parameters: {},
 		},
 		{
-			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
-			id: 10,
-			encrypt: false,
-			parameters: {},
-		},
-		{
 			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/playout-delay',
 			id: 11,
 			encrypt: false,
@@ -475,12 +457,6 @@ test('router.pipeToRouter() succeeds with video', async () => {
 		{
 			uri: 'urn:ietf:params:rtp-hdrext:toffset',
 			id: 9,
-			encrypt: false,
-			parameters: {},
-		},
-		{
-			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
-			id: 10,
 			encrypt: false,
 			parameters: {},
 		},
@@ -624,12 +600,6 @@ test('router.createPipeTransport() with enableRtx succeeds', async () => {
 		{
 			uri: 'urn:ietf:params:rtp-hdrext:toffset',
 			id: 9,
-			encrypt: false,
-			parameters: {},
-		},
-		{
-			uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
-			id: 10,
 			encrypt: false,
 			parameters: {},
 		},

--- a/node/src/test/test-PipeTransport.ts
+++ b/node/src/test/test-PipeTransport.ts
@@ -476,6 +476,47 @@ test('router.pipeToRouter() succeeds with video', async () => {
 	expect(pipeProducer.paused).toBe(true);
 }, 2000);
 
+test('router.pipeToRouter() gives abs-capture-time to the pipe Consumer if the Producer has it', async () => {
+	const videoProducer2 = await ctx.webRtcTransport1!.produce({
+		kind: 'video',
+		rtpParameters: {
+			mid: 'VIDEO2',
+			codecs: [
+				{
+					mimeType: 'video/VP8',
+					payloadType: 112,
+					clockRate: 90000,
+				},
+			],
+			headerExtensions: [
+				{
+					uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
+					id: 12,
+				},
+			],
+			encodings: [{ ssrc: 44444444 }],
+			rtcp: {
+				cname: 'FOOBAR',
+			},
+		},
+	});
+
+	const { pipeConsumer } = (await ctx.router1!.pipeToRouter({
+		producerId: videoProducer2.id,
+		router: ctx.router2!,
+	})) as {
+		pipeConsumer: mediasoup.types.Consumer;
+		pipeProducer: mediasoup.types.Producer;
+	};
+
+	expect(pipeConsumer.rtpParameters.headerExtensions).toContainEqual({
+		uri: 'http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time',
+		id: 10,
+		encrypt: false,
+		parameters: {},
+	});
+}, 2000);
+
 test('router.pipeToRouter() with unknown router, producerId or dataProducerId fails', async () => {
 	const router3 = await ctx.worker1!.createRouter({
 		mediaCodecs: ctx.mediaCodecs,

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,7 +3,13 @@
 ### NEXT
 
 - Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received ([PR #1886](https://github.com/versatica/mediasoup/pull/1886)).
-- Generate RTCP Sender Reports based on the capture instant of the media rather than on the packet arrival time ([PR #1887](https://github.com/versatica/mediasoup/pull/1887)).
+- Do not make generated RTCP Sender Reports depend on RTP packet arrival time ([issue #1881](https://github.com/versatica/mediasoup/issues/1881)):
+  - `RemoteClockOffsetEstimator` class ([PR #1882](https://github.com/versatica/mediasoup/pull/1882)).
+  - Prepare `RtpStream` classes for capture time based RTCP Sender Reports ([PR #1883](https://github.com/versatica/mediasoup/pull/1883), [PR #1888](https://github.com/versatica/mediasoup/pull/1888)).
+  - `RemoteCaptureTimeEstimator` class ([PR #1884](https://github.com/versatica/mediasoup/pull/1884)).
+  - Estimate the capture instant of each received RTP packet ([PR #1885](https://github.com/versatica/mediasoup/pull/1885)).
+  - Generate RTCP Sender Reports based on the capture instant of the media rather than on the packet arrival time ([PR #1887](https://github.com/versatica/mediasoup/pull/1887)).
+  - `SimulcastProducerStreamManager`: Apply new capture time logic and fix 'abs-capture-time' rewriting ([PR #1889](https://github.com/versatica/mediasoup/pull/1889)).
 
 ### 0.25.2
 

--- a/rust/src/ortc.rs
+++ b/rust/src/ortc.rs
@@ -679,6 +679,19 @@ pub(crate) fn get_consumable_rtp_parameters(
             continue;
         }
 
+        // 'abs-capture-time' is just proxied from the packets of this Producer, so don't announce it
+        // to Consumers unless this Producer negotiated it. Otherwise a Producer created out of a
+        // pipe Consumer would announce it and the worker would wait forever for an extension that
+        // is never going to arrive.
+        if cap_ext.uri == RtpHeaderExtensionUri::AbsCaptureTime
+            && !params
+                .header_extensions
+                .iter()
+                .any(|ext| ext.uri == cap_ext.uri)
+        {
+            continue;
+        }
+
         let consumable_ext = RtpHeaderExtensionParameters {
             uri: cap_ext.uri,
             id: cap_ext.preferred_id,

--- a/rust/src/router/transport.rs
+++ b/rust/src/router/transport.rs
@@ -571,6 +571,12 @@ pub(super) trait TransportImpl: TransportGeneric {
                 rtp_parameters.rtcp.cname = Some(cname);
             }
         }
+        // In a PipeTransport, give a random CNAME to a Producer that comes without one. Its own
+        // one, since a CNAME shared with the other Producers without CNAME would tell the worker
+        // that they all come from a same sender and share its clock.
+        else if rtp_parameters.rtcp.cname.is_none() {
+            rtp_parameters.rtcp.cname = Some(Uuid::new_v4().to_string());
+        }
 
         let router_rtp_capabilities = self.router().rtp_capabilities();
 

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -356,11 +356,6 @@ fn pipe_to_router_succeeds_with_audio() {
                     encrypt: false,
                 },
                 RtpHeaderExtensionParameters {
-                    uri: RtpHeaderExtensionUri::AbsCaptureTime,
-                    id: 10,
-                    encrypt: false,
-                },
-                RtpHeaderExtensionParameters {
                     uri: RtpHeaderExtensionUri::PlayoutDelay,
                     id: 11,
                     encrypt: false,
@@ -413,11 +408,6 @@ fn pipe_to_router_succeeds_with_audio() {
                 RtpHeaderExtensionParameters {
                     uri: RtpHeaderExtensionUri::DependencyDescriptor,
                     id: 7,
-                    encrypt: false,
-                },
-                RtpHeaderExtensionParameters {
-                    uri: RtpHeaderExtensionUri::AbsCaptureTime,
-                    id: 10,
                     encrypt: false,
                 },
                 RtpHeaderExtensionParameters {
@@ -523,11 +513,6 @@ fn pipe_to_router_succeeds_with_video() {
                     encrypt: false,
                 },
                 RtpHeaderExtensionParameters {
-                    uri: RtpHeaderExtensionUri::AbsCaptureTime,
-                    id: 10,
-                    encrypt: false,
-                },
-                RtpHeaderExtensionParameters {
                     uri: RtpHeaderExtensionUri::PlayoutDelay,
                     id: 11,
                     encrypt: false,
@@ -581,11 +566,6 @@ fn pipe_to_router_succeeds_with_video() {
                 RtpHeaderExtensionParameters {
                     uri: RtpHeaderExtensionUri::TimeOffset,
                     id: 9,
-                    encrypt: false,
-                },
-                RtpHeaderExtensionParameters {
-                    uri: RtpHeaderExtensionUri::AbsCaptureTime,
-                    id: 10,
                     encrypt: false,
                 },
                 RtpHeaderExtensionParameters {
@@ -855,11 +835,6 @@ fn create_with_enable_rtx_succeeds() {
                 RtpHeaderExtensionParameters {
                     uri: RtpHeaderExtensionUri::TimeOffset,
                     id: 9,
-                    encrypt: false,
-                },
-                RtpHeaderExtensionParameters {
-                    uri: RtpHeaderExtensionUri::AbsCaptureTime,
-                    id: 10,
                     encrypt: false,
                 },
                 RtpHeaderExtensionParameters {

--- a/rust/tests/integration/pipe_transport.rs
+++ b/rust/tests/integration/pipe_transport.rs
@@ -153,6 +153,36 @@ fn video_producer_options() -> ProducerOptions {
     options
 }
 
+fn video_producer_options_with_abs_capture_time() -> ProducerOptions {
+    ProducerOptions::new(
+        MediaKind::Video,
+        RtpParameters {
+            mid: Some("VIDEO2".to_string()),
+            codecs: vec![RtpCodecParameters::Video {
+                mime_type: MimeTypeVideo::Vp8,
+                payload_type: 112,
+                clock_rate: NonZeroU32::new(90000).unwrap(),
+                parameters: RtpCodecParametersParameters::default(),
+                rtcp_feedback: vec![],
+            }],
+            header_extensions: vec![RtpHeaderExtensionParameters {
+                uri: RtpHeaderExtensionUri::AbsCaptureTime,
+                id: 12,
+                encrypt: false,
+            }],
+            encodings: vec![RtpEncodingParameters {
+                ssrc: Some(44444444),
+                ..RtpEncodingParameters::default()
+            }],
+            rtcp: RtcpParameters {
+                cname: Some("FOOBAR".to_string()),
+                ..RtcpParameters::default()
+            },
+            msid: None,
+        },
+    )
+}
+
 fn data_producer_options() -> DataProducerOptions {
     let mut options = DataProducerOptions::new_sctp(
         SctpStreamParameters::new_unordered_with_life_time(666, 5000),
@@ -581,6 +611,34 @@ fn pipe_to_router_succeeds_with_video() {
             ],
         );
         assert!(pipe_producer.paused());
+    });
+}
+
+#[test]
+fn pipe_to_router_gives_abs_capture_time_to_pipe_consumer_if_producer_has_it() {
+    future::block_on(async move {
+        let (_worker1, _worker2, router1, router2, transport1, _transport2) = init().await;
+
+        let video_producer = transport1
+            .produce(video_producer_options_with_abs_capture_time())
+            .await
+            .expect("Failed to produce video");
+
+        let PipeProducerToRouterPair { pipe_consumer, .. } = router1
+            .pipe_producer_to_router(
+                video_producer.id(),
+                PipeToRouterOptions::new(router2.clone()),
+            )
+            .await
+            .expect("Failed to pipe video producer to router");
+
+        assert!(pipe_consumer.rtp_parameters().header_extensions.contains(
+            &RtpHeaderExtensionParameters {
+                uri: RtpHeaderExtensionUri::AbsCaptureTime,
+                id: 10,
+                encrypt: false,
+            }
+        ));
     });
 }
 

--- a/worker/include/DepLibUV.hpp
+++ b/worker/include/DepLibUV.hpp
@@ -8,33 +8,59 @@ class DepLibUV
 {
 public:
 	static void ClassInit();
+
 	static void ClassDestroy();
+
 	static void PrintVersion();
+
 	static void RunLoop();
+
 	static uv_loop_t* GetLoop()
 	{
 		return DepLibUV::loop;
 	}
+
 	static uint64_t GetTimeMs()
 	{
 		return static_cast<uint64_t>(uv_hrtime() / 1000000u);
 	}
+
+	/**
+	 * Offset between our own monotonic clock and the NTP epoch (ms).
+	 *
+	 * @remarks
+	 * - It is taken just once, in ClassInit(), so that the NTP timestamps we generate
+	 *   never step when the system clock is adjusted. They just drift away from the real
+	 *   wall clock as much as our monotonic clock does.
+	 */
+	static uint64_t GetNtpOffsetMs()
+	{
+		return DepLibUV::ntpOffsetMs;
+	}
+
 	static uint64_t GetTimeUs()
 	{
 		return static_cast<uint64_t>(uv_hrtime() / 1000u);
 	}
+
 	static uint64_t GetTimeNs()
 	{
 		return uv_hrtime();
 	}
-	// Used within libwebrtc dependency which uses int64_t values for time
-	// representation.
+
+	/**
+	 * Used within libwebrtc dependency which uses int64_t values for time
+	 * representation.
+	 */
 	static int64_t GetTimeMsInt64()
 	{
 		return static_cast<int64_t>(DepLibUV::GetTimeMs());
 	}
-	// Used within libwebrtc dependency which uses int64_t values for time
-	// representation.
+
+	/**
+	 * Used within libwebrtc dependency which uses int64_t values for time
+	 * representation.
+	 */
 	static int64_t GetTimeUsInt64()
 	{
 		return static_cast<int64_t>(DepLibUV::GetTimeUs());
@@ -42,6 +68,9 @@ public:
 
 private:
 	static thread_local uv_loop_t* loop;
+	// Distance from our own monotonic clock to the NTP epoch (ms), taken at
+	// ClassInit().
+	static thread_local uint64_t ntpOffsetMs;
 };
 
 #endif

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -61,6 +61,13 @@ namespace RTC
 			 */
 			virtual std::optional<uint64_t> OnProducerNeedLocalCaptureMs(
 			  RTC::Producer* producer, const RTC::RTP::RtpStreamRecv* rtpStream, uint32_t ts) = 0;
+			/**
+			 * Offset between the wall clock of the sender of this Producer and our own
+			 * monotonic one (ms).
+			 *
+			 * @returns No value while the offset cannot be told yet.
+			 */
+			virtual std::optional<int64_t> OnProducerNeedRemoteClockOffsetMs(const RTC::Producer* producer) = 0;
 		};
 
 	private:

--- a/worker/include/RTC/Producer.hpp
+++ b/worker/include/RTC/Producer.hpp
@@ -177,7 +177,7 @@ namespace RTC
 		 *   backwards after prolonged sender inactivity or a sequence number resync.
 		 */
 		void PostProcessRtpPacket(
-		  RTC::RTP::Packet* packet, const RTC::RTP::RtpStreamRecv* rtpStream, bool maxPacketTsChanged);
+		  RTC::RTP::Packet* packet, RTC::RTP::RtpStreamRecv* rtpStream, bool maxPacketTsChanged);
 		void EmitScore() const;
 		void EmitTraceEventRtpAndKeyFrameTypes(const RTC::RTP::Packet* packet, bool isRtx = false) const;
 		void EmitTraceEventPliType(uint32_t ssrc) const;

--- a/worker/include/RTC/RTCP/Packet.hpp
+++ b/worker/include/RTC/RTCP/Packet.hpp
@@ -14,7 +14,13 @@ namespace RTC
 		extern uint8_t SerializationBuffer[SerializationBufferSize];
 
 		// Maximum interval for regular RTCP mode.
-		constexpr uint16_t MaxAudioIntervalMs{ 5000 };
+		//
+		// NOTE: Audio does not take the 5000 ms that other implementations take, because our
+		// correspondence between NTP and RTP timestamps is not the fixed line of a real
+		// capture system but an estimation that moves. Refreshing it for audio less often
+		// than for video would make receivers combine measurements taken at different
+		// instants, and that difference is lip sync error.
+		constexpr uint16_t MaxAudioIntervalMs{ 1000 };
 		constexpr uint16_t MaxVideoIntervalMs{ 1000 };
 
 		enum class Type : uint8_t

--- a/worker/include/RTC/RTP/RtpStream.hpp
+++ b/worker/include/RTC/RTP/RtpStream.hpp
@@ -263,6 +263,10 @@ namespace RTC
 			uint64_t maxPacketMs{ 0u };
 			// When the media in the packet with highest timestamp was captured, in our own
 			// monotonic clock.
+			// NOTE: Only meaningful in a send stream, whose packets arrive already carrying
+			// their capture instant. In a receive stream it is the Producer that tells it,
+			// once this class has already seen the packet, so
+			// RtpStreamRecv::GetCaptureMapping() is what must be used there.
 			std::optional<uint64_t> maxPacketCaptureMs;
 			int32_t packetsLost{ 0 };
 			uint8_t fractionLost{ 0u };

--- a/worker/include/RTC/RTP/RtpStreamRecv.hpp
+++ b/worker/include/RTC/RTP/RtpStreamRecv.hpp
@@ -72,6 +72,24 @@ namespace RTC
 				std::vector<std::vector<RTC::RtpDataCounter>> spatialLayerCounters;
 			};
 
+		public:
+			/**
+			 * Correspondence between the RTP timeline of this stream and our own monotonic
+			 * clock.
+			 */
+			struct CaptureMapping
+			{
+				/**
+				 * Capture instant of the media carried by the RTP timestamp below, in our own
+				 * monotonic clock (ms).
+				 */
+				uint64_t captureMs;
+				/**
+				 * RTP timestamp the capture instant above refers to.
+				 */
+				uint32_t ts;
+			};
+
 		private:
 			/**
 			 * Data of a received RTCP Sender Report needed to report LSR and DLSR back in a
@@ -146,6 +164,41 @@ namespace RTC
 				}
 
 				return this->lastSenderReportTiming.value().receivedMs;
+			}
+
+			/**
+			 * Store the correspondence between the RTP timeline of this stream and our own
+			 * monotonic clock.
+			 *
+			 * @remarks
+			 * - Only the Producer can tell it, since translating the capture instant of the
+			 *   remote sender into our own clock needs the whole set of streams of that
+			 *   sender.
+			 *
+			 * @param captureMs - Capture instant of `ts` in our own monotonic clock.
+			 * @param ts - RTP timestamp the capture instant refers to.
+			 */
+			void SetCaptureMapping(uint64_t captureMs, uint32_t ts)
+			{
+				this->lastCaptureMapping = RTP::RtpStreamRecv::CaptureMapping{
+					.captureMs = captureMs,
+					.ts        = ts,
+				};
+			}
+
+			/**
+			 * Correspondence between the RTP timeline of this stream and our own monotonic
+			 * clock, as of the last RTP timestamp whose capture instant could be told.
+			 *
+			 * @remarks
+			 * - Once set it is never unset, so any two streams of a same sender that have it
+			 *   can always be aligned to each other.
+			 *
+			 * @returns No value if no capture instant could be told yet.
+			 */
+			std::optional<RTP::RtpStreamRecv::CaptureMapping> GetCaptureMapping() const
+			{
+				return this->lastCaptureMapping;
 			}
 
 			/**
@@ -250,6 +303,8 @@ namespace RTC
 			std::optional<SenderReportTiming> lastSenderReportTiming;
 			// Most recent `abs-capture-time` RTP header extension received.
 			std::optional<AbsCaptureTime> lastAbsCaptureTime;
+			// Most recent RTP timestamp whose capture instant could be told, along with it.
+			std::optional<CaptureMapping> lastCaptureMapping;
 			// Relative transit time for prev packet.
 			int32_t transit{ 0u };
 			uint8_t firSeqNumber{ 0u };

--- a/worker/include/RTC/RemoteCaptureTimeEstimator.hpp
+++ b/worker/include/RTC/RemoteCaptureTimeEstimator.hpp
@@ -61,6 +61,16 @@ namespace RTC
 		void SenderReportReceived(const RTC::RTP::RtpStreamRecv* rtpStream);
 
 		/**
+		 * Offset between the wall clock of this sender and our own monotonic one (ms).
+		 *
+		 * @returns No value while the offset cannot be told yet.
+		 */
+		std::optional<int64_t> GetClockOffsetMs() const
+		{
+			return this->clockOffsetEstimator.GetOffsetMs();
+		}
+
+		/**
 		 * Capture instant of the given RTP timestamp of the given RTP stream,
 		 * expressed in our own monotonic clock.
 		 *

--- a/worker/include/RTC/SimulcastProducerStreamManager.hpp
+++ b/worker/include/RTC/SimulcastProducerStreamManager.hpp
@@ -80,6 +80,9 @@ namespace RTC
 		int16_t spatialLayerToSync{ -1 };
 		// Timestamp synchronization.
 		int16_t tsReferenceSpatialLayer{ -1 };
+		// Spatial layer that was the RTP timestamp reference the last time its capture
+		// instant was known upon a received Sender Report.
+		int16_t tsReferenceSpatialLayerWithCaptureMapping{ -1 };
 		uint32_t tsOffset{ 0u };
 		bool keyFrameForTsOffsetRequested{ false };
 		// Old-packet filtering after spatial switch.

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -269,6 +269,7 @@ namespace RTC
 		uint8_t OnProducerNeedWorstRemoteFractionLost(RTC::Producer* producer, uint32_t mappedSsrc) override;
 		std::optional<uint64_t> OnProducerNeedLocalCaptureMs(
 		  RTC::Producer* producer, const RTC::RTP::RtpStreamRecv* rtpStream, uint32_t ts) override;
+		std::optional<int64_t> OnProducerNeedRemoteClockOffsetMs(const RTC::Producer* producer) override;
 
 		/* Pure virtual methods inherited from RTC::Consumer::Listener. */
 	public:

--- a/worker/include/Shared.hpp
+++ b/worker/include/Shared.hpp
@@ -56,6 +56,11 @@ public:
 		return DepLibUV::GetTimeUsInt64();
 	}
 
+	uint64_t GetNtpOffsetMs() override
+	{
+		return DepLibUV::GetNtpOffsetMs();
+	}
+
 private:
 	std::unique_ptr<Channel::ChannelMessageRegistrator> channelMessageRegistrator;
 	std::unique_ptr<Channel::ChannelNotifier> channelNotifier;

--- a/worker/include/SharedInterface.hpp
+++ b/worker/include/SharedInterface.hpp
@@ -72,6 +72,12 @@ public:
 	 * @todo Remove once not needed.
 	 */
 	virtual int64_t GetTimeUsInt64() = 0;
+
+	/**
+	 * Distance from the clock above to the NTP epoch (ms), which is what has to be added
+	 * to it to obtain the NTP timestamps of the RTCP we generate.
+	 */
+	virtual uint64_t GetNtpOffsetMs() = 0;
 };
 
 #endif

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -500,9 +500,11 @@ namespace Utils
 
 	class Time
 	{
-	private:
+	public:
 		// Seconds from Jan 1, 1900 to Jan 1, 1970.
-		static constexpr uint32_t UnixNtpOffset{ 0x83AA7E80 };
+		static constexpr uint32_t UnixNtpOffsetSec{ 0x83AA7E80 };
+
+	private:
 		// NTP fractional unit.
 		static constexpr uint64_t NtpFractionalUnit{ 1LL << 32 };
 
@@ -517,7 +519,11 @@ namespace Utils
 		{
 			Time::Ntp ntp{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
 
-			ntp.seconds = ms / 1000;
+			// NOTE: The truncation is intended. Seconds are 32 bits wide in NTP, so they wrap
+			// every 2^32 seconds since Jan 1, 1900, being Feb 7, 2036 the next time it
+			// happens. That is the NTP era and receivers deal with it by doing modular
+			// arithmetic, so there is nothing to protect against here.
+			ntp.seconds = static_cast<uint32_t>(ms / 1000);
 			ntp.fractions =
 			  static_cast<uint32_t>((static_cast<double>(ms % 1000) / 1000) * NtpFractionalUnit);
 
@@ -535,6 +541,41 @@ namespace Utils
 		static uint32_t TimeMsToAbsSendTime(uint64_t ms)
 		{
 			return static_cast<uint32_t>(((ms << 18) + 500) / 1000) & 0x00FFFFFF;
+		}
+
+		/**
+		 * Convert milliseconds into signed Q32.32 fixed point seconds, which is how the
+		 * `abs-capture-time` RTP header extension encodes its clock offset, being the
+		 * capture timestamp itself unsigned instead (UQ32.32).
+		 *
+		 * @returns No value if the given instant does not fit in the format, whose seconds
+		 * are 32 bits wide.
+		 *
+		 * @see https://datatracker.ietf.org/doc/html/draft-ietf-avtcore-abs-capture-time-00
+		 */
+		static std::optional<int64_t> TimeMs2Q32x32(int64_t ms)
+		{
+			// The seconds of the format are 32 bits wide, so from here on it does not fit.
+			static constexpr int64_t OutOfRangeMs{ (1LL << 31) * 1000 };
+
+			if (ms >= OutOfRangeMs || ms <= -OutOfRangeMs)
+			{
+				return std::nullopt;
+			}
+
+			return static_cast<int64_t>(
+			  std::round(static_cast<double>(ms) * (static_cast<double>(NtpFractionalUnit) / 1000)));
+		}
+
+		/**
+		 * Convert signed Q32.32 fixed point seconds into milliseconds.
+		 *
+		 * @see https://datatracker.ietf.org/doc/html/draft-ietf-avtcore-abs-capture-time-00
+		 */
+		static int64_t Q32x32ToTimeMs(int64_t q32x32)
+		{
+			return static_cast<int64_t>(
+			  std::round(static_cast<double>(q32x32) * (1000 / static_cast<double>(NtpFractionalUnit))));
 		}
 	};
 

--- a/worker/mocks/include/MockShared.hpp
+++ b/worker/mocks/include/MockShared.hpp
@@ -60,6 +60,13 @@ namespace mocks
 			return static_cast<int64_t>(GetTimeUs());
 		}
 
+		// NOTE: The NTP epoch is made to be the very clock given by argument, so that tests
+		// can reason about a single set of values.
+		uint64_t GetNtpOffsetMs() override
+		{
+			return 0;
+		}
+
 		// Methods for testing.
 	public:
 		MockBackoffTimerHandle* GetBackoffTimer(const std::string_view label) const

--- a/worker/src/DepLibUV.cpp
+++ b/worker/src/DepLibUV.cpp
@@ -3,10 +3,12 @@
 
 #include "DepLibUV.hpp"
 #include "Logger.hpp"
+#include "Utils.hpp"
 
 /* Class variables. */
 
 thread_local uv_loop_t* DepLibUV::loop{ nullptr };
+thread_local uint64_t DepLibUV::ntpOffsetMs{ 0 };
 
 /* Static methods for UV callbacks. */
 
@@ -48,6 +50,21 @@ void DepLibUV::ClassInit()
 	{
 		MS_ABORT("libuv loop initialization failed");
 	}
+
+	// Take the distance from our own monotonic clock to the NTP epoch just once, so that
+	// the NTP timestamps we generate never step when the system clock is adjusted.
+	uv_timeval64_t timeval{}; // NOLINT(cppcoreguidelines-pro-type-member-init)
+
+	if (uv_gettimeofday(std::addressof(timeval)) != 0)
+	{
+		MS_ABORT("uv_gettimeofday() failed");
+	}
+
+	const auto unixSec = static_cast<uint64_t>(timeval.tv_sec);
+	const auto unixMs  = (unixSec * 1000) + (static_cast<uint64_t>(timeval.tv_usec) / 1000);
+	const auto ntpMs   = unixMs + (static_cast<uint64_t>(Utils::Time::UnixNtpOffsetSec) * 1000);
+
+	DepLibUV::ntpOffsetMs = ntpMs - DepLibUV::GetTimeMs();
 }
 
 void DepLibUV::ClassDestroy()

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -771,7 +771,8 @@ namespace RTC
 		// Add a receiver reference time report if no present in the packet.
 		if (!packet->HasReceiverReferenceTime())
 		{
-			auto ntp                    = Utils::Time::TimeMs2Ntp(nowMs);
+			auto ntp = Utils::Time::TimeMs2Ntp(nowMs + this->shared->GetNtpOffsetMs());
+
 			receiverReferenceTimeReport = new RTC::RTCP::ReceiverReferenceTime();
 
 			receiverReferenceTimeReport->SetNtpSec(ntp.seconds);
@@ -1229,19 +1230,65 @@ namespace RTC
 			}
 
 			// Proxy http://www.webrtc.org/experiments/rtp-hdrext/abs-capture-time.
+			//
+			// The capture timestamp is left untouched since it belongs to the clock of the
+			// capture system, but the capture clock offset has to be rewritten. It tells the
+			// offset between the clock of the capture system and the clock of whoever sends
+			// the stream, and by forwarding the stream we become that sender:
+			//
+			//   capture NTP clock = sender NTP clock + capture clock offset
+			//
+			// @see https://datatracker.ietf.org/doc/html/draft-ietf-avtcore-abs-capture-time-00
 			extenValue = packet->GetExtensionValue(this->rtpHeaderExtensionIds.absCaptureTime, extenLen);
 
-			if (extenValue)
+			// NOTE: The extension value is 8 or 16 bytes long depending on whether it holds
+			// the capture clock offset or not.
+			if (extenValue && (extenLen == 8u || extenLen == 16u))
 			{
-				std::memcpy(bufferPtr, extenValue, extenLen);
+				// Offset between our own clock and the clock of the sender of this stream, in
+				// the format the extension uses.
+				const auto remoteClockOffsetMs = this->listener->OnProducerNeedRemoteClockOffsetMs(this);
 
-				extensions.emplace_back(
-				  /*type*/ RTC::RtpHeaderExtensionUri::Type::ABS_CAPTURE_TIME,
-				  /*id*/ static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::ABS_CAPTURE_TIME),
-				  /*len*/ extenLen,
-				  /*value*/ bufferPtr);
+				std::optional<int64_t> remoteClockOffsetQ32x32;
 
-				bufferPtr += extenLen;
+				if (remoteClockOffsetMs.has_value())
+				{
+					remoteClockOffsetQ32x32 = Utils::Time::TimeMs2Q32x32(remoteClockOffsetMs.value());
+				}
+
+				// NOTE: While that offset cannot be told, or is so large that it does not fit in
+				// the extension, there is no way to rewrite the capture clock offset, and it is
+				// better not to forward the extension than to forward it with a value we know
+				// wrong.
+				if (remoteClockOffsetQ32x32.has_value())
+				{
+					const auto absCaptureTimestamp = Utils::Byte::Get8Bytes(extenValue, 0);
+					// Offset between the clock of the capture system and the clock of the sender
+					// of this stream, as told by that sender. There is none when the extension
+					// comes in its shortened form, which is what a sender that captures its own
+					// media sends.
+					const int64_t incomingCaptureClockOffset =
+					  extenLen == 16u ? static_cast<int64_t>(Utils::Byte::Get8Bytes(extenValue, 8)) : 0;
+					// NOTE: The estimator gives our own clock minus the one of the sender, so
+					// subtracting it adds the offset of the sender against ours.
+					const int64_t captureClockOffset =
+					  incomingCaptureClockOffset - remoteClockOffsetQ32x32.value();
+
+					// The extension is always forwarded in its extended form, since the capture
+					// clock offset is always written.
+					extenLen = 16u;
+
+					Utils::Byte::Set8Bytes(bufferPtr, 0, absCaptureTimestamp);
+					Utils::Byte::Set8Bytes(bufferPtr, 8, static_cast<uint64_t>(captureClockOffset));
+
+					extensions.emplace_back(
+					  /*type*/ RTC::RtpHeaderExtensionUri::Type::ABS_CAPTURE_TIME,
+					  /*id*/ static_cast<uint8_t>(RTC::RtpHeaderExtensionUri::Type::ABS_CAPTURE_TIME),
+					  /*len*/ extenLen,
+					  /*value*/ bufferPtr);
+
+					bufferPtr += extenLen;
+				}
 			}
 
 			// Proxy http://www.webrtc.org/experiments/rtp-hdrext/playout-delay

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1247,19 +1247,18 @@ namespace RTC
 			{
 				// Offset between our own clock and the clock of the sender of this stream, in
 				// the format the extension uses.
+				//
+				// NOTE: While it cannot be told yet, and it never can if the sender sends no
+				// RTCP at all, both clocks are taken to be the same. Our own clock is real NTP
+				// and so is the one of any sender that fills this extension, so no offset is
+				// the most likely case rather than a wild guess.
 				const auto remoteClockOffsetMs = this->listener->OnProducerNeedRemoteClockOffsetMs(this);
+				const auto remoteClockOffsetQ32x32 =
+				  Utils::Time::TimeMs2Q32x32(remoteClockOffsetMs.value_or(0));
 
-				std::optional<int64_t> remoteClockOffsetQ32x32;
-
-				if (remoteClockOffsetMs.has_value())
-				{
-					remoteClockOffsetQ32x32 = Utils::Time::TimeMs2Q32x32(remoteClockOffsetMs.value());
-				}
-
-				// NOTE: While that offset cannot be told, or is so large that it does not fit in
-				// the extension, there is no way to rewrite the capture clock offset, and it is
-				// better not to forward the extension than to forward it with a value we know
-				// wrong.
+				// NOTE: An offset that does not fit in the extension means a sender whose clock
+				// is decades away from ours, and there is no value to write that would not be a
+				// lie, so the extension is not forwarded.
 				if (remoteClockOffsetQ32x32.has_value())
 				{
 					const auto absCaptureTimestamp = Utils::Byte::Get8Bytes(extenValue, 0);

--- a/worker/src/RTC/Producer.cpp
+++ b/worker/src/RTC/Producer.cpp
@@ -1416,12 +1416,12 @@ namespace RTC
 	}
 
 	inline void Producer::PostProcessRtpPacket(
-	  RTC::RTP::Packet* packet, const RTC::RTP::RtpStreamRecv* rtpStream, bool maxPacketTsChanged)
+	  RTC::RTP::Packet* packet, RTC::RTP::RtpStreamRecv* rtpStream, bool maxPacketTsChanged)
 	{
 		MS_TRACE();
 
 		// Store the capture instant of the packet holding the highest RTP timestamp of its
-		// stream, which is the only one the Sender Reports we send are built upon.
+		// stream, which is the one the Sender Reports we send are built upon.
 		if (maxPacketTsChanged)
 		{
 			const auto captureMs =
@@ -1430,6 +1430,10 @@ namespace RTC
 			if (captureMs.has_value())
 			{
 				packet->SetCaptureMs(captureMs.value());
+
+				// Also let the stream remember it, since this is the only place where the
+				// capture instant of a received packet can be told.
+				rtpStream->SetCaptureMapping(captureMs.value(), packet->GetTimestamp());
 			}
 		}
 

--- a/worker/src/RTC/RTP/Packet.cpp
+++ b/worker/src/RTC/RTP/Packet.cpp
@@ -1182,7 +1182,7 @@ namespace RTC
 			// Extension value can be 8 or 16 bytes depending on whether it contains
 			// estimated capture clock offset or not.
 			//
-			// https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time
+			// @see https://datatracker.ietf.org/doc/html/draft-ietf-avtcore-abs-capture-time-00
 			if (!extenValue || (extenLen != 8u && extenLen != 16u))
 			{
 				return false;

--- a/worker/src/RTC/RTP/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RTP/RtpStreamRecv.cpp
@@ -312,13 +312,24 @@ namespace RTC
 					ntp.seconds   = static_cast<uint32_t>(absCaptureTimestamp >> 32);
 					ntp.fractions = static_cast<uint32_t>(absCaptureTimestamp);
 
-					// NOTE: The estimated capture clock offset is ignored on purpose. All the
-					// streams of a same sender share its clock, which is all that inter stream
-					// synchronization needs.
-					this->lastAbsCaptureTime = AbsCaptureTime{
-						.ts    = packet->GetTimestamp(),
-						.ntpMs = Utils::Time::Ntp2TimeMs(ntp),
-					};
+					// The capture timestamp belongs to the clock of the capture system, which is
+					// not the clock of the sender of this stream when the media comes from
+					// somewhere else. The capture clock offset gives the instant back in the clock
+					// of the sender, which is the one this stream is estimated against:
+					//
+					//   capture NTP clock = sender NTP clock + capture clock offset
+					const auto captureMs = static_cast<int64_t>(Utils::Time::Ntp2TimeMs(ntp)) -
+					                       Utils::Time::Q32x32ToTimeMs(estimatedCaptureClockOffset);
+
+					// NOTE: A capture instant that is not positive means a capture clock offset
+					// that cannot be true, so there is nothing to store.
+					if (captureMs > 0)
+					{
+						this->lastAbsCaptureTime = AbsCaptureTime{
+							.ts    = packet->GetTimestamp(),
+							.ntpMs = static_cast<uint64_t>(captureMs),
+						};
+					}
 				}
 			}
 
@@ -635,7 +646,7 @@ namespace RTC
 
 			// Get the NTP representation of the current timestamp.
 			const uint64_t nowMs = this->shared->GetTimeMs();
-			auto ntp             = Utils::Time::TimeMs2Ntp(nowMs);
+			auto ntp             = Utils::Time::TimeMs2Ntp(nowMs + this->shared->GetNtpOffsetMs());
 
 			// Get the compact NTP representation of the current timestamp.
 			uint32_t compactNtp = (ntp.seconds & 0x0000FFFF) << 16;

--- a/worker/src/RTC/RTP/RtpStreamSend.cpp
+++ b/worker/src/RTC/RTP/RtpStreamSend.cpp
@@ -278,7 +278,7 @@ namespace RTC
 
 			// Get the NTP representation of the current timestamp.
 			const uint64_t nowMs = this->shared->GetTimeMs();
-			auto ntp             = Utils::Time::TimeMs2Ntp(nowMs);
+			auto ntp             = Utils::Time::TimeMs2Ntp(nowMs + this->shared->GetNtpOffsetMs());
 
 			// Get the compact NTP representation of the current timestamp.
 			uint32_t compactNtp = (ntp.seconds & 0x0000FFFF) << 16;
@@ -343,7 +343,7 @@ namespace RTC
 				return nullptr;
 			}
 
-			auto ntp     = Utils::Time::TimeMs2Ntp(nowMs);
+			auto ntp     = Utils::Time::TimeMs2Ntp(nowMs + this->shared->GetNtpOffsetMs());
 			auto* report = new RTC::RTCP::SenderReport();
 
 			// Calculate TS difference between now and the instant at which the media in the

--- a/worker/src/RTC/RtpDictionaries/RtcpParameters.cpp
+++ b/worker/src/RTC/RtpDictionaries/RtcpParameters.cpp
@@ -2,6 +2,7 @@
 // #define MS_LOG_DEV_LEVEL 3
 
 #include "Logger.hpp"
+#include "MediaSoupErrors.hpp"
 #include "RTC/RtpDictionaries.hpp"
 
 namespace RTC
@@ -12,10 +13,19 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// cname is optional.
-		if (flatbuffers::IsFieldPresent(data, FBS::RtpParameters::RtcpParameters::VT_CNAME))
+		// cname is mandatory. It is what identifies the streams that come from a same
+		// sender, and hence share its clock, so media of a sender that comes with no CNAME
+		// cannot be synchronized against the rest of the media of that same sender.
+		if (!flatbuffers::IsFieldPresent(data, FBS::RtpParameters::RtcpParameters::VT_CNAME))
 		{
-			this->cname = data->cname()->str();
+			MS_THROW_TYPE_ERROR("missing cname");
+		}
+
+		this->cname = data->cname()->str();
+
+		if (this->cname.empty())
+		{
+			MS_THROW_TYPE_ERROR("empty cname");
 		}
 
 		// reducedSize is optional, default value is true.

--- a/worker/src/RTC/SimulcastProducerStreamManager.cpp
+++ b/worker/src/RTC/SimulcastProducerStreamManager.cpp
@@ -164,8 +164,6 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// Any Sender Report is of interest and not just the first one of each stream,
-		// since a later one may be the one that makes the capture instant available.
 		if (first)
 		{
 			MS_DEBUG_TAG(simulcast, "first SenderReport [ssrc:%" PRIu32 "]", rtpStream->GetSsrc());
@@ -176,6 +174,22 @@ namespace RTC
 		auto* producerTsReferenceRtpStream = GetProducerTsReferenceRtpStream();
 
 		if (!producerTsReferenceRtpStream || !producerTsReferenceRtpStream->GetCaptureMapping().has_value())
+		{
+			return;
+		}
+
+		// Other than the first Sender Report of each stream, the only one worth checking
+		// layers upon is the one that makes the capture instant of the RTP timestamp
+		// reference stream known, since other spatial layers may become switchable then.
+		// NOTE: Doing it on every single Sender Report would ask the Transport to
+		// redistribute its outgoing bitrate at the pace of the RTCP of the sender and we
+		// don't want that.
+		const bool tsReferenceCaptureMappingIsNew =
+		  this->tsReferenceSpatialLayerWithCaptureMapping != this->tsReferenceSpatialLayer;
+
+		this->tsReferenceSpatialLayerWithCaptureMapping = this->tsReferenceSpatialLayer;
+
+		if (!first && !tsReferenceCaptureMappingIsNew)
 		{
 			return;
 		}
@@ -601,19 +615,42 @@ namespace RTC
 				const auto tsReferenceCaptureMapping = producerTsReferenceRtpStream->GetCaptureMapping();
 				const auto captureMapping            = producerRtpStream->GetCaptureMapping();
 
-				// Without the capture instant of both streams there is no way to align them,
-				// so take this one as the new TS reference and let its RTP timestamps go
-				// untouched, which is what would have been done had it been chosen as TS
-				// reference in the first place.
-				if (!tsReferenceCaptureMapping.has_value() || !captureMapping.has_value())
+				// Without the capture instant of the TS reference stream there is nothing to
+				// align this one to, so take this spatial layer as the new TS reference and
+				// let its RTP timestamps go untouched, which is what would have been done had
+				// it been chosen as TS reference in the first place.
+				if (!tsReferenceCaptureMapping.has_value())
 				{
 					MS_DEBUG_TAG(
 					  simulcast,
-					  "cannot tell the capture instant of both streams, using spatial layer %" PRIi16
-					  " as RTP timestamp reference",
+					  "cannot tell the capture instant of the TS reference stream, using spatial layer "
+					  "%" PRIi16 " as RTP timestamp reference",
 					  spatialLayer);
 
 					this->tsReferenceSpatialLayer = spatialLayer;
+				}
+				// The capture instant of this stream cannot be told yet, so there is no way to
+				// align it and no reason to give up a TS reference stream that is good. Discard
+				// the packet and wait, since the Sender Report that is missing is on its way.
+				else if (!captureMapping.has_value())
+				{
+					MS_DEBUG_TAG(
+					  simulcast,
+					  "cannot tell yet the capture instant of spatial layer %" PRIi16
+					  ", discarding packet [ssrc:%" PRIu32 ", seq:%" PRIu16 "]",
+					  spatialLayer,
+					  packet->GetSsrc(),
+					  packet->GetSequenceNumber());
+
+					// Ask for another key frame since this one is being discarded.
+					if (packet->IsKeyFrame())
+					{
+						RequestKeyFrame();
+					}
+
+					result.type = RtpPacketProcessResult::Type::SILENT_DROP;
+
+					return result;
 				}
 				else
 				{

--- a/worker/src/RTC/SimulcastProducerStreamManager.cpp
+++ b/worker/src/RTC/SimulcastProducerStreamManager.cpp
@@ -164,19 +164,18 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		// Just interested if this is the first Sender Report for a RTP stream.
-		if (!first)
+		// Any Sender Report is of interest and not just the first one of each stream,
+		// since a later one may be the one that makes the capture instant available.
+		if (first)
 		{
-			return;
+			MS_DEBUG_TAG(simulcast, "first SenderReport [ssrc:%" PRIu32 "]", rtpStream->GetSsrc());
 		}
 
-		MS_DEBUG_TAG(simulcast, "first SenderReport [ssrc:%" PRIu32 "]", rtpStream->GetSsrc());
-
-		// If our RTP timestamp reference stream does not yet have SR, do nothing
-		// since we know we won't be able to switch.
+		// If the capture instant of our RTP timestamp reference stream cannot be told
+		// yet, do nothing since we know we won't be able to switch.
 		auto* producerTsReferenceRtpStream = GetProducerTsReferenceRtpStream();
 
-		if (!producerTsReferenceRtpStream || !producerTsReferenceRtpStream->GetSenderReportMapping().has_value())
+		if (!producerTsReferenceRtpStream || !producerTsReferenceRtpStream->GetCaptureMapping().has_value())
 		{
 			return;
 		}
@@ -589,43 +588,48 @@ namespace RTC
 			{
 				tsOffset = 0u;
 			}
-			// If this is not the RTP stream we use as TS reference, do NTP based RTP
-			// TS synchronization.
+			// If this is not the RTP stream we use as TS reference, synchronize its RTP
+			// timestamps based on the capture instant of the media.
 			else
 			{
-				auto* producerTsReferenceRtpStream = GetProducerTsReferenceRtpStream();
-				auto* producerTargetRtpStream      = GetProducerTargetRtpStream();
+				const auto* producerTsReferenceRtpStream = GetProducerTsReferenceRtpStream();
+				// NOTE: The stream of the spatial layer of this packet, which is not always
+				// the one of the target spatial layer. A resync may be pending for the
+				// current spatial layer while the target one is a different one.
+				const auto* producerRtpStream = this->producerRtpStreams.at(spatialLayer);
 
-				const auto tsReferenceMapping = producerTsReferenceRtpStream->GetSenderReportMapping();
-				const auto targetMapping      = producerTargetRtpStream->GetSenderReportMapping();
+				const auto tsReferenceCaptureMapping = producerTsReferenceRtpStream->GetCaptureMapping();
+				const auto captureMapping            = producerRtpStream->GetCaptureMapping();
 
-				// NOTE: If we are here is because we have Sender Reports for both the
-				// TS reference stream and the target one.
-				MS_ASSERT(tsReferenceMapping.has_value(), "no Sender Report for TS reference RTP stream");
-				MS_ASSERT(targetMapping.has_value(), "no Sender Report for current RTP stream");
-
-				// Calculate NTP and TS stuff.
-				auto ntpMs1 = tsReferenceMapping.value().ntpMs;
-				auto ts1    = tsReferenceMapping.value().ts;
-				auto ntpMs2 = targetMapping.value().ntpMs;
-				auto ts2    = targetMapping.value().ts;
-				int64_t diffMs;
-
-				if (ntpMs2 >= ntpMs1)
+				// Without the capture instant of both streams there is no way to align them,
+				// so take this one as the new TS reference and let its RTP timestamps go
+				// untouched, which is what would have been done had it been chosen as TS
+				// reference in the first place.
+				if (!tsReferenceCaptureMapping.has_value() || !captureMapping.has_value())
 				{
-					diffMs = ntpMs2 - ntpMs1;
+					MS_DEBUG_TAG(
+					  simulcast,
+					  "cannot tell the capture instant of both streams, using spatial layer %" PRIi16
+					  " as RTP timestamp reference",
+					  spatialLayer);
+
+					this->tsReferenceSpatialLayer = spatialLayer;
 				}
 				else
 				{
-					diffMs = -1 * (ntpMs1 - ntpMs2);
+					// Calculate capture instant and TS stuff.
+					const auto captureMs1 = tsReferenceCaptureMapping.value().captureMs;
+					const auto ts1        = tsReferenceCaptureMapping.value().ts;
+					const auto captureMs2 = captureMapping.value().captureMs;
+					const auto ts2        = captureMapping.value().ts;
+					const int64_t diffMs = static_cast<int64_t>(captureMs2) - static_cast<int64_t>(captureMs1);
+					const int64_t diffTs  = diffMs * clockRate / 1000;
+					const uint32_t newTs2 = ts2 - diffTs;
+
+					// Apply offset. This is the difference that later must be removed from
+					// the sending RTP packet.
+					tsOffset = newTs2 - ts1;
 				}
-
-				const int64_t diffTs  = diffMs * clockRate / 1000;
-				const uint32_t newTs2 = ts2 - diffTs;
-
-				// Apply offset. This is the difference that later must be removed from
-				// the sending RTP packet.
-				tsOffset = newTs2 - ts1;
 			}
 
 			// When switching to a new stream it may happen that the timestamp of this
@@ -859,7 +863,7 @@ namespace RTC
 		if (
 		  newTargetSpatialLayer != -1 &&
 		  (this->tsReferenceSpatialLayer == -1 ||
-		   !GetProducerTsReferenceRtpStream()->GetSenderReportMapping().has_value()))
+		   !GetProducerTsReferenceRtpStream()->GetCaptureMapping().has_value()))
 		{
 			MS_DEBUG_TAG(
 			  simulcast, "using spatial layer %" PRIi16 " as RTP timestamp reference", newTargetSpatialLayer);
@@ -1051,7 +1055,7 @@ namespace RTC
 
 		return (
 		  this->tsReferenceSpatialLayer == -1 || spatialLayer == this->tsReferenceSpatialLayer ||
-		  this->producerRtpStreams.at(spatialLayer)->GetSenderReportMapping().has_value());
+		  this->producerRtpStreams.at(spatialLayer)->GetCaptureMapping().has_value());
 	}
 
 	RTC::RTP::RtpStreamRecv* SimulcastProducerStreamManager::GetProducerTsReferenceRtpStream() const

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -2628,6 +2628,34 @@ namespace RTC
 		return remoteCaptureTimeEstimator.GetLocalCaptureMs(rtpStream, ts);
 	}
 
+	std::optional<int64_t> Transport::OnProducerNeedRemoteClockOffsetMs(const RTC::Producer* producer)
+	{
+		MS_TRACE();
+
+		const auto it =
+		  this->mapCnameRemoteCaptureTimeEstimator.find(producer->GetRtpParameters().rtcp.cname);
+
+		if (it == this->mapCnameRemoteCaptureTimeEstimator.end())
+		{
+			return std::nullopt;
+		}
+
+		const auto& remoteCaptureTimeEstimator = it->second;
+		const auto clockOffsetMs               = remoteCaptureTimeEstimator.GetClockOffsetMs();
+
+		if (!clockOffsetMs.has_value())
+		{
+			return std::nullopt;
+		}
+
+		// NOTE: The estimator gives the offset against our own monotonic clock, while what
+		// a receiver reconstructs out of the Sender Reports we send is the clock we
+		// announce, so the distance to the NTP epoch has to be taken into account. Both
+		// terms are huge and their sum is small, so they are added as milliseconds before
+		// anything scales them up.
+		return clockOffsetMs.value() + static_cast<int64_t>(this->shared->GetNtpOffsetMs());
+	}
+
 	void Transport::OnConsumerSendRtpPacket(RTC::Consumer* consumer, RTC::RTP::Packet* packet)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -642,18 +642,11 @@ namespace RTC
 
 				// Take this Producer into account for the capture time estimation of its
 				// sender.
-				//
-				// NOTE: A Producer with no CNAME cannot be grouped with the other Producers
-				// of its sender, and sharing a single estimator among all the CNAME less
-				// Producers of a PipeTransport would mix the clocks of different senders.
 				{
 					const auto& cname = producer->GetRtpParameters().rtcp.cname;
 
-					if (!cname.empty())
-					{
-						this->mapCnameRemoteCaptureTimeEstimator[cname].UpdateSource(
-						  producer->GetRtpHeaderExtensionIds().absCaptureTime != 0);
-					}
+					this->mapCnameRemoteCaptureTimeEstimator[cname].UpdateSource(
+					  producer->GetRtpHeaderExtensionIds().absCaptureTime != 0);
 				}
 
 				MS_DEBUG_DEV("Producer created [producerId:%s]", producerId.c_str());

--- a/worker/test/src/RTC/TestConsumer.cpp
+++ b/worker/test/src/RTC/TestConsumer.cpp
@@ -104,7 +104,8 @@ namespace
 
 		encoding.ssrc = 1234567890;
 
-		rtpParameters.mid = "mid";
+		rtpParameters.mid        = "mid";
+		rtpParameters.rtcp.cname = "cname";
 		rtpParameters.codecs.emplace_back(codec);
 		rtpParameters.encodings.emplace_back(encoding);
 		rtpParameters.headerExtensions = std::vector<RTC::RtpHeaderExtensionParameters>();

--- a/worker/test/src/RTC/TestSimulcastProducerStreamManager.cpp
+++ b/worker/test/src/RTC/TestSimulcastProducerStreamManager.cpp
@@ -886,7 +886,8 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 		REQUIRE(manager->GetCurrentSpatialLayer() == 1);
 	}
 
-	SECTION("ProcessRtpPacket() takes the spatial layer as TS reference when it cannot be aligned")
+	SECTION(
+	  "ProcessRtpPacket() discards the packet while its spatial layer cannot tell its capture instant")
 	{
 		MockListener listener;
 		auto manager = createManager(
@@ -900,10 +901,11 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 		manager->ProducerRtpStream(rtpStream0.get(), MappedSsrc0);
 		manager->ProducerRtpStream(rtpStream1.get(), MappedSsrc1);
 
-		// Only layer 0 can tell its capture instant, so it stays as TS reference while
-		// layer 1 cannot be aligned to it.
+		// Only layer 0 can tell its capture instant, so it remains the TS reference one and
+		// layer 1 cannot be aligned to it yet.
 		rtpStream0->SetCaptureMapping(/*captureMs*/ 1000, /*ts*/ 1000);
 
+		// Set target layer to 0 and sync. This sets tsReferenceSpatialLayer = 0.
 		manager->UpdateTargetLayers(0, 0);
 
 		packet->SetSsrc(MappedSsrc0);
@@ -913,8 +915,10 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 
 		REQUIRE(manager->GetCurrentSpatialLayer() == 0);
 
-		// Aim at layer 1, whose RTP timeline cannot be placed on the one of layer 0.
+		// Aim at layer 1, whose RTP timeline cannot be placed on the one of layer 0 yet.
 		manager->UpdateTargetLayers(1, 0);
+
+		const auto keyFrameRequestCountBefore = listener.keyFrameRequestCount;
 
 		packet->SetSsrc(MappedSsrc1);
 		packet->SetSequenceNumber(1);
@@ -922,10 +926,132 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 		auto result = manager->ProcessRtpPacket(
 		  packet.get(), /*lastSentPacketHasMarker*/ false, /*clockRate*/ 90000, /*maxPacketTs*/ 0);
 
+		REQUIRE(result.type == RTC::ProducerStreamManager::RtpPacketProcessResult::Type::SILENT_DROP);
+		REQUIRE(manager->GetCurrentSpatialLayer() == 0);
+		// The discarded packet is not a key frame, so no key frame is requested for it.
+		REQUIRE(listener.keyFrameRequestCount == keyFrameRequestCountBefore);
+
+		// Once layer 1 can tell its capture instant the switch completes with the proper
+		// offset.
+		rtpStream1->SetCaptureMapping(/*captureMs*/ 500, /*ts*/ 1000);
+
+		packet->SetSequenceNumber(2);
+
+		result = manager->ProcessRtpPacket(
+		  packet.get(), /*lastSentPacketHasMarker*/ false, /*clockRate*/ 90000, /*maxPacketTs*/ 0);
+
 		REQUIRE(result.type == RTC::ProducerStreamManager::RtpPacketProcessResult::Type::FORWARD);
 		REQUIRE(result.spatialLayerSwitched == true);
-		REQUIRE(result.tsOffset == 0u);
+		REQUIRE(result.tsOffset == 45000u);
 		REQUIRE(manager->GetCurrentSpatialLayer() == 1);
+	}
+
+	SECTION(
+	  "ProcessRtpPacket() takes the spatial layer as TS reference when the TS reference one "
+	  "cannot tell its capture instant")
+	{
+		MockListener listener;
+		auto manager = createManager(
+		  &listener,
+		  /*ssrcs*/ TwoSsrcs,
+		  /*preferredLayers*/ { 1, 0 },
+		  /*keyFrameSupported*/ false);
+		auto rtpStream0 = createRtpStreamRecv(MappedSsrc0);
+		auto rtpStream1 = createRtpStreamRecv(MappedSsrc1);
+
+		manager->ProducerRtpStream(rtpStream0.get(), MappedSsrc0);
+		manager->ProducerRtpStream(rtpStream1.get(), MappedSsrc1);
+
+		// No stream can tell its capture instant in this SECTION.
+
+		// Feed packets and a Sender Report to both streams so that they get a score and
+		// RecalculateTargetLayers() takes them into account.
+		for (auto* rtpStream : { rtpStream0.get(), rtpStream1.get() })
+		{
+			packet->SetSsrc(rtpStream->GetSsrc());
+			feedRtpStreamRecv(rtpStream, packet.get(), 10);
+
+			RTC::RTCP::SenderReport sr;
+			sr.SetSsrc(rtpStream->GetSsrc());
+			sr.SetNtpSec(1000);
+			sr.SetNtpFrac(0);
+			sr.SetRtpTs(90000);
+			rtpStream->ReceiveRtcpSenderReport(&sr);
+		}
+
+		// Set target layer to 0 and sync. This sets tsReferenceSpatialLayer = 0.
+		manager->UpdateTargetLayers(0, 0);
+
+		packet->SetSsrc(MappedSsrc0);
+		packet->SetSequenceNumber(1);
+		manager->ProcessRtpPacket(
+		  packet.get(), /*lastSentPacketHasMarker*/ false, /*clockRate*/ 90000, /*maxPacketTs*/ 0);
+
+		REQUIRE(manager->GetCurrentSpatialLayer() == 0);
+
+		// Aim at layer 1. Since layer 0 cannot tell its capture instant, layer 1 takes over
+		// as TS reference. A transport reconnection then asks for a resync of whatever
+		// layer arrives first.
+		manager->UpdateTargetLayers(1, 0);
+		manager->OnTransportConnected();
+
+		REQUIRE(manager->GetTargetLayers().spatial == 1);
+
+		// A packet of the current layer 0 arrives. It is not the TS reference one and there
+		// is no way to align it to layer 1, so layer 0 takes over as TS reference and its
+		// RTP timestamps go untouched.
+		packet->SetSsrc(MappedSsrc0);
+		packet->SetSequenceNumber(2);
+
+		auto result = manager->ProcessRtpPacket(
+		  packet.get(), /*lastSentPacketHasMarker*/ false, /*clockRate*/ 90000, /*maxPacketTs*/ 0);
+
+		REQUIRE(result.type == RTC::ProducerStreamManager::RtpPacketProcessResult::Type::FORWARD);
+		REQUIRE(result.isSyncPacket == true);
+		REQUIRE(result.tsOffset == 0u);
+	}
+
+	SECTION(
+	  "ProducerRtcpSenderReport() checks layers upon a Sender Report that is not the first "
+	  "one of its stream")
+	{
+		MockListener listener;
+		auto manager    = createManager(&listener, /*ssrcs*/ TwoSsrcs, /*preferredLayers*/ { 1, 0 });
+		auto rtpStream0 = createRtpStreamRecv(MappedSsrc0);
+		auto rtpStream1 = createRtpStreamRecv(MappedSsrc1);
+
+		manager->ProducerRtpStream(rtpStream0.get(), MappedSsrc0);
+		manager->ProducerRtpStream(rtpStream1.get(), MappedSsrc1);
+
+		rtpStream0->SetCaptureMapping(/*captureMs*/ 1000, /*ts*/ 1000);
+		rtpStream1->SetCaptureMapping(/*captureMs*/ 1000, /*ts*/ 1000);
+
+		// Feed packets and a Sender Report to both streams so that they get a score and
+		// RecalculateTargetLayers() takes them into account.
+		for (auto* rtpStream : { rtpStream0.get(), rtpStream1.get() })
+		{
+			packet->SetSsrc(rtpStream->GetSsrc());
+			feedRtpStreamRecv(rtpStream, packet.get(), 10);
+
+			RTC::RTCP::SenderReport sr;
+			sr.SetSsrc(rtpStream->GetSsrc());
+			sr.SetNtpSec(1000);
+			sr.SetNtpFrac(0);
+			sr.SetRtpTs(90000);
+			rtpStream->ReceiveRtcpSenderReport(&sr);
+		}
+
+		// Set target layer to 0. This sets tsReferenceSpatialLayer = 0.
+		manager->UpdateTargetLayers(0, 0);
+
+		REQUIRE(manager->GetTargetLayers().spatial == 0);
+
+		// A Sender Report that is not the first one of its stream may be the one that made
+		// the capture instant of the TS reference stream known, so layers are checked and
+		// the preferred layer 1 is picked.
+		manager->ProducerRtcpSenderReport(rtpStream1.get(), /*first*/ false);
+
+		REQUIRE(manager->GetTargetLayers().spatial == 1);
 	}
 
 	SECTION("ProcessRtpPacket() calculates tsOffset of the spatial layer of the packet")

--- a/worker/test/src/RTC/TestSimulcastProducerStreamManager.cpp
+++ b/worker/test/src/RTC/TestSimulcastProducerStreamManager.cpp
@@ -598,7 +598,7 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 
 		manager->ProducerRtpStream(rtpStream0.get(), MappedSsrc0);
 
-		// Give score > 0 so RecalculateTargetLayers keeps target at layer 0.
+		// Give score > 0 so RecalculateTargetLayers() keeps target at layer 0.
 		manager->ProducerRtpStreamScore(rtpStream0.get(), /*score*/ 7, /*previousScore*/ 0);
 
 		// Set target and sync on layer 0.
@@ -639,7 +639,7 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 		manager->ProducerRtpStream(rtpStream0.get(), MappedSsrc0);
 		manager->ProducerRtpStream(rtpStream1.get(), MappedSsrc1);
 
-		// Both streams have score > 0 so RecalculateTargetLayers can pick layers.
+		// Both streams have score > 0 so RecalculateTargetLayers() can pick layers.
 		manager->ProducerRtpStreamScore(rtpStream0.get(), /*score*/ 7, /*previousScore*/ 0);
 		manager->ProducerRtpStreamScore(rtpStream1.get(), /*score*/ 7, /*previousScore*/ 0);
 
@@ -661,7 +661,7 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 
 		auto keyFrameCountBefore = listener.keyFrameRequestCount;
 
-		// Reconnect: RecalculateTargetLayers picks preferred layer 1,
+		// Reconnect: RecalculateTargetLayers() picks preferred layer 1,
 		// which differs from current (-1), so a keyframe is requested.
 		manager->OnTransportConnected();
 
@@ -681,7 +681,7 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 		REQUIRE(listener.keyFrameRequestCount == 0);
 	}
 
-	SECTION("RecalculateTargetLayers() skips spatial layer without Sender Report")
+	SECTION("RecalculateTargetLayers() skips spatial layer without capture instant")
 	{
 		MockListener listener;
 		auto manager    = createManager(&listener, /*ssrcs*/ TwoSsrcs, /*preferredLayers*/ { 1, 0 });
@@ -708,9 +708,9 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 		REQUIRE(manager->GetCurrentSpatialLayer() == 0);
 		REQUIRE(manager->GetTargetLayers().temporal == 0);
 
-		// Give both streams score > 0. RecalculateTargetLayers will be called
-		// but CanSwitchToSpatialLayer(1) returns false because layer 1 has no
-		// Sender Report and tsReferenceSpatialLayer is 0 (not -1).
+		// Give both streams score > 0. RecalculateTargetLayers() will be called
+		// but CanSwitchToSpatialLayer(1) returns false because the capture instant of
+		// layer 1 cannot be told and tsReferenceSpatialLayer is 0 (not -1).
 		manager->ProducerRtpStreamScore(rtpStream0.get(), /*score*/ 7, /*previousScore*/ 0);
 
 		REQUIRE(manager->GetTargetLayers().spatial == 0);
@@ -733,7 +733,7 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 		REQUIRE(result.tsOffset == 0u);
 	}
 
-	SECTION("RecalculateTargetLayers() switches to preferred layer after Sender Report")
+	SECTION("RecalculateTargetLayers() switches to preferred layer once its capture instant is known")
 	{
 		MockListener listener;
 		auto manager    = createManager(&listener, /*ssrcs*/ TwoSsrcs, /*preferredLayers*/ { 1, 0 });
@@ -757,8 +757,13 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 		manager->ProcessRtpPacket(
 		  packet.get(), /*lastSentPacketHasMarker*/ false, /*clockRate*/ 90000, /*maxPacketTs*/ 0);
 
-		// Target stays at 0 because layer 1 has no Sender Report.
+		// Target stays at 0 because the capture instant of layer 1 cannot be told.
 		REQUIRE(manager->GetTargetLayers().spatial == 0);
+
+		// Both layers hold RTP timestamp 1000 and both were captured at the same instant,
+		// which is what makes them alignable to each other.
+		rtpStream0->SetCaptureMapping(/*captureMs*/ 1000, /*ts*/ 1000);
+		rtpStream1->SetCaptureMapping(/*captureMs*/ 1000, /*ts*/ 1000);
 
 		// Feed packets to both streams so ReceiveRtcpSenderReport's UpdateScore
 		// doesn't drop the score to 0.
@@ -768,7 +773,7 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 		packet->SetSsrc(MappedSsrc1);
 		feedRtpStreamRecv(rtpStream1.get(), packet.get(), 10);
 
-		// Provide Sender Reports for both streams.
+		// Provide Sender Reports for both streams so that they get a score.
 		RTC::RTCP::SenderReport sr0;
 		sr0.SetSsrc(MappedSsrc0);
 		sr0.SetNtpSec(1000);
@@ -784,7 +789,7 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 		rtpStream1->ReceiveRtcpSenderReport(&sr1);
 
 		// Notify the manager about the first Sender Report for layer 1.
-		// This triggers MayChangeLayers → RecalculateTargetLayers.
+		// This triggers MayChangeLayers() -> RecalculateTargetLayers().
 		// Now CanSwitchToSpatialLayer(1) returns true, so preferred layer 1 is picked.
 		manager->ProducerRtcpSenderReport(rtpStream1.get(), /*first*/ true);
 
@@ -804,9 +809,203 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 		REQUIRE(result.type == RTC::ProducerStreamManager::RtpPacketProcessResult::Type::FORWARD);
 		REQUIRE(result.isSyncPacket == true);
 		REQUIRE(result.spatialLayerSwitched == true);
-		// Both SRs have the same NTP/RTP values, so tsOffset is 0.
+		// Both streams have the same capture instant and RTP timestamp, so tsOffset is 0.
 		REQUIRE(result.tsOffset == 0u);
 		REQUIRE(manager->GetCurrentSpatialLayer() == 1);
+	}
+
+	SECTION("ProcessRtpPacket() calculates tsOffset from the capture instant of both layers")
+	{
+		MockListener listener;
+		auto manager    = createManager(&listener, /*ssrcs*/ TwoSsrcs, /*preferredLayers*/ { 1, 0 });
+		auto rtpStream0 = createRtpStreamRecv(MappedSsrc0);
+		auto rtpStream1 = createRtpStreamRecv(MappedSsrc1);
+
+		manager->ProducerRtpStream(rtpStream0.get(), MappedSsrc0);
+		manager->ProducerRtpStream(rtpStream1.get(), MappedSsrc1);
+
+		// Set target layer to 0. This sets tsReferenceSpatialLayer = 0.
+		manager->UpdateTargetLayers(0, 0);
+
+		// Sync on layer 0 with a keyframe so current = 0.
+		packet->SetSsrc(MappedSsrc0);
+		packet->SetSequenceNumber(1);
+
+		auto* handler       = new MockPayloadDescriptorHandler();
+		handler->isKeyFrame = true;
+		packet->SetPayloadDescriptorHandler(handler);
+
+		manager->ProcessRtpPacket(
+		  packet.get(), /*lastSentPacketHasMarker*/ false, /*clockRate*/ 90000, /*maxPacketTs*/ 0);
+
+		// Both layers hold RTP timestamp 1000, but the one of layer 1 was captured 500 ms
+		// before the one of layer 0, so its RTP timeline runs 45000 ticks ahead.
+		rtpStream0->SetCaptureMapping(/*captureMs*/ 1000, /*ts*/ 1000);
+		rtpStream1->SetCaptureMapping(/*captureMs*/ 500, /*ts*/ 1000);
+
+		packet->SetSsrc(MappedSsrc0);
+		feedRtpStreamRecv(rtpStream0.get(), packet.get(), 10);
+
+		packet->SetSsrc(MappedSsrc1);
+		feedRtpStreamRecv(rtpStream1.get(), packet.get(), 10);
+
+		// Provide Sender Reports for both streams so that they get a score.
+		RTC::RTCP::SenderReport sr0;
+		sr0.SetSsrc(MappedSsrc0);
+		sr0.SetNtpSec(1000);
+		sr0.SetNtpFrac(0);
+		sr0.SetRtpTs(90000);
+		rtpStream0->ReceiveRtcpSenderReport(&sr0);
+
+		RTC::RTCP::SenderReport sr1;
+		sr1.SetSsrc(MappedSsrc1);
+		sr1.SetNtpSec(1000);
+		sr1.SetNtpFrac(0);
+		sr1.SetRtpTs(90000);
+		rtpStream1->ReceiveRtcpSenderReport(&sr1);
+
+		manager->ProducerRtcpSenderReport(rtpStream1.get(), /*first*/ true);
+
+		REQUIRE(manager->GetTargetLayers().spatial == 1);
+
+		// Send a keyframe from layer 1 to complete the spatial switch.
+		packet->SetSsrc(MappedSsrc1);
+		packet->SetSequenceNumber(100);
+		packet->SetTimestamp(91000);
+
+		auto* handler1       = new MockPayloadDescriptorHandler();
+		handler1->isKeyFrame = true;
+		packet->SetPayloadDescriptorHandler(handler1);
+
+		auto result = manager->ProcessRtpPacket(
+		  packet.get(), /*lastSentPacketHasMarker*/ false, /*clockRate*/ 90000, /*maxPacketTs*/ 0);
+
+		REQUIRE(result.type == RTC::ProducerStreamManager::RtpPacketProcessResult::Type::FORWARD);
+		REQUIRE(result.spatialLayerSwitched == true);
+		REQUIRE(result.tsOffset == 45000u);
+		REQUIRE(manager->GetCurrentSpatialLayer() == 1);
+	}
+
+	SECTION("ProcessRtpPacket() takes the spatial layer as TS reference when it cannot be aligned")
+	{
+		MockListener listener;
+		auto manager = createManager(
+		  &listener,
+		  /*ssrcs*/ TwoSsrcs,
+		  /*preferredLayers*/ { 1, 0 },
+		  /*keyFrameSupported*/ false);
+		auto rtpStream0 = createRtpStreamRecv(MappedSsrc0);
+		auto rtpStream1 = createRtpStreamRecv(MappedSsrc1);
+
+		manager->ProducerRtpStream(rtpStream0.get(), MappedSsrc0);
+		manager->ProducerRtpStream(rtpStream1.get(), MappedSsrc1);
+
+		// Only layer 0 can tell its capture instant, so it stays as TS reference while
+		// layer 1 cannot be aligned to it.
+		rtpStream0->SetCaptureMapping(/*captureMs*/ 1000, /*ts*/ 1000);
+
+		manager->UpdateTargetLayers(0, 0);
+
+		packet->SetSsrc(MappedSsrc0);
+		packet->SetSequenceNumber(1);
+		manager->ProcessRtpPacket(
+		  packet.get(), /*lastSentPacketHasMarker*/ false, /*clockRate*/ 90000, /*maxPacketTs*/ 0);
+
+		REQUIRE(manager->GetCurrentSpatialLayer() == 0);
+
+		// Aim at layer 1, whose RTP timeline cannot be placed on the one of layer 0.
+		manager->UpdateTargetLayers(1, 0);
+
+		packet->SetSsrc(MappedSsrc1);
+		packet->SetSequenceNumber(1);
+
+		auto result = manager->ProcessRtpPacket(
+		  packet.get(), /*lastSentPacketHasMarker*/ false, /*clockRate*/ 90000, /*maxPacketTs*/ 0);
+
+		REQUIRE(result.type == RTC::ProducerStreamManager::RtpPacketProcessResult::Type::FORWARD);
+		REQUIRE(result.spatialLayerSwitched == true);
+		REQUIRE(result.tsOffset == 0u);
+		REQUIRE(manager->GetCurrentSpatialLayer() == 1);
+	}
+
+	SECTION("ProcessRtpPacket() calculates tsOffset of the spatial layer of the packet")
+	{
+		MockListener listener;
+		auto manager = createManager(
+		  &listener,
+		  /*ssrcs*/ ThreeSsrcs,
+		  /*preferredLayers*/ { 2, 0 },
+		  /*keyFrameSupported*/ false);
+		auto rtpStream0 = createRtpStreamRecv(MappedSsrc0);
+		auto rtpStream1 = createRtpStreamRecv(MappedSsrc1);
+		auto rtpStream2 = createRtpStreamRecv(MappedSsrc2);
+
+		manager->ProducerRtpStream(rtpStream0.get(), MappedSsrc0);
+		manager->ProducerRtpStream(rtpStream1.get(), MappedSsrc1);
+		manager->ProducerRtpStream(rtpStream2.get(), MappedSsrc2);
+
+		// All layers hold RTP timestamp 1000. Layer 1 was captured 500 ms before layer 0
+		// and layer 2 a whole second before it, so their offsets differ.
+		rtpStream0->SetCaptureMapping(/*captureMs*/ 1000, /*ts*/ 1000);
+		rtpStream1->SetCaptureMapping(/*captureMs*/ 500, /*ts*/ 1000);
+		rtpStream2->SetCaptureMapping(/*captureMs*/ 0, /*ts*/ 1000);
+
+		// Feed packets and a Sender Report to every stream so that they all get a score
+		// and RecalculateTargetLayers() takes them into account.
+		for (auto* rtpStream : { rtpStream0.get(), rtpStream1.get(), rtpStream2.get() })
+		{
+			packet->SetSsrc(rtpStream->GetSsrc());
+			feedRtpStreamRecv(rtpStream, packet.get(), 10);
+
+			RTC::RTCP::SenderReport sr;
+			sr.SetSsrc(rtpStream->GetSsrc());
+			sr.SetNtpSec(1000);
+			sr.SetNtpFrac(0);
+			sr.SetRtpTs(90000);
+			rtpStream->ReceiveRtcpSenderReport(&sr);
+		}
+
+		// Set target layer to 0 and sync. This sets tsReferenceSpatialLayer = 0, which
+		// stays there for the rest of the SECTION since it has a capture mapping.
+		manager->UpdateTargetLayers(0, 0);
+
+		packet->SetSsrc(MappedSsrc0);
+		packet->SetSequenceNumber(1);
+		manager->ProcessRtpPacket(
+		  packet.get(), /*lastSentPacketHasMarker*/ false, /*clockRate*/ 90000, /*maxPacketTs*/ 0);
+
+		REQUIRE(manager->GetCurrentSpatialLayer() == 0);
+
+		// Switch to layer 1.
+		manager->UpdateTargetLayers(1, 0);
+
+		packet->SetSsrc(MappedSsrc1);
+		packet->SetSequenceNumber(1);
+
+		auto result = manager->ProcessRtpPacket(
+		  packet.get(), /*lastSentPacketHasMarker*/ false, /*clockRate*/ 90000, /*maxPacketTs*/ 0);
+
+		REQUIRE(result.spatialLayerSwitched == true);
+		REQUIRE(result.tsOffset == 45000u);
+		REQUIRE(manager->GetCurrentSpatialLayer() == 1);
+
+		// A transport reconnection asks for a resync of whatever layer arrives first, and
+		// moves the target to the preferred layer 2.
+		manager->OnTransportConnected();
+
+		REQUIRE(manager->GetTargetLayers().spatial == 2);
+
+		// A packet of the current layer 1 arrives while layer 2 is the target one, so the
+		// offset must be the one of layer 1 and not the one of layer 2.
+		packet->SetSsrc(MappedSsrc1);
+		packet->SetSequenceNumber(2);
+
+		result = manager->ProcessRtpPacket(
+		  packet.get(), /*lastSentPacketHasMarker*/ false, /*clockRate*/ 90000, /*maxPacketTs*/ 0);
+
+		REQUIRE(result.type == RTC::ProducerStreamManager::RtpPacketProcessResult::Type::FORWARD);
+		REQUIRE(result.isSyncPacket == true);
+		REQUIRE(result.tsOffset == 45000u);
 	}
 
 	SECTION("OnResumed() sets syncRequired")
@@ -840,7 +1039,7 @@ SCENARIO("SimulcastProducerStreamManager", "[rtp][producerstreammanager][simulca
 		// Call OnResumed — should set syncRequired.
 		manager->OnResumed();
 
-		// Reset target since OnResumed may have reset it via MayChangeLayers.
+		// Reset target since OnResumed may have reset it via MayChangeLayers().
 		manager->UpdateTargetLayers(0, 0);
 
 		// Prove syncRequired was set: next packet is a sync packet.

--- a/worker/test/src/Utils/TestTime.cpp
+++ b/worker/test/src/Utils/TestTime.cpp
@@ -16,4 +16,53 @@ SCENARIO("Utils::Time", "[utils][time]")
 		REQUIRE(ntp2.seconds == ntp.seconds);
 		REQUIRE(ntp2.fractions == ntp.fractions);
 	}
+
+	SECTION("TimeMs2Ntp()")
+	{
+		auto ntp = Utils::Time::TimeMs2Ntp(1500);
+
+		REQUIRE(ntp.seconds == 1);
+		// Half a second in NTP fractional units.
+		REQUIRE(ntp.fractions == 2147483648);
+
+		// A real NTP instant, seconds since Jan 1, 1900, which still fits in 32 bits.
+		ntp = Utils::Time::TimeMs2Ntp(3990000000750);
+
+		REQUIRE(ntp.seconds == 3990000000);
+		REQUIRE(Utils::Time::Ntp2TimeMs(ntp) == 3990000000750);
+	}
+
+	SECTION("TimeMs2Q32x32()")
+	{
+		// A whole second is the fractional unit itself.
+		// NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+		REQUIRE(Utils::Time::TimeMs2Q32x32(1000).value() == 4294967296);
+		// NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+		REQUIRE(Utils::Time::TimeMs2Q32x32(-1000).value() == -4294967296);
+		// NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+		REQUIRE(Utils::Time::TimeMs2Q32x32(0).value() == 0);
+		// NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+		REQUIRE(Utils::Time::TimeMs2Q32x32(1).value() == 4294967);
+
+		// Seconds are 32 bits wide in the format, so 2^31 seconds no longer fit.
+		constexpr int64_t OutOfRangeMs{ (1LL << 31) * 1000 };
+
+		REQUIRE(Utils::Time::TimeMs2Q32x32(OutOfRangeMs) == std::nullopt);
+		REQUIRE(Utils::Time::TimeMs2Q32x32(-OutOfRangeMs) == std::nullopt);
+		REQUIRE(Utils::Time::TimeMs2Q32x32(OutOfRangeMs - 1).has_value());
+		REQUIRE(Utils::Time::TimeMs2Q32x32(-OutOfRangeMs + 1).has_value());
+	}
+
+	SECTION("Q32x32ToTimeMs()")
+	{
+		REQUIRE(Utils::Time::Q32x32ToTimeMs(4294967296) == 1000);
+		REQUIRE(Utils::Time::Q32x32ToTimeMs(-4294967296) == -1000);
+		REQUIRE(Utils::Time::Q32x32ToTimeMs(0) == 0);
+
+		for (const int64_t ms : { 1, -1, 1000, -1000, 123456, -123456 })
+		{
+			// NOLINTNEXTLINE(bugprone-unchecked-optional-access)
+			REQUIRE(Utils::Time::Q32x32ToTimeMs(Utils::Time::TimeMs2Q32x32(ms).value()) == ms);
+		}
+	}
 }


### PR DESCRIPTION
# Details

- Related to #1881.
- `SimulcastProducerStreamManager` computes `tsOffset` from the capture mapping of the two streams involved instead of from their last Sender Report.
- With `abs-capture-time` negotiated, a layer no longer needs a Sender Report of its own to become switchable. It is usable as soon as its packets carry a capture instant. However, no matter 'abs-capture-time' or Sender Report mechanism is used, we need 3 Sender Reports (from any stream(s) of the sender, no matter which one(2), to have reliable capture instants so we don't generate Sender Reports for Consumers until that happens. Notice that this is not introduced by this PR but by a previous one.
- `SimulcastProducerStreamManager::ProducerRtcpSenderReport()` also checks layers upon the Sender Report that makes the capture instant of the RTP timestamp reference stream known for the first time, and not just upon the first Sender Report of each stream, since that one may be a later Sender Report of any of them (`RemoteCaptureTimeEstimator` needs at least 3 Sender Reports of the same sender, no matter which streams they belong to). Every other Sender Report is still ignored: checking layers upon all of them would ask the Transport to redistribute its outgoing bitrate at the pace of the RTCP of the sender, and that suppresses its own periodic BWE event.
- Make CNAME mandatory in `RtcpParameters` at worker level. `Transport` class in both Node and Rust layers already assign a CNAME to given RTP parameters in `produce()` if missing. this is because CNAME is now an important field because it is used as key in `RemoteCaptureTimeEstimator`'s internal map.
- Do not enable 'abs-capture-time' RTP extension in `producer.consumableRtpParameters` unless the Producer negotiated it, otherwise all pipe Consumers would enable 'abs-capture-time' extension despite their original Producer didn't enable it so in case of simulcast the final worker/transport/consumer would never receive 'abs-capture-time' extensions and could never switch to other spatial layers.
- Rewrite the estimated capture clock offset of the forwarded `abs-capture-time` extension instead of proxying it verbatim, since mediasoup becomes the sender of the stream and that field must tell the offset between the clock of the capture system and ours, and honour it when reading the extension using pipe transports (see [abs-capture-time spec](https://webrtc.googlesource.com/src/+/refs/heads/main/docs/native-code/rtp-hdrext/abs-capture-time/README.md)).
- Apply `Utils::Time::UnixNtpOffset()` so that the NTP field of the RTCP Sender Reports mediasoup generates is real NTP rather than mediasoup's monotonic clock.

## Bonus Tracks

- In `PipeTransport`, if a `Producer` is created without CNAME, asign a random one to it. We need CNAME since `RemoteCaptureTimeEstimator` uses it as key.
- `SimulcastProducerStreamManager`: Avoid layer switching to another layer by computing the RTP timestamp offset from the wrong stream:
  - `SimulcastProducerStreamManager::ProcessRtpPacket()` computes `tsOffset`and reads the two Sender Report mappings it needs from `GetProducerTsReferenceRtpStream()` and `GetProducerTargetRtpStream()`.
  - The second one is wrong. The offset is applied to the packet being processed, so it must come from the stream of the spatial layer that packet belongs to, and that is not always the target spatial layer.
  - The block is reached from two different situations:
    1. A switch to the target spatial layer, where the packet does belong to the target layer.
    2. A resync of the current spatial layer, requested by `OnTransportConnected()` or `OnResumed()`. Both set `syncRequired` with `spatialLayerToSync` at -1, so whatever layer arrives first is synced. Here the packet belongs to the current spatial layer, which differs from the target one whenever a switch is still pending its key frame.
  - In the second case the offset is taken from the Sender Report of the target layer and applied to packets of the current layer. Every SSRC of a simulcast sender has its own random RTP timestamp base, so the offset bears no relation to the correction the current layer needs. The receiver gets RTP timestamps that are off by that arbitrary difference, which breaks lip sync against the audio of the same sender and makes the jitter buffer see the timeline jump. It lasts for as long as that layer remains the selected one.
  - To reproduce, a `Consumer` sending layer 0, layer 1 selected as target and waiting for its key frame, then a transport reconnection or a Consumer resume, then a packet of layer 0 arriving before the key frame of layer 1.
  - The fix is to read the mapping of the stream the packet belongs to, this is: `producerRtpStreams.at(spatialLayer)`.