### PR TITLE
Worker: add `label` to `TimerHandle` class

### DIFF
--- a/worker/include/Shared.hpp
+++ b/worker/include/Shared.hpp
@@ -26,7 +26,7 @@ public:
 		return this->channelNotifier.get();
 	}
 
-	TimerHandleInterface* CreateTimer(TimerHandleInterface::Listener* listener) override;
+	TimerHandleInterface* CreateTimer(TimerHandleInterface::Listener* listener, std::string label) override;
 
 	BackoffTimerHandleInterface* CreateBackoffTimer(
 	  const BackoffTimerHandleInterface::BackoffTimerHandleOptions& options) override;

--- a/worker/include/SharedInterface.hpp
+++ b/worker/include/SharedInterface.hpp
@@ -29,7 +29,8 @@ public:
 	 * @remarks
 	 * - The caller is responsible for freeing it.
 	 */
-	virtual TimerHandleInterface* CreateTimer(TimerHandleInterface::Listener* listener) = 0;
+	virtual TimerHandleInterface* CreateTimer(
+	  TimerHandleInterface::Listener* listener, std::string label) = 0;
 
 	/**
 	 * Creates a BackoffTimerHandle timer.

--- a/worker/include/handles/TimerHandle.hpp
+++ b/worker/include/handles/TimerHandle.hpp
@@ -16,7 +16,7 @@ class TimerHandle : public TimerHandleInterface
 	friend class BackoffTimerHandle;
 
 private:
-	explicit TimerHandle(TimerHandleInterface::Listener* listener);
+	explicit TimerHandle(TimerHandleInterface::Listener* listener, std::string label);
 
 public:
 	TimerHandle& operator=(const TimerHandle&) = delete;
@@ -49,6 +49,11 @@ public:
 		return uv_is_active(reinterpret_cast<uv_handle_t*>(this->uvHandle)) != 0;
 	}
 
+	const std::string GetLabel() const override
+	{
+		return this->label;
+	}
+
 private:
 	void InternalClose();
 
@@ -59,6 +64,7 @@ public:
 private:
 	// Passed by argument.
 	TimerHandleInterface::Listener* listener{ nullptr };
+	const std::string label;
 	// Allocated by this.
 	uv_timer_t* uvHandle{ nullptr };
 	// Others.

--- a/worker/include/handles/TimerHandleInterface.hpp
+++ b/worker/include/handles/TimerHandleInterface.hpp
@@ -2,6 +2,7 @@
 #define MS_TIMER_HANDLE_INTERFACE_HPP
 
 #include "common.hpp"
+#include <string>
 
 class TimerHandleInterface
 {
@@ -38,6 +39,11 @@ public:
 	virtual uint64_t GetRepeat() const = 0;
 
 	virtual bool IsActive() const = 0;
+
+	/**
+	 * Label of this timer, given at creation time.
+	 */
+	virtual const std::string GetLabel() const = 0;
 };
 
 #endif

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -415,6 +415,7 @@ executable(
 mock_sources = [
   'mocks/src/MockShared.cpp',
   'mocks/src/handles/MockBackoffTimerHandle.cpp',
+  'mocks/src/handles/MockTimerHandle.cpp',
   'mocks/src/Channel/MockChannelMessageRegistrator.cpp',
   'mocks/src/RTC/SCTP/association/MockTransmissionControlBlockContext.cpp',
 ]

--- a/worker/mocks/include/MockShared.hpp
+++ b/worker/mocks/include/MockShared.hpp
@@ -6,6 +6,7 @@
 #include "SharedInterface.hpp"
 #include "mocks/include/Channel/MockChannelMessageRegistrator.hpp"
 #include "mocks/include/handles/MockBackoffTimerHandle.hpp"
+#include "mocks/include/handles/MockTimerHandle.hpp"
 #include <map>
 #include <string>
 #include <string_view>
@@ -30,7 +31,7 @@ namespace mocks
 			return this->channelNotifier.get();
 		}
 
-		TimerHandleInterface* CreateTimer(TimerHandleInterface::Listener* listener) override;
+		TimerHandleInterface* CreateTimer(TimerHandleInterface::Listener* listener, std::string label) override;
 
 		BackoffTimerHandleInterface* CreateBackoffTimer(
 		  const BackoffTimerHandleInterface::BackoffTimerHandleOptions& options) override;
@@ -69,6 +70,20 @@ namespace mocks
 
 		// Methods for testing.
 	public:
+		MockTimerHandle* GetTimer(const std::string_view label) const
+		{
+			const auto it = this->timers.find(std::string(label));
+
+			if (it != this->timers.end())
+			{
+				return it->second;
+			}
+			else
+			{
+				return nullptr;
+			}
+		}
+
 		MockBackoffTimerHandle* GetBackoffTimer(const std::string_view label) const
 		{
 			const auto it = this->backoffTimers.find(std::string(label));
@@ -90,6 +105,7 @@ namespace mocks
 		std::unique_ptr<::Channel::ChannelSocket> channelSocket;
 		std::unique_ptr<mocks::Channel::MockChannelMessageRegistrator> channelMessageRegistrator;
 		std::unique_ptr<::Channel::ChannelNotifier> channelNotifier;
+		std::map<std::string /*label*/, MockTimerHandle* /*timer*/> timers;
 		std::map<std::string /*label*/, MockBackoffTimerHandle* /*backoffTimer*/> backoffTimers;
 	};
 } // namespace mocks

--- a/worker/mocks/include/handles/MockTimerHandle.hpp
+++ b/worker/mocks/include/handles/MockTimerHandle.hpp
@@ -3,6 +3,7 @@
 
 #include "common.hpp"
 #include "handles/TimerHandleInterface.hpp"
+#include <limits>
 
 namespace mocks
 {
@@ -15,38 +16,49 @@ namespace mocks
 		friend class mocks::MockShared;
 
 	private:
-		explicit MockTimerHandle() = default;
+		explicit MockTimerHandle(
+		  TimerHandleInterface::Listener* listener,
+		  std::string label,
+		  std::function<uint64_t()> getTimeMs,
+		  std::function<void()> onDelete);
 
 	public:
 		MockTimerHandle& operator=(const MockTimerHandle&) = delete;
 
 		MockTimerHandle(const MockTimerHandle&) = delete;
 
-		~MockTimerHandle() override = default;
+		~MockTimerHandle() override
+		{
+			this->onDelete();
+		}
 
 	public:
+		void Dump(int indentation = 0) const;
+
 		void Start(uint64_t timeout, uint64_t repeat = 0) override
 		{
-			this->running = true;
 			this->timeout = timeout;
 			this->repeat  = repeat;
+
+			this->running     = true;
+			this->expiresAtMs = this->getTimeMs() + this->timeout;
 		}
 
 		void Stop() override
 		{
-			this->running = false;
+			this->running     = false;
+			this->expiresAtMs = std::numeric_limits<uint64_t>::max();
 		}
 
 		void Restart() override
 		{
-			this->running = true;
+			this->running     = true;
+			this->expiresAtMs = this->getTimeMs() + this->timeout;
 		}
 
 		void Restart(uint64_t timeout, uint64_t repeat = 0) override
 		{
-			this->running = true;
-			this->timeout = timeout;
-			this->repeat  = repeat;
+			Start(timeout, repeat);
 		}
 
 		uint64_t GetTimeout() const override
@@ -64,10 +76,46 @@ namespace mocks
 			return this->running;
 		}
 
+		const std::string GetLabel() const override
+		{
+			return this->label;
+		}
+
+		// Methods for testing.
+	public:
+		uint64_t GetExpiresAtMs() const
+		{
+			return this->expiresAtMs;
+		}
+
+		bool EvaluateHasExpired()
+		{
+			if (this->getTimeMs() >= this->expiresAtMs)
+			{
+				TriggerExpire();
+
+				return true;
+			}
+			else
+			{
+				return false;
+			}
+		}
+
 	private:
+		void TriggerExpire();
+
+	private:
+		// Passed by argument.
+		TimerHandleInterface::Listener* listener{ nullptr };
+		const std::string label;
+		std::function<uint64_t()> getTimeMs;
+		const std::function<void()> onDelete;
+		// Others.
 		bool running{ false };
 		uint64_t timeout{ 0u };
 		uint64_t repeat{ 0u };
+		uint64_t expiresAtMs{ std::numeric_limits<uint64_t>::max() };
 	};
 } // namespace mocks
 

--- a/worker/mocks/src/MockShared.cpp
+++ b/worker/mocks/src/MockShared.cpp
@@ -3,6 +3,7 @@
 
 #include "mocks/include/MockShared.hpp"
 #include "Logger.hpp"
+#include "MediaSoupErrors.hpp"
 #include "mocks/include/handles/MockTimerHandle.hpp"
 
 namespace mocks
