### PR TITLE
Worker: Fix transport-cc arrival time precision by working in microseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - Worker: New `RateCalculator` ([PR #1899](https://github.com/versatica/mediasoup/pull/1899)).
+- Worker: Fix transport-cc arrival time precision by working in microseconds ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
 
 ### 3.26.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### NEXT
 
 - Worker: New `RateCalculator` ([PR #1899](https://github.com/versatica/mediasoup/pull/1899)).
-- Worker: Fix transport-cc arrival time precision by working in microseconds ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Worker: Fix transport-cc arrival time precision by working in microseconds ([PR #1914](https://github.com/versatica/mediasoup/pull/1914)).
 
 ### 3.26.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### NEXT
 
 - Worker: New `RateCalculator` ([PR #1899](https://github.com/versatica/mediasoup/pull/1899)).
-- Worker: Fix transport-cc arrival time precision by working in microseconds ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
+- Worker: Fix transport-cc arrival time precision by working in microseconds ([PR #1914](https://github.com/versatica/mediasoup/pull/1914)).
 
 ### 0.27.0
 

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### NEXT
 
 - Worker: New `RateCalculator` ([PR #1899](https://github.com/versatica/mediasoup/pull/1899)).
+- Worker: Fix transport-cc arrival time precision by working in microseconds ([PR #XXXX](https://github.com/versatica/mediasoup/pull/XXXX)).
 
 ### 0.27.0
 

--- a/worker/deps/libwebrtc/libwebrtc/mediasoup_helpers.h
+++ b/worker/deps/libwebrtc/libwebrtc/mediasoup_helpers.h
@@ -18,11 +18,11 @@ namespace mediasoup_helpers
 		{
 			std::vector<webrtc::rtcp::ReceivedPacket> receivedPackets;
 
-			for (auto& packetResult : packet->GetPacketResults())
+			for (auto& packetStatus : packet->GetPacketStatuses())
 			{
-				if (packetResult.received)
+				if (packetStatus.received)
 				{
-					receivedPackets.emplace_back(packetResult.sequenceNumber, packetResult.delta);
+					receivedPackets.emplace_back(packetStatus.sequenceNumber, packetStatus.delta);
 				}
 			}
 
@@ -30,11 +30,11 @@ namespace mediasoup_helpers
 		}
 
 		/**
-		 * Get the reference time in microseconds, including any precision loss.
+		 * Get the reference time in microseconds.
 		 */
 		int64_t GetBaseTimeUs(const RTC::RTCP::FeedbackRtpTransportPacket* packet)
 		{
-			return packet->GetReferenceTimestamp() * 1000;
+			return packet->GetReferenceTimestampUs();
 		}
 
 		/**
@@ -42,7 +42,7 @@ namespace mediasoup_helpers
 		 */
 		int64_t GetBaseDeltaUs(const RTC::RTCP::FeedbackRtpTransportPacket* packet, int64_t prev_timestamp_us)
 		{
-			return packet->GetBaseDelta(prev_timestamp_us / 1000) * 1000;
+			return packet->GetBaseDeltaUs(prev_timestamp_us);
 		}
 	} // namespace FeedbackRtpTransport
 } // namespace mediasoup_helpers

--- a/worker/fuzzer/src/FuzzerUtils.cpp
+++ b/worker/fuzzer/src/FuzzerUtils.cpp
@@ -95,5 +95,5 @@ void FuzzerUtils::Fuzz(const uint8_t* data, size_t len)
 	auto ntp = Utils::Time::TimeMs2Ntp(static_cast<uint64_t>(len));
 
 	Utils::Time::Ntp2TimeMs(ntp);
-	Utils::Time::TimeMsToAbsSendTime(static_cast<uint64_t>(len));
+	Utils::Time::TimeUsToAbsSendTime(static_cast<int64_t>(len));
 }

--- a/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpTransport.cpp
+++ b/worker/fuzzer/src/RTC/RTCP/FuzzerFeedbackRtpTransport.cpp
@@ -10,11 +10,11 @@ void FuzzerRtcRtcpFeedbackRtpTransport::Fuzz(RTC::RTCP::FeedbackRtpTransportPack
 	packet->GetBaseSequenceNumber();
 	packet->GetPacketStatusCount();
 	packet->GetReferenceTime();
-	packet->GetReferenceTimestamp();
+	packet->GetReferenceTimestampUs();
 	packet->GetFeedbackPacketCount();
 	packet->GetLatestSequenceNumber();
-	packet->GetLatestTimestamp();
-	packet->GetPacketResults();
+	packet->GetLatestTimestampUs();
+	packet->GetPacketStatuses();
 	packet->GetPacketFractionLost();
 	packet->Serialize(RTC::RTCP::SerializationBuffer);
 }

--- a/worker/fuzzer/src/RTC/RTP/FuzzerPacket.cpp
+++ b/worker/fuzzer/src/RTC/RTP/FuzzerPacket.cpp
@@ -91,7 +91,7 @@ void FuzzerRtcRtcPacket::Fuzz(const uint8_t* data, size_t len)
 	packet->HasExtension(3);
 	packet->GetExtensionValue(3, extenLen);
 	packet->ReadAbsSendTime(absSendTime);
-	packet->UpdateAbsSendTime(12345678u);
+	packet->UpdateAbsSendTime(12345678);
 
 	packet->HasExtension(4);
 	packet->GetExtensionValue(4, extenLen);

--- a/worker/include/RTC/RTCP/FeedbackRtpTransport.hpp
+++ b/worker/include/RTC/RTCP/FeedbackRtpTransport.hpp
@@ -42,21 +42,25 @@ namespace RTC
 		class FeedbackRtpTransportPacket : public FeedbackRtpPacket
 		{
 		public:
-			static constexpr int64_t BaseTimeTick   = 64;
-			static constexpr int64_t TimeWrapPeriod = BaseTimeTick * (1ll << 24);
+			// Receive deltas are expressed in multiples of this.
+			static constexpr int64_t DeltaTickUs = 250;
+			// The reference time is expressed in multiples of this.
+			static constexpr int64_t BaseTimeTickUs = DeltaTickUs * (1 << 8);
+			// Period after which the reference time wraps around.
+			static constexpr int64_t TimeWrapPeriodUs = BaseTimeTickUs * (1ll << 24);
 
 		public:
-			struct PacketResult
+			struct PacketStatus
 			{
-				PacketResult(uint16_t sequenceNumber, bool received)
+				PacketStatus(uint16_t sequenceNumber, bool received)
 				  : sequenceNumber(sequenceNumber), received(received)
 				{
 				}
 
 				uint16_t sequenceNumber;   // Wide sequence number.
-				int16_t delta{ 0 };        // Delta.
+				int16_t delta{ 0 };        // Delta in DeltaTickUs units.
 				bool received{ false };    // Packet received or not.
-				int64_t receivedAtMs{ 0 }; // Received time (ms) in remote timestamp reference.
+				int64_t receivedAtUs{ 0 }; // Received time (us) in remote timestamp reference.
 			};
 
 		public:
@@ -100,8 +104,8 @@ namespace RTC
 				virtual void Dump(int indentation = 0) const                                     = 0;
 				virtual uint16_t GetCount() const                                                = 0;
 				virtual uint16_t GetReceivedStatusCount() const                                  = 0;
-				virtual void FillResults(
-				  std::vector<struct PacketResult>& packetResults, uint16_t& currentSequenceNumber) const = 0;
+				virtual void FillStatuses(
+				  std::vector<struct PacketStatus>& packetStatuses, uint16_t& currentSequenceNumber) const = 0;
 				virtual size_t Serialize(uint8_t* buffer) = 0;
 			};
 
@@ -127,8 +131,8 @@ namespace RTC
 					return this->count;
 				}
 				uint16_t GetReceivedStatusCount() const override;
-				void FillResults(
-				  std::vector<struct PacketResult>& packetResults,
+				void FillStatuses(
+				  std::vector<struct PacketStatus>& packetStatuses,
 				  uint16_t& currentSequenceNumber) const override;
 				size_t Serialize(uint8_t* buffer) override;
 
@@ -155,8 +159,8 @@ namespace RTC
 					return this->statuses.size();
 				}
 				uint16_t GetReceivedStatusCount() const override;
-				void FillResults(
-				  std::vector<struct PacketResult>& packetResults,
+				void FillStatuses(
+				  std::vector<struct PacketStatus>& packetStatuses,
 				  uint16_t& currentSequenceNumber) const override;
 				size_t Serialize(uint8_t* buffer) override;
 
@@ -182,8 +186,8 @@ namespace RTC
 					return this->statuses.size();
 				}
 				uint16_t GetReceivedStatusCount() const override;
-				void FillResults(
-				  std::vector<struct PacketResult>& packetResults,
+				void FillStatuses(
+				  std::vector<struct PacketStatus>& packetStatuses,
 				  uint16_t& currentSequenceNumber) const override;
 				size_t Serialize(uint8_t* buffer) override;
 
@@ -216,8 +220,8 @@ namespace RTC
 			{
 				return this->baseSet;
 			}
-			void SetBase(uint16_t sequenceNumber, uint64_t timestamp);
-			AddPacketResult AddPacket(uint16_t sequenceNumber, uint64_t timestamp, size_t maxRtcpPacketLen);
+			void SetBase(uint16_t sequenceNumber, int64_t timestampUs);
+			AddPacketResult AddPacket(uint16_t sequenceNumber, int64_t timestampUs, size_t maxRtcpPacketLen);
 			// Just for locally generated packets.
 			void Finish();
 			bool IsFull() const
@@ -247,27 +251,30 @@ namespace RTC
 			{
 				return this->referenceTime;
 			}
-			// NOTE: We only use this for testing purpose.
-			void SetReferenceTime(int64_t referenceTime)
+			/**
+			 * @remarks
+			 * - Only used for testing purposes.
+			 */
+			void SetReferenceTimeUs(int64_t referenceTimeUs)
 			{
-				this->referenceTime = (referenceTime % TimeWrapPeriod) / BaseTimeTick;
+				this->referenceTime = (referenceTimeUs % TimeWrapPeriodUs) / BaseTimeTickUs;
 			}
-			int64_t GetReferenceTimestamp() const // Reference time in ms.
+			int64_t GetReferenceTimestampUs() const // Reference time in us.
 			{
-				return TimeWrapPeriod + (static_cast<int64_t>(this->referenceTime) * BaseTimeTick);
+				return TimeWrapPeriodUs + (static_cast<int64_t>(this->referenceTime) * BaseTimeTickUs);
 			}
-			int64_t GetBaseDelta(const int64_t previousTimestampMs) const
+			int64_t GetBaseDeltaUs(const int64_t previousTimestampUs) const
 			{
-				int64_t delta = GetReferenceTimestamp() - previousTimestampMs;
+				int64_t delta = GetReferenceTimestampUs() - previousTimestampUs;
 
 				// Compensate for wrap around.
-				if (std::abs(delta - TimeWrapPeriod) < std::abs(delta))
+				if (std::abs(delta - TimeWrapPeriodUs) < std::abs(delta))
 				{
-					delta -= TimeWrapPeriod;
+					delta -= TimeWrapPeriodUs;
 				}
-				else if (std::abs(delta + TimeWrapPeriod) < std::abs(delta))
+				else if (std::abs(delta + TimeWrapPeriodUs) < std::abs(delta))
 				{
-					delta += TimeWrapPeriod;
+					delta += TimeWrapPeriodUs;
 				}
 
 				return delta;
@@ -284,11 +291,11 @@ namespace RTC
 			{
 				return this->latestSequenceNumber;
 			}
-			uint64_t GetLatestTimestamp() const // Just for locally generated packets.
+			int64_t GetLatestTimestampUs() const // Just for locally generated packets.
 			{
-				return this->latestTimestamp;
+				return this->latestTimestampUs;
 			}
-			std::vector<struct PacketResult> GetPacketResults() const;
+			std::vector<struct PacketStatus> GetPacketStatuses() const;
 			uint8_t GetPacketFractionLost() const;
 
 			/* Pure virtual methods inherited from Packet. */
@@ -330,7 +337,7 @@ namespace RTC
 			// Just for locally generated packets.
 			uint16_t latestSequenceNumber{ 0u };
 			// Just for locally generated packets.
-			uint64_t latestTimestamp{ 0u };
+			int64_t latestTimestampUs{ 0 };
 			uint16_t packetStatusCount{ 0u };
 			uint8_t feedbackPacketCount{ 0u };
 			std::vector<Chunk*> chunks;

--- a/worker/include/RTC/RTP/Packet.hpp
+++ b/worker/include/RTC/RTP/Packet.hpp
@@ -527,10 +527,10 @@ namespace RTC
 
 			/**
 			 * @remarks
-			 * - Contrary to `ReadAbsSendTime()` method, given `ms` is internally
+			 * - Contrary to `ReadAbsSendTime()` method, given `us` is internally
 			 *   converted to ABS Send Time.
 			 */
-			bool UpdateAbsSendTime(uint64_t ms) const;
+			bool UpdateAbsSendTime(int64_t us) const;
 
 			bool ReadTransportWideCc01(uint16_t& wideSeqNumber) const;
 

--- a/worker/include/RTC/TransportCongestionControlClient.hpp
+++ b/worker/include/RTC/TransportCongestionControlClient.hpp
@@ -71,7 +71,7 @@ namespace RTC
 		void TransportDisconnected();
 		void InsertPacket(webrtc::RtpPacketSendInfo& packetInfo);
 		webrtc::PacedPacketInfo GetPacingInfo();
-		void PacketSent(const webrtc::RtpPacketSendInfo& packetInfo, int64_t nowMs);
+		void PacketSent(const webrtc::RtpPacketSendInfo& packetInfo, int64_t nowUs);
 		void ReceiveEstimatedBitrate(uint32_t bitrate);
 		void ReceiveRtcpReceiverReport(RTC::RTCP::ReceiverReportPacket* packet, float rtt, int64_t nowMs);
 		void ReceiveRtcpTransportFeedback(const RTC::RTCP::FeedbackRtpTransportPacket* feedback);

--- a/worker/include/RTC/TransportCongestionControlServer.hpp
+++ b/worker/include/RTC/TransportCongestionControlServer.hpp
@@ -55,14 +55,14 @@ namespace RTC
 			}
 		}
 		double GetPacketLoss() const;
-		void IncomingPacket(uint64_t nowMs, const RTC::RTP::Packet* packet);
+		void IncomingPacket(int64_t nowUs, const RTC::RTP::Packet* packet);
 		void SetMaxIncomingBitrate(uint32_t bitrate);
 		void FillAndSendTransportCcFeedback();
 
 	private:
 		// Returns true if a feedback packet was sent.
 		bool SendTransportCcFeedback();
-		void MayDropOldPacketArrivalTimes(uint16_t seqNum, uint64_t nowMs);
+		void MayDropOldPacketArrivalTimes(uint16_t seqNum, int64_t nowUs);
 		void MaySendLimitationRembFeedback(uint64_t nowMs);
 		void UpdatePacketLoss(double packetLoss);
 		void ResetTransportCcFeedback(uint8_t feedbackPacketCount);
@@ -100,8 +100,8 @@ namespace RTC
 		// Whether any packet with transport wide sequence number was received.
 		bool transportWideSeqNumberReceived{ false };
 		uint16_t transportCcFeedbackWideSeqNumStart{ 0u };
-		// Map of arrival timestamp (ms) indexed by wide seq number.
-		std::map<uint16_t, uint64_t, RTC::SeqManager<uint16_t>::SeqLowerThan> mapPacketArrivalTimes;
+		// Map of arrival timestamp (us) indexed by wide seq number.
+		std::map<uint16_t, int64_t, RTC::SeqManager<uint16_t>::SeqLowerThan> mapPacketArrivalTimes;
 	};
 } // namespace RTC
 

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -538,9 +538,18 @@ namespace Utils
 			    std::round((static_cast<double>(ntp.fractions) * 1000) / NtpFractionalUnit)));
 		}
 
-		static uint32_t TimeMsToAbsSendTime(uint64_t ms)
+		/**
+		 * Convert microseconds into the 6.18 fixed point seconds of the
+		 * `abs-send-time` RTP header extension, whose resolution is hence 1/262144
+		 * of a second.
+		 */
+		static uint32_t TimeUsToAbsSendTime(int64_t us)
 		{
-			return static_cast<uint32_t>(((ms << 18) + 500) / 1000) & 0x00FFFFFF;
+			// NOTE: Only 24 bits are kept, so the value wraps every 64 seconds. Reduce
+			// the input to that period first so that the shift below cannot overflow.
+			const int64_t wrappedUs = us % (64 * 1000000);
+
+			return static_cast<uint32_t>(((wrappedUs << 18) + 500000) / 1000000) & 0x00FFFFFF;
 		}
 
 		/**

--- a/worker/include/Utils.hpp
+++ b/worker/include/Utils.hpp
@@ -545,9 +545,13 @@ namespace Utils
 		 */
 		static uint32_t TimeUsToAbsSendTime(int64_t us)
 		{
-			// NOTE: Only 24 bits are kept, so the value wraps every 64 seconds. Reduce
-			// the input to that period first so that the shift below cannot overflow.
-			const int64_t wrappedUs = us % (64 * 1000000);
+			// Period after which the 24 bits of the field wrap around.
+			constexpr int64_t WrapPeriodUs{ 64 * 1000000 };
+
+			// NOTE: Bring the given time into the period first. This keeps the shift
+			// below from overflowing, and makes a negative time yield the same value
+			// as the positive time it's congruent with rather than a meaningless one.
+			const int64_t wrappedUs = ((us % WrapPeriodUs) + WrapPeriodUs) % WrapPeriodUs;
 
 			return static_cast<uint32_t>(((wrappedUs << 18) + 500000) / 1000000) & 0x00FFFFFF;
 		}

--- a/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
+++ b/worker/src/RTC/RTCP/FeedbackRtpTransport.cpp
@@ -190,33 +190,27 @@ namespace RTC
 				chunk->Dump(indentation + 1);
 			}
 
-			MS_DUMP_CLEAN(indentation + 1, "<Deltas>");
-			for (auto delta : this->deltas)
-			{
-				MS_DUMP_CLEAN(indentation + 1, "  %" PRIi16 " ms", static_cast<int16_t>(delta / 4));
-			}
-			MS_DUMP_CLEAN(indentation + 1, "</Deltas>");
+			auto packetStatuses = GetPacketStatuses();
 
-			auto packetResults = GetPacketResults();
-
-			MS_DUMP_CLEAN(indentation + 1, "<PacketResults>");
-			for (auto& packetResult : packetResults)
+			MS_DUMP_CLEAN(indentation + 1, "<PacketStatuses>");
+			for (auto& packetStatus : packetStatuses)
 			{
-				if (packetResult.received)
+				if (packetStatus.received)
 				{
 					MS_DUMP_CLEAN(
 					  indentation + 1,
-					  "  seq:%" PRIu16 ", received:yes, receivedAtMs:%" PRIi64,
-					  packetResult.sequenceNumber,
-					  packetResult.receivedAtMs);
+					  "  seq:%" PRIu16 ", received:yes, delta:%" PRIi64 " us, receivedAtUs:%" PRIi64,
+					  packetStatus.sequenceNumber,
+					  static_cast<int64_t>(packetStatus.delta) * DeltaTickUs,
+					  packetStatus.receivedAtUs);
 				}
 				else
 				{
 					MS_DUMP_CLEAN(
-					  indentation + 1, "  seq:%" PRIu16 ", received:no", packetResult.sequenceNumber);
+					  indentation + 1, "  seq:%" PRIu16 ", received:no", packetStatus.sequenceNumber);
 				}
 			}
-			MS_DUMP_CLEAN(indentation + 1, "</PacketResults>");
+			MS_DUMP_CLEAN(indentation + 1, "</PacketStatuses>");
 			MS_DUMP_CLEAN(indentation, "</FeedbackRtpTransportPacket>");
 		}
 
@@ -279,21 +273,30 @@ namespace RTC
 			return offset;
 		}
 
