### PR TITLE
Improve worker build system (part 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Worker: Use `int64_t` for time everywhere ([PR #1918](https://github.com/versatica/mediasoup/pull/1918)).
 - Worker: Use `int64_t` for bitrate everywhere ([PR #1919](https://github.com/versatica/mediasoup/pull/1919)).
 - Improve worker build system ([PR #1920](https://github.com/versatica/mediasoup/pull/1920)).
+- Improve worker build system (part 2) ([PR #1923](https://github.com/versatica/mediasoup/pull/1923)).
 
 ### 3.26.0
 

--- a/doc/Building.md
+++ b/doc/Building.md
@@ -165,7 +165,7 @@ See all the tasks by running `invoke --list` within the `worker` folder.
 
 _NOTE:_ Tasks that require specific Meson options (such as `invoke test`, `invoke tidy`, `invoke test-asan-address`, `invoke test-asan-undefined` and `invoke fuzzer`) use their own Meson build directory within `worker/out/MEDIASOUP_BUILDTYPE`, so switching from a task to another doesn't reconfigure and rebuild everything. All of them install their binaries into `worker/out/MEDIASOUP_BUILDTYPE`.
 
-_NOTE:_ The "MESON_ARGS" environment variable is applied even if the build directory is already configured, since `invoke setup` passes `--reconfigure` to `meson setup` in that case. However Meson keeps every option that is not given again, so **dropping an option from "MESON_ARGS" does not revert it to its default value**. To go back to the default configuration, either pass the option with its default value or remove the build directory with `invoke clean-build`.
+_NOTE:_ The "MESON_ARGS" environment variable is always honored, even if the build directory is already configured. Meson would otherwise ignore it and keep the options the build directory was configured with, so `invoke setup` passes `--reconfigure` to `meson setup` and gives it every option in `worker/meson_options.txt` set to its default value before "MESON_ARGS", which comes later and hence wins. This means that **dropping an option from "MESON_ARGS" reverts it to its default value**, so "MESON_ARGS" alone decides how the worker is built.
 
 _NOTE:_ For some of these tasks to work, npm dependencies of `worker/scripts/package.json` must be installed:
 
@@ -207,12 +207,12 @@ Check the status of the Meson subprojects. It also prints whether there are upda
 
 ### `invoke update-wrap-file [subproject]`
 
-Updates the wrap file of a Meson subproject (those in `worker/subprojects` folder). After updating it, `invoke setup` must be called by passing `MESON_ARGS="--reconfigure"` environment variable. Usage example:
+Updates the wrap file of a Meson subproject (those in `worker/subprojects` folder). After updating it, `invoke setup` must be called. Usage example:
 
 ```bash
 cd worker
 invoke update-wrap-file openssl
-MESON_ARGS="--reconfigure" invoke setup
+invoke setup
 ```
 
 ### `invoke mediasoup-worker`

--- a/rust/CHANGELOG.md
+++ b/rust/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Worker: Use `int64_t` for time everywhere ([PR #1918](https://github.com/versatica/mediasoup/pull/1918)).
 - Worker: Use `int64_t` for bitrate everywhere ([PR #1919](https://github.com/versatica/mediasoup/pull/1919)).
 - Improve worker build system ([PR #1920](https://github.com/versatica/mediasoup/pull/1920)).
+- Improve worker build system (part 2) ([PR #1923](https://github.com/versatica/mediasoup/pull/1923)).
 
 ### 0.27.0
 

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -182,7 +182,9 @@ def default_meson_options():
             match = re.match(r"\s*option\('([^']+)'.*value:\s*([^,)]+)", line)
 
             if match:
-                options.append(f"-D{match.group(1)}={match.group(2).strip().strip(chr(39))}")
+                options.append(
+                    f"-D{match.group(1)}={match.group(2).strip().strip(chr(39))}"
+                )
 
     return " ".join(options)
 

--- a/worker/tasks.py
+++ b/worker/tasks.py
@@ -11,6 +11,7 @@ Usage:
 import glob
 import inspect
 import os
+import re
 import shutil
 import sys
 from contextlib import contextmanager, suppress
@@ -169,6 +170,23 @@ def meson_ninja(ctx):
     )
 
 
+def default_meson_options():
+    """
+    Return every option in meson_options.txt set to its default value
+    """
+
+    options = []
+
+    with open(f"{WORKER_DIR}/meson_options.txt", encoding="utf-8") as options_file:
+        for line in options_file:
+            match = re.match(r"\s*option\('([^']+)'.*value:\s*([^,)]+)", line)
+
+            if match:
+                options.append(f"-D{match.group(1)}={match.group(2).strip().strip(chr(39))}")
+
+    return " ".join(options)
+
+
 @task(pre=[meson_ninja])
 def setup(ctx, meson_args=MESON_ARGS, build_dir=BUILD_DIR):
     """
@@ -181,10 +199,17 @@ def setup(ctx, meson_args=MESON_ARGS, build_dir=BUILD_DIR):
     # changing MESON_ARGS would have no effect until the directory is removed.
     reconfigure = "--reconfigure" if os.path.isdir(f"{build_dir}/meson-info") else ""
 
+    # NOTE: Meson also keeps every option of an already configured build
+    # directory that is not given again, so all of them are passed with their
+    # default value before meson_args, which comes later and hence wins. Without
+    # this, removing an option from MESON_ARGS would silently keep the value it
+    # was given the previous time.
+    default_options = default_meson_options()
+
     if MEDIASOUP_BUILDTYPE == "Release":
         with cd_worker():
             ctx.run(
-                f'"{MESON}" setup {reconfigure} --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype release -Db_ndebug=true {meson_args} "{build_dir}"',
+                f'"{MESON}" setup {reconfigure} --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype release -Db_ndebug=true {default_options} {meson_args} "{build_dir}"',
                 echo=True,
                 pty=PTY_SUPPORTED,
                 shell=SHELL,
@@ -192,7 +217,7 @@ def setup(ctx, meson_args=MESON_ARGS, build_dir=BUILD_DIR):
     elif MEDIASOUP_BUILDTYPE == "Debug":
         with cd_worker():
             ctx.run(
-                f'"{MESON}" setup {reconfigure} --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype debug {meson_args} "{build_dir}"',
+                f'"{MESON}" setup {reconfigure} --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype debug {default_options} {meson_args} "{build_dir}"',
                 echo=True,
                 pty=PTY_SUPPORTED,
                 shell=SHELL,
@@ -200,7 +225,7 @@ def setup(ctx, meson_args=MESON_ARGS, build_dir=BUILD_DIR):
     else:
         with cd_worker():
             ctx.run(
-                f'"{MESON}" setup {reconfigure} --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype {MEDIASOUP_BUILDTYPE} -Db_ndebug=if-release {meson_args} "{build_dir}"',
+                f'"{MESON}" setup {reconfigure} --prefix "{MEDIASOUP_INSTALL_DIR}" --bindir "" --libdir "" --buildtype {MEDIASOUP_BUILDTYPE} -Db_ndebug=if-release {default_options} {meson_args} "{build_dir}"',
                 echo=True,
                 pty=PTY_SUPPORTED,
                 shell=SHELL,


### PR DESCRIPTION
# Details

- Make `MESON_ARGS` fully determine the build configuration
- `tasks.py`: Pass `--reconfigure` to `meson setup` when the build directory is already configured, so that `MESON_ARGS` is not silently ignored.
- `tasks.py`: Pass every option in `meson_options.txt` with its default value before `MESON_ARGS`, so that dropping an option from it reverts the option instead of keeping its previous value.

## What?

Imagine you do this (before this PR):

```bash
MESON_ARGS="-Dms_use_builtin_bwe=true" make
```

and then:

```bash
make
```

Resulting binary has `ms_use_builtin_bwe` set to `true`.

This is fixed in this PR.