@@ -16,11 +17,32 @@ namespace mocks
 		MS_TRACE();
 	}
 
-	TimerHandleInterface* MockShared::CreateTimer(TimerHandleInterface::Listener* /*listener*/)
+	TimerHandleInterface* MockShared::CreateTimer(
+	  TimerHandleInterface::Listener* listener, std::string label)
 	{
 		MS_TRACE();
 
-		return new MockTimerHandle();
+		// NOTE: Timers are indexed by label so that tests can retrieve them via
+		// GetTimer(). Two alive timers sharing a label would make that lookup
+		// ambiguous.
+		if (this->timers.find(label) != this->timers.end())
+		{
+			MS_THROW_ERROR("a timer with same label already exists [label:%s]", label.c_str());
+		}
+
+		auto* timer = new MockTimerHandle(
+		  listener,
+		  label,
+		  /*getTimeMs*/ this->getTimeMs,
+		  /*onDelete*/
+		  [this, label]()
+		  {
+			  this->timers.erase(label);
+		  });
+
+		this->timers[label] = timer;
+
+		return timer;
 	}
 
 	BackoffTimerHandleInterface* MockShared::CreateBackoffTimer(
@@ -29,6 +51,14 @@ namespace mocks
 		MS_TRACE();
 
 		const auto& label = options.label;
+
+		// NOTE: Backoff timers are indexed by label so that tests can retrieve them
+		// via GetBackoffTimer(). Two alive timers sharing a label would make that
+		// lookup ambiguous.
+		if (this->backoffTimers.find(label) != this->backoffTimers.end())
+		{
+			MS_THROW_ERROR("a backoff timer with same label already exists [label:%s]", label.c_str());
+		}
 
 		auto* backoffTimer = new MockBackoffTimerHandle(
 		  options,

--- a/worker/mocks/src/handles/MockTimerHandle.cpp
+++ b/worker/mocks/src/handles/MockTimerHandle.cpp
@@ -1,0 +1,75 @@
+#define MS_CLASS "mocks::MockTimerHandle"
+// #define MS_LOG_DEV_LEVEL 3
+
+#include "mocks/include/handles/MockTimerHandle.hpp"
+#include "Logger.hpp"
+#include "MediaSoupErrors.hpp"
+
+namespace mocks
+{
+	MockTimerHandle::MockTimerHandle(
+	  TimerHandleInterface::Listener* listener,
+	  std::string label,
+	  std::function<uint64_t()> getTimeMs,
+	  std::function<void()> onDelete)
+	  : listener(listener),
+	    label(std::move(label)),
+	    getTimeMs(std::move(getTimeMs)),
+	    onDelete(std::move(onDelete))
+	{
+		MS_TRACE();
+
+		if (!this->listener)
+		{
+			MS_THROW_TYPE_ERROR("listener must be given");
+		}
+
+		if (this->label.empty())
+		{
+			MS_THROW_TYPE_ERROR("label must be given");
+		}
+	}
+
+	void MockTimerHandle::Dump(int indentation) const
+	{
+		MS_TRACE();
+
+		const uint64_t nowMs = this->getTimeMs();
+
+		MS_DUMP_CLEAN(indentation, "<mocks::MockTimerHandle>");
+
+		MS_DUMP_CLEAN(indentation, "  label: %s", this->label.c_str());
+		MS_DUMP_CLEAN(indentation, "  timeout (ms): %" PRIu64, this->timeout);
+		MS_DUMP_CLEAN(indentation, "  repeat (ms): %" PRIu64, this->repeat);
+		MS_DUMP_CLEAN(indentation, "  running: %s", this->running ? "yes" : "no");
+		MS_DUMP_CLEAN(indentation, "  now (ms): %" PRIu64, nowMs);
+		MS_DUMP_CLEAN(indentation, "  expires at (ms): %" PRIu64, this->expiresAtMs);
+		MS_DUMP_CLEAN(indentation, "  expires in (ms): %" PRIu64, this->expiresAtMs - nowMs);
+
+		MS_DUMP_CLEAN(indentation, "</mocks::MockTimerHandle>");
+	}
+
+	void MockTimerHandle::TriggerExpire()
+	{
+		MS_TRACE();
+
+		// Schedule the next expiration, or deactivate the timer if it doesn't
+		// repeat, just like the real TimerHandle does. This is done before invoking
+		// the callback for two reasons: the listener may call Start(), Restart() or
+		// Stop() within it, which must win over this, and the listener may delete
+		// this instance within it, so nothing can be accessed afterwards.
+		if (this->repeat != 0)
+		{
+			this->running     = true;
+			this->expiresAtMs = this->getTimeMs() + this->repeat;
+		}
+		else
+		{
+			this->running     = false;
+			this->expiresAtMs = std::numeric_limits<uint64_t>::max();
+		}
+
+		// Notify the listener.
+		this->listener->OnTimer(this);
+	}
+} // namespace mocks

--- a/worker/src/RTC/ActiveSpeakerObserver.cpp
+++ b/worker/src/RTC/ActiveSpeakerObserver.cpp
@@ -111,7 +111,7 @@ namespace RTC
 			this->interval = 5000;
 		}
 
-		this->periodicTimer = this->shared->CreateTimer(this);
+		this->periodicTimer = this->shared->CreateTimer(this, "active-speaker-observer");
 
 		this->periodicTimer->Start(interval, interval);
 

--- a/worker/src/RTC/AudioLevelObserver.cpp
+++ b/worker/src/RTC/AudioLevelObserver.cpp
@@ -39,7 +39,7 @@ namespace RTC
 			this->interval = 5000;
 		}
 