-		void FeedbackRtpTransportPacket::SetBase(uint16_t sequenceNumber, uint64_t timestamp)
+		void FeedbackRtpTransportPacket::SetBase(uint16_t sequenceNumber, int64_t timestampUs)
 		{
 			MS_TRACE();
 
 			MS_ASSERT(!this->baseSet, "base already set");
 
-			this->baseSet              = true;
-			this->baseSequenceNumber   = sequenceNumber;
-			this->referenceTime        = static_cast<int32_t>((timestamp & 0x1FFFFFC0) / 64);
+			// Number of whole base time ticks elapsed.
+			const int64_t baseTimeTicks = timestampUs / BaseTimeTickUs;
+
+			this->baseSet            = true;
+			this->baseSequenceNumber = sequenceNumber;
+			// NOTE: The reference time is a 24 bits field that wraps around, which is
+			// what GetBaseDeltaUs() compensates for. Keeping fewer bits than that
+			// would make it wrap sooner than the compensation expects.
+			this->referenceTime        = static_cast<int32_t>(baseTimeTicks & 0xFFFFFF);
 			this->latestSequenceNumber = sequenceNumber - 1;
-			this->latestTimestamp      = (timestamp >> 6) * 64; // IMPORTANT: Loose precision.
+			// IMPORTANT: The reference time only carries whole base time ticks, so
+			// the remainder is lost here and recovered by the delta of the first
+			// added packet.
+			this->latestTimestampUs = baseTimeTicks * BaseTimeTickUs;
 		}
 
 		FeedbackRtpTransportPacket::AddPacketResult FeedbackRtpTransportPacket::AddPacket(
-		  uint16_t sequenceNumber, uint64_t timestamp, size_t maxRtcpPacketLen)
+		  uint16_t sequenceNumber, int64_t timestampUs, size_t maxRtcpPacketLen)
 		{
 			MS_TRACE();
 
@@ -323,24 +326,27 @@ namespace RTC
 				}
 			}
 
-			// Deltas are represented as multiples of 250 us.
+			// Deltas are represented as multiples of DeltaTickUs, rounded to the
+			// nearest tick.
 			// NOTE: Read it as int 64 to detect long elapsed times.
-			const int64_t delta64 = (timestamp - this->latestTimestamp) * 4;
+			const int64_t elapsedUs = timestampUs - this->latestTimestampUs;
+			const int64_t delta64   = elapsedUs >= 0 ? (elapsedUs + (DeltaTickUs / 2)) / DeltaTickUs
+			                                         : (elapsedUs - (DeltaTickUs / 2)) / DeltaTickUs;
 
 			if (
 			  delta64 > FeedbackRtpTransportPacket::maxPacketDelta ||
 			  delta64 < -1 * static_cast<int64_t>(FeedbackRtpTransportPacket::maxPacketDelta))
 			{
 				MS_WARN_DEV(
-				  "RTP packet delta exceeded [latestTimestamp:%" PRIu64 ", timestamp:%" PRIu64 "]",
-				  this->latestTimestamp,
-				  timestamp);
+				  "RTP packet delta exceeded [latestTimestampUs:%" PRIi64 ", timestampUs:%" PRIi64 "]",
+				  this->latestTimestampUs,
+				  timestampUs);
 
 				return AddPacketResult::FATAL;
 			}
 
 			// Delta in 16 bits signed.
-			auto delta = static_cast<int16_t>(delta64);
+			const auto delta = static_cast<int16_t>(delta64);
 
 			// Check whether another chunks and corresponding delta infos could be
 			// added.
@@ -370,8 +376,11 @@ namespace RTC
 			FillChunk(this->latestSequenceNumber, sequenceNumber, delta);
 
 			// Update latest seen sequence number and timestamp.
+			// NOTE: The timestamp is advanced by the quantized delta rather than set
+			// to the given one so that the rounding above doesn't accumulate along
+			// the packet.
 			this->latestSequenceNumber = sequenceNumber;
-			this->latestTimestamp      = timestamp;
+			this->latestTimestampUs += delta * DeltaTickUs;
 
 			return AddPacketResult::SUCCESS;
 		}
@@ -383,39 +392,38 @@ namespace RTC
 			AddPendingChunks();
 		}
 
