### PR TITLE
Worker: New `RateCalculator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Worker: New RateCalculator ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Worker: New RateCalculator ([PR #1899](https://github.com/versatica/mediasoup/pull/1899)).
 
 ### 3.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Worker: New RateCalculator ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 3.26.0
 
 - **Breaking change:** Simulcast and SVC: Limit temporal layer to the preferred one ([PR #1892](https://github.com/versatica/mediasoup/pull/1892)).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Worker: New RateCalculator ([PR #1899](https://github.com/versatica/mediasoup/pull/1899)).
+- Worker: New `RateCalculator` ([PR #1899](https://github.com/versatica/mediasoup/pull/1899)).
 
 ### 3.26.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Worker: New RateCalculator ([PR #1899](https://github.com/versatica/mediasoup/pull/1899)).
+- Worker: New `RateCalculator` ([PR #1899](https://github.com/versatica/mediasoup/pull/1899)).
 
 ### 0.27.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### NEXT
 
+- Worker: New RateCalculator ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+
 ### 0.27.0
 
 - **Breaking change:** Simulcast and SVC: Limit temporal layer to the preferred one ([PR #1892](https://github.com/versatica/mediasoup/pull/1892)).

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### NEXT
 
-- Worker: New RateCalculator ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Worker: New RateCalculator ([PR #1899](https://github.com/versatica/mediasoup/pull/1899)).
 
 ### 0.27.0
 

--- a/worker/include/RTC/RateCalculator.hpp
+++ b/worker/include/RTC/RateCalculator.hpp
@@ -51,32 +51,32 @@ namespace RTC
 		// Window size (in milliseconds). Always >= 1.
 		size_t windowSizeMs{ DefaultWindowSize };
 		// Item size (in milliseconds). Always >= 1.
-		size_t itemSizeMs{ 1u };
+		size_t itemSizeMs{ 1 };
 		// Precomputed `scale / windowSizeMs`.
 		double rateScale{ 0.0 };
 		// Ring of items, each one holding the count of the data within it. Never
 		// empty, and always long enough to cover the whole window.
 		std::vector<size_t> buffer;
 		// Index of the newest item. Always < buffer.size().
-		size_t newestItemIndex{ 0u };
+		size_t newestItemIndex{ 0 };
 		// Time (in milliseconds) at which the newest item starts.
-		uint64_t newestItemStartTimeMs{ 0u };
+		uint64_t newestItemStartTimeMs{ 0 };
 		// Sum of the count of every item.
-		size_t totalCount{ 0u };
+		size_t totalCount{ 0 };
 		// Total bytes accounted for. Not affected by Reset().
-		size_t bytes{ 0u };
+		size_t bytes{ 0 };
 		// Rate memoized by GetRate(), only valid while both `lastTimeMs` and
 		// `lastTotalCount` below still match. `lastTotalCount` is the one that makes
 		// any Update() changing the rate invalidate this implicitly, so that the hot
 		// path needs no memoization store.
 		// NOTE: No "not calculated yet" mark is needed, since the initial and post
 		// Reset() state is a valid entry on its own: a zero rate for a zero count.
-		uint32_t lastRate{ 0u };
+		uint32_t lastRate{ 0 };
 		// Time of the latest GetRate() call. Prevents reusing `lastRate` once time
 		// has moved on and there is data pending expiration.
-		uint64_t lastTimeMs{ 0u };
+		uint64_t lastTimeMs{ 0 };
 		// Total count at the latest GetRate() call.
-		size_t lastTotalCount{ 0u };
+		size_t lastTotalCount{ 0 };
 	};
 
 	class RtpDataCounter
@@ -112,7 +112,7 @@ namespace RTC
 		// account.
 		bool ignorePaddingOnlyPackets{ false };
 		RateCalculator rate;
-		size_t packets{ 0u };
+		size_t packets{ 0 };
 	};
 } // namespace RTC
 

--- a/worker/include/RTC/RateCalculator.hpp
+++ b/worker/include/RTC/RateCalculator.hpp
@@ -8,8 +8,18 @@
 
 namespace RTC
 {
-	// It is considered that the time source increases monotonically.
-	// ie: the current timestamp can never be minor than a timestamp in the past.
+	/**
+	 * Sliding window rate meter.
+	 *
+	 * Data is accumulated into a ring of fixed duration items that covers the
+	 * whole window. The in-window total is kept incrementally, so both Update()
+	 * and GetRate() are O(1) amortized.
+	 *
+	 * It is considered that the time source increases monotonically. Timestamps
+	 * going backwards are however tolerated (time comparisons are wrap safe):
+	 * data still within the window is added to the newest item, older data is
+	 * ignored, and nothing is ever expired ahead of time.
+	 */
 	class RateCalculator
 	{
 	public:
@@ -35,42 +45,38 @@ namespace RTC
 		void Reset();
 
 	private:
-		void RemoveOldData(uint64_t nowMs);
+		bool SlideWindow(uint64_t nowMs);
 
 	private:
-		struct BufferItem
-		{
-			size_t count{ 0u };
-			uint64_t timeMs{ 0u };
-		};
-
-	private:
-		// Window Size (in milliseconds).
+		// Window size (in milliseconds). Always >= 1.
 		size_t windowSizeMs{ DefaultWindowSize };
-		// Scale in which the rate is represented.
-		float scale{ DefaultBpsScale };
-		// Window Size (number of items).
-		uint16_t windowItems{ DefaultWindowItems };
-		// Item Size (in milliseconds), calculated as: windowSizeMs / windowItems.
-		size_t itemSizeMs{ 0u };
-		// Buffer to keep data.
-		std::vector<BufferItem> buffer;
-		// Time (in milliseconds) for last item in the time window.
-		std::optional<uint64_t> newestItemStartTimeMs{ std::nullopt };
-		// Index for the last item in the time window.
-		int32_t newestItemIndex{ -1 };
-		// Time (in milliseconds) for oldest item in the time window.
-		std::optional<uint64_t> oldestItemStartTimeMs{ std::nullopt };
-		// Index for the oldest item in the time window.
-		int32_t oldestItemIndex{ -1 };
-		// Total count in the time window.
+		// Item size (in milliseconds). Always >= 1.
+		size_t itemSizeMs{ 1u };
+		// Precomputed `scale / windowSizeMs`.
+		double rateScale{ 0.0 };
+		// Ring of items, each one holding the count of the data within it. Never
+		// empty, and always long enough to cover the whole window.
+		std::vector<size_t> buffer;
+		// Index of the newest item. Always < buffer.size().
+		size_t newestItemIndex{ 0u };
+		// Time (in milliseconds) at which the newest item starts.
+		uint64_t newestItemStartTimeMs{ 0u };
+		// Sum of the count of every item.
 		size_t totalCount{ 0u };
-		// Total bytes transmitted.
+		// Total bytes accounted for. Not affected by Reset().
 		size_t bytes{ 0u };
-		// Last value calculated by GetRate().
+		// Rate memoized by GetRate(), only valid while both `lastTimeMs` and
+		// `lastTotalCount` below still match. `lastTotalCount` is the one that makes
+		// any Update() changing the rate invalidate this implicitly, so that the hot
+		// path needs no memoization store.
+		// NOTE: No "not calculated yet" mark is needed, since the initial and post
+		// Reset() state is a valid entry on its own: a zero rate for a zero count.
 		uint32_t lastRate{ 0u };
-		// Last time GetRate() was called.
-		std::optional<uint64_t> lastTimeMs{ std::nullopt };
+		// Time of the latest GetRate() call. Prevents reusing `lastRate` once time
+		// has moved on and there is data pending expiration.
+		uint64_t lastTimeMs{ 0u };
+		// Total count at the latest GetRate() call.
+		size_t lastTotalCount{ 0u };
 	};
 
 	class RtpDataCounter

--- a/worker/include/RTC/RateCalculator.hpp
+++ b/worker/include/RTC/RateCalculator.hpp
@@ -23,9 +23,9 @@ namespace RTC
 	class RateCalculator
 	{
 	public:
-		static constexpr size_t DefaultWindowSize{ 1000u };
+		static constexpr size_t DefaultWindowSize{ 1000 };
 		static constexpr float DefaultBpsScale{ 8000.0f };
-		static constexpr uint16_t DefaultWindowItems{ 100u };
+		static constexpr uint16_t DefaultWindowItems{ 100 };
 
 	public:
 		explicit RateCalculator(

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -3,129 +3,75 @@
 
 #include "RTC/RateCalculator.hpp"
 #include "Logger.hpp"
-#include "Utils.hpp"
-#include <cmath>   // std::trunc()
-#include <cstring> // std::memset()
+#include <cmath>  // std::trunc()
+#include <limits> // std::numeric_limits()
 
 namespace RTC
 {
 	RateCalculator::RateCalculator(size_t windowSizeMs, float scale, uint16_t windowItems)
-	  : windowSizeMs(windowSizeMs),
-	    scale(scale),
-	    windowItems(windowItems),
-	    itemSizeMs(std::max(windowSizeMs / windowItems, size_t{ 1 }))
 	{
 		MS_TRACE();
 
-		this->buffer.resize(windowItems);
+		// Clamp the given values so every derived value is safe to use.
+		this->windowSizeMs = std::max(windowSizeMs, size_t{ 1u });
 
-		std::memset(
-		  static_cast<void*>(std::addressof(this->buffer.front())),
-		  0,
-		  sizeof(BufferItem) * this->buffer.size());
+		const size_t items = std::max<size_t>(windowItems, 1u);
+
+		// Item granularity, rounded up so that `items` items always suffice to cover
+		// the window.
+		this->itemSizeMs = std::max((this->windowSizeMs + items - 1) / items, size_t{ 1u });
+
+		// Number of items needed to cover the whole window, rounded up. It is never
+		// higher than `items`, and it guarantees that in-window data can never
+		// overrun the ring. The window it spans overshoots windowSizeMs by less than
+		// one item, which is inherent to splitting the window into items.
+		this->buffer.resize((this->windowSizeMs + this->itemSizeMs - 1) / this->itemSizeMs);
+
+		this->rateScale = static_cast<double>(scale) / static_cast<double>(this->windowSizeMs);
 	}
 
 	void RateCalculator::Update(size_t size, uint64_t nowMs)
 	{
 		MS_TRACE();
 
-		// Ignore too old data. Should never happen.
-		if (this->oldestItemStartTimeMs.has_value() && Utils::Number::IsLowerThan<uint64_t>(nowMs, *this->oldestItemStartTimeMs))
+		// Ignore data older than the window. Should never happen.
+		if (!SlideWindow(nowMs))
 		{
-			MS_WARN_DEV("nowMs < this->oldestItemStartTimeMs, should never happen");
+			MS_WARN_DEV("given nowMs is older than the current window, ignoring data");
 
 			return;
 		}
 
-		// Increase bytes.
-		this->bytes += size;
-
-		RemoveOldData(nowMs);
-
-		// If the elapsed time from the newest item start time is greater than the
-		// item size (in milliseconds), increase the item index.
-		if (
-		  this->newestItemIndex < 0 || !this->newestItemStartTimeMs.has_value() ||
-		  Utils::Number::IsHigherOrEqualThan<uint64_t>(
-		    nowMs - *this->newestItemStartTimeMs, this->itemSizeMs))
-		{
-			this->newestItemIndex++;
-			this->newestItemStartTimeMs = nowMs;
-
-			if (this->newestItemIndex >= this->windowItems)
-			{
-				MS_DEBUG_DEV("this->newestItemIndex >= this->windowItems, setting this->newestItemIndex = 0");
-
-				this->newestItemIndex = 0;
-			}
-
-			// Advance oldestItemIndex if buffer is full.
-			// NOTE: This avoids a crash:
-			//   https://github.com/versatica/mediasoup/issues/1316
-			if (this->newestItemIndex == this->oldestItemIndex && this->oldestItemIndex != -1)
-			{
-				if (++this->oldestItemIndex >= this->windowItems)
-				{
-					this->oldestItemIndex = 0;
-				}
-			}
-
-			MS_ASSERT(
-			  this->newestItemIndex != this->oldestItemIndex || this->oldestItemIndex == -1,
-			  "newest index overlaps with the oldest one [newestItemIndex:%" PRIi32
-			  ", oldestItemIndex:%" PRIi32 "]",
-			  this->newestItemIndex,
-			  this->oldestItemIndex);
-
-			// Set the newest item.
-			BufferItem& item = this->buffer[this->newestItemIndex];
-
-			item.count  = size;
-			item.timeMs = nowMs;
-		}
-		else
-		{
-			// Update the newest item.
-			BufferItem& item = this->buffer[this->newestItemIndex];
-
-			item.count += size;
-		}
-
-		// Set the oldest item index and time, if not set.
-		if (this->oldestItemIndex < 0)
-		{
-			MS_DEBUG_DEV(
-			  "this->oldestItemIndex < 0, setting this->oldestItemIndex and this->oldestItemStartTimeMs");
-
-			this->oldestItemIndex       = this->newestItemIndex;
-			this->oldestItemStartTimeMs = nowMs;
-		}
-
+		this->buffer[this->newestItemIndex] += size;
 		this->totalCount += size;
-
-		// Reset `lastRate` and `lastTimeMs` so `GetRate()` will calculate rate
-		// again even if called with same now in the same loop iteration.
-		this->lastRate   = 0;
-		this->lastTimeMs = std::nullopt;
+		this->bytes += size;
 	}
 
 	uint32_t RateCalculator::GetRate(uint64_t nowMs)
 	{
 		MS_TRACE();
 
-		if (this->lastTimeMs.has_value() && nowMs == *this->lastTimeMs)
+		// If both keys match, the memoized rate is still exact. `lastRate` is a pure
+		// function of `totalCount`, so the value is right, and no expiration can be
+		// pending: SlideWindow() already ran for this very `nowMs` and
+		// `newestItemStartTimeMs` only moves forward afterwards, while the initial and
+		// post Reset() state has an empty ring anyway.
+		if (nowMs == this->lastTimeMs && this->totalCount == this->lastTotalCount)
 		{
-			MS_DEBUG_DEV("nowMs == this->lastTimeMs, early return");
+			MS_DEBUG_DEV("nothing changed since the latest call, early return");
 
 			return this->lastRate;
 		}
 
-		RemoveOldData(nowMs);
+		SlideWindow(nowMs);
 
-		const float scale = this->scale / this->windowSizeMs;
+		const double rate = std::trunc((static_cast<double>(this->totalCount) * this->rateScale) + 0.5);
 
-		this->lastTimeMs = nowMs;
-		this->lastRate   = static_cast<uint32_t>(std::trunc((this->totalCount * scale) + 0.5f));
+		// NOTE: Must be read after SlideWindow(), which may have expired data.
+		this->lastTotalCount = this->totalCount;
+		this->lastTimeMs     = nowMs;
+		this->lastRate       = static_cast<uint32_t>(
+		  std::min(rate, static_cast<double>(std::numeric_limits<uint32_t>::max())));
 
 		return this->lastRate;
 	}
@@ -134,73 +80,89 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		std::memset(
-		  static_cast<void*>(std::addressof(this->buffer.front())),
-		  0,
-		  sizeof(BufferItem) * this->buffer.size());
+		std::ranges::fill(this->buffer, 0u);
 
-		this->newestItemStartTimeMs = std::nullopt;
-		this->newestItemIndex       = -1;
-		this->oldestItemStartTimeMs = std::nullopt;
-		this->oldestItemIndex       = -1;
+		this->newestItemIndex       = 0u;
+		this->newestItemStartTimeMs = 0u;
 		this->totalCount            = 0u;
 		this->lastRate              = 0u;
-		this->lastTimeMs            = std::nullopt;
+		this->lastTimeMs            = 0u;
+		this->lastTotalCount        = 0u;
 	}
 
-	void RateCalculator::RemoveOldData(uint64_t nowMs)
+	/**
+	 * Expires the items that no longer belong to the window ending at `nowMs`,
+	 * and makes the item holding `nowMs` the newest one.
+	 *
+	 * Returns false if `nowMs` is so far in the past that it lies outside of the
+	 * window, in which case nothing is modified.
+	 */
+	bool RateCalculator::SlideWindow(uint64_t nowMs)
 	{
 		MS_TRACE();
 
-		if (!this->oldestItemStartTimeMs.has_value())
+		// Time elapsed since the newest item started. The subtraction is done in
+		// unsigned arithmetic and then reinterpreted as signed, so it is wrap safe
+		// and negative when `nowMs` lies in the past.
+		const auto elapsedMs = static_cast<int64_t>(nowMs - this->newestItemStartTimeMs);
+
+		// `nowMs` is older than the whole window.
+		if (elapsedMs <= -static_cast<int64_t>(this->windowSizeMs))
 		{
-			return;
+			return false;
 		}
 
-		// No item set.
-		if (this->newestItemIndex < 0 || this->oldestItemIndex < 0)
+		// `nowMs` belongs to the newest item, or to an already existing one still
+		// within the window, so there is nothing to expire.
+		if (elapsedMs < static_cast<int64_t>(this->itemSizeMs))
 		{
-			return;
+			return true;
 		}
 
-		const uint64_t newOldestTime = nowMs - this->windowSizeMs;
+		const uint64_t steps = static_cast<uint64_t>(elapsedMs) / this->itemSizeMs;
 
-		// Oldest item already removed.
-		if (Utils::Number::IsLowerThan<uint64_t>(newOldestTime, *this->oldestItemStartTimeMs))
+		// A whole window elapsed since the newest item, so every item is gone.
+		if (steps >= this->buffer.size())
 		{
-			return;
-		}
+			MS_DEBUG_DEV("a whole window elapsed, resetting every item");
 
-		// A whole window size time has elapsed since last entry. Reset the buffer.
-		if (
-		  this->newestItemStartTimeMs.has_value() &&
-		  Utils::Number::IsHigherOrEqualThan<uint64_t>(newOldestTime, *this->newestItemStartTimeMs))
-		{
-			MS_DEBUG_DEV("newOldestTime >= this->newestItemStartTimeMs, resetting the buffer");
-
-			Reset();
-
-			return;
-		}
-
-		while (Utils::Number::IsHigherOrEqualThan<uint64_t>(newOldestTime, *this->oldestItemStartTimeMs))
-		{
-			BufferItem& oldestItem = this->buffer[this->oldestItemIndex];
-
-			this->totalCount -= oldestItem.count;
-
-			oldestItem.count  = 0u;
-			oldestItem.timeMs = 0u;
-
-			if (++this->oldestItemIndex >= this->windowItems)
+			// NOTE: totalCount is the sum of every item, so a zero total means that
+			// the ring is already zeroed.
+			if (this->totalCount != 0u)
 			{
-				this->oldestItemIndex = 0;
+				std::ranges::fill(this->buffer, 0u);
+
+				this->totalCount = 0u;
 			}
 
-			const BufferItem& newOldestItem = this->buffer[this->oldestItemIndex];
+			this->newestItemIndex       = 0u;
+			this->newestItemStartTimeMs = nowMs;
 
-			this->oldestItemStartTimeMs = newOldestItem.timeMs;
+			return true;
 		}
+
+		// Walk the ring forward. Every item being passed holds the count of exactly
+		// buffer.size() items ago, which is now out of the window.
+		for (uint64_t i{ 0u }; i < steps; ++i)
+		{
+			if (++this->newestItemIndex == this->buffer.size())
+			{
+				this->newestItemIndex = 0u;
+			}
+
+			this->totalCount -= this->buffer[this->newestItemIndex];
+
+			this->buffer[this->newestItemIndex] = 0u;
+		}
+
+		// Advance by whole items rather than jumping to `nowMs`. The window is
+		// derived from item geometry (buffer.size() * itemSizeMs) instead of from per
+		// item timestamps, so absorbing the `elapsedMs % itemSizeMs` remainder here
+		// would stretch items past itemSizeMs, making the ring span more time than
+		// windowSizeMs and hence over-report the rate.
+		this->newestItemStartTimeMs += steps * this->itemSizeMs;
+
+		return true;
 	}
 
 	void RtpDataCounter::Update(const RTC::RTP::Packet* packet)

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -19,7 +19,7 @@ namespace RTC
 
 		// Item granularity, rounded up so that `items` items always suffice to cover
 		// the window.
-		this->itemSizeMs = std::max<size_t>((this->windowSizeMs + items - 1) / items, 1);
+		this->itemSizeMs = (this->windowSizeMs + items - 1) / items;
 
 		// Number of items needed to cover the whole window, rounded up. It is never
 		// higher than `items`, and it guarantees that in-window data can never

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -3,8 +3,9 @@
 
 #include "RTC/RateCalculator.hpp"
 #include "Logger.hpp"
-#include <cmath>  // std::trunc()
-#include <limits> // std::numeric_limits()
+#include <cmath>   // std::trunc()
+#include <limits>  // std::numeric_limits()
+#include <utility> // std::cmp_less()
 
 namespace RTC
 {
@@ -114,7 +115,7 @@ namespace RTC
 
 		// `nowMs` belongs to the newest item, or to an already existing one still
 		// within the window, so there is nothing to expire.
-		if (elapsedMs < static_cast<int64_t>(this->itemSizeMs))
+		if (std::cmp_less(elapsedMs, this->itemSizeMs))
 		{
 			return true;
 		}

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -3,9 +3,8 @@
 
 #include "RTC/RateCalculator.hpp"
 #include "Logger.hpp"
-#include <cmath>   // std::trunc()
-#include <limits>  // std::numeric_limits()
-#include <utility> // std::cmp_less()
+#include <cmath>  // std::trunc()
+#include <limits> // std::numeric_limits()
 
 namespace RTC
 {

--- a/worker/src/RTC/RateCalculator.cpp
+++ b/worker/src/RTC/RateCalculator.cpp
@@ -13,13 +13,13 @@ namespace RTC
 		MS_TRACE();
 
 		// Clamp the given values so every derived value is safe to use.
-		this->windowSizeMs = std::max(windowSizeMs, size_t{ 1u });
+		this->windowSizeMs = std::max<size_t>(windowSizeMs, 1);
 
-		const size_t items = std::max<size_t>(windowItems, 1u);
+		const size_t items = std::max<size_t>(windowItems, 1);
 
 		// Item granularity, rounded up so that `items` items always suffice to cover
 		// the window.
-		this->itemSizeMs = std::max((this->windowSizeMs + items - 1) / items, size_t{ 1u });
+		this->itemSizeMs = std::max<size_t>((this->windowSizeMs + items - 1) / items, 1);
 
 		// Number of items needed to cover the whole window, rounded up. It is never
 		// higher than `items`, and it guarantees that in-window data can never
@@ -80,14 +80,14 @@ namespace RTC
 	{
 		MS_TRACE();
 
-		std::ranges::fill(this->buffer, 0u);
+		std::ranges::fill(this->buffer, 0);
 
-		this->newestItemIndex       = 0u;
-		this->newestItemStartTimeMs = 0u;
-		this->totalCount            = 0u;
-		this->lastRate              = 0u;
-		this->lastTimeMs            = 0u;
-		this->lastTotalCount        = 0u;
+		this->newestItemIndex       = 0;
+		this->newestItemStartTimeMs = 0;
+		this->totalCount            = 0;
+		this->lastRate              = 0;
+		this->lastTimeMs            = 0;
+		this->lastTotalCount        = 0;
 	}
 
 	/**
@@ -128,14 +128,14 @@ namespace RTC
 
 			// NOTE: totalCount is the sum of every item, so a zero total means that
 			// the ring is already zeroed.
-			if (this->totalCount != 0u)
+			if (this->totalCount != 0)
 			{
-				std::ranges::fill(this->buffer, 0u);
+				std::ranges::fill(this->buffer, 0);
 
-				this->totalCount = 0u;
+				this->totalCount = 0;
 			}
 
-			this->newestItemIndex       = 0u;
+			this->newestItemIndex       = 0;
 			this->newestItemStartTimeMs = nowMs;
 
 			return true;
@@ -143,16 +143,16 @@ namespace RTC
 
 		// Walk the ring forward. Every item being passed holds the count of exactly
 		// buffer.size() items ago, which is now out of the window.
-		for (uint64_t i{ 0u }; i < steps; ++i)
+		for (uint64_t i{ 0 }; i < steps; ++i)
 		{
 			if (++this->newestItemIndex == this->buffer.size())
 			{
-				this->newestItemIndex = 0u;
+				this->newestItemIndex = 0;
 			}
 
 			this->totalCount -= this->buffer[this->newestItemIndex];
 
-			this->buffer[this->newestItemIndex] = 0u;
+			this->buffer[this->newestItemIndex] = 0;
 		}
 
 		// Advance by whole items rather than jumping to `nowMs`. The window is

--- a/worker/test/src/RTC/TestRateCalculator.cpp
+++ b/worker/test/src/RTC/TestRateCalculator.cpp
@@ -163,7 +163,7 @@ SCENARIO("RateCalculator", "[rate-calculator]")
 	//   https://github.com/versatica/mediasoup/issues/1316
 	SECTION("buffer overflow should not crash")
 	{
-		// window: 1000ms, items: 3 (granularity: 333ms)
+		// window: 1000ms, items: 3 (granularity: 334ms)
 		RTC::RateCalculator rate(1000, 8000, 3);
 
 		// clang-format off

--- a/worker/test/src/RTC/TestRateCalculator.cpp
+++ b/worker/test/src/RTC/TestRateCalculator.cpp
@@ -178,4 +178,106 @@ SCENARIO("RateCalculator", "[rate-calculator]")
 
 		validate(rate, nowMs, input);
 	}
+
+	// NOTE: This pins the item grid alignment. Items must advance by whole
+	// itemSizeMs steps so that a full ring always spans the window size. If the
+	// newest item start time jumped to nowMs instead, items would absorb the
+	// elapsed time remainder, the ring would span more time than the window, and
+	// the rate would be over-reported.
+	SECTION("item boundaries do not drift with traffic timing")
+	{
+		// window: 1000ms, items: 100 (granularity: 10ms)
+		RTC::RateCalculator rate(1000, 8000, 100);
+
+		// 11ms spacing, deliberately not a multiple of the 10ms granularity.
+		for (uint64_t i{ 0u }; i <= 100u; ++i)
+		{
+			rate.Update(1, nowMs + (i * 11u));
+		}
+
+		// The ring spans the items starting at [110, 1100], which hold the 91
+		// packets sent at 110, 121 ... 1100.
+		REQUIRE(rate.GetRate(nowMs + 1100u) == 91u * 8u);
+	}
+
+	// NOTE: This pins the GetRate() memoization key, which is both nowMs and the
+	// total count. Keying it on nowMs alone would return a stale rate.
+	SECTION("rate is recalculated after Update() with the same now")
+	{
+		RTC::RateCalculator rate(1000, 8000, 100);
+
+		rate.Update(5, nowMs);
+
+		REQUIRE(rate.GetRate(nowMs) == 40);
+
+		rate.Update(5, nowMs);
+
+		REQUIRE(rate.GetRate(nowMs) == 80);
+
+		rate.Update(5, nowMs);
+
+		REQUIRE(rate.GetRate(nowMs) == 120);
+
+		// Repeated reads with no Update() in between must be stable.
+		REQUIRE(rate.GetRate(nowMs) == 120);
+		REQUIRE(rate.GetRate(nowMs) == 120);
+	}
+
+	// NOTE: This pins the item size rounding for a window size which is not a
+	// multiple of it. Rounding the item size down would make a full ring span more
+	// time than the window, over-reporting the rate.
+	SECTION("window not divisible by items spans the window size")
+	{
+		// window: 1000ms, items: 3 (granularity: 334ms)
+		RTC::RateCalculator rate(1000, 8000, 3);
+
+		// Feed way past the ring size, so that any extra span accumulates.
+		for (uint64_t i{ 0u }; i < 100u; ++i)
+		{
+			rate.Update(1, nowMs + (i * 334u));
+		}
+
+		// Steady state is a full ring of 3 items holding 1 byte each.
+		REQUIRE(rate.GetRate(nowMs + (99u * 334u)) == 24);
+	}
+
+	// NOTE: This pins that the GetRate() memoization needs no "not calculated yet"
+	// mark. Its zeroed initial state is a valid entry, so a read at time 0 must be
+	// neither a stale hit nor a miss returning something else than 0.
+	SECTION("rate at time 0 on a fresh and on a reset calculator")
+	{
+		RTC::RateCalculator rate(1000, 8000, 100);
+
+		REQUIRE(rate.GetRate(0) == 0);
+
+		rate.Update(5, 0);
+
+		REQUIRE(rate.GetRate(0) == 40);
+
+		rate.Reset();
+
+		REQUIRE(rate.GetRate(0) == 0);
+
+		rate.Update(5, 0);
+
+		REQUIRE(rate.GetRate(0) == 40);
+	}
+
+	// NOTE: This pins the constructor clamping. A zero number of items used to
+	// divide by zero, and a zero window size to leave an empty buffer.
+	SECTION("degenerate constructor arguments are clamped")
+	{
+		RTC::RateCalculator noItems(1000, 8000, 0);
+		RTC::RateCalculator oneItem(1000, 8000, 1);
+		RTC::RateCalculator noWindow(0, 8000, 100);
+
+		noItems.Update(5, nowMs);
+		oneItem.Update(5, nowMs);
+		noWindow.Update(5, nowMs);
+
+		REQUIRE(noItems.GetRate(nowMs) == 40);
+		REQUIRE(oneItem.GetRate(nowMs) == 40);
+		// The window size is clamped to 1ms.
+		REQUIRE(noWindow.GetRate(nowMs) == 40000);
+	}
 }

--- a/worker/test/src/RTC/TestRateCalculator.cpp
+++ b/worker/test/src/RTC/TestRateCalculator.cpp
@@ -190,14 +190,14 @@ SCENARIO("RateCalculator", "[rate-calculator]")
 		RTC::RateCalculator rate(1000, 8000, 100);
 
 		// 11ms spacing, deliberately not a multiple of the 10ms granularity.
-		for (uint64_t i{ 0u }; i <= 100u; ++i)
+		for (uint64_t i{ 0 }; i <= 100; ++i)
 		{
-			rate.Update(1, nowMs + (i * 11u));
+			rate.Update(1, nowMs + (i * 11));
 		}
 
 		// The ring spans the items starting at [110, 1100], which hold the 91
 		// packets sent at 110, 121 ... 1100.
-		REQUIRE(rate.GetRate(nowMs + 1100u) == 91u * 8u);
+		REQUIRE(rate.GetRate(nowMs + 1100) == 91 * 8);
 	}
 
 	// NOTE: This pins the GetRate() memoization key, which is both nowMs and the
@@ -232,13 +232,13 @@ SCENARIO("RateCalculator", "[rate-calculator]")
 		RTC::RateCalculator rate(1000, 8000, 3);
 
 		// Feed way past the ring size, so that any extra span accumulates.
-		for (uint64_t i{ 0u }; i < 100u; ++i)
+		for (uint64_t i{ 0 }; i < 100; ++i)
 		{
-			rate.Update(1, nowMs + (i * 334u));
+			rate.Update(1, nowMs + (i * 334));
 		}
 
 		// Steady state is a full ring of 3 items holding 1 byte each.
-		REQUIRE(rate.GetRate(nowMs + (99u * 334u)) == 24);
+		REQUIRE(rate.GetRate(nowMs + (99 * 334)) == 24);
 	}
 
 	// NOTE: This pins that the GetRate() memoization needs no "not calculated yet"


### PR DESCRIPTION
- Items hold just their count and the oldest one is derived from the ring geometry, replacing four correlated position members with one.
- The ring is sized to always cover the window, so the #1316 overrun, its count leak and the rate it over-reported become unrepresentable rather than worked around.
- Degenerate constructor arguments are clamped, closing a division by zero, an out of bounds access and an unclamped rate cast.
- The memoized rate is keyed by total count as well as time, so `Update()` needs no invalidation store.
- Roughly 2x faster per call and about half the memory per instance, with identical output in the shipped configurations.
- Added regression tests covering the invariants above.

Note: I was willing to rewrite this class since a long time as it became more and more complex with the time. It comes out we've made it ~2x faster. This class is a hot path as its methods (`Update()`, `GetRate()`) are called several times per packet. The performance gain may not be that much in the big picture, comparing with packet send/recv and `srtp`, but this class always showed up in performance tests, so it's a noticiable performance enhancement too.