-		this->periodicTimer = this->shared->CreateTimer(this);
+		this->periodicTimer = this->shared->CreateTimer(this, "audio-level-observer");
 
 		this->periodicTimer->Start(this->interval, this->interval);
 

--- a/worker/src/RTC/DtlsTransport.cpp
+++ b/worker/src/RTC/DtlsTransport.cpp
@@ -780,7 +780,7 @@ namespace RTC
 		DTLS_set_timer_cb(this->ssl, onSslDtlsTimer);
 
 		// Set the DTLS timer.
-		this->timer = this->shared->CreateTimer(this);
+		this->timer = this->shared->CreateTimer(this, "dtls-transport");
 
 		return;
 

--- a/worker/src/RTC/ICE/IceServer.cpp
+++ b/worker/src/RTC/ICE/IceServer.cpp
@@ -937,7 +937,7 @@ namespace RTC
 			// Create the ICE consent check timer if it doesn't exist.
 			if (!this->consentCheckTimer)
 			{
-				this->consentCheckTimer = this->shared->CreateTimer(this);
+				this->consentCheckTimer = this->shared->CreateTimer(this, "ice-server-consent-check");
 			}
 
 			this->consentCheckTimer->Start(this->consentTimeoutMs);

--- a/worker/src/RTC/KeyFrameRequestManager.cpp
+++ b/worker/src/RTC/KeyFrameRequestManager.cpp
@@ -10,7 +10,9 @@ static constexpr uint32_t KeyFrameRetransmissionWaitTime{ 1000u };
 
 RTC::PendingKeyFrameInfo::PendingKeyFrameInfo(
   PendingKeyFrameInfo::Listener* listener, SharedInterface* shared, uint32_t ssrc)