-		std::vector<struct FeedbackRtpTransportPacket::PacketResult> FeedbackRtpTransportPacket::GetPacketResults() const
+		std::vector<struct FeedbackRtpTransportPacket::PacketStatus> FeedbackRtpTransportPacket::GetPacketStatuses() const
 		{
 			MS_TRACE();
 
-			std::vector<struct PacketResult> packetResults;
+			std::vector<struct PacketStatus> packetStatuses;
 
 			uint16_t currentSequenceNumber = this->baseSequenceNumber - 1;
 
 			for (auto* chunk : this->chunks)
 			{
-				chunk->FillResults(packetResults, currentSequenceNumber);
+				chunk->FillStatuses(packetStatuses, currentSequenceNumber);
 			}
 
 			size_t deltaIdx{ 0u };
-			// NOLINTNEXTLINE(bugprone-misplaced-widening-cast)
-			auto currentReceivedAtMs = static_cast<int64_t>(this->referenceTime * 64);
+			auto currentReceivedAtUs = GetReferenceTimestampUs();
 
-			for (size_t idx{ 0u }; idx < packetResults.size(); ++idx)
+			for (size_t idx{ 0u }; idx < packetStatuses.size(); ++idx)
 			{
-				auto& packetResult = packetResults[idx];
+				auto& packetStatus = packetStatuses[idx];
 
-				if (!packetResult.received)
+				if (!packetStatus.received)
 				{
 					continue;
 				}
 
-				currentReceivedAtMs += this->deltas.at(deltaIdx) / 4;
-				packetResult.delta        = this->deltas.at(deltaIdx);
-				packetResult.receivedAtMs = currentReceivedAtMs;
+				currentReceivedAtUs += this->deltas.at(deltaIdx) * DeltaTickUs;
+				packetStatus.delta        = this->deltas.at(deltaIdx);
+				packetStatus.receivedAtUs = currentReceivedAtUs;
 				deltaIdx++;
 			}
 
-			return packetResults;
+			return packetStatuses;
 		}
 
 		uint8_t FeedbackRtpTransportPacket::GetPacketFractionLost() const
@@ -752,8 +760,8 @@ namespace RTC
 			}
 		}
 
-		void FeedbackRtpTransportPacket::RunLengthChunk::FillResults(
-		  std::vector<struct FeedbackRtpTransportPacket::PacketResult>& packetResults,
+		void FeedbackRtpTransportPacket::RunLengthChunk::FillStatuses(
+		  std::vector<struct FeedbackRtpTransportPacket::PacketStatus>& packetStatuses,
 		  uint16_t& currentSequenceNumber) const
 		{
 			MS_TRACE();
@@ -763,7 +771,7 @@ namespace RTC
 
 			for (uint16_t count{ 1u }; count <= this->count; ++count)
 			{
-				packetResults.emplace_back(++currentSequenceNumber, received);
+				packetStatuses.emplace_back(++currentSequenceNumber, received);
 			}
 		}
 
@@ -876,8 +884,8 @@ namespace RTC
 			return count;
 		}
 
-		void FeedbackRtpTransportPacket::OneBitVectorChunk::FillResults(
-		  std::vector<struct FeedbackRtpTransportPacket::PacketResult>& packetResults,
+		void FeedbackRtpTransportPacket::OneBitVectorChunk::FillStatuses(
+		  std::vector<struct FeedbackRtpTransportPacket::PacketStatus>& packetStatuses,
 		  uint16_t& currentSequenceNumber) const
 		{
 			MS_TRACE();
@@ -886,7 +894,7 @@ namespace RTC
 			{
 				const bool received = (status == Status::SmallDelta || status == Status::LargeDelta);
 
-				packetResults.emplace_back(++currentSequenceNumber, received);
+				packetStatuses.emplace_back(++currentSequenceNumber, received);
 			}
 		}
 
@@ -1016,8 +1024,8 @@ namespace RTC
 			return count;
 		}
 
-		void FeedbackRtpTransportPacket::TwoBitVectorChunk::FillResults(
-		  std::vector<struct FeedbackRtpTransportPacket::PacketResult>& packetResults,
+		void FeedbackRtpTransportPacket::TwoBitVectorChunk::FillStatuses(
+		  std::vector<struct FeedbackRtpTransportPacket::PacketStatus>& packetStatuses,
 		  uint16_t& currentSequenceNumber) const
 		{
 			MS_TRACE();
@@ -1026,7 +1034,7 @@ namespace RTC
 			{
 				const bool received = (status == Status::SmallDelta || status == Status::LargeDelta);
 
-				packetResults.emplace_back(++currentSequenceNumber, received);
+				packetStatuses.emplace_back(++currentSequenceNumber, received);
 			}
 		}
 

--- a/worker/src/RTC/RTP/Packet.cpp
+++ b/worker/src/RTC/RTP/Packet.cpp
@@ -962,7 +962,7 @@ namespace RTC
 			return true;
 		}
 
-		bool Packet::UpdateAbsSendTime(uint64_t ms) const
+		bool Packet::UpdateAbsSendTime(int64_t us) const
 		{
 			MS_TRACE();
 
@@ -974,7 +974,7 @@ namespace RTC
 				return false;
 			}
 
-			auto absSendTime = Utils::Time::TimeMsToAbsSendTime(ms);
+			auto absSendTime = Utils::Time::TimeUsToAbsSendTime(us);
 
 			Utils::Byte::Set3Bytes(extenValue, 0, absSendTime);
 

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -1516,12 +1516,10 @@ namespace RTC
 		// them.
 		packet->AssignExtensionIds(this->recvRtpHeaderExtensionIds);
 
-		auto nowMs = this->shared->GetTimeMs();
-
 		// Feed the TransportCongestionControlServer.
 		if (this->tccServer)
 		{
-			this->tccServer->IncomingPacket(nowMs, packet);
+			this->tccServer->IncomingPacket(this->shared->GetTimeUsInt64(), packet);
 		}
 
 		// Get the associated Producer.
@@ -2591,7 +2589,7 @@ namespace RTC
 #endif
 
 		// Update abs-send-time if present.
-		packet->UpdateAbsSendTime(this->shared->GetTimeMs());
+		packet->UpdateAbsSendTime(this->shared->GetTimeUsInt64());
 
 		// Update transport wide sequence number if present.
 		if (
@@ -2630,7 +2628,7 @@ namespace RTC
 
 					  if (tccClient)
 					  {
-						  tccClient->PacketSent(packetInfo, shared->GetTimeMsInt64());
+						  tccClient->PacketSent(packetInfo, shared->GetTimeUsInt64());
 					  }
 				  }
 			  });
@@ -2650,7 +2648,7 @@ namespace RTC
 		MS_TRACE();
 
 		// Update abs-send-time if present.
-		packet->UpdateAbsSendTime(this->shared->GetTimeMs());
+		packet->UpdateAbsSendTime(this->shared->GetTimeUsInt64());
 
 		// Update transport wide sequence number if present.
 		if (
@@ -2684,7 +2682,7 @@ namespace RTC
 
 					  if (tccClient)
 					  {
-						  tccClient->PacketSent(packetInfo, shared->GetTimeMsInt64());
+						  tccClient->PacketSent(packetInfo, shared->GetTimeUsInt64());
 					  }
 				  }
 			  });
@@ -3273,7 +3271,7 @@ namespace RTC
 		MS_TRACE();
 
 		// Update abs-send-time if present.
-		packet->UpdateAbsSendTime(this->shared->GetTimeMs());
+		packet->UpdateAbsSendTime(this->shared->GetTimeUsInt64());
 
 		// Update transport wide sequence number if present.
 		if (
@@ -3310,7 +3308,7 @@ namespace RTC
 
 					  if (tccClient)
 					  {
-						  tccClient->PacketSent(packetInfo, shared->GetTimeMsInt64());
+						  tccClient->PacketSent(packetInfo, shared->GetTimeUsInt64());
 					  }
 				  }
 			  });

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -159,7 +159,7 @@ namespace RTC
 	}
 
 	void TransportCongestionControlClient::PacketSent(
-	  const webrtc::RtpPacketSendInfo& packetInfo, int64_t nowMs)
+	  const webrtc::RtpPacketSendInfo& packetInfo, int64_t nowUs)
 	{
 		MS_TRACE();
 
@@ -169,7 +169,10 @@ namespace RTC
 		}
 
 		// Notify the transport feedback adapter about the sent packet.
-		const rtc::SentPacket sentPacket(packetInfo.transport_sequence_number, nowMs);
+		// NOTE: The send time is truncated to whole milliseconds because that's the
+		// resolution the current estimator takes.
+		const rtc::SentPacket sentPacket(packetInfo.transport_sequence_number, nowUs / 1000);
+
 		this->rtpTransportControllerSend->OnSentPacket(sentPacket, packetInfo.length);
 	}
 
@@ -225,9 +228,9 @@ namespace RTC
 		const size_t expectedPackets = feedback->GetPacketStatusCount();
 		size_t lostPackets           = 0;
 
-		for (const auto& result : feedback->GetPacketResults())
+		for (const auto& packetStatus : feedback->GetPacketStatuses())
 		{
-			if (!result.received)
+			if (!packetStatus.received)
 			{
 				lostPackets += 1;
 			}

--- a/worker/src/RTC/TransportCongestionControlServer.cpp
+++ b/worker/src/RTC/TransportCongestionControlServer.cpp
@@ -9,9 +9,9 @@ namespace RTC
 {
 	/* Static. */
 
-	static constexpr uint64_t TransportCcFeedbackSendInterval{ 100u }; // In ms.
-	static constexpr uint64_t LimitationRembInterval{ 1500u };         // In ms.
-	static constexpr uint64_t PacketArrivalTimestampWindow{ 500u };    // In ms.
+	static constexpr uint64_t TransportCcFeedbackSendIntervalMs{ 100u };
+	static constexpr uint64_t LimitationRembIntervalMs{ 1500u };
+	static constexpr int64_t PacketArrivalTimestampWindowUs{ 500 * 1000 };
 	static constexpr uint8_t UnlimitedRembNumPackets{ 4u };
 	static constexpr size_t PacketLossHistogramLength{ 24 };
 
@@ -70,7 +70,7 @@ namespace RTC
 			case RTC::BweType::TRANSPORT_CC:
 			{
 				this->transportCcFeedbackSendPeriodicTimer->Start(
-				  TransportCcFeedbackSendInterval, TransportCcFeedbackSendInterval);
+				  TransportCcFeedbackSendIntervalMs, TransportCcFeedbackSendIntervalMs);
 
 				break;
 			}
@@ -106,7 +106,7 @@ namespace RTC
 		return this->packetLoss;
 	}
 
-	void TransportCongestionControlServer::IncomingPacket(uint64_t nowMs, const RTC::RTP::Packet* packet)
+	void TransportCongestionControlServer::IncomingPacket(int64_t nowUs, const RTC::RTP::Packet* packet)
 	{
 		MS_TRACE();
 
@@ -122,7 +122,7 @@ namespace RTC
 				}
 
 				// Only insert the packet when receiving it for the first time.
-				if (!this->mapPacketArrivalTimes.try_emplace(wideSeqNumber, nowMs).second)
+				if (!this->mapPacketArrivalTimes.try_emplace(wideSeqNumber, nowUs).second)
 				{
 					break;
 				}
@@ -141,13 +141,13 @@ namespace RTC
 
 				this->transportWideSeqNumberReceived = true;
 
-				MayDropOldPacketArrivalTimes(wideSeqNumber, nowMs);
+				MayDropOldPacketArrivalTimes(wideSeqNumber, nowUs);
 
 				// Update the RTCP media SSRC of the ongoing Transport-CC Feedback packet.
 				this->transportCcFeedbackSenderSsrc = 0u;
 				this->transportCcFeedbackMediaSsrc  = packet->GetSsrc();
 
-				MaySendLimitationRembFeedback(nowMs);
+				MaySendLimitationRembFeedback(nowUs / 1000);
 
 				break;
 			}
@@ -161,12 +161,8 @@ namespace RTC
 					break;
 				}
 
-				// NOTE: nowMs is uint64_t but we need to "convert" it to int64_t before
-				// we give it to libwebrtc lib (althought this is implicit in the
-				// conversion so it would be converted within the method call).
-				auto nowMsInt64 = static_cast<int64_t>(nowMs);
-
-				this->rembServer->IncomingPacket(nowMsInt64, packet->GetPayloadLength(), *packet, absSendTime);
+				this->rembServer->IncomingPacket(
+				  nowUs / 1000, packet->GetPayloadLength(), *packet, absSendTime);
 
 				break;
 			}
