### PR TITLE
Simulcast and SVC: Limit temporal layer to the preferred one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Simulcast and SVC: Limit temporal layer to the preferred one ([PR #1892](https://github.com/versatica/mediasoup/pull/1892)).
+- **Breaking change:** Simulcast and SVC: Limit temporal layer to the preferred one ([PR #1892](https://github.com/versatica/mediasoup/pull/1892)).
 
 ### 3.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Simulcast and SVC: Limit temporal layer to the preferred one ([PR #1892](https://github.com/versatica/mediasoup/pull/1892)).
+
 ### 3.25.0
 
 - Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received ([PR #1886](https://github.com/versatica/mediasoup/pull/1886)).

--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -339,7 +339,7 @@ export class ConsumerImpl<ConsumerAppData extends AppData = AppData>
 		if (typeof spatialLayer !== 'number') {
 			throw new TypeError('spatialLayer must be a number');
 		}
-		if (temporalLayer !== undefined && typeof temporalLayer !== 'number') {
+		if (temporalLayer != null && typeof temporalLayer !== 'number') {
 			throw new TypeError('if given, temporalLayer must be a number');
 		}
 

--- a/node/src/Consumer.ts
+++ b/node/src/Consumer.ts
@@ -339,7 +339,7 @@ export class ConsumerImpl<ConsumerAppData extends AppData = AppData>
 		if (typeof spatialLayer !== 'number') {
 			throw new TypeError('spatialLayer must be a number');
 		}
-		if (temporalLayer && typeof temporalLayer !== 'number') {
+		if (temporalLayer !== undefined && typeof temporalLayer !== 'number') {
 			throw new TypeError('if given, temporalLayer must be a number');
 		}
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Simulcast and SVC: Limit temporal layer to the preferred one ([PR #1892](https://github.com/versatica/mediasoup/pull/1892)).
+- **Breaking change:** Simulcast and SVC: Limit temporal layer to the preferred one ([PR #1892](https://github.com/versatica/mediasoup/pull/1892)).
 
 ### 0.26.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Simulcast and SVC: Limit temporal layer to the preferred one ([PR #1892](https://github.com/versatica/mediasoup/pull/1892)).
+
 ### 0.26.0
 
 - Worker: Fix undefined behavior in `RtpStreamRecv::UpdateScore()` when no packets were received ([PR #1886](https://github.com/versatica/mediasoup/pull/1886)).

--- a/worker/src/RTC/SimulcastProducerStreamManager.cpp
+++ b/worker/src/RTC/SimulcastProducerStreamManager.cpp
@@ -262,8 +262,13 @@ namespace RTC
 			{
 				continue;
 			}
-			// If this is higher than preferred spatial layer, abort.
-			else if (spatialLayer > this->preferredLayers.spatial)
+			// If this is higher than preferred spatial layer, abort unless we don't
+			// have a provisional spatial layer yet (so no lower one is usable) or this
+			// is the provisional one (so we may still increase its temporal layer).
+			else if (
+			  spatialLayer > this->preferredLayers.spatial &&
+			  this->provisionalTargetLayers.spatial != -1 &&
+			  spatialLayer != this->provisionalTargetLayers.spatial)
 			{
 				MS_DEBUG_DEV(
 				  "avoid upgrading to spatial layer %" PRIi16
@@ -315,8 +320,14 @@ namespace RTC
 
 			temporalLayer = 0;
 
+			// Don't consider temporal layers above the preferred one, nor above the
+			// ones this stream has.
+			const auto maxTemporalLayer = std::min(
+			  static_cast<int16_t>(producerRtpStream->GetTemporalLayers() - 1),
+			  this->preferredLayers.temporal);
+
 			// Check bitrate of every temporal layer.
-			for (; std::cmp_less(temporalLayer, producerRtpStream->GetTemporalLayers()); ++temporalLayer)
+			for (; temporalLayer <= maxTemporalLayer; ++temporalLayer)
 			{
 				// Ignore temporal layers lower than the one we already have (taking
 				// into account the spatial layer too).
@@ -1004,6 +1015,13 @@ namespace RTC
 				continue;
 			}
 
+			// Don't go above the preferred spatial layer if we already found a usable
+			// lower one.
+			if (spatialLayer > this->preferredLayers.spatial && newTargetLayers.spatial != -1)
+			{
+				break;
+			}
+
 			newTargetLayers.spatial = spatialLayer;
 
 			// If this is the preferred or higher spatial layer take it and exit.
@@ -1015,19 +1033,11 @@ namespace RTC
 
 		if (newTargetLayers.spatial != -1)
 		{
-			if (newTargetLayers.spatial == this->preferredLayers.spatial)
-			{
-				newTargetLayers.temporal = this->preferredLayers.temporal;
-			}
-			else if (newTargetLayers.spatial < this->preferredLayers.spatial)
-			{
-				newTargetLayers.temporal =
-				  static_cast<int16_t>(this->encodingContext->GetTemporalLayers() - 1);
-			}
-			else
-			{
-				newTargetLayers.temporal = 0;
-			}
+			// Don't consider temporal layers above the preferred one, nor above the
+			// ones this stream has.
+			newTargetLayers.temporal = std::min(
+			  this->preferredLayers.temporal,
+			  static_cast<int16_t>(this->encodingContext->GetTemporalLayers() - 1));
 		}
 
 		// Return true if any target layer changed.

--- a/worker/src/RTC/SimulcastProducerStreamManager.cpp
+++ b/worker/src/RTC/SimulcastProducerStreamManager.cpp
@@ -238,6 +238,11 @@ namespace RTC
 		uint32_t requiredBitrate{ 0u };
 		int16_t spatialLayer{ 0 };
 		int16_t temporalLayer{ 0 };
+		// Whether a usable spatial layer has been found, in which case we must not
+		// go above the preferred spatial layer. Same criteria as in
+		// RecalculateTargetLayers(), so both take the same decision no matter the
+		// bitrate of the layer.
+		bool usableSpatialLayerFound{ this->provisionalTargetLayers.spatial != -1 };
 
 		for (size_t sIdx{ 0u }; sIdx < this->producerRtpStreams.size(); ++sIdx)
 		{
@@ -262,12 +267,11 @@ namespace RTC
 			{
 				continue;
 			}
-			// If this is higher than preferred spatial layer, abort unless we don't
-			// have a provisional spatial layer yet (so no lower one is usable) or this
-			// is the provisional one (so we may still increase its temporal layer).
+			// If this is higher than preferred spatial layer, abort unless no lower
+			// spatial layer is usable or this is the provisional one (so we may still
+			// increase its temporal layer).
 			else if (
-			  spatialLayer > this->preferredLayers.spatial &&
-			  this->provisionalTargetLayers.spatial != -1 &&
+			  spatialLayer > this->preferredLayers.spatial && usableSpatialLayerFound &&
 			  spatialLayer != this->provisionalTargetLayers.spatial)
 			{
 				MS_DEBUG_DEV(
@@ -317,6 +321,9 @@ namespace RTC
 			{
 				continue;
 			}
+
+			// This spatial layer is usable even if it has no bitrate at all.
+			usableSpatialLayerFound = true;
 
 			temporalLayer = 0;
 

--- a/worker/src/RTC/SvcProducerStreamManager.cpp
+++ b/worker/src/RTC/SvcProducerStreamManager.cpp
@@ -190,9 +190,14 @@ namespace RTC
 
 			temporalLayer = 0;
 
+			// Don't consider temporal layers above the preferred one, nor above the
+			// ones this stream has.
+			const auto maxTemporalLayer = std::min(
+			  static_cast<int16_t>(this->producerRtpStream->GetTemporalLayers() - 1),
+			  this->preferredLayers.temporal);
+
 			// Check bitrate of every temporal layer.
-			for (; std::cmp_less(temporalLayer, this->producerRtpStream->GetTemporalLayers());
-			     ++temporalLayer)
+			for (; temporalLayer <= maxTemporalLayer; ++temporalLayer)
 			{
 				// Ignore temporal layers lower than the one we already have (taking
 				// into account the spatial layer too).
@@ -247,8 +252,11 @@ namespace RTC
 				}
 			}
 
-			// If this is the preferred or higher spatial layer, take it and exit.
-			if (spatialLayer >= this->preferredLayers.spatial)
+			// If this is the preferred or higher spatial layer, take it and exit,
+			// unless we have not found any usable spatial layer yet.
+			if (
+			  spatialLayer >= this->preferredLayers.spatial &&
+			  this->provisionalTargetLayers.spatial != -1)
 			{
 				break;
 			}
@@ -589,6 +597,13 @@ namespace RTC
 				continue;
 			}
 
+			// Don't go above the preferred spatial layer if we already found a usable
+			// lower one.
+			if (spatialLayer > this->preferredLayers.spatial && newTargetLayers.spatial != -1)
+			{
+				break;
+			}
+
 			newTargetLayers.spatial = spatialLayer;
 
 			// If this is the preferred or higher spatial layer and has bitrate,
@@ -601,19 +616,11 @@ namespace RTC
 
 		if (newTargetLayers.spatial != -1)
 		{
-			if (newTargetLayers.spatial == this->preferredLayers.spatial)
-			{
-				newTargetLayers.temporal = this->preferredLayers.temporal;
-			}
-			else if (newTargetLayers.spatial < this->preferredLayers.spatial)
-			{
-				newTargetLayers.temporal =
-				  static_cast<int16_t>(this->encodingContext->GetTemporalLayers() - 1);
-			}
-			else
-			{
-				newTargetLayers.temporal = 0;
-			}
+			// Don't consider temporal layers above the preferred one, nor above the
+			// ones this stream has.
+			newTargetLayers.temporal = std::min(
+			  this->preferredLayers.temporal,
+			  static_cast<int16_t>(this->encodingContext->GetTemporalLayers() - 1));
 		}
 
 	done:

--- a/worker/src/RTC/SvcProducerStreamManager.cpp
+++ b/worker/src/RTC/SvcProducerStreamManager.cpp
@@ -254,9 +254,7 @@ namespace RTC
 
 			// If this is the preferred or higher spatial layer, take it and exit,
 			// unless we have not found any usable spatial layer yet.
-			if (
-			  spatialLayer >= this->preferredLayers.spatial &&
-			  this->provisionalTargetLayers.spatial != -1)
+			if (spatialLayer >= this->preferredLayers.spatial && this->provisionalTargetLayers.spatial != -1)
 			{
 				break;
 			}


### PR DESCRIPTION
# Details

- Modify `IncreaseLayer()` in `SimulcastProducerStreamManager` and `SvcProducerStreamManager` so temporal layer is always capped at `min(stream temporal layers - 1, preferred.temporal)`.
- `IncreaseLayer()` no longer stops below the preferred spatial layer when no lower one is usable, and can still raise the temporal layer of the one it already holds.
- Of course, if `consumer.setPreferredLayers()` is called without specifying any `temporalLayer`, then it's assumed that the highest possible temporal layer is desired (no behavior change here).

## Notes

- Acknowledgements to @ggarber who wrote a similar PR very long ago but for whatever reason I don't remember it was closed. See PR #665.