### PR TITLE
SCTP: Fix `SackChunk::GetValidatedGapAckBlocks()` returning a bogus gap-ack-block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received ([PR #1886](https://github.com/versatica/mediasoup/pull/1886)).
 - Generate RTCP Sender Reports based on the capture instant of the media rather than on the packet arrival time ([PR #1887](https://github.com/versatica/mediasoup/pull/1887)).
+- SCTP: Fix `SackChunk::GetValidatedGapAckBlocks()` returning a bogus gap-ack-block ([PR #1890](https://github.com/versatica/mediasoup/pull/1890)).
 
 ### 3.24.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received ([PR #1886](https://github.com/versatica/mediasoup/pull/1886)).
 - Generate RTCP Sender Reports based on the capture instant of the media rather than on the packet arrival time ([PR #1887](https://github.com/versatica/mediasoup/pull/1887)).
-- SCTP: Fix `SackChunk::GetValidatedGapAckBlocks()` returning a bogus gap-ack-block ([PR #1890](https://github.com/versatica/mediasoup/pull/1890)).
+- SCTP: Fix `SackChunk::GetValidatedGapAckBlocks()` returning a bogus gap-ack-block ([PR #1891](https://github.com/versatica/mediasoup/pull/1891)).
 
 ### 3.24.2
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received ([PR #1886](https://github.com/versatica/mediasoup/pull/1886)).
 - Generate RTCP Sender Reports based on the capture instant of the media rather than on the packet arrival time ([PR #1887](https://github.com/versatica/mediasoup/pull/1887)).
+- SCTP: Fix `SackChunk::GetValidatedGapAckBlocks()` returning a bogus gap-ack-block ([PR #1890](https://github.com/versatica/mediasoup/pull/1890)).
 
 ### 0.25.2
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received ([PR #1886](https://github.com/versatica/mediasoup/pull/1886)).
 - Generate RTCP Sender Reports based on the capture instant of the media rather than on the packet arrival time ([PR #1887](https://github.com/versatica/mediasoup/pull/1887)).
-- SCTP: Fix `SackChunk::GetValidatedGapAckBlocks()` returning a bogus gap-ack-block ([PR #1890](https://github.com/versatica/mediasoup/pull/1890)).
+- SCTP: Fix `SackChunk::GetValidatedGapAckBlocks()` returning a bogus gap-ack-block ([PR #1891](https://github.com/versatica/mediasoup/pull/1891)).
 
 ### 0.25.2
 

--- a/worker/src/RTC/SCTP/packet/chunks/SackChunk.cpp
+++ b/worker/src/RTC/SCTP/packet/chunks/SackChunk.cpp
@@ -204,14 +204,18 @@ namespace RTC
 				const uint16_t start = GetAckBlockStartAt(idx);
 				const uint16_t end   = GetAckBlockEndAt(idx);
 
-				if (end > start)
+				// NOTE: A block with `end == start` is a legal single TSN block, so it
+				// must be kept. dcSCTP's `ChunkValidators::Clean()` uses `end > start`
+				// here, which contradicts its own `ChunkValidators::Validate()` (it
+				// accepts `end == start`) and needlessly discards valid ack information.
+				if (end >= start)
 				{
 					gapAckBlocks.emplace_back(start, end);
 				}
 			}
 
 			// Not more than at most one remaining? Exit early.
-			if (gapAckBlocks.size() == 1)
+			if (gapAckBlocks.size() <= 1)
 			{
 				return gapAckBlocks;
 			}


### PR DESCRIPTION
# Details

When sanitizing a malformed SACK chunk, if every gap-ack-block is discarded by the sanity filter, the early-exit check `size() == 1` did not trigger, and the final `resize(writeIdx + 1)` grew the empty vector back to a single zero-initialized `{start: 0, end: 0}` block instead of returning an empty list.