@@ -192,7 +188,7 @@ namespace RTC
 		for (; it != this->mapPacketArrivalTimes.end(); ++it)
 		{
 			auto sequenceNumber = it->first;
-			auto timestamp      = it->second;
+			auto timestampUs    = it->second;
 
 			// If the base is not set in this packet let's set it.
 			// NOTE: This maybe needed many times during this loop since the current
@@ -201,11 +197,12 @@ namespace RTC
 			if (!this->transportCcFeedbackPacket->IsBaseSet())
 			{
 				// Set base sequence num and reference time.
-				this->transportCcFeedbackPacket->SetBase(this->transportCcFeedbackWideSeqNumStart, timestamp);
+				this->transportCcFeedbackPacket->SetBase(
+				  this->transportCcFeedbackWideSeqNumStart, timestampUs);
 			}
 
 			auto result = this->transportCcFeedbackPacket->AddPacket(
-			  sequenceNumber, timestamp, this->maxRtcpPacketLen);
+			  sequenceNumber, timestampUs, this->maxRtcpPacketLen);
 
 			switch (result)
 			{
@@ -316,9 +313,9 @@ namespace RTC
 		const size_t expectedPackets = this->transportCcFeedbackPacket->GetPacketStatusCount();
 		size_t lostPackets           = 0;
 
-		for (const auto& result : this->transportCcFeedbackPacket->GetPacketResults())
+		for (const auto& packetStatus : this->transportCcFeedbackPacket->GetPacketStatuses())
 		{
-			if (!result.received)
+			if (!packetStatus.received)
 			{
 				lostPackets += 1;
 			}
@@ -334,22 +331,22 @@ namespace RTC
 		return true;
 	}
 
-	void TransportCongestionControlServer::MayDropOldPacketArrivalTimes(uint16_t seqNum, uint64_t nowMs)
+	void TransportCongestionControlServer::MayDropOldPacketArrivalTimes(uint16_t seqNum, int64_t nowUs)
 	{
 		MS_TRACE();
 
-		// Ignore nowMs value if it's smaller than PacketArrivalTimestampWindow in
+		// Ignore nowUs value if it's smaller than PacketArrivalTimestampWindowUs in
 		// order to avoid negative values (should never happen) and return early if
 		// the condition is met.
-		if (nowMs >= PacketArrivalTimestampWindow)
+		if (nowUs >= PacketArrivalTimestampWindowUs)
 		{
-			const uint64_t expiryTimestamp = nowMs - PacketArrivalTimestampWindow;
-			auto it                        = this->mapPacketArrivalTimes.begin();
+			const int64_t expiryTimestampUs = nowUs - PacketArrivalTimestampWindowUs;
+			auto it                         = this->mapPacketArrivalTimes.begin();
 
 			while (it != this->mapPacketArrivalTimes.end() &&
 			       it->first != this->transportCcFeedbackWideSeqNumStart &&
 			       RTC::SeqManager<uint16_t>::IsSeqLowerThan(it->first, seqNum) &&
-			       it->second <= expiryTimestamp)
+			       it->second <= expiryTimestampUs)
 			{
 				it = this->mapPacketArrivalTimes.erase(it);
 			}
@@ -370,7 +367,7 @@ namespace RTC
 		if (
 		  ((this->bweType != RTC::BweType::REMB && this->maxIncomingBitrate != 0u) ||
 			 this->unlimitedRembCounter > 0u) &&
-		  (nowMs - this->limitationRembSentAtMs > LimitationRembInterval ||
+		  (nowMs - this->limitationRembSentAtMs > LimitationRembIntervalMs ||
 			 this->unlimitedRembCounter == UnlimitedRembNumPackets))
 		{
 			MS_DEBUG_DEV(

--- a/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
+++ b/worker/test/src/RTC/RTCP/TestFeedbackRtpTransport.cpp
@@ -1,5 +1,4 @@
 #include "common.hpp"
-#include "Logger.hpp"
 #include "RTC/RTCP/FeedbackRtpTransport.hpp"
 #include <catch2/catch_test_macros.hpp>
 #include <cstring> // std::memcmp()
@@ -8,13 +7,13 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 {
 	struct TestFeedbackRtpTransportInput
 	{
-		TestFeedbackRtpTransportInput(uint16_t sequenceNumber, uint64_t timestamp, size_t maxPacketSize)
-		  : sequenceNumber(sequenceNumber), timestamp(timestamp), maxPacketSize(maxPacketSize)
+		TestFeedbackRtpTransportInput(uint16_t sequenceNumber, int64_t timestampUs, size_t maxPacketSize)
+		  : sequenceNumber(sequenceNumber), timestampUs(timestampUs), maxPacketSize(maxPacketSize)
 		{
 		}
 
 		uint16_t sequenceNumber{ 0u };
-		uint64_t timestamp{ 0u };
+		int64_t timestampUs{ 0 };
 		size_t maxPacketSize{ 0u };
 	};
 
@@ -26,43 +25,49 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 	auto verify =
 	  [](
 	    const std::vector<struct TestFeedbackRtpTransportInput>& inputs,
-	    std::vector<struct RTC::RTCP::FeedbackRtpTransportPacket::PacketResult> packetResults)
+	    const std::vector<struct RTC::RTCP::FeedbackRtpTransportPacket::PacketStatus>& packetStatuses)
 	{
-		auto inputsIterator        = inputs.begin();
-		auto packetResultsIterator = packetResults.begin();
-		auto lastInput             = *inputsIterator;
+		// The reference time only carries whole base time ticks and wraps around,
+		// so the reconstructed times sit in a frame shifted a constant amount from
+		// the given ones. The shift comes from the timestamp the base was set with,
+		// which is the first input.
+		const int64_t baseTimeTicks =
+		  inputs.front().timestampUs / RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTickUs;
+		const int64_t frameOffsetUs = RTC::RTCP::FeedbackRtpTransportPacket::TimeWrapPeriodUs +
+		                              (((baseTimeTicks & 0xFFFFFF) - baseTimeTicks) *
+		                               RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTickUs);
 
-		for (++inputsIterator; inputsIterator != inputs.end(); ++inputsIterator, ++packetResultsIterator)
+		auto packetStatusesIterator = packetStatuses.begin();
+		auto lastInput              = inputs.front();
+
+		for (auto inputsIterator = inputs.begin() + 1; inputsIterator != inputs.end(); ++inputsIterator)
 		{
 			const auto& input             = *inputsIterator;
-			auto& packetResult            = *packetResultsIterator;
 			const uint16_t missingPackets = input.sequenceNumber - lastInput.sequenceNumber - 1;
 
-			if (missingPackets > 0)
+			// All missing packets must be represented in packetStatuses.
+			for (uint16_t i{ 0u }; i < missingPackets; ++i)
 			{
-				// All missing packets must be represented in packetResults.
-				for (uint16_t i{ 0u }; i < missingPackets; ++i)
-				{
-					packetResult = *packetResultsIterator;
+				REQUIRE(packetStatusesIterator != packetStatuses.end());
+				REQUIRE(packetStatusesIterator->sequenceNumber == lastInput.sequenceNumber + i + 1);
+				REQUIRE(packetStatusesIterator->received == false);
 
-					REQUIRE(packetResult.sequenceNumber == lastInput.sequenceNumber + i + 1);
-					REQUIRE(packetResult.received == false);
+				++packetStatusesIterator;
+			}
 
-					packetResultsIterator++;
-				}
-			}
-			else
-			{
-				REQUIRE(packetResult.sequenceNumber == lastInput.sequenceNumber + 1);
-				REQUIRE(packetResult.sequenceNumber == input.sequenceNumber);
-				REQUIRE(packetResult.received == true);
-				REQUIRE(
-				  static_cast<int32_t>(packetResult.receivedAtMs & 0x1FFFFFC0) / 64 ==
-				  static_cast<int32_t>(input.timestamp & 0x1FFFFFC0) / 64);
-			}
+			REQUIRE(packetStatusesIterator != packetStatuses.end());
+			REQUIRE(packetStatusesIterator->sequenceNumber == input.sequenceNumber);
+			REQUIRE(packetStatusesIterator->received == true);
+			// Deltas carry the arrival times with no loss as long as the given ones
+			// are multiples of a delta tick.
+			REQUIRE(packetStatusesIterator->receivedAtUs == input.timestampUs + frameOffsetUs);
+
+			++packetStatusesIterator;
 
 			lastInput = input;
 		}
+
+		REQUIRE(packetStatusesIterator == packetStatuses.end());
 	};
 
 	SECTION(
@@ -75,21 +80,21 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		/* clang-format off */
 		std::vector<struct TestFeedbackRtpTransportInput> inputs =
 		{
-			{ 999, 1000000000, RtcpMtu },  // Pre base.
-			{ 1000, 1000000000, RtcpMtu }, // Base.
-			{ 1001, 1000000001, RtcpMtu },
-			{ 1002, 1000000012, RtcpMtu },
-			{ 1003, 1000000015, RtcpMtu },
-			{ 1004, 1000000017, RtcpMtu },
-			{ 1005, 1000000018, RtcpMtu },
-			{ 1006, 1000000018, RtcpMtu },
-			{ 1007, 1000000018, RtcpMtu },
-			{ 1008, 1000000018, RtcpMtu },
-			{ 1009, 1000000019, RtcpMtu },
-			{ 1010, 1000000010, RtcpMtu },
-			{ 1011, 1000000011, RtcpMtu },
-			{ 1012, 1000000011, RtcpMtu },
-			{ 1013, 1000000013, RtcpMtu }
+			{ 999, 1000000000000, RtcpMtu },  // Pre base.
+			{ 1000, 1000000000000, RtcpMtu }, // Base.
+			{ 1001, 1000000001000, RtcpMtu },
+			{ 1002, 1000000012000, RtcpMtu },
+			{ 1003, 1000000015000, RtcpMtu },
+			{ 1004, 1000000017000, RtcpMtu },
+			{ 1005, 1000000018000, RtcpMtu },
+			{ 1006, 1000000018000, RtcpMtu },
+			{ 1007, 1000000018000, RtcpMtu },
+			{ 1008, 1000000018000, RtcpMtu },
+			{ 1009, 1000000019000, RtcpMtu },
+			{ 1010, 1000000010000, RtcpMtu },
+			{ 1011, 1000000011000, RtcpMtu },
+			{ 1012, 1000000011000, RtcpMtu },
+			{ 1013, 1000000013000, RtcpMtu }
 		};
 		/* clang-format on */
 
@@ -99,32 +104,32 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		{
 			if (std::addressof(input) == std::addressof(inputs.front()))
 			{
-				packet->SetBase(input.sequenceNumber + 1, input.timestamp);
+				packet->SetBase(input.sequenceNumber + 1, input.timestampUs);
 			}
 			else
 			{
-				packet->AddPacket(input.sequenceNumber, input.timestamp, input.maxPacketSize);
+				packet->AddPacket(input.sequenceNumber, input.timestampUs, input.maxPacketSize);
 			}
 		}
 
 		REQUIRE(packet->GetLatestSequenceNumber() == 1013);
-		REQUIRE(packet->GetLatestTimestamp() == 1000000013);
+		REQUIRE(packet->GetLatestTimestampUs() == 1000000013000);
 
 		// Add a packet with greater seq number but older timestamp.
-		packet->AddPacket(1014, 1000000013 - 128, RtcpMtu);
-		inputs.emplace_back(1014, 1000000013 - 128, RtcpMtu);
+		packet->AddPacket(1014, 1000000013000 - 128000, RtcpMtu);
+		inputs.emplace_back(1014, 1000000013000 - 128000, RtcpMtu);
 
 		REQUIRE(packet->GetLatestSequenceNumber() == 1014);
-		REQUIRE(packet->GetLatestTimestamp() == 1000000013 - 128);
+		REQUIRE(packet->GetLatestTimestampUs() == 1000000013000 - 128000);
 
-		packet->AddPacket(1015, 1000000015, RtcpMtu);
-		inputs.emplace_back(1015, 1000000015, RtcpMtu);
+		packet->AddPacket(1015, 1000000015000, RtcpMtu);
+		inputs.emplace_back(1015, 1000000015000, RtcpMtu);
 
 		REQUIRE(packet->GetLatestSequenceNumber() == 1015);
-		REQUIRE(packet->GetLatestTimestamp() == 1000000015);
+		REQUIRE(packet->GetLatestTimestampUs() == 1000000015000);
 
 		packet->Finish();
-		verify(inputs, packet->GetPacketResults());
+		verify(inputs, packet->GetPacketStatuses());
 
 		REQUIRE(packet->GetBaseSequenceNumber() == 1000);
 		REQUIRE(packet->GetPacketStatusCount() == 16);
@@ -167,9 +172,9 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		/* clang-format off */
 		std::vector<TestFeedbackRtpTransportInput> inputs =
 		{
-			{ 999, 1000000000, RtcpMtu }, // Pre base.
-			{ 1000, 1000000000, RtcpMtu }, // Base.
-			{ 1050, 1000000216, RtcpMtu }
+			{ 999, 1000000000000, RtcpMtu }, // Pre base.
+			{ 1000, 1000000000000, RtcpMtu }, // Base.
+			{ 1050, 1000000216000, RtcpMtu }
 		};
 		/* clang-format on */
 
@@ -179,23 +184,23 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		{
 			if (std::addressof(input) == std::addressof(inputs.front()))
 			{
-				packet->SetBase(input.sequenceNumber + 1, input.timestamp);
+				packet->SetBase(input.sequenceNumber + 1, input.timestampUs);
 			}
 			else
 			{
-				packet->AddPacket(input.sequenceNumber, input.timestamp, input.maxPacketSize);
+				packet->AddPacket(input.sequenceNumber, input.timestampUs, input.maxPacketSize);
 			}
 		}
 
 		packet->Finish();
-		verify(inputs, packet->GetPacketResults());
+		verify(inputs, packet->GetPacketStatuses());
 
 		REQUIRE(packet->GetBaseSequenceNumber() == 1000);
 		REQUIRE(packet->GetPacketStatusCount() == 51);
 		REQUIRE(packet->GetFeedbackPacketCount() == 10);
 		REQUIRE(packet->GetPacketFractionLost() > 0);
 		REQUIRE(packet->GetLatestSequenceNumber() == 1050);
-		REQUIRE(packet->GetLatestTimestamp() == 1000000216);
+		REQUIRE(packet->GetLatestTimestampUs() == 1000000216000);
 
 		SECTION("serialize packet instance")
 		{
@@ -231,13 +236,13 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		/* clang-format off */
 		std::vector<TestFeedbackRtpTransportInput> inputs =
 		{
-			{ 999, 1000000000, RtcpMtu },  // Pre base.
-			{ 1000, 1000000000, RtcpMtu }, // Base.
-			{ 1001, 1000000100, RtcpMtu },
-			{ 1002, 1000000200, RtcpMtu },
-			{ 1015, 1000000300, RtcpMtu },
-			{ 1016, 1000000400, RtcpMtu },
-			{ 1017, 1000000500, RtcpMtu }
+			{ 999, 1000000000000, RtcpMtu },  // Pre base.
+			{ 1000, 1000000000000, RtcpMtu }, // Base.
+			{ 1001, 1000000100000, RtcpMtu },
+			{ 1002, 1000000200000, RtcpMtu },
+			{ 1015, 1000000300000, RtcpMtu },
+			{ 1016, 1000000400000, RtcpMtu },
+			{ 1017, 1000000500000, RtcpMtu }
 		};
 		/* clang-format on */
 
@@ -249,23 +254,23 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		{
 			if (std::addressof(input) == std::addressof(inputs.front()))
 			{
-				packet->SetBase(input.sequenceNumber + 1, input.timestamp);
+				packet->SetBase(input.sequenceNumber + 1, input.timestampUs);
 			}
 			else
 			{
-				packet->AddPacket(input.sequenceNumber, input.timestamp, input.maxPacketSize);
+				packet->AddPacket(input.sequenceNumber, input.timestampUs, input.maxPacketSize);
 			}
 		}
 
 		packet->Finish();
-		verify(inputs, packet->GetPacketResults());
+		verify(inputs, packet->GetPacketStatuses());
 
 		REQUIRE(packet->GetBaseSequenceNumber() == 1000);
 		REQUIRE(packet->GetPacketStatusCount() == 18);
 		REQUIRE(packet->GetFeedbackPacketCount() == 1);
 		REQUIRE(packet->GetPacketFractionLost() > 0);
 		REQUIRE(packet->GetLatestSequenceNumber() == 1017);
-		REQUIRE(packet->GetLatestTimestamp() == 1000000500);
+		REQUIRE(packet->GetLatestTimestampUs() == 1000000500000);
 
 		SECTION("serialize packet instance")
 		{
@@ -299,9 +304,9 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 	SECTION("create FeedbackRtpTransportPacket, incomplete two bit vector chunk")
 	{
 		std::vector<TestFeedbackRtpTransportInput> inputs = {
-			{ 999,  1000000000, RtcpMtu }, // Pre base.
-			{ 1000, 1000000100, RtcpMtu }, // Base.
-			{ 1001, 1000000700, RtcpMtu },
+			{ 999,  1000000000000, RtcpMtu }, // Pre base.
+			{ 1000, 1000000100000, RtcpMtu }, // Base.
+			{ 1001, 1000000700000, RtcpMtu },
 		};
 
 		auto packet = std::make_unique<RTC::RTCP::FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
@@ -312,23 +317,23 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		{
 			if (std::addressof(input) == std::addressof(inputs.front()))
 			{
-				packet->SetBase(input.sequenceNumber + 1, input.timestamp);
+				packet->SetBase(input.sequenceNumber + 1, input.timestampUs);
 			}
 			else
 			{
-				packet->AddPacket(input.sequenceNumber, input.timestamp, input.maxPacketSize);
+				packet->AddPacket(input.sequenceNumber, input.timestampUs, input.maxPacketSize);
 			}
 		}
 
 		packet->Finish();
-		verify(inputs, packet->GetPacketResults());
+		verify(inputs, packet->GetPacketStatuses());
 
 		REQUIRE(packet->GetBaseSequenceNumber() == 1000);
 		REQUIRE(packet->GetPacketStatusCount() == 2);
 		REQUIRE(packet->GetFeedbackPacketCount() == 1);
 		REQUIRE(packet->GetPacketFractionLost() == 0);
 		REQUIRE(packet->GetLatestSequenceNumber() == 1001);
-		REQUIRE(packet->GetLatestTimestamp() == 1000000700);
+		REQUIRE(packet->GetLatestTimestampUs() == 1000000700000);
 
 		SECTION("serialize packet instance")
 		{
@@ -364,15 +369,15 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		/* clang-format off */
 		std::vector<TestFeedbackRtpTransportInput> inputs =
 		{
-			{ 999, 1000000000, RtcpMtu },  // Pre base.
-			{ 1000, 1000000000, RtcpMtu }, // Base.
-			{ 1001, 1000000003, RtcpMtu },
-			{ 1002, 1000000003, RtcpMtu },
-			{ 1003, 1000000003, RtcpMtu },
-			{ 1004, 1000000004, RtcpMtu },
-			{ 1005, 1000000005, RtcpMtu },
-			{ 1006, 1000000005, RtcpMtu },
-			{ 1007, 1000000007, RtcpMtu }
+			{ 999, 1000000000000, RtcpMtu },  // Pre base.
+			{ 1000, 1000000000000, RtcpMtu }, // Base.
+			{ 1001, 1000000003000, RtcpMtu },
+			{ 1002, 1000000003000, RtcpMtu },
+			{ 1003, 1000000003000, RtcpMtu },
+			{ 1004, 1000000004000, RtcpMtu },
+			{ 1005, 1000000005000, RtcpMtu },
+			{ 1006, 1000000005000, RtcpMtu },
+			{ 1007, 1000000007000, RtcpMtu }
 		};
 		/* clang-format on */
 
@@ -384,23 +389,23 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		{
 			if (std::addressof(input) == std::addressof(inputs.front()))
 			{
-				packet->SetBase(input.sequenceNumber + 1, input.timestamp);
+				packet->SetBase(input.sequenceNumber + 1, input.timestampUs);
 			}
 			else
 			{
-				packet->AddPacket(input.sequenceNumber, input.timestamp, input.maxPacketSize);
+				packet->AddPacket(input.sequenceNumber, input.timestampUs, input.maxPacketSize);
 			}
 		}
 
 		packet->Finish();
-		verify(inputs, packet->GetPacketResults());
+		verify(inputs, packet->GetPacketStatuses());
 
 		REQUIRE(packet->GetBaseSequenceNumber() == 1000);
 		REQUIRE(packet->GetPacketStatusCount() == 8);
 		REQUIRE(packet->GetFeedbackPacketCount() == 1);
 		REQUIRE(packet->GetPacketFractionLost() == 0);
 		REQUIRE(packet->GetLatestSequenceNumber() == 1007);
-		REQUIRE(packet->GetLatestTimestamp() == 1000000007);
+		REQUIRE(packet->GetLatestTimestampUs() == 1000000007000);
 
 		alignas(4) uint8_t buffer[1024];
 		auto len = packet->Serialize(buffer);
@@ -428,19 +433,19 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		}
 
 		auto latestWideSeqNumber = packet->GetLatestSequenceNumber();
-		auto latestTimestamp     = packet->GetLatestTimestamp();
+		auto latestTimestampUs   = packet->GetLatestTimestampUs();
 
 		/* clang-format off */
 		std::vector<TestFeedbackRtpTransportInput> inputs2 =
 		{
-			{ latestWideSeqNumber, latestTimestamp, RtcpMtu },
-			{ 1008, 1000000008, RtcpMtu },
-			{ 1009, 1000000009, RtcpMtu },
-			{ 1010, 1000000010, RtcpMtu },
-			{ 1011, 1000000010, RtcpMtu },
-			{ 1012, 1000000010, RtcpMtu },
-			{ 1013, 1000000014, RtcpMtu },
-			{ 1014, 1000000014, RtcpMtu }
+			{ latestWideSeqNumber, latestTimestampUs, RtcpMtu },
+			{ 1008, 1000000008000, RtcpMtu },
+			{ 1009, 1000000009000, RtcpMtu },
+			{ 1010, 1000000010000, RtcpMtu },
+			{ 1011, 1000000010000, RtcpMtu },
+			{ 1012, 1000000010000, RtcpMtu },
+			{ 1013, 1000000014000, RtcpMtu },
+			{ 1014, 1000000014000, RtcpMtu }
 		};
 		/* clang-format on */
 
@@ -452,23 +457,23 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		{
 			if (std::addressof(input) == std::addressof(inputs2.front()))
 			{
-				packet2->SetBase(input.sequenceNumber + 1, input.timestamp);
+				packet2->SetBase(input.sequenceNumber + 1, input.timestampUs);
 			}
 			else
 			{
-				packet2->AddPacket(input.sequenceNumber, input.timestamp, input.maxPacketSize);
+				packet2->AddPacket(input.sequenceNumber, input.timestampUs, input.maxPacketSize);
 			}
 		}
 
 		packet2->Finish();
-		verify(inputs2, packet2->GetPacketResults());
+		verify(inputs2, packet2->GetPacketStatuses());
 
 		REQUIRE(packet2->GetBaseSequenceNumber() == 1008);
 		REQUIRE(packet2->GetPacketStatusCount() == 7);
 		REQUIRE(packet2->GetFeedbackPacketCount() == 2);
 		REQUIRE(packet2->GetPacketFractionLost() == 0);
 		REQUIRE(packet2->GetLatestSequenceNumber() == 1014);
-		REQUIRE(packet2->GetLatestTimestamp() == 1000000014);
+		REQUIRE(packet2->GetLatestTimestampUs() == 1000000014000);
 
 		len = packet2->Serialize(buffer);
 
@@ -521,9 +526,9 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		REQUIRE(packet->GetPacketStatusCount() == 13);
 		REQUIRE(packet->GetReferenceTime() == 6275825); // 0x5FC2F1 (signed 24 bits)
 		REQUIRE(
-		  packet->GetReferenceTimestamp() ==
-		  RTC::RTCP::FeedbackRtpTransportPacket::TimeWrapPeriod +
-		    (static_cast<int64_t>(6275825) * RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTick));
+		  packet->GetReferenceTimestampUs() ==
+		  RTC::RTCP::FeedbackRtpTransportPacket::TimeWrapPeriodUs +
+		    (static_cast<int64_t>(6275825) * RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTickUs));
 		REQUIRE(packet->GetFeedbackPacketCount() == 3);
 
 		SECTION("serialize packet")
@@ -559,9 +564,9 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		REQUIRE(packet->GetPacketStatusCount() == 0);
 		REQUIRE(packet->GetReferenceTime() == -2); // 0xFFFFFE = -2 (signed 24 bits)
 		REQUIRE(
-		  packet->GetReferenceTimestamp() ==
-		  RTC::RTCP::FeedbackRtpTransportPacket::TimeWrapPeriod +
-		    (static_cast<int64_t>(-2) * RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTick));
+		  packet->GetReferenceTimestampUs() ==
+		  RTC::RTCP::FeedbackRtpTransportPacket::TimeWrapPeriodUs +
+		    (static_cast<int64_t>(-2) * RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTickUs));
 		REQUIRE(packet->GetFeedbackPacketCount() == 1);
 
 		SECTION("serialize packet")
@@ -598,9 +603,9 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		REQUIRE(packet->GetPacketStatusCount() == 2);
 		REQUIRE(packet->GetReferenceTime() == -4368470);
 		REQUIRE(
-		  packet->GetReferenceTimestamp() ==
-		  RTC::RTCP::FeedbackRtpTransportPacket::TimeWrapPeriod +
-		    (static_cast<int64_t>(-4368470) * RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTick));
+		  packet->GetReferenceTimestampUs() ==
+		  RTC::RTCP::FeedbackRtpTransportPacket::TimeWrapPeriodUs +
+		    (static_cast<int64_t>(-4368470) * RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTickUs));
 
 		REQUIRE(packet->GetFeedbackPacketCount() == 0);
 
@@ -619,9 +624,10 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		using FeedbackPacketsMeta = struct
 		{
 			int32_t baseTimeRaw;
-			int64_t baseTimeMs;
+			int64_t baseTimeUs;
 			uint16_t baseSequence;
 			size_t packetStatusCount;
+			// In DeltaTickUs units, so these are the delta bytes of the buffer below.
 			std::vector<int16_t> deltas;
 			std::vector<uint8_t> buffer;
 		};
@@ -630,36 +636,36 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 		// were generated by chrome in direction of mediasoup.
 		const std::vector<FeedbackPacketsMeta> feedbackPacketsMeta = {
 			{ .baseTimeRaw       = 35504,
-			 .baseTimeMs        = 1076014080,
+			 .baseTimeUs        = 1076014080000,
 			 .baseSequence      = 13,
 			 .packetStatusCount = 1,
-			 .deltas            = std::vector<int16_t>{ 57 },
+			 .deltas            = std::vector<int16_t>{ 228 },
 			 .buffer = std::vector<uint8_t>{ 0xaf, 0xcd, 0x00, 0x05, 0xfa, 0x17, 0xfa, 0x17,
 			                                  0x00, 0x00, 0x04, 0xd2, 0x00, 0x0d, 0x00, 0x01,
 			                                  0x00, 0x8A, 0xB0, 0x00, 0x20, 0x01, 0xE4, 0x01 }     },
 			{ .baseTimeRaw       = 35504,
-			 .baseTimeMs        = 1076014080,
+			 .baseTimeUs        = 1076014080000,
 			 .baseSequence      = 14,
 			 .packetStatusCount = 4,
-			 .deltas            = std::vector<int16_t>{ 58, 2, 3, 55 },
+			 .deltas            = std::vector<int16_t>{ 232, 8, 12, 220 },
 			 .buffer = std::vector<uint8_t>{ 0xaf, 0xcd, 0x00, 0x06, 0xFA, 0x17, 0xFA, 0x17, 0x1C, 0xB7,
 			                                  0xDA, 0xF3, 0x00, 0x0E, 0x00, 0x04, 0x00, 0x8A, 0xB0, 0x01,
 			                                  0x20, 0x04, 0xE8, 0x08, 0x0C, 0xDC, 0x00, 0x02 }     },
 			{ .baseTimeRaw       = 35505,
-			 .baseTimeMs        = 1076014144,
+			 .baseTimeUs        = 1076014144000,
 			 .baseSequence      = 18,
 			 .packetStatusCount = 5,
-			 .deltas            = std::vector<int16_t>{ 60, 6, 5, 9, 22 },
+			 .deltas            = std::vector<int16_t>{ 240, 24, 20, 36, 88 },
 			 .buffer = std::vector<uint8_t>{ 0xAF, 0xCD, 0x00, 0x06, 0xFA, 0x17, 0xFA, 0x17, 0x1C, 0xB7,
 			                                  0xDA, 0xF3, 0x00, 0x12, 0x00, 0x05, 0x00, 0x8A, 0xB1, 0x02,
 			                                  0x20, 0x05, 0xF0, 0x18, 0x14, 0x24, 0x58, 0x01 }     },
 
 			{ .baseTimeRaw       = 617873,
-			 .baseTimeMs        = 1113285696,
+			 .baseTimeUs        = 1113285696000,
 			 .baseSequence      = 2924,
 			 .packetStatusCount = 22,
-			 .deltas =
-			    std::vector<int16_t>{ 3, 5, 5, 0, 10, 0, 0, 4, 0, 1, 0, 2, 0, 2, 0, 2, 0, 2, 0, 1, 0, 4 },
+			 .deltas            = std::vector<int16_t>{ 12, 20, 20, 0, 40, 0, 0, 16, 0, 4, 0,
+			                                             8,  0,  8,  0, 8,  0, 8, 0,  4, 0, 16 },
 			 .buffer = std::vector<uint8_t>{ 0x8F, 0xCD, 0x00, 0x0A, 0xFA, 0x17, 0xFA, 0x17, 0x06,
 			                                  0xF5, 0x11, 0x4C, 0x0B, 0x6C, 0x00, 0x16, 0x09, 0x6D,
 			                                  0x91, 0xEE, 0x20, 0x16, 0x0C, 0x14, 0x14, 0x00, 0x28,
@@ -667,86 +673,86 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 			                                  0x00, 0x08, 0x00, 0x08, 0x00, 0x04, 0x00, 0x10 }     },
 
 			{ .baseTimeRaw       = -4368470,
-			 .baseTimeMs        = 794159744,
+			 .baseTimeUs        = 794159744000,
 			 .baseSequence      = 1,
 			 .packetStatusCount = 2,
-			 .deltas            = std::vector<int16_t>{ 35, 17 },
+			 .deltas            = std::vector<int16_t>{ 140, 68 },
 			 .buffer = std::vector<uint8_t>{ 0x8F, 0xCD, 0x00, 0x05, 0xFA, 0x17, 0xFA, 0x17,
 			                                  0x39, 0xE9, 0x42, 0x38, 0x00, 0x01, 0x00, 0x02,
 			                                  0xBD, 0x57, 0xAA, 0x00, 0x20, 0x02, 0x8C, 0x44 }     },
 
 			{ .baseTimeRaw       = 818995,
-			 .baseTimeMs        = 1126157504,
+			 .baseTimeUs        = 1126157504000,
 			 .baseSequence      = 930,
 			 .packetStatusCount = 5,
-			 .deltas            = std::vector<int16_t>{ 62, 18, 5, 6, 19 },
+			 .deltas            = std::vector<int16_t>{ 248, 72, 20, 24, 76 },
 			 .buffer = std::vector<uint8_t>{ 0xAF, 0xCD, 0x00, 0x06, 0xFA, 0x17, 0xFA, 0x17, 0x26, 0x9E,
 			                                  0x8E, 0x50, 0x03, 0xA2, 0x00, 0x05, 0x0C, 0x7F, 0x33, 0x9F,
 			                                  0x20, 0x05, 0xF8, 0x48, 0x14, 0x18, 0x4C, 0x01 }     },
 			{ .baseTimeRaw       = 818996,
-			 .baseTimeMs        = 1126157568,
+			 .baseTimeUs        = 1126157568000,
 			 .baseSequence      = 921,
 			 .packetStatusCount = 7,
-			 .deltas            = std::vector<int16_t>{ 14, 5, 6, 6, 7, 14, 5 },
+			 .deltas            = std::vector<int16_t>{ 56, 20, 24, 24, 28, 56, 20 },
 			 .buffer =
 			    std::vector<uint8_t>{ 0xAF, 0xCD, 0x00, 0x07, 0xFA, 0x17, 0xFA, 0x17, 0x33, 0xB0, 0x4A,
 			                          0xE8, 0x03, 0x99, 0x00, 0x07, 0x0C, 0x7F, 0x34, 0x9F, 0x20, 0x07,
 			                          0x38, 0x14, 0x18, 0x18, 0x1C, 0x38, 0x14, 0x00, 0x00, 0x03 } },
 			{ .baseTimeRaw       = 818996,
-			 .baseTimeMs        = 1126157568,
+			 .baseTimeUs        = 1126157568000,
 			 .baseSequence      = 935,
 			 .packetStatusCount = 7,
-			 .deltas            = std::vector<int16_t>{ 57, 0, 6, 5, 5, 24, 0 },
+			 .deltas            = std::vector<int16_t>{ 228, 0, 24, 20, 20, 96, 0 },
 			 .buffer =
 			    std::vector<uint8_t>{ 0xAF, 0xCD, 0x00, 0x07, 0xFA, 0x17, 0xFA, 0x17, 0x26, 0x9E, 0x8E,
 			                          0x50, 0x03, 0xA7, 0x00, 0x07, 0x0C, 0x7F, 0x34, 0xA0, 0x20, 0x07,
 			                          0xE4, 0x00, 0x18, 0x14, 0x14, 0x60, 0x00, 0x00, 0x00, 0x03 } },
 			{ .baseTimeRaw       = 818996,
-			 .baseTimeMs        = 1126157568,
+			 .baseTimeUs        = 1126157568000,
 			 .baseSequence      = 928,
 			 .packetStatusCount = 5,
-			 .deltas            = std::vector<int16_t>{ 63, 11, 21, 6, 0 },
+			 .deltas            = std::vector<int16_t>{ 252, 44, 84, 24, 0 },
 			 .buffer = std::vector<uint8_t>{ 0xAF, 0xCD, 0x00, 0x06, 0xFA, 0x17, 0xFA, 0x17, 0x33, 0xB0,
 			                                  0x4A, 0xE8, 0x03, 0xA0, 0x00, 0x05, 0x0C, 0x7F, 0x34, 0xA0,
 			                                  0x20, 0x05, 0xFC, 0x2C, 0x54, 0x18, 0x00, 0x01 }     },
 			{ .baseTimeRaw       = 818997,
-			 .baseTimeMs        = 1126157632,
+			 .baseTimeUs        = 1126157632000,
 			 .baseSequence      = 942,
 			 .packetStatusCount = 6,
-			 .deltas            = std::vector<int16_t>{ 39, 13, 9, 5, 4, 13 },
+			 .deltas            = std::vector<int16_t>{ 156, 52, 36, 20, 16, 52 },
 			 .buffer = std::vector<uint8_t>{ 0x8F, 0xCD, 0x00, 0x06, 0xFA, 0x17, 0xFA, 0x17, 0x26, 0x9E,
 			                                  0x8E, 0x50, 0x03, 0xAE, 0x00, 0x06, 0x0C, 0x7F, 0x35, 0xA1,
 			                                  0x20, 0x06, 0x9C, 0x34, 0x24, 0x14, 0x10, 0x34 }     },
 			{ .baseTimeRaw       = 821523,
-			 .baseTimeMs        = 1126319296,
+			 .baseTimeUs        = 1126319296000,
 			 .baseSequence      = 10,
 			 .packetStatusCount = 7,
-			 .deltas            = std::vector<int16_t>{ 25, 2, 2, 3, 1, 1, 3 },
+			 .deltas            = std::vector<int16_t>{ 100, 8, 8, 12, 4, 4, 12 },
 			 .buffer =
 			    std::vector<uint8_t>{ 0xAF, 0xCD, 0x00, 0x07, 0xFA, 0x17, 0xFA, 0x17, 0x00, 0x00, 0x04,
 			                          0xD2, 0x00, 0x0A, 0x00, 0x07, 0x0C, 0x89, 0x13, 0x00, 0x20, 0x07,
 			                          0x64, 0x08, 0x08, 0x0C, 0x04, 0x04, 0x0C, 0x00, 0x00, 0x03 } },
 			{ .baseTimeRaw       = 821524,
-			 .baseTimeMs        = 1126319360,
+			 .baseTimeUs        = 1126319360000,
 			 .baseSequence      = 17,
 			 .packetStatusCount = 2,
-			 .deltas            = std::vector<int16_t>{ 44, 18 },
+			 .deltas            = std::vector<int16_t>{ 176, 72 },
 			 .buffer = std::vector<uint8_t>{ 0x8F, 0xCD, 0x00, 0x05, 0xFA, 0x17, 0xFA, 0x17,
 			                                  0x08, 0xEB, 0x06, 0xD7, 0x00, 0x11, 0x00, 0x02,
 			                                  0x0C, 0x89, 0x14, 0x01, 0x20, 0x02, 0xB0, 0x48 }     },
 			{ .baseTimeRaw       = 821524,
-			 .baseTimeMs        = 1126319360,
+			 .baseTimeUs        = 1126319360000,
 			 .baseSequence      = 17,
 			 .packetStatusCount = 1,
-			 .deltas            = std::vector<int16_t>{ 62 },
+			 .deltas            = std::vector<int16_t>{ 248 },
 			 .buffer = std::vector<uint8_t>{ 0xAF, 0xCD, 0x00, 0x05, 0xFA, 0x17, 0xFA, 0x17,
 			                                  0x20, 0x92, 0x5E, 0xB7, 0x00, 0x11, 0x00, 0x01,
 			                                  0x0C, 0x89, 0x14, 0x00, 0x20, 0x01, 0xF8, 0x01 }     },
 			{ .baseTimeRaw       = 821526,
-			 .baseTimeMs        = 1126319488,
+			 .baseTimeUs        = 1126319488000,
 			 .baseSequence      = 19,
 			 .packetStatusCount = 4,
-			 .deltas            = std::vector<int16_t>{ 4, 0, 4, 0 },
+			 .deltas            = std::vector<int16_t>{ 16, 0, 16, 0 },
 			 .buffer = std::vector<uint8_t>{ 0xAF, 0xCD, 0x00, 0x06, 0xFA, 0x17, 0xFA, 0x17, 0x08, 0xEB,
 			                                  0x06, 0xD7, 0x00, 0x13, 0x00, 0x04, 0x0C, 0x89, 0x16, 0x02,
 			                                  0x20, 0x04, 0x10, 0x00, 0x10, 0x00, 0x00, 0x02 }     }
@@ -761,48 +767,71 @@ SCENARIO("RTCP Feedback RTP Transport", "[rtcp][feedback-rtp][transport]")
 			};
 
 			REQUIRE(feedback->GetReferenceTime() == packetMeta.baseTimeRaw);
-			REQUIRE(feedback->GetReferenceTimestamp() == packetMeta.baseTimeMs);
+			REQUIRE(feedback->GetReferenceTimestampUs() == packetMeta.baseTimeUs);
 			REQUIRE(feedback->GetBaseSequenceNumber() == packetMeta.baseSequence);
 			REQUIRE(feedback->GetPacketStatusCount() == packetMeta.packetStatusCount);
 
-			auto packetsResults = feedback->GetPacketResults();
+			auto packetStatuses = feedback->GetPacketStatuses();
 
 			int deltasIt = 0;
 			for (const auto& delta : packetMeta.deltas)
 			{
-				auto resultDelta = packetsResults[deltasIt].delta;
-				REQUIRE(static_cast<int16_t>(resultDelta / 4) == delta);
+				REQUIRE(packetStatuses[deltasIt].delta == delta);
 				deltasIt++;
 			}
 		}
 	}
 
-	SECTION("check GetBaseDelta() wraparound")
+	SECTION("check GetBaseDeltaUs() wraparound")
 	{
-		static const auto MaxBaseTime = RTC::RTCP::FeedbackRtpTransportPacket::TimeWrapPeriod -
-		                                RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTick;
+		static constexpr int64_t MaxBaseTimeUs{ RTC::RTCP::FeedbackRtpTransportPacket::TimeWrapPeriodUs -
+		                                        RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTickUs };
 
 		auto packet1 = std::make_unique<RTC::RTCP::FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
 		auto packet2 = std::make_unique<RTC::RTCP::FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
 		auto packet3 = std::make_unique<RTC::RTCP::FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
 
-		packet1->SetReferenceTime(MaxBaseTime);
-		packet2->SetReferenceTime(MaxBaseTime + RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTick);
-		packet3->SetReferenceTime(
-		  MaxBaseTime + RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTick +
-		  RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTick);
+		packet1->SetReferenceTimeUs(MaxBaseTimeUs);
+		packet2->SetReferenceTimeUs(MaxBaseTimeUs + RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTickUs);
+		packet3->SetReferenceTimeUs(
+		  MaxBaseTimeUs + RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTickUs +
+		  RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTickUs);
 
 		REQUIRE(packet1->GetReferenceTime() == 16777215);
 		REQUIRE(packet2->GetReferenceTime() == 0);
 		REQUIRE(packet3->GetReferenceTime() == 1);
 
-		REQUIRE(packet1->GetReferenceTimestamp() == 2147483584);
-		REQUIRE(packet2->GetReferenceTimestamp() == 1073741824);
-		REQUIRE(packet3->GetReferenceTimestamp() == 1073741888);
+		REQUIRE(packet1->GetReferenceTimestampUs() == 2147483584000);
+		REQUIRE(packet2->GetReferenceTimestampUs() == 1073741824000);
+		REQUIRE(packet3->GetReferenceTimestampUs() == 1073741888000);
 
-		REQUIRE(packet1->GetBaseDelta(packet1->GetReferenceTimestamp()) == 0);
-		REQUIRE(packet2->GetBaseDelta(packet1->GetReferenceTimestamp()) == 64);
-		REQUIRE(packet3->GetBaseDelta(packet2->GetReferenceTimestamp()) == 64);
-		REQUIRE(packet3->GetBaseDelta(packet1->GetReferenceTimestamp()) == 128);
+		REQUIRE(packet1->GetBaseDeltaUs(packet1->GetReferenceTimestampUs()) == 0);
+		REQUIRE(packet2->GetBaseDeltaUs(packet1->GetReferenceTimestampUs()) == 64000);
+		REQUIRE(packet3->GetBaseDeltaUs(packet2->GetReferenceTimestampUs()) == 64000);
+		REQUIRE(packet3->GetBaseDeltaUs(packet1->GetReferenceTimestampUs()) == 128000);
+	}
+
+	SECTION("SetBase() wraps the reference time over the whole period GetBaseDeltaUs() compensates for")
+	{
+		// Timestamp sitting on the last whole base time tick before the reference
+		// time wraps around.
+		static constexpr int64_t LastTickUs{ RTC::RTCP::FeedbackRtpTransportPacket::TimeWrapPeriodUs -
+		                                     RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTickUs };
+
+		auto packet1 = std::make_unique<RTC::RTCP::FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
+		auto packet2 = std::make_unique<RTC::RTCP::FeedbackRtpTransportPacket>(senderSsrc, mediaSsrc);
+
+		packet1->SetBase(1000, LastTickUs);
+		packet2->SetBase(1001, LastTickUs + RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTickUs);
+
+		REQUIRE(packet1->GetReferenceTime() == 16777215);
+		REQUIRE(packet2->GetReferenceTime() == 0);
+
+		// Both packets are a single tick apart, so the wrap around must be
+		// compensated. It would not be if the reference time wrapped sooner than
+		// the period GetBaseDeltaUs() knows about.
+		REQUIRE(
+		  packet2->GetBaseDeltaUs(packet1->GetReferenceTimestampUs()) ==
+		  RTC::RTCP::FeedbackRtpTransportPacket::BaseTimeTickUs);
 	}
 }

--- a/worker/test/src/RTC/RTP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTP/TestPacket.cpp
@@ -1547,9 +1547,9 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(packet->ReadTransportWideCc01(readWideSeqNumber));
 		REQUIRE(readWideSeqNumber == wideSeqNumber);
 
-		std::string newMid{ "mid-®2" };
-		int64_t newAbsSendtimeUs{ 999999250 };
-		uint16_t newWideSeqNumber{ 5556 };
+		const std::string newMid{ "mid-®2" };
+		const int64_t newAbsSendtimeUs{ 999999250 };
+		const uint16_t newWideSeqNumber{ 5556 };
 
 		REQUIRE(packet->UpdateMid(newMid));
 		REQUIRE(packet->UpdateAbsSendTime(newAbsSendtimeUs));

--- a/worker/test/src/RTC/RTP/TestPacket.cpp
+++ b/worker/test/src/RTC/RTP/TestPacket.cpp
@@ -1548,11 +1548,11 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(readWideSeqNumber == wideSeqNumber);
 
 		std::string newMid{ "mid-®2" };
-		uint64_t newAbsSendtimeMs{ 999999 };
+		int64_t newAbsSendtimeUs{ 999999250 };
 		uint16_t newWideSeqNumber{ 5556 };
 
 		REQUIRE(packet->UpdateMid(newMid));
-		REQUIRE(packet->UpdateAbsSendTime(newAbsSendtimeMs));
+		REQUIRE(packet->UpdateAbsSendTime(newAbsSendtimeUs));
 		REQUIRE(packet->UpdateTransportWideCc01(newWideSeqNumber));
 
 		REQUIRE(packet->ReadMid(readMid));
@@ -1560,7 +1560,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(packet->ReadRid(readRid));
 		REQUIRE(readRid == rid);
 		REQUIRE(packet->ReadAbsSendTime(readAbsSendtime));
-		REQUIRE(readAbsSendtime == Utils::Time::TimeMsToAbsSendTime(newAbsSendtimeMs));
+		REQUIRE(readAbsSendtime == Utils::Time::TimeUsToAbsSendTime(newAbsSendtimeUs));
 		REQUIRE(packet->ReadTransportWideCc01(readWideSeqNumber));
 		REQUIRE(readWideSeqNumber == newWideSeqNumber);
 
@@ -1587,7 +1587,7 @@ SCENARIO("RTP Packet", "[serializable][rtp][packet]")
 		REQUIRE(packet2->ReadRid(readRid));
 		REQUIRE(readRid == rid);
 		REQUIRE(packet2->ReadAbsSendTime(readAbsSendtime));
-		REQUIRE(readAbsSendtime == Utils::Time::TimeMsToAbsSendTime(newAbsSendtimeMs));
+		REQUIRE(readAbsSendtime == Utils::Time::TimeUsToAbsSendTime(newAbsSendtimeUs));
 		REQUIRE(packet2->ReadTransportWideCc01(readWideSeqNumber));
 		REQUIRE(readWideSeqNumber == newWideSeqNumber);
 	}

--- a/worker/test/src/RTC/TestTransportCongestionControlServer.cpp
+++ b/worker/test/src/RTC/TestTransportCongestionControlServer.cpp
@@ -13,14 +13,14 @@ SCENARIO("TransportCongestionControlServer", "[rtp]")
 	struct TestTransportCongestionControlServerInput
 	{
 		uint16_t wideSeqNumber;
-		uint64_t nowMs;
+		int64_t nowUs;
 	};
 
 	struct TestTransportCongestionControlServerResult
 	{
 		uint16_t wideSeqNumber;
 		bool received;
-		uint64_t timestamp;
+		int64_t timestampUs;
 	};
 
 	using TestResults = std::deque<std::vector<TestTransportCongestionControlServerResult>>;
@@ -39,27 +39,32 @@ SCENARIO("TransportCongestionControlServer", "[rtp]")
 				return;
 			}
 