-  : listener(listener), ssrc(ssrc), timer(shared->CreateTimer(this))
+  : listener(listener),
+    ssrc(ssrc),
+    timer(shared->CreateTimer(this, "key-frame-request-manager-pending-key-frame-info"))
 {
 	MS_TRACE();
 
@@ -39,7 +41,9 @@ void RTC::PendingKeyFrameInfo::OnTimer(TimerHandleInterface* timer)
 
 RTC::KeyFrameRequestDelayer::KeyFrameRequestDelayer(
   KeyFrameRequestDelayer::Listener* listener, SharedInterface* shared, uint32_t ssrc, uint32_t delay)
-  : listener(listener), ssrc(ssrc), timer(shared->CreateTimer(this))
+  : listener(listener),
+    ssrc(ssrc),
+    timer(shared->CreateTimer(this, "key-frame-request-manager-key-frame-request-delayer"))
 {
 	MS_TRACE();
 

--- a/worker/src/RTC/NackGenerator.cpp
+++ b/worker/src/RTC/NackGenerator.cpp
@@ -20,7 +20,7 @@ namespace RTC
 	  : listener(listener),
 	    shared(shared),
 	    sendNackDelayMs(sendNackDelayMs),
-	    timer(shared->CreateTimer(this)),
+	    timer(shared->CreateTimer(this, "nack-generator")),
 	    rtt(DefaultRtt)
 	{
 		MS_TRACE();

--- a/worker/src/RTC/RTP/RtpStreamRecv.cpp
+++ b/worker/src/RTC/RTP/RtpStreamRecv.cpp
@@ -207,7 +207,8 @@ namespace RTC
 			{
 				// Run the RTP inactivity periodic timer (use a different timeout if DTX is
 				// enabled).
-				this->inactivityCheckPeriodicTimer = this->shared->CreateTimer(this);
+				this->inactivityCheckPeriodicTimer =
+				  this->shared->CreateTimer(this, "rtp-stream-recv-inactivity-check");
 
 				this->inactivityCheckPeriodicTimer->Start(
 				  this->params.useDtx ? InactivityCheckIntervalWithDtx : InactivityCheckInterval);

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -84,7 +84,7 @@ namespace RTC
 		}
 
 		// Create the RTCP timer.
-		this->rtcpTimer = this->shared->CreateTimer(this);
+		this->rtcpTimer = this->shared->CreateTimer(this, "transport-rtcp");
 	}
 
 	Transport::~Transport()

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -78,7 +78,8 @@ namespace RTC
 		// videos are muted or using screensharing with still images)
 		this->rtpTransportControllerSend->EnablePeriodicAlrProbing(true);
 
-		this->processTimer = this->shared->CreateTimer(this);
+		this->processTimer =
+		  this->shared->CreateTimer(this, "transport-congestion-control-client-process");
 
 		this->processTimer->Start(
 		  std::min(

--- a/worker/src/RTC/TransportCongestionControlServer.cpp
+++ b/worker/src/RTC/TransportCongestionControlServer.cpp
@@ -34,7 +34,8 @@ namespace RTC
 				ResetTransportCcFeedback(0u);
 
 				// Create the feedback send periodic timer.
-				this->transportCcFeedbackSendPeriodicTimer = this->shared->CreateTimer(this);
+				this->transportCcFeedbackSendPeriodicTimer =
+				  this->shared->CreateTimer(this, "transport-congestion-control-server-feedback-send");
 
 				break;
 			}

--- a/worker/src/Shared.cpp
+++ b/worker/src/Shared.cpp
@@ -19,11 +19,11 @@ Shared::~Shared()
 	MS_TRACE();
 }
 
-TimerHandleInterface* Shared::CreateTimer(TimerHandleInterface::Listener* listener)
+TimerHandleInterface* Shared::CreateTimer(TimerHandleInterface::Listener* listener, std::string label)
 {
 	MS_TRACE();
 
-	return new TimerHandle(listener);
+	return new TimerHandle(listener, std::move(label));
 }
 
 BackoffTimerHandleInterface* Shared::CreateBackoffTimer(

--- a/worker/src/handles/BackoffTimerHandle.cpp
+++ b/worker/src/handles/BackoffTimerHandle.cpp
@@ -37,7 +37,7 @@ BackoffTimerHandle::BackoffTimerHandle(BackoffTimerHandleOptions options)
 		  BackoffTimerHandleInterface::MaxTimeoutMs);
 	}
 
-	this->timer = new TimerHandle(this);
+	this->timer = new TimerHandle(this, this->label);
 }
 
 BackoffTimerHandle::~BackoffTimerHandle()

--- a/worker/src/handles/TimerHandle.cpp
+++ b/worker/src/handles/TimerHandle.cpp
@@ -24,10 +24,26 @@ static void onCloseTimer(uv_handle_t* handle)
 
 /* Instance methods. */
 
-TimerHandle::TimerHandle(TimerHandleInterface::Listener* listener)
-  : listener(listener), uvHandle(new uv_timer_t)
+TimerHandle::TimerHandle(TimerHandleInterface::Listener* listener, std::string label)
+  : listener(listener), label(std::move(label)), uvHandle(new uv_timer_t)
 {
 	MS_TRACE();
+
+	if (!this->listener)
+	{
+		delete this->uvHandle;
+		this->uvHandle = nullptr;
+
+		MS_THROW_TYPE_ERROR("listener must be given");
+	}
+
+	if (this->label.empty())
+	{
+		delete this->uvHandle;
+		this->uvHandle = nullptr;
+
+		MS_THROW_TYPE_ERROR("label must be given");
+	}
 
 	this->uvHandle->data = static_cast<void*>(this);
 


### PR DESCRIPTION
# Details

- Same as in `BackoffTimerHandle` and its interface and mock class.
- Useful for tests (not yet but it will be).