### PR TITLE
Add Meson option to use the new built-in BWE

### DIFF
--- a/doc/Building.md
+++ b/doc/Building.md
@@ -165,6 +165,8 @@ See all the tasks by running `invoke --list` within the `worker` folder.
 
 _NOTE:_ Tasks that require specific Meson options (such as `invoke test`, `invoke tidy`, `invoke test-asan-address`, `invoke test-asan-undefined` and `invoke fuzzer`) use their own Meson build directory within `worker/out/MEDIASOUP_BUILDTYPE`, so switching from a task to another doesn't reconfigure and rebuild everything. All of them install their binaries into `worker/out/MEDIASOUP_BUILDTYPE`.
 
+_NOTE:_ The "MESON_ARGS" environment variable is applied even if the build directory is already configured, since `invoke setup` passes `--reconfigure` to `meson setup` in that case. However Meson keeps every option that is not given again, so **dropping an option from "MESON_ARGS" does not revert it to its default value**. To go back to the default configuration, either pass the option with its default value or remove the build directory with `invoke clean-build`.
+
 _NOTE:_ For some of these tasks to work, npm dependencies of `worker/scripts/package.json` must be installed:
 
 ```bash

--- a/worker/fuzzer/src/fuzzer.cpp
+++ b/worker/fuzzer/src/fuzzer.cpp
@@ -3,7 +3,9 @@
 #include "common.hpp"
 #include "DepLibSRTP.hpp"
 #include "DepLibUV.hpp"
+#ifndef MS_USE_BUILTIN_BWE
 #include "DepLibWebRTC.hpp"
+#endif
 #include "DepOpenSSL.hpp"
 #include "FuzzerUtils.hpp"
 #include "RTC/DtlsTransport.hpp"
@@ -144,7 +146,9 @@ namespace
 		DepLibUV::ClassInit();
 		DepOpenSSL::ClassInit();
 		DepLibSRTP::ClassInit();
+#ifndef MS_USE_BUILTIN_BWE
 		DepLibWebRTC::ClassInit();
+#endif
 		Utils::Crypto::ClassInit();
 		RTC::DtlsTransport::ClassInit();
 

--- a/worker/include/RTC/Transport.hpp
+++ b/worker/include/RTC/Transport.hpp
@@ -23,8 +23,10 @@
 #include "RTC/SCTP/public/Message.hpp"
 #include "RTC/SCTP/public/SctpTypes.hpp"
 #include "RTC/SctpListener.hpp"
+#ifndef MS_USE_BUILTIN_BWE
 #include "RTC/TransportCongestionControlClient.hpp"
 #include "RTC/TransportCongestionControlServer.hpp"
+#endif
 #include "SharedInterface.hpp"
 #include <ankerl/unordered_dense.h>
 #include <string>
@@ -37,8 +39,10 @@ namespace RTC
 	                  public RTC::DataProducer::Listener,
 	                  public RTC::DataConsumer::Listener,
 	                  public RTC::SCTP::AssociationListenerInterface,
+#ifndef MS_USE_BUILTIN_BWE
 	                  public RTC::TransportCongestionControlClient::Listener,
 	                  public RTC::TransportCongestionControlServer::Listener,
+#endif
 	                  public Channel::ChannelSocket::RequestHandler,
 	                  public Channel::ChannelSocket::NotificationHandler,
 	                  public TimerHandleInterface::Listener
@@ -232,8 +236,10 @@ namespace RTC
 		virtual void DistributeAvailableOutgoingBitrate() final;
 		virtual void ComputeOutgoingDesiredBitrate(bool forceBitrate = false) final;
 		virtual void EmitTraceEventProbationType(RTC::RTP::Packet* packet) const final;
+#ifndef MS_USE_BUILTIN_BWE
 		virtual void EmitTraceEventBweType(
 		  RTC::TransportCongestionControlClient::Bitrates& bitrates) const final;
+#endif
 
 		/* Pure virtual methods inherited from RTC::Producer::Listener. */
 	public:
@@ -318,6 +324,7 @@ namespace RTC
 		void OnAssociationTotalBufferedAmountLow() override;
 		bool OnAssociationIsTransportReadyForSctp() override;
 
+#ifndef MS_USE_BUILTIN_BWE
 		/* Pure virtual methods inherited from RTC::TransportCongestionControlClient::Listener. */
 	public:
 		void OnTransportCongestionControlClientBitrates(
@@ -332,6 +339,7 @@ namespace RTC
 	public:
 		void OnTransportCongestionControlServerSendRtcpPacket(
 		  RTC::TransportCongestionControlServer* tccServer, RTC::RTCP::Packet* packet) override;
+#endif
 
 		/* Pure virtual methods inherited from TimerHandleInterface::Listener. */
 	public:
@@ -362,8 +370,10 @@ namespace RTC
 		TimerHandleInterface* rtcpTimer{ nullptr };
 		// Allocated by this.
 		std::unique_ptr<RTC::SCTP::AssociationInterface> sctpAssociation{ nullptr };
+#ifndef MS_USE_BUILTIN_BWE
 		std::shared_ptr<RTC::TransportCongestionControlClient> tccClient{ nullptr };
 		std::shared_ptr<RTC::TransportCongestionControlServer> tccServer{ nullptr };
+#endif
 		// Others.
 		bool direct{ false }; // Whether this Transport allows direct communication.
 		bool isDestroying{ false };
@@ -377,7 +387,12 @@ namespace RTC
 		RTC::RtpDataCounter recvRtxTransmission;
 		RTC::RtpDataCounter sendRtxTransmission;
 		RTC::RtpDataCounter sendProbationTransmission;
+#ifdef MS_USE_BUILTIN_BWE
+		// TODO: The built-in downlink BWE hands the sequence number out, so this
+		// counter goes away.
+#else
 		uint16_t transportWideCcSeq{ 0 };
+#endif
 		int64_t initialAvailableOutgoingBitrate{ 600000 };
 		int64_t maxIncomingBitrate{ 0 };
 		int64_t maxOutgoingBitrate{ 0 };

--- a/worker/include/RTC/TransportCongestionControlClient.hpp
+++ b/worker/include/RTC/TransportCongestionControlClient.hpp
@@ -18,8 +18,6 @@
 
 namespace RTC
 {
-	constexpr int64_t TransportCongestionControlMinOutgoingBitrate{ 30000 };
-
 	class TransportCongestionControlClient : public webrtc::PacketRouter,
 	                                         public webrtc::TargetTransferRateObserver,
 	                                         public TimerHandleInterface::Listener
@@ -53,10 +51,15 @@ namespace RTC
 		};
 
 	public:
+		/**
+		 * @param absoluteMinOutgoingBitrate - Bitrate the target is never taken
+		 *   below (bps), whatever the API asks for.
+		 */
 		TransportCongestionControlClient(
 		  RTC::TransportCongestionControlClient::Listener* listener,
 		  SharedInterface* shared,
 		  RTC::BweType bweType,
+		  int64_t absoluteMinOutgoingBitrate,
 		  int64_t initialAvailableBitrate,
 		  int64_t maxOutgoingBitrate,
 		  int64_t minOutgoingBitrate);
@@ -121,8 +124,9 @@ namespace RTC
 		RTC::RTP::ProbationGenerator* probationGenerator{ nullptr };
 		TimerHandleInterface* processTimer{ nullptr };
 		// Others.
-		RTC::BweType bweType;
-		int64_t initialAvailableBitrate{ 0 };
+		const RTC::BweType bweType;
+		const int64_t absoluteMinOutgoingBitrate;
+		const int64_t initialAvailableBitrate;
 		int64_t maxOutgoingBitrate{ 0 };
 		int64_t minOutgoingBitrate{ 0 };
 		Bitrates bitrates;

--- a/worker/include/Settings.hpp
+++ b/worker/include/Settings.hpp
@@ -38,7 +38,9 @@ public:
 		uint16_t rtcMaxPort{ 59999 };
 		std::string dtlsCertificateFile;
 		std::string dtlsPrivateKeyFile;
+#ifndef MS_USE_BUILTIN_BWE
 		std::string libwebrtcFieldTrials{ "WebRTC-Bwe-AlrLimitedBackoff/Enabled/" };
+#endif
 	};
 
 public:

--- a/worker/meson.build
+++ b/worker/meson.build
@@ -26,20 +26,6 @@ if host_machine.system() == 'windows'
   ]
 endif
 
-if get_option('ms_build_tests')
-  cpp_args += [
-    '-DMS_TEST',
-    '-DMS_LOG_STD'
-  ]
-endif
-
-if get_option('ms_build_fuzzer')
-  cpp_args += [
-    '-DMS_FUZZER',
-    '-DMS_LOG_STD'
-  ]
-endif
-
 if get_option('ms_log_trace')
   cpp_args += [
     '-DMS_LOG_TRACE',
@@ -70,6 +56,26 @@ if get_option('ms_dump_rtp_shared_packet_memory_usage')
   ]
 endif
 
+if get_option('ms_build_tests')
+  cpp_args += [
+    '-DMS_TEST',
+    '-DMS_LOG_STD',
+  ]
+endif
+
+if get_option('ms_build_fuzzer')
+  cpp_args += [
+    '-DMS_FUZZER',
+    '-DMS_LOG_STD',
+  ]
+endif
+
+if get_option('ms_use_builtin_bwe')
+  cpp_args += [
+    '-DMS_USE_BUILTIN_BWE',
+  ]
+endif
+
 cpp = meson.get_compiler('cpp')
 
 # This is a workaround to define FLATBUFFERS_LOCALE_INDEPENDENT=0 outside
@@ -86,7 +92,6 @@ common_sources = [
   'src/lib.cpp',
   'src/DepLibSRTP.cpp',
   'src/DepLibUV.cpp',
-  'src/DepLibWebRTC.cpp',
   'src/DepOpenSSL.cpp',
   'src/Logger.cpp',
   'src/MediaSoupErrors.cpp',
@@ -142,8 +147,6 @@ common_sources = [
   'src/RTC/TcpConnection.cpp',
   'src/RTC/TcpServer.cpp',
   'src/RTC/Transport.cpp',
-  'src/RTC/TransportCongestionControlClient.cpp',
-  'src/RTC/TransportCongestionControlServer.cpp',
   'src/RTC/TransportTuple.cpp',
   'src/RTC/TrendCalculator.cpp',
   'src/RTC/UdpSocket.cpp',
@@ -295,6 +298,16 @@ common_sources = [
   'src/RTC/SCTP/public/Message.cpp',
 ]
 
+# The deps/libwebrtc bandwidth estimation is only built when the built-in one is
+# not used.
+if not get_option('ms_use_builtin_bwe')
+  common_sources += [
+    'src/DepLibWebRTC.cpp',
+    'src/RTC/TransportCongestionControlClient.cpp',
+    'src/RTC/TransportCongestionControlServer.cpp',
+  ]
+endif
+
 libuv_proj = subproject(
   'libuv',
   default_options: [
@@ -321,14 +334,6 @@ libsrtp3_proj = subproject(
   ],
 )
 
-abseil_cpp_proj = subproject(
-  'abseil-cpp',
-  default_options: [
-    'warning_level=0',
-    'cpp_std=c++17',
-  ],
-)
-
 ankerl_unordered_dense_dep = dependency('unordered_dense')
 
 flatbuffers_proj = subproject(
@@ -341,20 +346,13 @@ flatbuffers_proj = subproject(
 # flatbuffers schemas subdirectory.
 subdir('fbs')
 
-# Add current build directory so libwebrtc has access to FBS folder.
-libwebrtc_include_directories = include_directories('include', 'fbs')
-
-subdir('deps/libwebrtc')
-
 dependencies = [
   libuv_proj.get_variable('libuv_dep'),
   openssl_proj.get_variable('openssl_dep'),
   libsrtp3_proj.get_variable('libsrtp3_dep'),
-  abseil_cpp_proj.get_variable('absl_container_dep'),
   ankerl_unordered_dense_dep,
   flatbuffers_proj.get_variable('flatbuffers_dep'),
   flatbuffers_generator_dep,
-  libwebrtc_dep,
 ]
 
 link_whole = [
@@ -362,10 +360,33 @@ link_whole = [
   openssl_proj.get_variable('libcrypto_lib'),
   openssl_proj.get_variable('libssl_lib'),
   libsrtp3_proj.get_variable('libsrtp3'),
-  abseil_cpp_proj.get_variable('absl_container_lib'),
   flatbuffers_proj.get_variable('flatbuffers_lib'),
-  libwebrtc,
 ]
+
+if not get_option('ms_use_builtin_bwe')
+  # NOTE: abseil-cpp is in the tree only because deps/libwebrtc needs it.
+  abseil_cpp_proj = subproject(
+    'abseil-cpp',
+    default_options: [
+      'warning_level=0',
+      'cpp_std=c++17',
+    ],
+  )
+
+  # Add current build directory so libwebrtc has access to FBS folder.
+  libwebrtc_include_directories = include_directories('include', 'fbs')
+
+  subdir('deps/libwebrtc')
+
+  dependencies += [
+    abseil_cpp_proj.get_variable('absl_container_dep'),
+    libwebrtc_dep,
+  ]
+  link_whole += [
+    abseil_cpp_proj.get_variable('absl_container_lib'),
+    libwebrtc,
+  ]
+endif
 
 if host_machine.system() == 'windows'
   wingetopt_proj = subproject(
@@ -446,7 +467,6 @@ test_sources = [
   'test/src/RTC/TestRtpEncodingParameters.cpp',
   'test/src/RTC/TestSeqManager.cpp',
   'test/src/RTC/TestSubchannelsCodec.cpp',
-  'test/src/RTC/TestTransportCongestionControlServer.cpp',
   'test/src/RTC/TestTransportTuple.cpp',
   'test/src/RTC/TestTrendCalculator.cpp',
   'test/src/RTC/BWE/helpers/LinkSimulator.cpp',
@@ -576,6 +596,12 @@ test_sources = [
   'test/src/Utils/TestTime.cpp',
   'test/src/Utils/TestUnwrappedSequenceNumber.cpp',
 ]
+
+if not get_option('ms_use_builtin_bwe')
+  test_sources += [
+    'test/src/RTC/TestTransportCongestionControlServer.cpp',
+  ]
+endif
 
 mediasoup_worker_test = executable(
   'mediasoup-worker-test',

--- a/worker/meson_options.txt
+++ b/worker/meson_options.txt
@@ -5,3 +5,4 @@ option('ms_dump_rtp_payload_descriptor', type: 'boolean', value: false, descript
 option('ms_dump_rtp_shared_packet_memory_usage', type: 'boolean', value: false, description: 'prints information about total memory allocated by RTC::RTP::SharedPacket instances')
 option('ms_build_tests', type: 'boolean', value: false, description: 'Must be enabled when building mediasoup worker tests')
 option('ms_build_fuzzer', type: 'boolean', value: false, description: 'Must be enabled when building mediasoup worker fuzzer')
+option('ms_use_builtin_bwe', type: 'boolean', value: false, description: 'Use the new built-in bandwidth estimation module')

--- a/worker/src/RTC/Transport.cpp
+++ b/worker/src/RTC/Transport.cpp
@@ -15,6 +15,7 @@
 #include "RTC/RTCP/FeedbackRtpNack.hpp"
 #include "RTC/RTCP/FeedbackRtpTransport.hpp"
 #include "RTC/RTCP/XrDelaySinceLastRr.hpp"
+#include "RTC/RTP/ProbationGenerator.hpp"
 #include "RTC/RtpDictionaries.hpp"
 #include "RTC/SCTP/association/Association.hpp"
 #include "RTC/SCTP/public/SctpOptions.hpp"
@@ -23,14 +24,21 @@
 #ifdef MS_RTC_LOGGER_RTP
 #include "RTC/RtcLogger.hpp"
 #endif
+#ifndef MS_USE_BUILTIN_BWE
 #include <libwebrtc/modules/rtp_rtcp/include/rtp_rtcp_defines.h> // webrtc::RtpPacketSendInfo
+#endif
 #include <array>
-#include <iterator> // std::ostream_iterator
-#include <limits>   // std::numeric_limits
-#include <map>      // std::multimap
+#include <limits> // std::numeric_limits
+#include <map>    // std::multimap
 
 namespace RTC
 {
+	/* Static. */
+
+	// Bitrate the outgoing target is never taken below (bps), whatever the API
+	// asks for.
+	static constexpr int64_t AbsoluteMinOutgoingBitrate{ 30000 };
+
 	/* Instance methods. */
 
 	Transport::Transport(
@@ -441,6 +449,29 @@ namespace RTC
 			}
 		}
 
+#ifdef MS_USE_BUILTIN_BWE
+		// TODO: Take these from the built-in downlink and uplink BWE.
+		const flatbuffers::Optional<uint64_t> availableOutgoingBitrate{ flatbuffers::nullopt };
+		const flatbuffers::Optional<uint64_t> availableIncomingBitrate{ flatbuffers::nullopt };
+		const flatbuffers::Optional<double> rtpPacketLossReceived{ flatbuffers::nullopt };
+		const flatbuffers::Optional<double> rtpPacketLossSent{ flatbuffers::nullopt };
+#else
+		const auto availableOutgoingBitrate =
+		  this->tccClient ? flatbuffers::Optional<uint64_t>(
+		                      static_cast<uint64_t>(this->tccClient->GetAvailableBitrate()))
+			                : flatbuffers::nullopt;
+		const auto availableIncomingBitrate =
+		  this->tccServer ? flatbuffers::Optional<uint64_t>(
+		                      static_cast<uint64_t>(this->tccServer->GetAvailableBitrate()))
+			                : flatbuffers::nullopt;
+		const auto rtpPacketLossReceived =
+		  this->tccServer ? flatbuffers::Optional<double>(this->tccServer->GetPacketLoss())
+			                : flatbuffers::nullopt;
+		const auto rtpPacketLossSent =
+		  this->tccClient ? flatbuffers::Optional<double>(this->tccClient->GetPacketLoss())
+			                : flatbuffers::nullopt;
+#endif
+
 		return FBS::Transport::CreateStatsDirect(
 		  builder,
 		  // transportId.
@@ -479,13 +510,9 @@ namespace RTC
 		  // probationSendBitrate.
 		  static_cast<uint64_t>(this->sendProbationTransmission.GetBitrate(nowMs)),
 		  // availableOutgoingBitrate.
-		  this->tccClient ? flatbuffers::Optional<uint64_t>(
-		                      static_cast<uint64_t>(this->tccClient->GetAvailableBitrate()))
-			                : flatbuffers::nullopt,
+		  availableOutgoingBitrate,
 		  // availableIncomingBitrate.
-		  this->tccServer ? flatbuffers::Optional<uint64_t>(
-		                      static_cast<uint64_t>(this->tccServer->GetAvailableBitrate()))
-			                : flatbuffers::nullopt,
+		  availableIncomingBitrate,
 		  // maxIncomingBitrate.
 		  this->maxIncomingBitrate > 0
 		    ? flatbuffers::Optional<uint64_t>(static_cast<uint64_t>(this->maxIncomingBitrate))
@@ -499,11 +526,9 @@ namespace RTC
 		    ? flatbuffers::Optional<uint64_t>(static_cast<uint64_t>(this->minOutgoingBitrate))
 				: flatbuffers::nullopt,
 		  // rtpPacketLossReceived.
-		  this->tccServer ? flatbuffers::Optional<double>(this->tccServer->GetPacketLoss())
-			                : flatbuffers::nullopt,
+		  rtpPacketLossReceived,
 		  // rtpPacketLossSent.
-		  this->tccClient ? flatbuffers::Optional<double>(this->tccClient->GetPacketLoss())
-			                : flatbuffers::nullopt);
+		  rtpPacketLossSent);
 	}
 
 	void Transport::HandleRequest(Channel::ChannelRequest* request)
@@ -524,10 +549,14 @@ namespace RTC
 
 				request->Accept();
 
+#ifdef MS_USE_BUILTIN_BWE
+				// TODO: Pass maxIncomingBitrate to the built-in uplink BWE.
+#else
 				if (this->tccServer)
 				{
 					this->tccServer->SetMaxIncomingBitrate(this->maxIncomingBitrate);
 				}
+#endif
 
 				break;
 			}
@@ -540,11 +569,10 @@ namespace RTC
 				const auto bitrate = static_cast<int64_t>(std::min<uint64_t>(
 				  body->maxOutgoingBitrate(), static_cast<uint64_t>(std::numeric_limits<int64_t>::max())));
 
-				if (bitrate > 0 && bitrate < RTC::TransportCongestionControlMinOutgoingBitrate)
+				if (bitrate > 0 && bitrate < AbsoluteMinOutgoingBitrate)
 				{
 					MS_THROW_TYPE_ERROR(
-					  "bitrate must be >= %" PRIi64 " or 0 (unlimited)",
-					  RTC::TransportCongestionControlMinOutgoingBitrate);
+					  "bitrate must be >= %" PRIi64 " or 0 (unlimited)", AbsoluteMinOutgoingBitrate);
 				}
 				else if (bitrate > 0 && bitrate < this->minOutgoingBitrate)
 				{
@@ -553,6 +581,10 @@ namespace RTC
 					  this->minOutgoingBitrate);
 				}
 
+#ifdef MS_USE_BUILTIN_BWE
+				// TODO: Pass maxOutgoingBitrate to the built-in downlink BWE.
+				this->maxOutgoingBitrate = bitrate;
+#else
 				if (this->tccClient)
 				{
 					// NOTE: This may throw so don't update things before calling this
@@ -568,6 +600,7 @@ namespace RTC
 				{
 					this->maxOutgoingBitrate = bitrate;
 				}
+#endif
 
 				request->Accept();
 
@@ -582,11 +615,10 @@ namespace RTC
 				const auto bitrate = static_cast<int64_t>(std::min<uint64_t>(
 				  body->minOutgoingBitrate(), static_cast<uint64_t>(std::numeric_limits<int64_t>::max())));
 
-				if (bitrate > 0 && bitrate < RTC::TransportCongestionControlMinOutgoingBitrate)
+				if (bitrate > 0 && bitrate < AbsoluteMinOutgoingBitrate)
 				{
 					MS_THROW_TYPE_ERROR(
-					  "bitrate must be >= %" PRIi64 " or 0 (unlimited)",
-					  RTC::TransportCongestionControlMinOutgoingBitrate);
+					  "bitrate must be >= %" PRIi64 " or 0 (unlimited)", AbsoluteMinOutgoingBitrate);
 				}
 				else if (bitrate > 0 && this->maxOutgoingBitrate > 0 && bitrate > this->maxOutgoingBitrate)
 				{
@@ -595,6 +627,10 @@ namespace RTC
 					  this->maxOutgoingBitrate);
 				}
 
+#ifdef MS_USE_BUILTIN_BWE
+				// TODO: Pass minOutgoingBitrate to the built-in downlink BWE.
+				this->minOutgoingBitrate = bitrate;
+#else
 				if (this->tccClient)
 				{
 					// NOTE: This may throw so don't update things before calling this
@@ -610,6 +646,7 @@ namespace RTC
 				{
 					this->minOutgoingBitrate = bitrate;
 				}
+#endif
 
 				request->Accept();
 
@@ -720,6 +757,10 @@ namespace RTC
 
 				request->Accept(FBS::Response::Body::Transport_ProduceResponse, responseOffset);
 
+#ifdef MS_USE_BUILTIN_BWE
+				// TODO: Create the built-in uplink BWE here, choosing transport-cc or
+				// REMB out of the Producer RTP header extensions and RTCP feedback.
+#else
 				// Check if TransportCongestionControlServer or REMB server must be
 				// created.
 				const auto& rtpHeaderExtensionIds = producer->GetRtpHeaderExtensionIds();
@@ -797,6 +838,7 @@ namespace RTC
 						}
 					}
 				}
+#endif
 
 				break;
 			}
@@ -863,6 +905,11 @@ namespace RTC
 
 				request->Accept(FBS::Response::Body::Transport_ConsumeResponse, responseOffset);
 
+#ifdef MS_USE_BUILTIN_BWE
+				// TODO: Create the built-in downlink BWE here, choosing transport-cc or
+				// REMB out of the Consumer RTP header extensions and RTCP feedback, and
+				// tell every Consumer that we manage its bitrate.
+#else
 				// Check if Transport Congestion Control client must be created.
 				const auto& rtpHeaderExtensionIds = consumer->GetRtpHeaderExtensionIds();
 				const auto& codecs                = consumer->GetRtpParameters().codecs;
@@ -942,6 +989,7 @@ namespace RTC
 						  this,
 						  this->shared,
 						  bweType,
+						  AbsoluteMinOutgoingBitrate,
 						  this->initialAvailableOutgoingBitrate,
 						  this->maxOutgoingBitrate,
 						  this->minOutgoingBitrate);
@@ -959,6 +1007,7 @@ namespace RTC
 				{
 					consumer->SetExternallyManagedBitrate();
 				}
+#endif
 
 				if (IsConnected())
 				{
@@ -1313,10 +1362,14 @@ namespace RTC
 
 				// This may be the latest active Consumer with BWE. If so we have to stop
 				// probation.
+#ifdef MS_USE_BUILTIN_BWE
+				// TODO: Do it when the built-in downlink BWE is in place.
+#else
 				if (this->tccClient)
 				{
 					ComputeOutgoingDesiredBitrate(/*forceBitrate*/ true);
 				}
+#endif
 
 				break;
 			}
@@ -1480,6 +1533,9 @@ namespace RTC
 		// Start the RTCP timer.
 		this->rtcpTimer->Start(RTC::RTCP::MaxVideoIntervalMs / 2);
 
+#ifdef MS_USE_BUILTIN_BWE
+		// TODO: Tell the built-in downlink and uplink BWE.
+#else
 		// Tell the TransportCongestionControlClient.
 		if (this->tccClient)
 		{
@@ -1491,6 +1547,7 @@ namespace RTC
 		{
 			this->tccServer->TransportConnected();
 		}
+#endif
 	}
 
 	void Transport::Disconnected()
@@ -1508,6 +1565,9 @@ namespace RTC
 		// Stop the RTCP timer.
 		this->rtcpTimer->Stop();
 
+#ifdef MS_USE_BUILTIN_BWE
+		// TODO: Tell the built-in downlink and uplink BWE.
+#else
 		// Tell the TransportCongestionControlClient.
 		if (this->tccClient)
 		{
@@ -1519,6 +1579,7 @@ namespace RTC
 		{
 			this->tccServer->TransportDisconnected();
 		}
+#endif
 	}
 
 	void Transport::ReceiveRtpPacket(RTC::RTP::Packet* packet, int64_t receivedAtUs)
@@ -1533,11 +1594,15 @@ namespace RTC
 		// them.
 		packet->AssignExtensionIds(this->recvRtpHeaderExtensionIds);
 
+#ifdef MS_USE_BUILTIN_BWE
+		// TODO: Feed the built-in uplink BWE.
+#else
 		// Feed the TransportCongestionControlServer.
 		if (this->tccServer)
 		{
 			this->tccServer->IncomingPacket(receivedAtUs, packet);
 		}
+#endif
 
 		// Get the associated Producer.
 		RTC::Producer* producer = this->rtpListener.GetProducer(packet);
@@ -1921,6 +1986,9 @@ namespace RTC
 					consumer->ReceiveRtcpReceiverReport(report, receivedAtUs);
 				}
 
+#ifdef MS_USE_BUILTIN_BWE
+				// TODO: Feed the Receiver Report to the built-in downlink BWE.
+#else
 				if (this->tccClient && !this->mapConsumers.empty())
 				{
 					float rttMs = 0;
@@ -1940,6 +2008,7 @@ namespace RTC
 
 					this->tccClient->ReceiveRtcpReceiverReport(rr, rttMs, receivedAtUs);
 				}
+#endif
 
 				break;
 			}
@@ -2033,11 +2102,16 @@ namespace RTC
 						{
 							auto* remb = static_cast<RTC::RTCP::FeedbackPsRembPacket*>(afb);
 
+#ifdef MS_USE_BUILTIN_BWE
+							// TODO: Pass the REMB bitrate to the built-in downlink BWE.
+							(void)remb;
+#else
 							// Pass it to the TCC client.
 							if (this->tccClient && this->tccClient->GetBweType() == RTC::BweType::REMB)
 							{
 								this->tccClient->ReceiveEstimatedBitrate(remb->GetBitrate());
 							}
+#endif
 
 							break;
 						}
@@ -2119,10 +2193,15 @@ namespace RTC
 					{
 						auto* feedback = static_cast<RTC::RTCP::FeedbackRtpTransportPacket*>(packet);
 
+#ifdef MS_USE_BUILTIN_BWE
+						// TODO: Feed the transport-cc feedback to the built-in downlink BWE.
+						(void)feedback;
+#else
 						if (this->tccClient)
 						{
 							this->tccClient->ReceiveRtcpTransportFeedback(feedback);
 						}
+#endif
 
 						break;
 					}
@@ -2315,6 +2394,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifdef MS_USE_BUILTIN_BWE
+		// TODO: Distribute the bitrate the built-in downlink BWE reports.
+#else
 		MS_ASSERT(this->tccClient, "no TransportCongestionClient");
 
 		std::multimap<uint8_t, RTC::Consumer*> multimapPriorityConsumer;
@@ -2394,12 +2476,17 @@ namespace RTC
 
 			consumer->ApplyLayers();
 		}
+#endif
 	}
 
 	void Transport::ComputeOutgoingDesiredBitrate(bool forceBitrate)
 	{
 		MS_TRACE();
 
+#ifdef MS_USE_BUILTIN_BWE
+		// TODO: Give the total desired bitrate to the built-in downlink BWE.
+		(void)forceBitrate;
+#else
 		MS_ASSERT(this->tccClient, "no TransportCongestionClient");
 
 		int64_t totalDesiredBitrate{ 0 };
@@ -2415,6 +2502,7 @@ namespace RTC
 		MS_DEBUG_DEV("total desired bitrate: %" PRIi64, totalDesiredBitrate);
 
 		this->tccClient->SetDesiredBitrate(totalDesiredBitrate, forceBitrate);
+#endif
 	}
 
 	inline void Transport::EmitTraceEventProbationType(RTC::RTP::Packet* /*packet*/) const
@@ -2440,6 +2528,7 @@ namespace RTC
 		  notification);
 	}
 
+#ifndef MS_USE_BUILTIN_BWE
 	inline void Transport::EmitTraceEventBweType(
 	  RTC::TransportCongestionControlClient::Bitrates& bitrates) const
 	{
@@ -2477,6 +2566,7 @@ namespace RTC
 		  FBS::Notification::Body::Transport_TraceNotification,
 		  notification);
 	}
+#endif
 
 	void Transport::OnProducerPaused(RTC::Producer* producer)
 	{
@@ -2606,6 +2696,11 @@ namespace RTC
 		// Update abs-send-time if present.
 		packet->UpdateAbsSendTime(this->shared->GetTimeUs());
 
+#ifdef MS_USE_BUILTIN_BWE
+		// TODO: Write the transport wide sequence number the built-in downlink BWE
+		// hands out and register the send in it.
+		SendRtpPacket(consumer, packet);
+#else
 		// Update transport wide sequence number if present.
 		if (
 		  this->tccClient && this->tccClient->GetBweType() == RTC::BweType::TRANSPORT_CC &&
@@ -2654,6 +2749,7 @@ namespace RTC
 		{
 			SendRtpPacket(consumer, packet);
 		}
+#endif
 
 		this->sendRtpTransmission.Update(packet);
 	}
@@ -2665,6 +2761,11 @@ namespace RTC
 		// Update abs-send-time if present.
 		packet->UpdateAbsSendTime(this->shared->GetTimeUs());
 
+#ifdef MS_USE_BUILTIN_BWE
+		// TODO: Write the transport wide sequence number the built-in downlink BWE
+		// hands out and register the send in it.
+		SendRtpPacket(consumer, packet);
+#else
 		// Update transport wide sequence number if present.
 		if (
 		  this->tccClient && this->tccClient->GetBweType() == RTC::BweType::TRANSPORT_CC &&
@@ -2708,6 +2809,7 @@ namespace RTC
 		{
 			SendRtpPacket(consumer, packet);
 		}
+#endif
 
 		this->sendRtxTransmission.Update(packet);
 	}
@@ -2730,7 +2832,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifndef MS_USE_BUILTIN_BWE
 		MS_ASSERT(this->tccClient, "no TransportCongestionClient");
+#endif
 
 		DistributeAvailableOutgoingBitrate();
 		ComputeOutgoingDesiredBitrate();
@@ -2740,7 +2844,9 @@ namespace RTC
 	{
 		MS_TRACE();
 
+#ifndef MS_USE_BUILTIN_BWE
 		MS_ASSERT(this->tccClient, "no TransportCongestionClient");
+#endif
 
 		DistributeAvailableOutgoingBitrate();
 
@@ -2780,10 +2886,14 @@ namespace RTC
 		delete consumer;
 
 		// This may be the latest active Consumer with BWE. If so we have to stop probation.
+#ifdef MS_USE_BUILTIN_BWE
+		// TODO: Do it when the built-in downlink BWE is in place.
+#else
 		if (this->tccClient)
 		{
 			ComputeOutgoingDesiredBitrate(/*forceBitrate*/ true);
 		}
+#endif
 	}
 
 	void Transport::OnDataProducerMessageReceived(
@@ -3263,6 +3373,7 @@ namespace RTC
 		return IsConnected() && (!this->mapDataProducers.empty() || !this->mapDataConsumers.empty());
 	}
 
+#ifndef MS_USE_BUILTIN_BWE
 	void Transport::OnTransportCongestionControlClientBitrates(
 	  RTC::TransportCongestionControlClient* /*tccClient*/,
 	  RTC::TransportCongestionControlClient::Bitrates& bitrates)
@@ -3357,6 +3468,7 @@ namespace RTC
 
 		SendRtcpPacket(packet);
 	}
+#endif
 
 	void Transport::OnTimer(TimerHandleInterface* timer)
 	{

--- a/worker/src/RTC/TransportCongestionControlClient.cpp
+++ b/worker/src/RTC/TransportCongestionControlClient.cpp
@@ -12,8 +12,6 @@ namespace RTC
 {
 	/* Static. */
 
-	// NOTE: TransportCongestionControlMinOutgoingBitrate is defined in
-	// TransportCongestionControlClient.hpp and exposed publicly.
 	// NOTE: These are double rather than float because they are applied to bitrates,
 	// and float only holds exact integers up to 2^24 (16.7 Mbps).
 	static constexpr double MaxBitrateMarginFactor{ 0.1 };
@@ -28,14 +26,15 @@ namespace RTC
 	  RTC::TransportCongestionControlClient::Listener* listener,
 	  SharedInterface* shared,
 	  RTC::BweType bweType,
+	  int64_t absoluteMinOutgoingBitrate,
 	  int64_t initialAvailableBitrate,
 	  int64_t maxOutgoingBitrate,
 	  int64_t minOutgoingBitrate)
 	  : listener(listener),
 	    shared(shared),
 	    bweType(bweType),
-	    initialAvailableBitrate(
-	      std::max<int64_t>(initialAvailableBitrate, RTC::TransportCongestionControlMinOutgoingBitrate)),
+	    absoluteMinOutgoingBitrate(absoluteMinOutgoingBitrate),
+	    initialAvailableBitrate(std::max<int64_t>(initialAvailableBitrate, absoluteMinOutgoingBitrate)),
 	    maxOutgoingBitrate(maxOutgoingBitrate),
 	    minOutgoingBitrate(minOutgoingBitrate)
 	{
@@ -323,7 +322,7 @@ namespace RTC
 		ApplyBitrateUpdates();
 
 		this->bitrates.minBitrate =
-		  std::max<int64_t>(this->minOutgoingBitrate, RTC::TransportCongestionControlMinOutgoingBitrate);
+		  std::max<int64_t>(this->minOutgoingBitrate, this->absoluteMinOutgoingBitrate);
 	}
 
 	void TransportCongestionControlClient::SetDesiredBitrate(int64_t desiredBitrate, bool force)
@@ -355,12 +354,12 @@ namespace RTC
 #endif
 
 		this->bitrates.minBitrate =
-		  std::max<int64_t>(this->minOutgoingBitrate, RTC::TransportCongestionControlMinOutgoingBitrate);
+		  std::max<int64_t>(this->minOutgoingBitrate, this->absoluteMinOutgoingBitrate);
 
 		// NOTE: Setting 'startBitrate' to 'availableBitrate' has proven to generate
 		// more stable values.
-		this->bitrates.startBitrate = std::max<int64_t>(
-		  RTC::TransportCongestionControlMinOutgoingBitrate, this->bitrates.availableBitrate);
+		this->bitrates.startBitrate =
+		  std::max<int64_t>(this->absoluteMinOutgoingBitrate, this->bitrates.availableBitrate);
 
 		ApplyBitrateUpdates();
 	}
@@ -414,7 +413,7 @@ namespace RTC
 		}
 
 		this->bitrates.minBitrate =
-		  std::max<int64_t>(this->minOutgoingBitrate, RTC::TransportCongestionControlMinOutgoingBitrate);
+		  std::max<int64_t>(this->minOutgoingBitrate, this->absoluteMinOutgoingBitrate);
 
 		MS_DEBUG_DEV(
 		  "[desiredBitrate:%" PRIi64 ", desiredBitrateTrend:%" PRIu32 ", startBitrate:%" PRIi64

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -58,7 +58,9 @@ void Settings::SetConfiguration(int argc, char* argv[])
 		{ .name="rtcMaxPort",           .has_arg=optional_argument, .flag=nullptr, .val='M' },
 		{ .name="dtlsCertificateFile",  .has_arg=optional_argument, .flag=nullptr, .val='c' },
 		{ .name="dtlsPrivateKeyFile",   .has_arg=optional_argument, .flag=nullptr, .val='p' },
+#ifndef MS_USE_BUILTIN_BWE
 		{ .name="libwebrtcFieldTrials", .has_arg=optional_argument, .flag=nullptr, .val='W' },
+#endif
 		{ .name=nullptr,                .has_arg=0,                 .flag=nullptr,  .val=0  }
 	};
 	// clang-format on
@@ -144,6 +146,10 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 			case 'W':
 			{
+#ifdef MS_USE_BUILTIN_BWE
+				// TODO: Remove when we only support the built-in BWE.
+				MS_WARN_TAG(info, "ignoring libwebrtcFieldTrials since this worker uses the built-in BWE");
+#else
 				stringValue = std::string(optarg);
 
 				if (stringValue != Settings::configuration.libwebrtcFieldTrials)
@@ -154,6 +160,7 @@ void Settings::SetConfiguration(int argc, char* argv[])
 
 					Settings::configuration.libwebrtcFieldTrials = stringValue;
 				}
+#endif
 
 				break;
 			}
@@ -364,11 +371,13 @@ void Settings::PrintConfiguration()
 		  info, "  dtlsCertificateFile: %s", Settings::configuration.dtlsCertificateFile.c_str());
 		MS_DEBUG_TAG(info, "  dtlsPrivateKeyFile: %s", Settings::configuration.dtlsPrivateKeyFile.c_str());
 	}
+#ifndef MS_USE_BUILTIN_BWE
 	if (!Settings::configuration.libwebrtcFieldTrials.empty())
 	{
 		MS_DEBUG_TAG(
 		  info, "  libwebrtcFieldTrials: %s", Settings::configuration.libwebrtcFieldTrials.c_str());
 	}
+#endif
 
 	MS_DEBUG_TAG(info, "</configuration>");
 }

--- a/worker/src/Settings.cpp
+++ b/worker/src/Settings.cpp
@@ -58,9 +58,10 @@ void Settings::SetConfiguration(int argc, char* argv[])
 		{ .name="rtcMaxPort",           .has_arg=optional_argument, .flag=nullptr, .val='M' },
 		{ .name="dtlsCertificateFile",  .has_arg=optional_argument, .flag=nullptr, .val='c' },
 		{ .name="dtlsPrivateKeyFile",   .has_arg=optional_argument, .flag=nullptr, .val='p' },
-#ifndef MS_USE_BUILTIN_BWE
+		// NOTE: The libwebrtcFieldTrials option is still allowed until we only
+		// support the built-in BWE.
+		// TODO: Remove when we only support the built-in BWE.
 		{ .name="libwebrtcFieldTrials", .has_arg=optional_argument, .flag=nullptr, .val='W' },
-#endif
 		{ .name=nullptr,                .has_arg=0,                 .flag=nullptr,  .val=0  }
 	};
 	// clang-format on

--- a/worker/src/lib.cpp
+++ b/worker/src/lib.cpp
@@ -8,7 +8,9 @@
 #include "Channel/ChannelSocket.hpp"
 #include "DepLibSRTP.hpp"
 #include "DepLibUV.hpp"
+#ifndef MS_USE_BUILTIN_BWE
 #include "DepLibWebRTC.hpp"
+#endif
 #include "DepOpenSSL.hpp"
 #include "Logger.hpp"
 #include "MediaSoupErrors.hpp"
@@ -150,7 +152,9 @@ extern "C" int mediasoup_worker_run(
 		// Initialize static stuff.
 		DepOpenSSL::ClassInit();
 		DepLibSRTP::ClassInit();
+#ifndef MS_USE_BUILTIN_BWE
 		DepLibWebRTC::ClassInit();
+#endif
 		Utils::Crypto::ClassInit();
 		RTC::DtlsTransport::ClassInit();
 		RTC::SrtpSession::ClassInit();
@@ -168,7 +172,9 @@ extern "C" int mediasoup_worker_run(
 		// Free static stuff.
 		DepLibSRTP::ClassDestroy();
 		Utils::Crypto::ClassDestroy();
+#ifndef MS_USE_BUILTIN_BWE
 		DepLibWebRTC::ClassDestroy();
+#endif
 		RTC::DtlsTransport::ClassDestroy();
 		DepLibUV::ClassDestroy();
 

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -175,10 +175,16 @@ def setup(ctx, meson_args=MESON_ARGS, build_dir=BUILD_DIR):
     Run meson setup
     """
 
+    # NOTE: Given an already configured build directory, "meson setup" just
+    # prints "Directory already configured" and exits successfully, silently
+    # ignoring the given options. So it must be told to reconfigure it or
+    # changing MESON_ARGS would have no effect until the directory is removed.
+    reconfigure = "--reconfigure" if os.path.isdir(f"{build_dir}/meson-info") else ""
+
     if MEDIASOUP_BUILDTYPE == "Release":
         with cd_worker():
             ctx.run(
-                f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype release -Db_ndebug=true {meson_args} "{build_dir}"',
+                f'"{MESON}" setup {reconfigure} --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype release -Db_ndebug=true {meson_args} "{build_dir}"',
                 echo=True,
                 pty=PTY_SUPPORTED,
                 shell=SHELL,
@@ -186,7 +192,7 @@ def setup(ctx, meson_args=MESON_ARGS, build_dir=BUILD_DIR):
     elif MEDIASOUP_BUILDTYPE == "Debug":
         with cd_worker():
             ctx.run(
-                f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype debug {meson_args} "{build_dir}"',
+                f'"{MESON}" setup {reconfigure} --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype debug {meson_args} "{build_dir}"',
                 echo=True,
                 pty=PTY_SUPPORTED,
                 shell=SHELL,
@@ -194,7 +200,7 @@ def setup(ctx, meson_args=MESON_ARGS, build_dir=BUILD_DIR):
     else:
         with cd_worker():
             ctx.run(
-                f'"{MESON}" setup --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype {MEDIASOUP_BUILDTYPE} -Db_ndebug=if-release {meson_args} "{build_dir}"',
+                f'"{MESON}" setup {reconfigure} --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype {MEDIASOUP_BUILDTYPE} -Db_ndebug=if-release {meson_args} "{build_dir}"',
                 echo=True,
                 pty=PTY_SUPPORTED,
                 shell=SHELL,

--- a/worker/test/src/tests.cpp
+++ b/worker/test/src/tests.cpp
@@ -1,7 +1,9 @@
 #include "common.hpp"
 #include "DepLibSRTP.hpp"
 #include "DepLibUV.hpp"
+#ifndef MS_USE_BUILTIN_BWE
 #include "DepLibWebRTC.hpp"
+#endif
 #include "DepOpenSSL.hpp"
 #include "Settings.hpp"
 #include "Utils.hpp"
@@ -46,7 +48,9 @@ int main(int argc, char* argv[])
 	DepLibUV::ClassInit();
 	DepOpenSSL::ClassInit();
 	DepLibSRTP::ClassInit();
+#ifndef MS_USE_BUILTIN_BWE
 	DepLibWebRTC::ClassInit();
+#endif
 	Utils::Crypto::ClassInit();
 
 	Catch::Session session;
@@ -56,7 +60,9 @@ int main(int argc, char* argv[])
 	// Free static stuff.
 	DepLibSRTP::ClassDestroy();
 	Utils::Crypto::ClassDestroy();
+#ifndef MS_USE_BUILTIN_BWE
 	DepLibWebRTC::ClassDestroy();
+#endif
 	DepLibUV::ClassDestroy();
 
 	return status;


### PR DESCRIPTION
# Details

- Related to #1895
- `meson_options.txt`: Add "ms_use_builtin_bwe" option (false by default). If enabled it does not build `deps/libwebrtc` (and `abseil-cpp` subproject) and it runs the new built-in BWE (which is not yet finished and not even used at all, but at least we have the places where things must be done).

## Bonus track

- `tasks.py`: Pass `--reconfigure` to `meson setup` when the build directory is already configured, so that changing `MESON_ARGS` takes effect instead of being silently ignored.
  - **Note:** Meson keeps every option that is not given again, so dropping an option from `MESON_ARGS` does not revert it to its default.