-			auto packetResults = tccPacket->GetPacketResults();
+			auto packetStatuses = tccPacket->GetPacketStatuses();
 
 			REQUIRE(!this->results.empty());
 
 			auto testResults = this->results.front();
 			this->results.pop_front();
 
-			REQUIRE(testResults.size() == packetResults.size());
+			REQUIRE(testResults.size() == packetStatuses.size());
 
-			auto packetResultIt = packetResults.begin();
+			auto packetStatusIt = packetStatuses.begin();
 			auto testResultIt   = testResults.begin();
 
-			for (; packetResultIt != packetResults.end() && testResultIt != testResults.end();
-			     ++packetResultIt, ++testResultIt)
+			for (; packetStatusIt != packetStatuses.end() && testResultIt != testResults.end();
+			     ++packetStatusIt, ++testResultIt)
 			{
-				REQUIRE(packetResultIt->sequenceNumber == testResultIt->wideSeqNumber);
-				REQUIRE(packetResultIt->received == testResultIt->received);
+				REQUIRE(packetStatusIt->sequenceNumber == testResultIt->wideSeqNumber);
+				REQUIRE(packetStatusIt->received == testResultIt->received);
 
-				if (packetResultIt->received)
+				if (packetStatusIt->received)
 				{
-					REQUIRE(packetResultIt->receivedAtMs == static_cast<int64_t>(testResultIt->timestamp));
+					// The reconstructed times sit in the frame of the reference time,
+					// which is shifted by a whole wrap period so that it's positive
+					// regardless of the sign of the reference time on the wire.
+					REQUIRE(
+					  packetStatusIt->receivedAtUs ==
+					  RTC::RTCP::FeedbackRtpTransportPacket::TimeWrapPeriodUs + testResultIt->timestampUs);
 				}
 			}
 		}
@@ -122,22 +127,23 @@ SCENARIO("TransportCongestionControlServer", "[rtp]")
 		// Save results.
 		listener.SetResults(results);
 
-		uint64_t startTs = inputs[0].nowMs;
-		uint64_t TransportCcFeedbackSendInterval{ 100u }; // In ms.
+		static constexpr int64_t TransportCcFeedbackSendIntervalUs{ 100 * 1000 };
+
+		int64_t startTsUs = inputs[0].nowUs;
 
 		for (auto input : inputs)
 		{
 			// Periodic sending TCC packets.
-			uint64_t diffTs = input.nowMs - startTs;
+			const int64_t diffTsUs = input.nowUs - startTsUs;
 
-			if (diffTs >= TransportCcFeedbackSendInterval)
+			if (diffTsUs >= TransportCcFeedbackSendIntervalUs)
 			{
 				tccServer.FillAndSendTransportCcFeedback();
-				startTs = input.nowMs;
+				startTsUs = input.nowUs;
 			}
 
 			packet->UpdateTransportWideCc01(input.wideSeqNumber);
-			tccServer.IncomingPacket(input.nowMs, packet.get());
+			tccServer.IncomingPacket(input.nowUs, packet.get());
 		}
 
 		tccServer.FillAndSendTransportCcFeedback();
@@ -149,25 +155,25 @@ SCENARIO("TransportCongestionControlServer", "[rtp]")
 		// clang-format off
 		std::vector<TestTransportCongestionControlServerInput> inputs
 		{
-			{ 1u, 1000u },
-			{ 2u, 1050u },
-			{ 3u, 1100u },
-			{ 4u, 1150u },
-			{ 5u, 1200u },
+			{ 1u, 1000000 },
+			{ 2u, 1050000 },
+			{ 3u, 1100000 },
+			{ 4u, 1150000 },
+			{ 5u, 1200000 },
 		};
 
 		TestResults results
 		{
 			{
-				{ 1u, true, 1000u },
-				{ 2u, true, 1050u },
+				{ 1u, true, 1000000 },
+				{ 2u, true, 1050000 },
 			},
 			{
-				{ 3u, true, 1100u },
-				{ 4u, true, 1150u },
+				{ 3u, true, 1100000 },
+				{ 4u, true, 1150000 },
 			},
 			{
-				{ 5u, true, 1200u },
+				{ 5u, true, 1200000 },
 			},
 		};
 		// clang-format on
@@ -180,23 +186,23 @@ SCENARIO("TransportCongestionControlServer", "[rtp]")
 		// clang-format off
 		std::vector<TestTransportCongestionControlServerInput> inputs
 		{
-			{  1u, 1000u },
-			{  3u, 1050u },
-			{  5u, 1100u },
-			{  6u, 1150u },
+			{  1u, 1000000 },
+			{  3u, 1050000 },
+			{  5u, 1100000 },
+			{  6u, 1150000 },
 		};
 
 		TestResults results
 		{
 			{
-				{ 1u,  true, 1000u },
-				{ 2u, false,    0u },
-				{ 3u,  true, 1050u },
+				{ 1u,  true, 1000000 },
+				{ 2u, false,       0 },
+				{ 3u,  true, 1050000 },
 			},
 			{
-				{ 4u, false,    0u },
-				{ 5u,  true, 1100u },
-				{ 6u,  true, 1150u },
+				{ 4u, false,       0 },
+				{ 5u,  true, 1100000 },
+				{ 6u,  true, 1150000 },
 			},
 		};
 		// clang-format on
@@ -209,25 +215,25 @@ SCENARIO("TransportCongestionControlServer", "[rtp]")
 		// clang-format off
 		std::vector<TestTransportCongestionControlServerInput> inputs
 		{
-			{  1u, 1000u },
-			{  1u, 1050u },
-			{  2u, 1100u },
-			{  3u, 1150u },
-			{  3u, 1200u },
-			{  4u, 1250u },
+			{  1u, 1000000 },
+			{  1u, 1050000 },
+			{  2u, 1100000 },
+			{  3u, 1150000 },
+			{  3u, 1200000 },
+			{  4u, 1250000 },
 		};
 
 		TestResults results
 		{
 			{
-				{ 1u,  true, 1000u },
+				{ 1u,  true, 1000000 },
 			},
 			{
-				{ 2u,  true, 1100u },
-				{ 3u,  true, 1150u },
+				{ 2u,  true, 1100000 },
+				{ 3u,  true, 1150000 },
 			},
 			{
-				{ 4u,  true, 1250u },
+				{ 4u,  true, 1250000 },
 			},
 		};
 		// clang-format on
@@ -240,30 +246,30 @@ SCENARIO("TransportCongestionControlServer", "[rtp]")
 		// clang-format off
 		std::vector<TestTransportCongestionControlServerInput> inputs
 		{
-			{ 1u, 1000u },
-			{ 2u, 1050u },
-			{ 4u, 1100u },
-			{ 5u, 1150u },
-			{ 3u, 1200u }, // Out of order
-			{ 6u, 1250u },
+			{ 1u, 1000000 },
+			{ 2u, 1050000 },
+			{ 4u, 1100000 },
+			{ 5u, 1150000 },
+			{ 3u, 1200000 }, // Out of order
+			{ 6u, 1250000 },
 		};
 
 		TestResults results
 		{
 			{
-				{ 1u, true, 1000u },
-				{ 2u, true, 1050u },
+				{ 1u, true, 1000000 },
+				{ 2u, true, 1050000 },
 			},
 			{
-				{ 3u, false,    0u },
-				{ 4u,  true, 1100u },
-				{ 5u,  true, 1150u },
+				{ 3u, false,       0 },
+				{ 4u,  true, 1100000 },
+				{ 5u,  true, 1150000 },
 			},
 			{
-				{ 3u, true, 1200u },
-				{ 4u, true, 1100u },
-				{ 5u, true, 1150u },
-				{ 6u, true, 1250u },
+				{ 3u, true, 1200000 },
+				{ 4u, true, 1100000 },
+				{ 5u, true, 1150000 },
+				{ 6u, true, 1250000 },
 			},
 		};
 		// clang-format on

--- a/worker/test/src/Utils/TestTime.cpp
+++ b/worker/test/src/Utils/TestTime.cpp
@@ -32,6 +32,32 @@ SCENARIO("Utils::Time", "[utils][time]")
 		REQUIRE(Utils::Time::Ntp2TimeMs(ntp) == 3990000000750);
 	}
 
+	SECTION("TimeUsToAbsSendTime()")
+	{
+		// A whole second is the fractional unit itself, being the format 6.18 fixed
+		// point seconds.
+		REQUIRE(Utils::Time::TimeUsToAbsSendTime(1000000) == 262144);
+		REQUIRE(Utils::Time::TimeUsToAbsSendTime(1500000) == 393216);
+		REQUIRE(Utils::Time::TimeUsToAbsSendTime(0) == 0);
+		// Resolution is 1/262144 of a second, so a couple of microseconds already
+		// move the value.
+		REQUIRE(Utils::Time::TimeUsToAbsSendTime(2) == 1);
+
+		// Only 6 bits of seconds are kept, so the value wraps every 64 seconds.
+		constexpr int64_t WrapPeriodUs{ 64 * 1000000 };
+
+		REQUIRE(Utils::Time::TimeUsToAbsSendTime(WrapPeriodUs) == 0);
+		REQUIRE(
+		  Utils::Time::TimeUsToAbsSendTime(WrapPeriodUs + 1000000) ==
+		  Utils::Time::TimeUsToAbsSendTime(1000000));
+
+		// A negative time yields the value of the positive time it's congruent with.
+		REQUIRE(
+		  Utils::Time::TimeUsToAbsSendTime(-1000000) ==
+		  Utils::Time::TimeUsToAbsSendTime(WrapPeriodUs - 1000000));
+		REQUIRE(Utils::Time::TimeUsToAbsSendTime(-WrapPeriodUs) == 0);
+	}
+
 	SECTION("TimeMs2Q32x32()")
 	{
 		// A whole second is the fractional unit itself.


### PR DESCRIPTION
# Details

- Related to https://github.com/versatica/mediasoup/issues/1895 (but also applies to current mediasoup's BWE based on libwebrtc dependencly).
- transport-cc RTCP feedback packet carries arrival times as deltas in units of 250 µs, but mediasoup handled them in milliseconds on both sides (send and receive sides).
- When generating transport-cc feedback, arrival times were captured and stored in milliseconds and then multiplied by 4, so every delta we emit is a multiple of 4 ticks. We were throwing away three quarters of the format's resolution in the feedback that we send to the RTP sender, and such a feedback drives the remote sender's bandwidth estimation.
- When consuming transport-cc feedback, `FeedbackRtpTransportPacket::GetPacketResults()` rebuilt each arrival time with `currentReceivedAtMs += delta / 4`. That integer division discards up to 249 µs per received packet and accumulates into a running base, so the error is drift across the whole feedback packet rather than a per-packet rounding, and it is biased: truncation towards zero rounds positive deltas down and negative ones (reordering) up. A drifting arrival base is indistinguishable from queue build-up, which is exactly the signal a delay-based estimator reacts to.
- On top of that, the reconstructed times were anchored on `referenceTime * 64` while `FeedbackRtpTransportPacket::GetReferenceTimestamp()` and `FeedbackRtpTransportPacket::GetBaseDelta()` are anchored on `TimeWrapPeriod + referenceTime * 64`. The offset exists because the reference time is a signed 24 bits field that can arrive negative and wrap, so the two accessors were returning values in different time frames and the reconstructed one could go negative.
- Arrival times, reference times and packet deltas are now `int64_t` microseconds end to end. `TransportCongestionControlServer::IncomingPacket()` takes microseconds and keeps `mapPacketArrivalTimes` in microseconds, so the feedback it generates carries the full resolution of the format. Its REMB branch converts down to milliseconds for `RemoteBitrateEstimatorAbsSendTime`, the only consumer that still needs them. `FeedbackRtpTransportPacket` takes and returns microseconds throughout, rounds each delta to the nearest tick and advances its running timestamp by the quantized delta so that rounding does not accumulate along a feedback packet, and `FeedbackRtpTransportPacket::GetPacketStatuses()` reconstructs arrival times in the same frame as `FeedbackRtpTransportPacket::GetBaseDeltaUs()`.
- `TransportCongestionControlClient::PacketSent()` now takes the send time in microseconds too. This does not change behaviour yet, since it still truncates to milliseconds for libwebrtc's `rtc::SentPacket`, but send timestamps are the other half of the delay signal and this puts the boundary in the right unit for the native estimator that will consume it.
- Finally, `RTC::RTP::Packet::UpdateAbsSendTime()` takes microseconds and `Utils::Time::TimeMsToAbsSendTime()` becomes `Utils::Time::TimeUsToAbsSendTime()`.
- Fix `FeedbackRtpTransportPacket::SetBase()` which also kept the reference time within 23 bits, while `FeedbackRtpTransportPacket::GetBaseDeltaUs()` compensates the wrap around over the full 24 bits period of the field. The two did not match, so when our own reference tick counter rolled over (every 6.21 days of worker uptime) the base delta came out as −6.21 days and neither compensation branch fired. A receiver of our feedback would see an unexpected timestamp and drop the arrival times of that feedback packet. The base is now masked to the full 24 bits, so the same rollover yields a delta of exactly one tick.